### PR TITLE
Update NUKE to version 10 and Spectre.Console to 0.55.0

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Nuke.Common" Version="10.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/JasperFx.Events/CommandLine/ConsoleView.cs
+++ b/src/JasperFx.Events/CommandLine/ConsoleView.cs
@@ -42,7 +42,7 @@ internal class ConsoleView: IConsoleView
             }
         }
 
-        AnsiConsole.Render(tree);
+        AnsiConsole.Write(tree);
         AnsiConsole.WriteLine();
     }
 

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -33,7 +33,7 @@
     <ItemGroup>
         <PackageReference Include="FastExpressionCompiler" Version="5.3.0" />
         <PackageReference Include="ImTools" Version="4.0.0"/>
-        <PackageReference Include="Spectre.Console" Version="0.53.0" />
+        <PackageReference Include="Spectre.Console" Version="0.55.0" />
         <PackageReference Include="Polly.Core" Version="8.6.5" />
     </ItemGroup>
 


### PR DESCRIPTION
The `ConsoleView` was using obsoleted `Render` method which just calls `Write` internally, the `Render` was removed in 0.55. Same NUKE/NET 10 update treatment as there was for Wolverine.