### PR TITLE
Bugfix: Current statistics not updated on HighWaterStatus.Changed

### DIFF
--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
@@ -201,7 +201,7 @@ public class HighWaterAgent: IDisposable
         // don't bother sending updates if the current position is 0
         if (statistics.CurrentMark == 0 || statistics.CurrentMark == _tracker.HighWaterMark)
         {
-            if (status == HighWaterStatus.CaughtUp)
+            if (status != HighWaterStatus.Stale)
             {
                 // Update the current stats if the status is not stale
                 // This ensures the current stats timestamp is up-to-date, and not just set to the time of the last changed


### PR DESCRIPTION
I have encountered a problem where the async daemon would stall in case of multiple event gaps. It would advance the HighWaterMark past the first gap, but then not advance further.

This happens because the statistics are not updated when the HighWaterStatus has status changed, and therefore the daemon fell into an endless loop without getting past the next gap. Only when restarting the daemon, it would clear the next gap, but then get stuck again if there were more gaps.