### PR TITLE
Display database name in projection rebuilds.

### DIFF
--- a/src/JasperFx.Events/CommandLine/ConsoleView.cs
+++ b/src/JasperFx.Events/CommandLine/ConsoleView.cs
@@ -66,7 +66,7 @@ internal class ConsoleView: IConsoleView
 
     public void WriteStartingToRebuildProjections(ProjectionSelection selection, string databaseName)
     {
-        AnsiConsole.WriteLine($"Starting to rebuild projections {selection.Subscriptions.Select(x => x.Name).Join(", ")} ");
+        AnsiConsole.WriteLine($"Starting to rebuild projections {selection.Subscriptions.Select(x => x.Name).Join(", ")} in {databaseName}");
     }
 
     public void DisplayNoAsyncProjections()


### PR DESCRIPTION
When rebuilding projections for multiple tenants in multiple databases, it should display the database name along with the projection name.