### PR TITLE
Resolve IServiceScopeFactory from the ServiceContainer

### DIFF
--- a/src/JasperFx/CodeGeneration/Services/ServiceProviderPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceProviderPlan.cs
@@ -17,6 +17,20 @@ internal class ServiceProviderFamily : ServiceFamily
     }
 }
 
+internal class ServiceScopeFactoryFamily : ServiceFamily
+{
+    public ServiceScopeFactoryFamily() : base(typeof(IServiceScopeFactory), Array.Empty<ServiceDescriptor>())
+    {
+        
+    }
+
+    public override ServicePlan? BuildDefaultPlan(ServiceContainer graph, List<ServiceDescriptor> trail)
+    {
+        return new ServiceProviderPlan(new ServiceDescriptor(typeof(IServiceScopeFactory), typeof(ServiceDescriptor),
+            ServiceLifetime.Singleton));
+    }
+}
+
 internal class ServiceProviderPlan : ServicePlan
 {
     public ServiceProviderPlan(ServiceDescriptor descriptor) : base(descriptor)

--- a/src/JasperFx/ServiceContainer.cs
+++ b/src/JasperFx/ServiceContainer.cs
@@ -221,6 +221,13 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
             return family;
         }
         
+        if (serviceType == typeof(IServiceScopeFactory))
+        {
+            family = new ServiceScopeFactoryFamily();
+            _families = _families.AddOrUpdate(serviceType, family);
+            return family;
+        }
+        
         if (IsEnumerable(serviceType))
         {
             family = new ArrayFamily(serviceType);


### PR DESCRIPTION
Add a special case for resolving `IServiceScopeFactory` from the `ServiceContainer`. I ran into this issue in Wolverine when migrating from an old version and moving away from Lamar. We have some services that are injected into message handlers that use `IServiceScopeFactory`. Of course, we could replace all of those usages with `IServiceProvider`, but it is nicer to inject `IServiceScopeFactory` directly.