### PR TITLE
Discover [NaturalKeySource] on static methods of self-aggregating aggregates

### DIFF
--- a/src/EventTests/Projections/NaturalKeySourceDiscoveryTests.cs
+++ b/src/EventTests/Projections/NaturalKeySourceDiscoveryTests.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using Shouldly;
+
+namespace EventTests.Projections;
+
+public class NaturalKeySourceDiscoveryTests
+{
+    [Fact]
+    public void discovers_natural_key_source_on_instance_method_of_aggregate()
+    {
+        // Classic pattern: [NaturalKeySource] on an instance Apply method of a mutable
+        // aggregate. This pathway already worked — keep it covered.
+        var projection = new NkInstanceMethodProjection();
+
+        projection.NaturalKeyDefinition.ShouldNotBeNull();
+        var mapping = projection.NaturalKeyDefinition!.EventMappings
+            .SingleOrDefault(m => m.EventType == typeof(NkCreatedEvent));
+        mapping.ShouldNotBeNull();
+
+        var extracted = mapping!.Extractor(new NkCreatedEvent("abc"));
+        extracted.ShouldBe(new NkAggregateKey("abc"));
+    }
+
+    [Fact]
+    public void discovers_natural_key_source_on_static_factory_of_self_aggregating_aggregate()
+    {
+        // Regression for https://github.com/JasperFx/marten/issues/4277: the discovery
+        // scan previously skipped static methods on docType when the projection and
+        // aggregate were the same (self-aggregating records/classes). A static factory
+        // such as `public static TDoc Create(TEvent e) => new(...);` is the canonical
+        // self-aggregating shape and MUST be picked up.
+        var projection = new NkSelfAggregatingProjection();
+
+        projection.NaturalKeyDefinition.ShouldNotBeNull();
+        var mapping = projection.NaturalKeyDefinition!.EventMappings
+            .SingleOrDefault(m => m.EventType == typeof(NkCreatedEvent));
+        mapping.ShouldNotBeNull();
+
+        var extracted = mapping!.Extractor(new NkCreatedEvent("self-agg"));
+        extracted.ShouldBe(new NkSelfAggregate(default, new NkAggregateKey("self-agg")).Key);
+    }
+
+    [Fact]
+    public void discovers_natural_key_source_on_static_method_of_separate_projection_class()
+    {
+        // Sibling coverage: a separate projection class with a static [NaturalKeySource]
+        // continues to work via the property-matching fallback on the event payload.
+        var projection = new NkSeparateProjectionClass();
+
+        projection.NaturalKeyDefinition.ShouldNotBeNull();
+        var mapping = projection.NaturalKeyDefinition!.EventMappings
+            .SingleOrDefault(m => m.EventType == typeof(NkSeparateProjectionCreatedEvent));
+        mapping.ShouldNotBeNull();
+
+        var extracted = mapping!.Extractor(new NkSeparateProjectionCreatedEvent(new NkAggregateKey("separate")));
+        extracted.ShouldBe(new NkAggregateKey("separate"));
+    }
+}
+
+// ───────────────────────── fixtures ─────────────────────────
+
+public record NkAggregateKey(string Value);
+
+public record NkCreatedEvent(string Key);
+
+// Classic instance-method aggregate (pre-#4277 behavior).
+public class NkInstanceAggregate
+{
+    public Guid Id { get; set; }
+
+    [NaturalKey]
+    public NkAggregateKey Key { get; set; } = default!;
+
+    [NaturalKeySource]
+    public void Apply(NkCreatedEvent e) => Key = new NkAggregateKey(e.Key);
+}
+
+public class NkInstanceMethodProjection : SingleStreamProjection<NkInstanceAggregate, NkAggregateKey>
+{
+}
+
+// Self-aggregating record with a static [NaturalKeySource] factory — the #4277 shape.
+public sealed record NkSelfAggregate(Guid Id, [property: NaturalKey] NkAggregateKey Key)
+{
+    [NaturalKeySource]
+    public static NkSelfAggregate Create(NkCreatedEvent e) => new(Guid.NewGuid(), new NkAggregateKey(e.Key));
+}
+
+public class NkSelfAggregatingProjection : SingleStreamProjection<NkSelfAggregate, NkAggregateKey>
+{
+}
+
+// Separate projection class with a static method — the property-matching fallback path.
+public class NkSeparateProjectionAggregate
+{
+    public Guid Id { get; set; }
+
+    [NaturalKey]
+    public NkAggregateKey Key { get; set; } = default!;
+}
+
+public record NkSeparateProjectionCreatedEvent(NkAggregateKey Key);
+
+public class NkSeparateProjectionClass : SingleStreamProjection<NkSeparateProjectionAggregate, NkAggregateKey>
+{
+    [NaturalKeySource]
+    public static NkSeparateProjectionAggregate Create(NkSeparateProjectionCreatedEvent e)
+        => new() { Key = e.Key };
+}

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -414,12 +414,16 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
 
         var definition = new NaturalKeyDefinition(docType, naturalKeyProp);
 
