### PR TITLE
Fall back to System Console if Spectre Console fails

### DIFF
--- a/src/JasperFx/CommandLine/CommandExecutor.cs
+++ b/src/JasperFx/CommandLine/CommandExecutor.cs
@@ -50,7 +50,7 @@ public class CommandExecutor
             }
             catch (Exception)
             {
-                AnsiConsole.Write(ex.ToString());
+                Console.Write(ex.ToString());
             }
 
             return 1;


### PR DESCRIPTION
Ran into [this bug](https://github.com/spectreconsole/spectre.console/issues/1495) in Spectre.Console. Took me a while to figure out since the exception was only thrown in my pipeline.

I think it makes sense to fall back to `System.Console` if Spectre fails. That way you always get the actual exception in the logs and not the exception Spectre throws.