### PR TITLE
JasperFx.Events 1.29.0: per-message metadata on side-effect PublishMessage

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
@@ -137,6 +137,16 @@ public abstract class JasperFxMultiStreamProjectionBase<TDoc, TId, TOperations, 
                             await sink.PublishAsync(message, slice.TenantId).ConfigureAwait(false);
                         }
                     }
+
+                    // Independent path: messages enqueued with per-message metadata.
+                    if (slice.PublishedMessagesWithMetadata != null)
+                    {
+                        var sink = await operations.GetOrStartMessageSink().ConfigureAwait(false);
+                        foreach (var (message, metadata) in slice.PublishedMessagesWithMetadata)
+                        {
+                            await sink.PublishAsync(message, metadata).ConfigureAwait(false);
+                        }
+                    }
                 }
             }
         }

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -137,6 +137,16 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
                 await sink.PublishAsync(message, stream.TenantId).ConfigureAwait(false);
             }
         }
+
+        // Independent path: messages enqueued with per-message metadata.
+        if (slice.PublishedMessagesWithMetadata != null)
+        {
+            var sink = await session.GetOrStartMessageSink().ConfigureAwait(false);
+            foreach (var (message, metadata) in slice.PublishedMessagesWithMetadata)
+            {
+                await sink.PublishAsync(message, metadata).ConfigureAwait(false);
+            }
+        }
     }
 
     private void maybeArchiveStream(IProjectionStorage<TDoc, TId> storage, StreamAction action, TId id, bool ownsStream)

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -303,6 +303,16 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             foreach (var message in slice.PublishedMessages)
                 await batch.PublishMessageAsync(message, slice.TenantId).ConfigureAwait(false);
         }
+
+        // Independent path for messages enqueued with per-message metadata via
+        // slice.PublishMessage(message, metadata). Metadata carries through to the
+        // IMessageSink implementation (e.g. Wolverine), which maps it onto its
+        // native delivery options.
+        if (slice.PublishedMessagesWithMetadata != null)
+        {
+            foreach (var (message, metadata) in slice.PublishedMessagesWithMetadata)
+                await batch.PublishMessageAsync(message, metadata).ConfigureAwait(false);
+        }
     }
 
     private record EventSliceExecution(

--- a/src/JasperFx.Events/EventSlice.cs
+++ b/src/JasperFx.Events/EventSlice.cs
@@ -22,10 +22,21 @@ public interface IEventSlice<T>: IEventSlice
     void PublishMessage(object message);
 
     /// <summary>
+    ///     Publish a side-effect message with per-message metadata. Metadata flows
+    ///     through to the configured <see cref="IMessageSink"/> so downstream
+    ///     integrations (e.g. Wolverine) can stamp the outgoing envelope with the
+    ///     supplied correlation id, causation id, headers, and user name. The
+    ///     default implementation drops the metadata and forwards to
+    ///     <see cref="PublishMessage(object)"/> so implementations that don't
+    ///     track metadata stay binary-compatible.
+    /// </summary>
+    void PublishMessage(object message, MessageMetadata metadata) => PublishMessage(message);
+
+    /// <summary>
     /// The current snapshot of this projected aggregate
     /// </summary>
     T? Snapshot { get; }
-    
+
     /// <summary>
     /// The current snapshot of this projected aggregate
     /// </summary>
@@ -34,6 +45,14 @@ public interface IEventSlice<T>: IEventSlice
 
     IEnumerable<IEvent> RaisedEvents();
     IEnumerable<object> PublishedMessages();
+
+    /// <summary>
+    ///     Messages enqueued via <see cref="PublishMessage(object, MessageMetadata)"/>,
+    ///     paired with their metadata. Defaults to an empty sequence for
+    ///     implementations that only support the metadata-less overload.
+    /// </summary>
+    IEnumerable<(object Message, MessageMetadata Metadata)> PublishedMessagesWithMetadata()
+        => [];
 }
 
 /// <summary>
@@ -132,6 +151,15 @@ public class EventSlice<TDoc, TId>: IComparer<IEvent>, IEventSlice<TDoc>
     public List<IEvent>? RaisedEvents { get; private set; }
     public List<object>? PublishedMessages { get; private set; }
 