-        // Discover [NaturalKeySource] methods on the aggregate type (instance methods)
+        // Discover [NaturalKeySource] methods on the aggregate type. Include BOTH instance
+        // methods (the classic Apply(TEvent) pattern on the aggregate) AND static methods
+        // (self-aggregating records/classes that expose a static factory such as
+        //   public static TDoc Create(TEvent e) => new TDoc(...);
+        // as in https://github.com/JasperFx/marten/issues/4277).
         discoverNaturalKeySourceMethods(definition, naturalKeyProp, docType,
-            BindingFlags.Public | BindingFlags.Instance);
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
 
-        // Also discover [NaturalKeySource] methods on the projection type itself
-        // (static methods on the projection class, e.g., Create/Apply methods)
+        // Also discover [NaturalKeySource] methods on a separate projection class when
+        // the projection is not the aggregate itself.
         if (projectionType != docType)
         {
             discoverNaturalKeySourceMethods(definition, naturalKeyProp, projectionType,
@@ -503,6 +507,24 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 Expression.Call(docParam, method, Expression.Convert(eventParam, eventType)),
                 Expression.Convert(Expression.Property(docParam, naturalKeyProp), typeof(object))
             );
+
+            return Expression.Lambda<Func<object, object?>>(body, eventParam).Compile();
+        }
+
+        // For static factory methods on the aggregate itself that return a new TDoc
+        // (the self-aggregating pattern — see JasperFx/marten#4277):
+        //   public static TDoc Create(TEvent e) => new TDoc(...);
+        // We can safely call the method with the raw event data and read the natural
+        // key property off the returned aggregate.
+        if (method.IsStatic && method.DeclaringType == docType && method.ReturnType == docType)
+        {
+            var eventType = firstParamType;
+
+            var body = Expression.Convert(
+                Expression.Property(
+                    Expression.Call(method, Expression.Convert(eventParam, eventType)),
+                    naturalKeyProp),
+                typeof(object));
 
             return Expression.Lambda<Func<object, object?>>(body, eventParam).Compile();
         }

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>1.29.0</Version>
+        <Version>1.29.1</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Addresses [JasperFx/marten#4277](https://github.com/JasperFx/marten/issues/4277).

## Problem

For self-aggregating aggregates — records or classes where the projection and the aggregate are the same type — the \`[NaturalKeySource]\` attribute was silently ignored when placed on a static factory such as

```csharp
public sealed record MyAggregate(Guid Id, [property: NaturalKey] MyKey Key)
{
    [NaturalKeySource]
    public static MyAggregate Create(MyCreated e) => new(e.Id, new MyKey(e.Key));
}
```

The discovery scan in \`JasperFxAggregationProjectionBase.discoverNaturalKey\` only picked up instance methods on the aggregate type, and a second scan only ran for static methods on a \*different\* projection class. When the projection and the aggregate were the same type the second scan was skipped, so the natural-key lookup row was never written and \`FetchForWriting<TDoc, TKey>(key)\` returned a null aggregate.

## Fix

Two small changes:

1. **\`discoverNaturalKey\`** — include \`BindingFlags.Static\` alongside \`BindingFlags.Instance\` when scanning \`docType\`. Static methods on the aggregate are now candidates regardless of whether the projection is a separate class. Cleanly covers \@mfmadsen's suggestion in the issue.
2. **\`buildExtractor\`** — add a branch for static methods on \`docType\` that return \`docType\`. Invoke the factory with the raw event payload and read the natural-key property off the returned aggregate, matching the semantics of the existing instance-method path.

## Test coverage

New file \`src/EventTests/Projections/NaturalKeySourceDiscoveryTests.cs\` with three tests exercising the three discovery pathways directly against \`NaturalKeyDefinition.EventMappings\`:

- instance method on aggregate (pre-existing shape)
- **static factory on self-aggregating aggregate (#4277)**
- static method on a separate projection class (property-matching fallback)

All three pass on net8.0 / net9.0 / net10.0. Full \`EventTests\` suite (222 tests) stays green.

## Version

\`JasperFx.Events\` bumped to **1.29.1** (patch bump — bug fix, no API changes).

## Companion PR

A Marten-side companion PR adds an end-to-end regression test using the exact shape from the issue, matching \`Bug_4197_fetch_for_writing_natural_key.cs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)