### PR TITLE
CodeGeneration/RuntimeCompiler split: enable Roslyn-free production deployments

### DIFF
--- a/src/GeneratorTarget/WriteCommand.cs
+++ b/src/GeneratorTarget/WriteCommand.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using JasperFx.CodeGeneration;
 using JasperFx.CommandLine;
-using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GeneratorTarget;

--- a/src/JasperFx.RuntimeCompiler/CodeFileExtensions.cs
+++ b/src/JasperFx.RuntimeCompiler/CodeFileExtensions.cs
@@ -10,9 +10,26 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace JasperFx.RuntimeCompiler
 {
+    /// <summary>
+    /// Legacy extension methods for <see cref="ICodeFile"/>. These have been
+    /// superseded by <see cref="JasperFx.CodeGeneration.CodeFileExtensions"/>,
+    /// which moves orchestration into the trimming-friendly
+    /// <c>JasperFx.CodeGeneration</c> namespace and removes the hidden
+    /// <c>?? new AssemblyGenerator()</c> fallback that previously bound every
+    /// consumer to Roslyn at runtime.
+    ///
+    /// Migration: change <c>using JasperFx.RuntimeCompiler;</c> to
+    /// <c>using JasperFx.CodeGeneration;</c> and ensure an
+    /// <see cref="IAssemblyGenerator"/> is registered in DI when runtime
+    /// compilation is required (e.g.,
+    /// <c>services.AddSingleton&lt;IAssemblyGenerator, AssemblyGenerator&gt;()</c>).
+    /// Consumers that pre-generate code in Static mode no longer need any
+    /// reference to <c>JasperFx.RuntimeCompiler</c>.
+    /// </summary>
     public static class CodeFileExtensions
     {
 
+        [Obsolete("Use JasperFx.CodeGeneration.CodeFileExtensions.Initialize instead and register IAssemblyGenerator explicitly in DI when runtime compilation is needed. The legacy fallback to 'new AssemblyGenerator()' hides the Roslyn dependency in non-AOT scenarios.")]
         public static async Task Initialize(this ICodeFile file, GenerationRules rules, ICodeFileCollection parent, IServiceProvider? services)
         {
             var @namespace = parent.ToNamespace(rules);
@@ -76,6 +93,7 @@ namespace JasperFx.RuntimeCompiler
         /// <param name="parent"></param>
         /// <param name="services"></param>
         /// <exception cref="ExpectedTypeMissingException"></exception>
+        [Obsolete("Use JasperFx.CodeGeneration.CodeFileExtensions.InitializeSynchronously instead and register IAssemblyGenerator explicitly in DI when runtime compilation is needed. The legacy fallback to 'new AssemblyGenerator()' hides the Roslyn dependency in non-AOT scenarios.")]
         public static void InitializeSynchronously(this ICodeFile file, GenerationRules rules, ICodeFileCollection parent, IServiceProvider? services)
         {
             var logger = services?.GetService(typeof(ILogger<IAssemblyGenerator>)) as ILogger ?? NullLogger.Instance;
@@ -153,6 +171,7 @@ namespace JasperFx.RuntimeCompiler
             }
         }
 
+        [Obsolete("Use JasperFx.CodeGeneration.CodeFileExtensions.WriteCodeFile instead.")]
         public static void WriteCodeFile(this ICodeFile file, ICodeFileCollection parent, GenerationRules rules, string code)
         {
             try

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>4.4.0</Version>
+        <Version>4.5.0</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx/CodeGeneration/CodeFileExtensions.cs
+++ b/src/JasperFx/CodeGeneration/CodeFileExtensions.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration.Commands;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JasperFx.CodeGeneration;
+
+/// <summary>
+/// Extension methods for <see cref="ICodeFile"/> that orchestrate code generation
+/// without binding to any specific <see cref="IAssemblyGenerator"/> implementation.
+/// <para>
+/// These methods replace the equivalent methods in
+/// <c>JasperFx.RuntimeCompiler.CodeFileExtensions</c>, which had a hidden
+/// <c>?? new AssemblyGenerator()</c> fallback that hard-bound consumers to the
+/// <c>JasperFx.RuntimeCompiler</c> package (and through it, Roslyn). Consumers
+/// targeting AOT or that want to remove Roslyn from their production deployments
+/// can now reference only this method (in the <see cref="JasperFx.CodeGeneration"/>
+/// namespace), provide a registered <see cref="IAssemblyGenerator"/> if they need
+/// runtime compilation, and otherwise omit the <c>JasperFx.RuntimeCompiler</c>
+/// package reference entirely.
+/// </para>
+/// </summary>
+public static class CodeFileExtensions
+{
+    /// <summary>
+    /// Initialize dynamic code compilation by either loading the expected type
+    /// from the supplied assembly or dynamically generating and compiling the code
+    /// on demand.
+    /// <para>
+    /// Unlike the legacy
+    /// <c>JasperFx.RuntimeCompiler.CodeFileExtensions.InitializeSynchronously</c>,
+    /// this method does NOT silently fall back to creating an internal Roslyn
+    /// <c>AssemblyGenerator</c>. If the configured <see cref="GenerationRules.TypeLoadMode"/>
+    /// requires runtime compilation but no <see cref="IAssemblyGenerator"/> is
+    /// registered in the supplied <paramref name="services"/>, an
+    /// <see cref="InvalidOperationException"/> is thrown with guidance to either
+    /// pre-generate code (Static mode) or register an <see cref="IAssemblyGenerator"/>.
+    /// </para>
+    /// </summary>
+    /// <exception cref="ExpectedTypeMissingException">
+    /// Thrown when <see cref="GenerationRules.TypeLoadMode"/> is
+    /// <see cref="TypeLoadMode.Static"/> and the expected pre-built type is not
+    /// found in the application assembly.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when runtime compilation is required (Dynamic mode, or Auto-mode
+    /// fallback) but no <see cref="IAssemblyGenerator"/> is registered in DI.
+    /// </exception>
+    public static void InitializeSynchronously(this ICodeFile file, GenerationRules rules,
+        ICodeFileCollection parent, IServiceProvider? services)
+    {
+        var logger = services?.GetService(typeof(ILogger<IAssemblyGenerator>)) as ILogger ?? NullLogger.Instance;
+        var @namespace = parent.ToNamespace(rules);
+
+        if (rules.TypeLoadMode == TypeLoadMode.Dynamic)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Generated code for {Namespace}.{FileName}", parent.ChildNamespace, file.FileName);
+            }
+
+            var generatedAssembly = parent.StartAssembly(rules);
+            file.AssembleTypes(generatedAssembly);
+            var serviceVariables = parent is ICodeFileCollectionWithServices
+                ? services?.GetService(typeof(IServiceVariableSource)) as IServiceVariableSource
+                : null;
+            if (serviceVariables != null && file.TryReplaceServiceProvider(out var serviceProvider))
+            {
+                serviceVariables.ReplaceServiceProvider(serviceProvider);
+            }
+
+            var compiler = ResolveAssemblyGenerator(services);
+            compiler.Compile(generatedAssembly, serviceVariables);
+
+            if (serviceVariables != null && serviceVariables.ServiceLocations().Any())
+            {
+                file.AssertServiceLocationsAreAllowed(serviceVariables.ServiceLocations(), services);
+            }
+
+            file.AttachTypesSynchronously(rules, generatedAssembly.Assembly!, services, @namespace);
+
+            return;
+        }
+
+        var found = file.AttachTypesSynchronously(rules, rules.ApplicationAssembly, services, @namespace);
+        if (found && logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug("Types from code file {Namespace}.{FileName} were loaded from assembly {Assembly}",
+                parent.ChildNamespace, file.FileName, rules.ApplicationAssembly.GetName());
+        }
+
+        if (!found)
+        {
+            if (rules.TypeLoadMode == TypeLoadMode.Static && !DynamicCodeBuilder.WithinCodegenCommand)
+            {
+                throw new ExpectedTypeMissingException(
+                    $"Could not load expected pre-built types for code file {file.FileName} ({file}) from assembly {rules.ApplicationAssembly.FullName}. You may want to verify that this is the correct assembly for pre-generated types.");
+            }
+
+            var generatedAssembly = parent.StartAssembly(rules);
+            file.AssembleTypes(generatedAssembly);
+            var serviceVariables = services?.GetService(typeof(IServiceVariableSource)) as IServiceVariableSource;
+            if (serviceVariables != null && file.TryReplaceServiceProvider(out var serviceProvider))
+            {
+                serviceVariables.ReplaceServiceProvider(serviceProvider);
+            }
+
+            var compiler = ResolveAssemblyGenerator(services);
+            compiler.Compile(generatedAssembly, serviceVariables, out var code);
+
+            if (serviceVariables != null && serviceVariables.ServiceLocations().Any())
+            {
+                file.AssertServiceLocationsAreAllowed(serviceVariables.ServiceLocations(), services);
+            }
+
+            file.AttachTypesSynchronously(rules, generatedAssembly.Assembly!, services, @namespace);
+
+            if (rules.SourceCodeWritingEnabled)
+            {
+                file.WriteCodeFile(parent, rules, code!);
+            }
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Generated and compiled code in memory for {Namespace}.{FileName} ({File})",
+                    parent.ChildNamespace, file.FileName, file);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="InitializeSynchronously"/>. Same semantics
+    /// regarding <see cref="IAssemblyGenerator"/> resolution.
+    /// </summary>
+    /// <exception cref="ExpectedTypeMissingException"/>
+    /// <exception cref="InvalidOperationException"/>
+    public static async Task Initialize(this ICodeFile file, GenerationRules rules,
+        ICodeFileCollection parent, IServiceProvider? services)
+    {
+        var @namespace = parent.ToNamespace(rules);
+
+        if (rules.TypeLoadMode == TypeLoadMode.Dynamic)
+        {
+            Console.WriteLine($"Generated code for {parent.ChildNamespace}.{file.FileName}");
+
+            var generatedAssembly = parent.StartAssembly(rules);
+            file.AssembleTypes(generatedAssembly);
+            var serviceVariables = parent is ICodeFileCollectionWithServices
+                ? services?.GetService(typeof(IServiceVariableSource)) as IServiceVariableSource
+                : null;
+
+            var compiler = ResolveAssemblyGenerator(services);
+            compiler.Compile(generatedAssembly, serviceVariables);
+            await file.AttachTypes(rules, generatedAssembly.Assembly!, services, @namespace);
+
+            return;
+        }
+
+        var found = await file.AttachTypes(rules, rules.ApplicationAssembly, services, @namespace);
+        if (found)
+        {
+            Console.WriteLine($"Types from code file {parent.ChildNamespace}.{file.FileName} were loaded from assembly {rules.ApplicationAssembly.GetName()}");
+        }
+
+        if (!found)
+        {
+            if (rules.TypeLoadMode == TypeLoadMode.Static && !DynamicCodeBuilder.WithinCodegenCommand)
+            {
+                throw new ExpectedTypeMissingException(
+                    $"Could not load expected pre-built types for code file {file.FileName} ({file})");
+            }
+
+            var generatedAssembly = parent.StartAssembly(rules);
+            file.AssembleTypes(generatedAssembly);
+            var serviceVariables = services?.GetService(typeof(IServiceVariableSource)) as IServiceVariableSource;
+
+            var compiler = ResolveAssemblyGenerator(services);
+            compiler.Compile(generatedAssembly, serviceVariables, out var code);
+
+            await file.AttachTypes(rules, generatedAssembly.Assembly!, services, @namespace);
+
+            if (rules.SourceCodeWritingEnabled)
+            {
+                file.WriteCodeFile(parent, rules, code);
+            }
+
+            Console.WriteLine($"Generated and compiled code in memory for {parent.ChildNamespace}.{file.FileName}");
+        }
+    }
+
+    /// <summary>
+    /// Write the supplied generated code to the configured export directory.
+    /// </summary>
+    public static void WriteCodeFile(this ICodeFile file, ICodeFileCollection parent, GenerationRules rules, string code)
+    {
+        try
+        {
+            var directory = parent.ToExportDirectory(rules.GeneratedCodeOutputPath);
+            var fileName = Path.Combine(directory, file.FileName.Replace(" ", "_") + ".cs");
+            File.WriteAllText(fileName, code);
+            Console.WriteLine("Generated code to " + fileName.ToFullPath());
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Unable to write code file for " + file.FileName);
+            Console.WriteLine(e.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Resolve the <see cref="IAssemblyGenerator"/> from the supplied service
+    /// provider, throwing a clear, actionable error if none is registered.
+    /// </summary>
+    /// <remarks>
+    /// The legacy <c>JasperFx.RuntimeCompiler.CodeFileExtensions</c> silently
+    /// fell back to <c>new AssemblyGenerator()</c>, which masked the missing
+    /// registration and dragged Roslyn into every consumer's deployment. Callers
+    /// that need runtime compilation must now register an
+    /// <see cref="IAssemblyGenerator"/> in DI (typically via
+    /// <c>services.AddSingleton&lt;IAssemblyGenerator, AssemblyGenerator&gt;()</c>
+    /// from the <c>JasperFx.RuntimeCompiler</c> package). Callers that pre-generate
+    /// all code in Static mode never reach this method and so do not need the
+    /// dependency at all.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">No <see cref="IAssemblyGenerator"/> registered.</exception>
+    private static IAssemblyGenerator ResolveAssemblyGenerator(IServiceProvider? services)
+    {
+        var generator = services?.GetService(typeof(IAssemblyGenerator)) as IAssemblyGenerator;
+        if (generator != null) return generator;
+
+        throw new InvalidOperationException(
+            "No IAssemblyGenerator is registered in the application's service provider, but runtime code generation was requested. " +
+            "Either: (a) install the JasperFx.RuntimeCompiler package and call services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>() to enable runtime Roslyn compilation, " +
+            "or (b) pre-generate all code (typically with 'dotnet run -- codegen write') and set GenerationRules.TypeLoadMode = TypeLoadMode.Static so runtime compilation is never invoked.");
+    }
+}

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>1.27.0</Version>
+        <Version>1.28.0</Version>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
## Summary

Splits the orchestration of code generation from the Roslyn implementation. Moves `Initialize` / `InitializeSynchronously` / `WriteCodeFile` extensions from the `JasperFx.RuntimeCompiler` namespace into `JasperFx.CodeGeneration` (i.e., into the `JasperFx` package, no Roslyn dependency), and removes the silent \"`?? new AssemblyGenerator()`\" fallback that previously hard-bound every consumer to Roslyn.

The legacy methods stay in place, marked `[Obsolete]` with a clear migration message — existing consumers (Wolverine, Marten, community projects) keep working until they migrate.

## Why

Discovered while planning Wolverine cold-start optimizations (jasperfx/wolverine#1577). The `?? new AssemblyGenerator()` fallback in `JasperFx.RuntimeCompiler.CodeFileExtensions` is what hard-binds every consumer to Roslyn. Even though `IAssemblyGenerator` itself lives in `JasperFx.CodeGeneration` (the trimming-friendly package), the extension methods that orchestrate compilation lived in `JasperFx.RuntimeCompiler` and silently constructed `AssemblyGenerator` if none was registered in DI.

After this PR, downstream packages (Wolverine, Marten) can:

1. Update `using JasperFx.RuntimeCompiler;` → `using JasperFx.CodeGeneration;` at the four (Wolverine) / three (Marten) call sites
2. Drop their direct `<PackageReference Include=\"JasperFx.RuntimeCompiler\" />`
3. Move that registration into an opt-in extension package (e.g., `Wolverine.RuntimeCompilation` / `Marten.RuntimeCompilation`)
4. Production deployments that pre-generate code with `TypeLoadMode.Static` never need Roslyn — major cold-start, deployment-size, and AOT-readiness wins

## Changes

| File | Change |
|------|--------|
| `src/JasperFx/CodeGeneration/CodeFileExtensions.cs` (new) | New extension methods. Same signatures and behavior as the originals, except `IAssemblyGenerator` MUST be registered in DI when codegen path is taken — otherwise throws `InvalidOperationException` with actionable guidance. |
| `src/JasperFx.RuntimeCompiler/CodeFileExtensions.cs` | Class-level docstring documents the migration. The three methods (`Initialize`, `InitializeSynchronously`, `WriteCodeFile`) now carry `[Obsolete]` with the migration message. **No behavior change** — the fallback remains for backward compatibility. |
| `src/GeneratorTarget/WriteCommand.cs` | Drops `using JasperFx.RuntimeCompiler;` to disambiguate the new (now-ambiguous) `Initialize` extension call. The only in-tree consumer hit by the ambiguity. |
| `src/JasperFx/JasperFx.csproj` | Version: 1.27.0 → 1.28.0 (additive new API) |
| `src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj` | Version: 4.4.0 → 4.5.0 (additive `[Obsolete]` markers, no behavior change) |

## Behavior contract

For the new `JasperFx.CodeGeneration.CodeFileExtensions`:

- **`TypeLoadMode.Static` + types pre-built into application assembly** — never touches `IAssemblyGenerator`, no DI requirement. Identical to legacy.
- **`TypeLoadMode.Static` + missing pre-built types + within `codegen` command** — falls into the runtime-compilation path; requires registered `IAssemblyGenerator` (it would have done this in the legacy path too, just silently).
- **`TypeLoadMode.Auto` + missing pre-built types** — same as above.
- **`TypeLoadMode.Dynamic`** — always requires registered `IAssemblyGenerator`.

The exception thrown when no `IAssemblyGenerator` is registered:

> No IAssemblyGenerator is registered in the application's service provider, but runtime code generation was requested. Either: (a) install the JasperFx.RuntimeCompiler package and call `services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>()` to enable runtime Roslyn compilation, or (b) pre-generate all code (typically with 'dotnet run -- codegen write') and set `GenerationRules.TypeLoadMode = TypeLoadMode.Static` so runtime compilation is never invoked.

## Migration guidance for downstream packages

### Wolverine
Files to update (`using JasperFx.RuntimeCompiler;` → `using JasperFx.CodeGeneration;`):
- `src/Wolverine/Runtime/Handlers/HandlerGraph.cs:9`
- `src/Http/Wolverine.Http/HttpChain.EndpointBuilder.cs:5`
- `src/Wolverine.Grpc/WolverineGrpcExtensions.cs:6`
- `src/Wolverine/HostBuilderExtensions.cs:20`

The DI registration at `HostBuilderExtensions.cs:104` (`services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>()`) is the only thing keeping `JasperFx.RuntimeCompiler` in the Wolverine.dll deployment surface — moving it into a new `Wolverine.RuntimeCompilation` opt-in package is a follow-up PR on the Wolverine side.

### Marten
Files to update (`using JasperFx.RuntimeCompiler;` → `using JasperFx.CodeGeneration;`):
- `src/Marten/Internal/ProviderGraph.cs:8`
- `src/Marten/Internal/SecondaryStoreConfig.cs:10`
- `src/Marten/DocumentStore.CompiledQueryCollection.cs:10`
- `src/Marten/MartenServiceCollectionExtensions.cs:16`

Marten also has a direct `new AssemblyGenerator()` instantiation at `src/Marten/Events/CodeGeneration/EventDocumentStorageGenerator.cs:47` — that's a separate concern and remains in `JasperFx.RuntimeCompiler`'s scope.

## Test plan

- [x] `CodegenTests` net9.0: 305/305 pass
- [x] `CoreTests` net9.0: 389/389 pass
- [x] Full multi-framework solution build: 0 errors (only pre-existing CS warnings)
- [x] No `[Obsolete]` warnings inside JasperFx itself (test files use `JasperFx.RuntimeCompiler.Scenarios`, not the obsolete extensions)
- [ ] CI on full matrix (net8/net9/net10)

## Versions to release

- `JasperFx` 1.28.0
- `JasperFx.RuntimeCompiler` 4.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)