+    /// <summary>
+    ///     Messages published with metadata via
+    ///     <see cref="IEventSlice{T}.PublishMessage(object, MessageMetadata)"/>.
+    ///     Kept on a separate list from <see cref="PublishedMessages"/> so the
+    ///     existing metadata-less path is undisturbed. Null until the first
+    ///     metadata-carrying call.
+    /// </summary>
+    public List<(object Message, MessageMetadata Metadata)>? PublishedMessagesWithMetadata { get; private set; }
+
     void IEventSlice<TDoc>.AppendEvent<TEvent>(Guid streamId, TEvent @event)
     {
         RaisedEvents ??= new();
@@ -164,6 +192,15 @@ public class EventSlice<TDoc, TId>: IComparer<IEvent>, IEventSlice<TDoc>
         PublishedMessages ??= new();
         PublishedMessages.Add(message);
     }
+
+    void IEventSlice<TDoc>.PublishMessage(object message, MessageMetadata metadata)
+    {
+        PublishedMessagesWithMetadata ??= new();
+        PublishedMessagesWithMetadata.Add((message, metadata));
+    }
+
+    IEnumerable<(object Message, MessageMetadata Metadata)> IEventSlice<TDoc>.PublishedMessagesWithMetadata()
+        => PublishedMessagesWithMetadata ?? [];
 
     /// <summary>
     ///     The related aggregate document

--- a/src/JasperFx.Events/IMessageSink.cs
+++ b/src/JasperFx.Events/IMessageSink.cs
@@ -3,4 +3,15 @@ namespace JasperFx.Events;
 public interface IMessageSink
 {
     ValueTask PublishAsync<T>(T message, string tenantId);
+
+    /// <summary>
+    ///     Publish a side-effect message with per-message metadata. Implementations
+    ///     consume <paramref name="metadata"/> to stamp delivery options on the
+    ///     outgoing envelope (tenant, correlation id, causation id, headers, user
+    ///     name). The default implementation forwards to the tenant-only overload
+    ///     for implementers that don't care about metadata — so this is a purely
+    ///     additive addition and does not break existing implementations.
+    /// </summary>
+    ValueTask PublishAsync<T>(T message, MessageMetadata metadata)
+        => PublishAsync(message, metadata.TenantId);
 }

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>1.28.1</Version>
+        <Version>1.29.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/JasperFx.Events/MessageMetadata.cs
+++ b/src/JasperFx.Events/MessageMetadata.cs
@@ -1,0 +1,62 @@
+namespace JasperFx.Events;
+
+/// <summary>
+///     Per-message metadata carried through the projection side-effect publishing
+///     pipeline (<see cref="IEventSlice{T}.PublishMessage(object, MessageMetadata)"/> →
+///     <see cref="Projections.IProjectionBatch.PublishMessageAsync(object, MessageMetadata)"/> →
+///     <see cref="IMessageSink.PublishAsync{T}(T, MessageMetadata)"/>). Implementers
+///     consuming the sink (e.g. Wolverine) map these fields onto their native
+///     delivery options so that user-authored projections can stamp a specific
+///     <see cref="IMetadataContext.CorrelationId"/>, <see cref="IMetadataContext.CausationId"/>,
+///     or custom headers on emitted commands.
+///
+///     This struct is a value type on purpose — it travels through the side-effect
+///     pipeline by copy and should never allocate beyond the optional
+///     <see cref="Headers"/> dictionary that only materializes when actually used.
+/// </summary>
+public struct MessageMetadata : IMetadataContext
+{
+    public MessageMetadata(string tenantId)
+    {
+        TenantId = tenantId;
+    }
+
+    /// <inheritdoc />
+    public string TenantId { get; set; }
+
+    /// <inheritdoc />
+    public string? CausationId { get; set; }
+
+    /// <inheritdoc />
+    public string? CorrelationId { get; set; }
+
+    /// <inheritdoc />
+    [Obsolete("Prefer CurrentUserName")]
+    public string? LastModifiedBy { get; set; }
+
+    /// <inheritdoc />
+    public string? CurrentUserName { get; set; }
+
+    private Dictionary<string, object>? _headers;
+
+    /// <inheritdoc />
+    public Dictionary<string, object>? Headers => _headers;
+
+    /// <summary>
+    ///     Attach a header value. Lazy-allocates the underlying dictionary so
+    ///     the metadata struct stays allocation-free when no headers are used.
+    /// </summary>
+    public MessageMetadata WithHeader(string key, object value)
+    {
+        _headers ??= new Dictionary<string, object>();
+        _headers[key] = value;
+        return this;
+    }
+
+    public bool CausationIdEnabled => CausationId is not null;
+    public bool CorrelationIdEnabled => CorrelationId is not null;
+    public bool HeadersEnabled => _headers is { Count: > 0 };
+#pragma warning disable CS0618
+    public bool UserNameEnabled => CurrentUserName is not null || LastModifiedBy is not null;
+#pragma warning restore CS0618
+}

