### PR TITLE
Gate Archived handling on single-stream projection ownership (#4093)

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Runtime.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Runtime.cs
@@ -111,7 +111,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
 
             return new(snapshot, ActionType.Delete);
         }
-        
+
         snapshot = await _evolve(snapshot, identity, session, events, cancellation);
 
         if (snapshot == null)
@@ -141,6 +141,19 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
     public virtual ValueTask<TDoc?> EvolveAsync(TDoc? snapshot, TId id, TQuerySession session, IEvent e,
         CancellationToken cancellation)
     {
+        // Archived is a terminal stream marker, not an aggregate-creating event. In a
+        // composite with multiple single-stream children, a sibling projection may see
+        // an Archived event for a stream it does not own — if that projection defines
+        // Create(Archived), the default flow would otherwise materialize a phantom
+        // aggregate under the other projection's stream id. Guard: when no snapshot
+        // exists, skip Archived. Once a snapshot exists (either pre-loaded or created
+        // by a preceding event in the same slice), Apply(Archived) hooks still run.
+        // See issue JasperFx/marten#4093.
+        if (snapshot == null && e is IEvent<Archived>)
+        {
+            return new ValueTask<TDoc?>(default(TDoc));
+        }
+
         return (snapshot == null
             ? _application.Create(e, session, cancellation)
             : _application.ApplyAsync(snapshot, e, session, cancellation)!)!;

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -97,10 +97,15 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
                 (_, transformed) = tryApplyMetadata(stream.Events, transformed, id, storage);
                 
                 if (transformed == null && action != ActionType.Delete && action != ActionType.HardDelete) continue;
-                
+
                 storage.ApplyInline(transformed, action, id, stream.TenantId);
-                
-                maybeArchiveStream(storage, stream, id);
+
+                // Gate archival on whether this projection owns the stream. Ownership
+                // is signalled by a pre-loaded snapshot OR a materialized one from the
+                // slice. In a composite projection with multiple single-stream children,
+                // sibling projections that do not own this stream skip the archive.
+                // See issue JasperFx/marten#4093.
+                maybeArchiveStream(storage, stream, id, ownsStream: snapshot != null || transformed != null);
 
                 if (session.EnableSideEffectsOnInlineProjections)
                 {
@@ -134,9 +139,18 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
         }
     }
 
-    private void maybeArchiveStream(IProjectionStorage<TDoc, TId> storage, StreamAction action, TId id)
+    private void maybeArchiveStream(IProjectionStorage<TDoc, TId> storage, StreamAction action, TId id, bool ownsStream)
     {
-        if (Scope == AggregationScope.SingleStream && action.Events.OfType<IEvent<Archived>>().Any())
+        if (Scope != AggregationScope.SingleStream) return;
+
+        // Only the single-stream projection that actually owns the stream — as signalled
+        // by a snapshot being present either before or after the slice is applied —
+        // should archive the stream. In a composite projection with multiple single
+        // stream children, sibling projections otherwise fire redundant (or phantom)
+        // stream-archival operations. See issue JasperFx/marten#4093.
+        if (!ownsStream) return;
+
+        if (action.Events.OfType<IEvent<Archived>>().Any())
         {
             storage.ArchiveStream(id, action.TenantId);
         }

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -186,7 +186,11 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
                 await processPossibleSideEffects(batch, operations, slice).ConfigureAwait(false);
             }
 
-            maybeArchiveStream(storage, slice);
+            // Only archive from the perspective of a projection that actually owns the stream.
+            // The delete-type branch only fires when a pre-existing snapshot is present
+            // (otherwise buildActionAsync returns Nothing), so slice.Snapshot signals ownership.
+            // See issue JasperFx/marten#4093.
+            maybeArchiveStream(storage, slice, ownsStream: slice.Snapshot != null);
             storage.Delete(slice.Id);
             return;
         }
@@ -195,7 +199,7 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             slice.Events(), cancellation);
 
         slice.RecordAction(action);
