### PR TITLE
Fix missing null check in TryBuildPlan for unresolvable dependencies

### DIFF
--- a/src/JasperFx/CodeGeneration/Services/ConstructorPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ConstructorPlan.cs
@@ -133,7 +133,7 @@ internal class ConstructorPlan : ServicePlan
                     dependencies.Add(graph.FindDefault(p.ParameterType, trail));
                 }
 
-                if (dependencies.OfType<InvalidPlan>().Any())
+                if (dependencies.OfType<InvalidPlan>().Any() || dependencies.Any(x => x == null))
                 {
                     plan = new InvalidPlan(descriptor);
                     return true;

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>1.24.0</Version>
+        <Version>1.24.1</Version>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
## Summary
- Restores the `dependencies.Any(x => x == null)` null check that was accidentally removed when DefaultValuePlan support was added in 3d56b5c
- Bumps JasperFx version to 1.24.1

## Problem
Handlers with constructor dependencies on unregistered interfaces (e.g., `CreateBug218Handler(IBug218Repository)` where `IBug218Repository` is not in DI) cause `ArgumentOutOfRangeException: Missing dependencies` instead of being gracefully handled as `InvalidPlan`.

The root cause: `graph.FindDefault()` returns `null` for unregistered interface types. The null flows into the dependencies list, bypasses the `InvalidPlan`-only check, and reaches the `ConstructorPlan` constructor which validates against nulls.

This breaks Wolverine's Marten and EF Core test suites where handler assemblies contain test handlers whose dependencies are only registered in specific test fixtures.

## Test plan
- [x] `nuke` succeeds locally
- [ ] Wolverine Marten tests pass with updated JasperFx
- [ ] Wolverine EF Core tests pass with updated JasperFx

🤖 Generated with [Claude Code](https://claude.com/claude-code)