--- a/src/JasperFx.Events/Projections/IProjectionBatch.cs
+++ b/src/JasperFx.Events/Projections/IProjectionBatch.cs
@@ -14,6 +14,17 @@ public interface IProjectionBatch : IAsyncDisposable
     Task PublishMessageAsync(object message, string tenantId);
 
     /// <summary>
+    ///     Publish a side-effect message with per-message metadata. Downstream
+    ///     <see cref="IMessageSink"/> consumers use the metadata to stamp delivery
+    ///     options (correlation id, causation id, headers, user name) on outgoing
+    ///     envelopes. The default implementation drops the metadata and forwards
+    ///     to the tenant-only overload so implementations that don't care about
+    ///     metadata stay binary-compatible.
+    /// </summary>
+    Task PublishMessageAsync(object message, MessageMetadata metadata)
+        => PublishMessageAsync(message, metadata.TenantId);
+
+    /// <summary>
     /// Only necessary within composite projection execution
     /// </summary>
     /// <param name="range"></param>


### PR DESCRIPTION
## Summary

Adds an independent path through the side-effect publishing pipeline that lets projection authors attach per-message metadata (correlation id, causation id, tenant, headers, user name) when calling `PublishMessage` from inside `RaiseSideEffects`.

## Motivation

Wolverine's Marten integration builds a fresh `MessageContext` for side-effect publishing, which means the outgoing Wolverine envelope is never stamped with the originating event's correlation id. Users have no per-message override because `PublishMessage` only accepts the message object itself. See JasperFx/wolverine#2545 for the motivating scenario.

This PR opens the path. The Marten and Wolverine PRs will follow once this is released.

## New surface

- **`MessageMetadata`** struct implementing `IMetadataContext` — a lightweight value carrier. `Headers` lazy-allocates so unused metadata stays allocation-free.
- **`IMessageSink.PublishAsync<T>(T message, MessageMetadata metadata)`** — new overload with a default implementation forwarding to the tenant-only overload.
- **`IEventSlice<T>.PublishMessage(object message, MessageMetadata metadata)`** + **`PublishedMessagesWithMetadata()`** — same story.
- **`IProjectionBatch.PublishMessageAsync(object message, MessageMetadata metadata)`** — same story.

## Internal routing

`EventSlice<TDoc,TId>` keeps the original `PublishedMessages` list untouched and adds a separate `PublishedMessagesWithMetadata` list. The three projection dispatch sites (`AggregationRunner`, inline single-stream, and inline multi-stream projections) iterate both lists independently, so the original path remains byte-identical for callers that don't opt in.

## Compatibility

All new interface members carry default implementations that drop the metadata and forward to the existing signatures. Every existing implementation of `IMessageSink` / `IEventSlice<T>` / `IProjectionBatch` compiles and runs unchanged. Strictly additive.

## Test plan
- [x] `dotnet test src/EventTests` — 219/219 pass
- [x] `dotnet test src/EventStoreTests` — 72/72 pass
- [ ] CI across net8 / net9 / net10

## Downstream

Once this ships as `JasperFx.Events 1.29.0`:
1. Marten: add an overload on `ProjectionBatch.PublishMessageAsync` forwarding to `IMessageSink.PublishAsync(message, metadata)`.
2. Wolverine: implement the metadata-aware overload on `MartenToWolverineMessageBatch`, mapping to `DeliveryOptions` (JasperFx/wolverine#2545).

🤖 Generated with [Claude Code](https://claude.com/claude-code)