-        
+
         if (action == ActionType.Nothing)
         {
             return;
@@ -203,7 +207,10 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
 
         (var lastEvent, snapshot) = Projection.TryApplyMetadata(slice.Events(), snapshot, slice.Id, storage);
 
-        maybeArchiveStream(storage, slice);
+        // Ownership: either there was a pre-loaded snapshot or the slice's events
+        // materialized one. Siblings that did neither skip the archive.
+        // See issue JasperFx/marten#4093.
+        maybeArchiveStream(storage, slice, ownsStream: slice.Snapshot != null || snapshot != null);
 
         if (mode == ShardExecutionMode.Continuous)
         {
@@ -263,9 +270,18 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         }
     }
 
-    private void maybeArchiveStream(IProjectionStorage<TDoc, TId> storage, EventSlice<TDoc, TId> slice)
+    private void maybeArchiveStream(IProjectionStorage<TDoc, TId> storage, EventSlice<TDoc, TId> slice, bool ownsStream)
     {
-        if (Projection.Scope == AggregationScope.SingleStream && slice.Events().OfType<IEvent<Archived>>().Any())
+        if (Projection.Scope != AggregationScope.SingleStream) return;
+
+        // Only the single-stream projection that actually owns the stream — as signalled
+        // by a snapshot being present either before or after the slice is applied —
+        // should archive the stream. In a composite projection with multiple single
+        // stream children, sibling projections otherwise fire redundant (or phantom)
+        // stream-archival operations. See issue JasperFx/marten#4093.
+        if (!ownsStream) return;
+
+        if (slice.Events().OfType<IEvent<Archived>>().Any())
         {
             storage.ArchiveStream(slice.Id, slice.TenantId);
         }

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>1.27.0</Version>
+        <Version>1.28.0</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Addresses [JasperFx/marten#4093](https://github.com/JasperFx/marten/issues/4093).

## Problem

When multiple single-stream projections share a composite group, every child sees every slice. An `Archived` event raised on one child's stream was previously also routed through sibling projections, which could:

1. Create a phantom document in a sibling that happens to declare `Create(Archived)` (legal but almost always accidental in a composite)
2. Issue redundant `mt_archive_stream` operations from siblings that have no snapshot for the stream id

## Fix

Two symmetric guards, keyed on "does this projection own the stream" — measured by whether the projection has a snapshot either before or after the slice is applied:

- **Evolve-time** (`JasperFxAggregationProjectionBase.Runtime.cs`): in `EvolveAsync`, when `snapshot == null` and the event is `Archived`, skip. Once a snapshot exists — either pre-loaded or materialized by a preceding event in the same slice — `Apply(Archived, current)` hooks run normally.
- **Archive-time** (`AggregationRunner.cs` async path + `JasperFxSingleStreamProjectionBase.cs` inline path): `maybeArchiveStream` takes a new `ownsStream` flag. Call sites pass `pre-snapshot != null || post-snapshot != null`. If neither is set, the archive is skipped.

## Compatibility

- Existing `Apply(Archived, current)` patterns on genuine owners keep working (verified with Marten's `Bug_3874` regression and the full archiving + aggregation suite — 300/300 pass).
- `Archived` on a fresh stream that also contains creating events still archives correctly: the first event materializes the snapshot, subsequent `Apply(Archived)` and the archive call both see ownership.
- `Deletes<Archived>()` (explicit registration, rare) continues to work because the delete-type branch checks pre-load ownership only, which matches the prior behavior of requiring an existing snapshot.

## Testing (in Marten)

Companion PR JasperFx/marten#TBD adds `Bug_4093_archived_in_composite_projections.cs` with two scenarios:

- Composite containing a contrived `Bug4093BarProjection` with `Create(Archived)` no longer materializes a phantom `Bug4093BarDoc` for another child's stream id.
- An owning child still archives its stream; a non-owning child is a no-op.

Both pass on net8.0 / net9.0 / net10.0.

## Version

`JasperFx.Events` bumped to `1.28.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)