### PR TITLE
Downgrade CodeAnalysis to avoid dependency on .NET 9 packages

### DIFF
--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -5,9 +5,9 @@
         <Version>4.0.0</Version>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.14.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.13.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We are having issues deploying our application with Marten 8.

The issue is that Marten 8 depends on `System.Collections.Immutable (>= 9.0.0)` through [Microsoft.CodeAnalysis (4.14.0)](https://www.nuget.org/packages/Microsoft.CodeAnalysis).

We are deploying using .NET 8 R2R images which have .NET assemblies precompiled, and therefore fail on startup with this error:
```
Process terminated. MVID mismatch between loaded assembly 'System.Collections.Immutable' (MVID = {d1a28d33-0f88-4b7b-86f7-bdac23bc6b2f}) and an assembly with the same simple name embedded in the native image 'full-composite.r2r.dll' (MVID = {a0a8102e-c7b5-4bf5-a264-afc55cdf1ac9})
```

By downgrading Microsoft.CodeAnalysis to the previous version 4.13.0, we would avoid this issue since that version only depends on .NET 8 packages.

I have run the JasperFx tests successfully (except for a few that failed already, probably because of my Danish locale).