### PR TITLE
Fix for aggregation runner calling StoreProjection

### DIFF
--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -178,7 +178,7 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
                 break;
             case ActionType.Store:
                 cache.Store(slice.Id, snapshot!);
-                storage.StoreProjection(snapshot!, lastEvent, Projection.Scope);
+                storage.Store(snapshot!);
                 break;
             case ActionType.HardDelete:
                 cache.TryRemove(slice.Id);
@@ -187,10 +187,10 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             case ActionType.UnDeleteAndStore:
                 storage.UnDelete(snapshot!);
                 cache.Store(slice.Id, snapshot!);
-                storage.StoreProjection(snapshot!, lastEvent, Projection.Scope);
+                storage.Store(snapshot!);
                 break;
             case ActionType.StoreThenSoftDelete:
-                storage.StoreProjection(snapshot!, lastEvent, Projection.Scope);
+	            storage.Store(snapshot!);
                 cache.TryRemove(slice.Id);
                 storage.Delete(slice.Id);
                 break;


### PR DESCRIPTION
Not sure why it calls StoreProjection.  This always leads to a not implemented exception in marten.  

This is a reference to the bug test created here.  This pull request also has more information.
https://github.com/JasperFx/marten/pull/3898