### PR TITLE
Add WithAlternateSession to SliceGroup enrichment chain

### DIFF
--- a/src/EventTests/Projections/WithAlternateSessionTests.cs
+++ b/src/EventTests/Projections/WithAlternateSessionTests.cs
@@ -1,0 +1,178 @@
+using JasperFx;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using Shouldly;
+
+namespace EventTests.Projections;
+
+/// <summary>
+/// Tests for SliceGroup.EntityStep.WithAlternateSession — the hook that enables
+/// enrichment from ancillary stores (or any IStorageOperations other than the primary).
+/// </summary>
+public class WithAlternateSessionTests
+{
+    private readonly SliceGroup<LetterCounts, Guid> theGroup;
+    private readonly PrimarySession primarySession = new();
+    private readonly AncillarySession ancillarySession = new();
+
+    public WithAlternateSessionTests()
+    {
+        theGroup = new SliceGroup<LetterCounts, Guid>();
+        theGroup.Operations = primarySession;
+    }
+
+    private Guid AddSlice(string text, string userName)
+    {
+        var events = text.ToLetterEventsWithWrapper();
+        if (userName.IsNotEmpty())
+            events = events.Concat([Event.For(new Assigned(userName))]);
+        var slice = new EventSlice<LetterCounts, Guid>(Guid.NewGuid(), StorageConstants.DefaultTenantId, events);
+        theGroup.Slices[slice.Id] = slice;
+        return slice.Id;
+    }
+
+    [Fact]
+    public async Task alternate_session_storage_is_used_instead_of_primary()
+    {
+        var id = AddSlice("AAABCCDDDD", "Bill");
+        // Only ancillary knows about Bill — primary has no data
+        ancillarySession.Users["Bill"] = new User("Bill", "William");
+
+        await theGroup.EnrichWith<User>()
+            .WithAlternateSession(ancillarySession)
+            .ForEvent<Assigned>()
+            .ForEntityId(x => x.UserName)
+            .EnrichAsync((slice, e, user) =>
+                slice.ReplaceEvent(e, new AssignedToUser(user)));
+
+        theGroup.Slices[id].Events().OfType<IEvent<AssignedToUser>>().Single().Data.User.UserName
+            .ShouldBe("Bill");
+        ancillarySession.FetchStorageWasCalled.ShouldBeTrue();
+        primarySession.FetchStorageWasCalled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task alternate_session_is_disposed_after_enrichment_completes()
+    {
+        AddSlice("AAABCCDDDD", "Bill");
+        ancillarySession.Users["Bill"] = new User("Bill", "William");
+
+        await theGroup.EnrichWith<User>()
+            .WithAlternateSession(ancillarySession)
+            .ForEvent<Assigned>()
+            .ForEntityId(x => x.UserName)
+            .EnrichAsync((slice, e, user) => { });
+
+        ancillarySession.WasDisposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task alternate_session_is_disposed_even_when_no_matching_events()
+    {
+        // Slice with no Assigned events
+        AddSlice("AAABCCDDDD", "");
+
+        await theGroup.EnrichWith<User>()
+            .WithAlternateSession(ancillarySession)
+            .ForEvent<Assigned>()
+            .ForEntityId(x => x.UserName)
+            .EnrichAsync((slice, e, user) => { });
+
+        ancillarySession.WasDisposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task primary_session_is_not_disposed_by_normal_enrichment()
+    {
+        AddSlice("AAABCCDDDD", "Bill");
+        primarySession.Users["Bill"] = new User("Bill", "William");
+
+        await theGroup.EnrichWith<User>()
+            .ForEvent<Assigned>()
+            .ForEntityId(x => x.UserName)
+            .EnrichAsync((slice, e, user) => { });
+
+        primarySession.WasDisposed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task add_references_also_works_via_alternate_session()
+    {
+        var id = AddSlice("AAABCCDDDD", "Bill");
+        ancillarySession.Users["Bill"] = new User("Bill", "William");
+
+        await theGroup.EnrichWith<User>()
+            .WithAlternateSession(ancillarySession)
+            .ForEvent<Assigned>()
+            .ForEntityId(x => x.UserName)
+            .AddReferences();
+
+        theGroup.Slices[id].Events().OfType<IEvent<References<User>>>().ShouldNotBeEmpty();
+        ancillarySession.WasDisposed.ShouldBeTrue();
+    }
+
+    // ── fakes ──────────────────────────────────────────────────────────────────
+
+    private class PrimarySession : FakeStorageOperations
+    {
+    }
+
+    private class AncillarySession : FakeStorageOperations
+    {
+    }
+
+    private abstract class FakeStorageOperations : IStorageOperations, IProjectionStorage<User, string>
+    {
+        public Dictionary<string, User> Users = new();
+        public bool WasDisposed;
+        public bool FetchStorageWasCalled;
+
+        // IStorageOperations
+        ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            WasDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+
+        Task<IProjectionStorage<TDoc, TId>> IStorageOperations.FetchProjectionStorageAsync<TDoc, TId>(
+            string tenantId, CancellationToken cancellationToken)
+        {
+            FetchStorageWasCalled = true;
+            return Task.FromResult((IProjectionStorage<TDoc, TId>)(object)this);
+        }
+
+        bool IStorageOperations.EnableSideEffectsOnInlineProjections => false;
+
+        ValueTask<IMessageSink> IStorageOperations.GetOrStartMessageSink() =>
+            throw new NotImplementedException();
+
+        // IProjectionStorage<User, string>
+        string IProjectionStorage<User, string>.TenantId => StorageConstants.DefaultTenantId;
+
+        Task<IReadOnlyDictionary<string, User>> IProjectionStorage<User, string>.LoadManyAsync(
+            string[] identities, CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyDictionary<string, User>>(Users);
+
+        Task<User> IProjectionStorage<User, string>.LoadAsync(string id, CancellationToken cancellation) =>
+            throw new NotImplementedException();
+
+        void IIdentitySetter<User, string>.SetIdentity(User document, string identity) =>
+            throw new NotImplementedException();
+
+        string IIdentitySetter<User, string>.Identity(User document) => document.UserName;
+
+        void IProjectionStorage<User, string>.HardDelete(User snapshot) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.UnDelete(User snapshot) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.Store(User snapshot) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.Delete(string identity) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.HardDelete(User snapshot, string tenantId) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.UnDelete(User snapshot, string tenantId) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.Store(User snapshot, string id, string tenantId) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.Delete(string identity, string tenantId) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.StoreProjection(User aggregate, IEvent? lastEvent, AggregationScope scope) => throw new NotImplementedException();
+        void IProjectionStorage<User, string>.ArchiveStream(string sliceId, string tenantId) => throw new NotImplementedException();
+    }
+}

--- a/src/JasperFx.Events/Grouping/SliceGroup.cs
+++ b/src/JasperFx.Events/Grouping/SliceGroup.cs
@@ -1,6 +1,7 @@
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Daemon;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JasperFx.Events.Grouping;
 
@@ -206,6 +207,27 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
         /// </summary>
         public EntityStep<TEntity> WithAlternateSession(IStorageOperations alternateSession)
             => new(parent, alternateSession, disposeAfterUse: true);
+
+        /// <summary>
+        /// Switch enrichment to load entities from an ancillary store resolved from the DI container.
+        /// The store must have been registered via <c>AddMartenStore&lt;TStore&gt;()</c> (or equivalent),
+        /// which also registers a <c>Func&lt;TStore, IStorageOperations&gt;</c> session factory.
+        /// A lightweight session is opened per enrichment call and disposed automatically.
+        /// </summary>
+        /// <typeparam name="TStore">The ancillary store interface registered in DI.</typeparam>
+        public EntityStep<TEntity> UsingStore<TStore>() where TStore : class
+        {
+            var sp = Services
+                ?? throw new InvalidOperationException(
+                    $"UsingStore<{typeof(TStore).Name}>() requires a session with a ServiceProvider. " +
+                    "Ensure the store is configured via AddMarten() or AddMartenStore().");
+            var factory = sp.GetService<Func<TStore, IStorageOperations>>()
+                ?? throw new InvalidOperationException(
+                    $"No Func<{typeof(TStore).Name}, IStorageOperations> is registered in DI. " +
+                    $"Did you call AddMartenStore<{typeof(TStore).Name}>()?");
+            var store = sp.GetRequiredService<TStore>();
+            return WithAlternateSession(factory(store));
+        }
     }
 
     public class EventStep<TEntity, TEvent>(SliceGroup<TDoc, TId> parent, IStorageOperations session, bool disposeAfterUse = false) where TEvent : notnull where TEntity : notnull

--- a/src/JasperFx.Events/Grouping/SliceGroup.cs
+++ b/src/JasperFx.Events/Grouping/SliceGroup.cs
@@ -184,18 +184,31 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
         return null;
     }
 
-    public class EntityStep<TEntity>(SliceGroup<TDoc, TId> parent, IStorageOperations session)
+    public class EntityStep<TEntity>(SliceGroup<TDoc, TId> parent, IStorageOperations session, bool disposeAfterUse = false)
     {
+        /// <summary>
+        /// Service provider from the current session. Used by store-specific extensions
+        /// (e.g. Marten's UsingStore&lt;T&gt;()) to resolve ancillary stores from DI.
+        /// </summary>
+        public IServiceProvider? Services => session.Services;
+
         /// <summary>
         /// On which event type can you find an identity of type TId for the entity TDoc?
         /// This can be a marker interface. Think of this as equivalent to the LINQ OfType<T>() operator
         /// </summary>
         /// <typeparam name="TEvent"></typeparam>
         /// <returns></returns>
-        public EventStep<TEntity, TEvent> ForEvent<TEvent>() => new(parent, session);
+        public EventStep<TEntity, TEvent> ForEvent<TEvent>() => new(parent, session, disposeAfterUse);
+
+        /// <summary>
+        /// Switch enrichment to load entities from an alternate session (e.g. an ancillary store).
+        /// The alternate session will be disposed after enrichment completes.
+        /// </summary>
+        public EntityStep<TEntity> WithAlternateSession(IStorageOperations alternateSession)
+            => new(parent, alternateSession, disposeAfterUse: true);
     }
 
-    public class EventStep<TEntity, TEvent>(SliceGroup<TDoc, TId> parent, IStorageOperations session) where TEvent : notnull where TEntity : notnull
+    public class EventStep<TEntity, TEvent>(SliceGroup<TDoc, TId> parent, IStorageOperations session, bool disposeAfterUse = false) where TEvent : notnull where TEntity : notnull
     {
         /// <summary>
         /// Specify *how* the enrichment can find the identity TId from the events of type TEvent for entities
@@ -206,7 +219,7 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
         /// <returns></returns>
         public IdentityStep<TEntity, TEvent, TEntityId> ForEntityId<TEntityId>(
             Func<TEvent, TEntityId> identitySource) =>
-            new(parent, session, e => identitySource(e.Data));
+            new(parent, session, e => identitySource(e.Data), disposeAfterUse);
 
         /// <summary>
         /// Specify *how* the enrichment can find the identity TId from the events of type TEvent for entities
@@ -217,7 +230,7 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
         /// <returns></returns>
         public IdentityStep<TEntity, TEvent, TEntityId> ForEntityIdFromEvent<TEntityId>(
             Func<IEvent<TEvent>, TEntityId> identitySource) =>
-            new(parent, session, identitySource);
+            new(parent, session, identitySource, disposeAfterUse);
 
         /// <summary>
         /// Execute a batched enrichment operation for events of type <typeparamref name="TEvent"/>,
@@ -292,7 +305,8 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
     public class IdentityStep<TEntity, TEvent, TEntityId>(
         SliceGroup<TDoc, TId> parent,
         IStorageOperations session,
-        Func<IEvent<TEvent>, TEntityId> identitySource) where TEvent : notnull
+        Func<IEvent<TEvent>, TEntityId> identitySource,
+        bool disposeAfterUse = false) where TEvent : notnull
     {
         public async Task EnrichAsync(
             Action<EventSlice<TDoc, TId>, IEvent<TEvent>, TEntity> application)
@@ -320,34 +334,41 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
 
         internal async Task<IAggregateCache<TEntityId, TEntity>> FetchEntitiesAsync()
         {
-            var cache = parent.findCache<TEntityId, TEntity>();
-            
-            var storage = await session.FetchProjectionStorageAsync<TEntity, TEntityId>(parent.TenantId, CancellationToken.None);
-            var events = parent.Slices.SelectMany(x => x.Events());
-            
-            var ids = events.OfType<IEvent<TEvent>>().Select(identitySource).ToArray();
-            if (!ids.Any())
+            try
             {
-                return new NulloAggregateCache<TEntityId, TEntity>();
-            }
+                var cache = parent.findCache<TEntityId, TEntity>();
 
-            if (cache == null)
+                var storage = await session.FetchProjectionStorageAsync<TEntity, TEntityId>(parent.TenantId, CancellationToken.None);
+                var events = parent.Slices.SelectMany(x => x.Events());
+
+                var ids = events.OfType<IEvent<TEvent>>().Select(identitySource).ToArray();
+                if (!ids.Any())
+                {
+                    return new NulloAggregateCache<TEntityId, TEntity>();
+                }
+
+                if (cache == null)
+                {
+                    var dict = await storage.LoadManyAsync(ids, CancellationToken.None);
+                    return new DictionaryAggregateCache<TEntityId, TEntity>(dict);
+                }
+
+                var toLoad = ids.Where(id => !cache.Contains(id)).ToArray();
+                if (!toLoad.Any()) return cache;
+
+                var loaded = await storage.LoadManyAsync(toLoad, CancellationToken.None);
+
+                foreach (var pair in loaded)
+                {
+                    cache.Store(pair.Key, pair.Value);
+                }
+
+                return cache;
+            }
+            finally
             {
-                var dict = await storage.LoadManyAsync(ids, CancellationToken.None);
-                return new DictionaryAggregateCache<TEntityId, TEntity>(dict);
+                if (disposeAfterUse) await session.DisposeAsync();
             }
-
-            var toLoad = ids.Where(id => !cache.Contains(id)).ToArray();
-            if (!toLoad.Any()) return cache;
-
-            var loaded = await storage.LoadManyAsync(toLoad, CancellationToken.None);
-
-            foreach (var pair in loaded)
-            {
-                cache.Store(pair.Key, pair.Value);
-            }
-
-            return cache;
         }
     }
 

--- a/src/JasperFx.Events/IStorageOperations.cs
+++ b/src/JasperFx.Events/IStorageOperations.cs
@@ -10,4 +10,11 @@ public interface IStorageOperations : IAsyncDisposable
     bool EnableSideEffectsOnInlineProjections { get; }
 
     ValueTask<IMessageSink> GetOrStartMessageSink();
+
+    /// <summary>
+    /// Service provider for the current session. Used to resolve ancillary stores
+    /// for cross-store enrichment. Implementations should return the DI container
+    /// scoped to this session; the default is null.
+    /// </summary>
+    IServiceProvider? Services => null;
 }


### PR DESCRIPTION
## Summary

Enables declarative enrichment from ancillary stores by extending the `EnrichWith<T>()` fluent chain in `SliceGroup`.

- Adds `IServiceProvider? Services { get; }` default member to `IStorageOperations` so Marten extensions can resolve DI services from the session
- Threads a `disposeAfterUse` flag through `EntityStep` → `EventStep` → `IdentityStep`; the alternate session is disposed in a `finally` block after enrichment completes
- Adds `EntityStep<TEntity>.WithAlternateSession(IStorageOperations)` — redirects enrichment loading to a different session with automatic dispose-after-use semantics; the primary store session is never disposed
- Caching is fully preserved: `findCache<TEntityId, TEntity>()` is still called first; the alternate session is only hit on cache misses
- Adds `WithAlternateSessionTests` (5 tests) covering: alternate storage used, session disposed, session disposed on no-match, primary not disposed, `AddReferences` via alternate

## Related

Marten feature request: https://github.com/JasperFx/marten/issues/4300