### PR TITLE
Added smart project root resolution for code generation in Console apps

### DIFF
--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -108,18 +108,10 @@ public class JasperFxOptionsTests
     }
     
     [Fact]
-    public void resolve_project_root_returns_null_for_non_bin_path()
+    public void resolve_project_root_returns_null_for_nonexistent_path()
     {
-        // Path that doesn't contain bin folder should return null
-        var result = JasperFxOptions.ResolveProjectRoot("/some/project/path");
-        result.ShouldBeNull();
-    }
-    
-    [Fact]
-    public void resolve_project_root_returns_null_for_path_without_bin_separator()
-    {
-        // Path that contains "bin" but not as a directory should return null
-        var result = JasperFxOptions.ResolveProjectRoot("/some/binary/path");
+        // Non-existent path should return null gracefully without throwing
+        var result = JasperFxOptions.ResolveProjectRoot("/nonexistent/fake/path/xyz123");
         result.ShouldBeNull();
     }
     

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -197,7 +197,13 @@ public class JasperFxOptions : SystemPartBase
         var directory = new DirectoryInfo(currentPath);
         while (directory != null)
         {
-            // If we find a .csproj, we've found a project root.
+            if (!directory.Exists)
+            {
+                directory = directory.Parent;
+                continue;
+            }
+                
+            // If we find a .csproj, we've found a project root
             // If there are multiple (unlikely in this structure), the closest one wins.
             if (directory.GetFiles("*.csproj").Length != 0)
             {


### PR DESCRIPTION
New AutoResolveProjectRoot option on JasperFxOptions that climbs up from bin folders to find .csproj/.sln files during codegen commands. Helps Console/Worker apps avoid writing generated code to bin folder. Disabled by default for backward compatibility.

[https://github.com/JasperFx/jasperfx/issues/135](135)