### PR TITLE
separating commands to tear down all projection storage with only tea…

### DIFF
--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -566,7 +566,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
 
         // Tear down the current state
-        await _store.TeardownExistingProjectionProgressAsync(Database, subscriptionName, token).ConfigureAwait(false);
+        await _store.TeardownExistingProjectionStateAsync(Database, subscriptionName, token).ConfigureAwait(false);
 
         if (token.IsCancellationRequested)
         {
@@ -603,7 +603,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         if (source.Lifecycle == ProjectionLifecycle.Inline)
         {
             // Tear down the current state
-            await _store.TeardownExistingProjectionProgressAsync(Database, subscriptionName, token).ConfigureAwait(false);
+            await _store.DeleteProjectionProgressAsync(Database, subscriptionName, token).ConfigureAwait(false);
         }
     }
 

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -66,7 +66,28 @@ public interface IEventStore<TOperations, TQuerySession> : IEventStore where TOp
 
     Task RewindAgentProgressAsync(IEventDatabase database, string shardName, CancellationToken token, long sequenceFloor);
 
+    [Obsolete("This was badly named as in the current implementation it is really TeardownExistingProjectionStateAsync()")]
     Task TeardownExistingProjectionProgressAsync(IEventDatabase database, string subscriptionName,
+        CancellationToken token);
+
+    /// <summary>
+    /// Tear down all stored projection data and the projection progression
+    /// </summary>
+    /// <param name="database"></param>
+    /// <param name="subscriptionName"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task TeardownExistingProjectionStateAsync(IEventDatabase database, string subscriptionName,
+        CancellationToken token);
+    
+    /// <summary>
+    /// Delete *only* any persisted projection progress data
+    /// </summary>
+    /// <param name="database"></param>
+    /// <param name="subscriptionName"></param>
+    /// <param name="token"></param>
+    /// <returns></returns>
+    Task DeleteProjectionProgressAsync(IEventDatabase database, string subscriptionName,
         CancellationToken token);
 
     ValueTask<IProjectionBatch<TOperations, TQuerySession>> StartProjectionBatchAsync(EventRange range,


### PR DESCRIPTION
…ring down the progression data