### PR TITLE
Cold-start + AOT prep for Marten 9.0 (4 stacked commits)

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
@@ -97,7 +97,7 @@ public abstract class JasperFxMultiStreamProjectionBase<TDoc, TId, TOperations, 
         _defaultSlicer.FanOut(fanOutFunc, mode);
     }
 
-    async Task IInlineProjection<TOperations>.ApplyAsync(TOperations operations, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+    async Task IInlineProjection<TOperations>.ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams, CancellationToken cancellation)
     {
         var events = streams.SelectMany(x => x.Events).ToArray();
         var slicer = BuildSlicer(operations);

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -70,14 +70,16 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
         return this;
     }
 
-    async Task IInlineProjection<TOperations>.ApplyAsync(TOperations session, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+    async Task IInlineProjection<TOperations>.ApplyAsync(TOperations session, IEnumerable<StreamAction> streams, CancellationToken cancellation)
     {
-        // Screen out any stream that doesn't have any matching events
-        streams = streams.Where(x => AppliesTo(x.Events.Select(x => x.EventType).ToArray())).ToArray();
-        
-        if (streams.Count == 0) return;
-        
-        var groups = streams.GroupBy(x => x.TenantId).ToArray();
+        // Screen out any stream that doesn't have any matching events.
+        // 9.0 (#4306): the parameter is now IEnumerable<StreamAction>, so we
+        // materialize once locally and work with the concrete array.
+        var matching = streams.Where(x => AppliesTo(x.Events.Select(e => e.EventType).ToArray())).ToArray();
+
+        if (matching.Length == 0) return;
+
+        var groups = matching.GroupBy(x => x.TenantId).ToArray();
         foreach (var group in groups)
         {
             var storage = await session.FetchProjectionStorageAsync<TDoc, TId>(group.Key, cancellation);

--- a/src/JasperFx.Events/Projections/ContainerScoped/ProjectionSourceWrapperBase.cs
+++ b/src/JasperFx.Events/Projections/ContainerScoped/ProjectionSourceWrapperBase.cs
@@ -84,7 +84,7 @@ public abstract class ProjectionSourceWrapperBase<TSource, TOperations, TQuerySe
     public abstract ISubscriptionExecution BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILogger logger,
         ShardName shardName);
 
-    public async Task ApplyAsync(TOperations operations, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+    public async Task ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams, CancellationToken cancellation)
     {
         using var scope = _serviceProvider.CreateScope();
         var sp = scope.ServiceProvider;

--- a/src/JasperFx.Events/Projections/ContainerScoped/ScopedProjectionWrapper.cs
+++ b/src/JasperFx.Events/Projections/ContainerScoped/ScopedProjectionWrapper.cs
@@ -77,7 +77,7 @@ public class ScopedProjectionWrapper<TProjection, TOperations, TQuerySession> : 
     public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
     public Type ImplementationType => typeof(TProjection);
 
-    public Task ApplyAsync(TOperations operations, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+    public Task ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams, CancellationToken cancellation)
     {
         var events = streams.SelectMany(x => x.Events).ToList();
         return ApplyAsync(operations, events, cancellation);

--- a/src/JasperFx.Events/Projections/IInlineProjection.cs
+++ b/src/JasperFx.Events/Projections/IInlineProjection.cs
@@ -6,12 +6,30 @@ namespace JasperFx.Events.Projections;
 public interface IInlineProjection<TOperations>
 {
     /// <summary>
-    ///     Apply inline projections during asynchronous operations
+    ///     Apply inline projections during asynchronous operations.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The <paramref name="streams"/> parameter is typed as
+    ///         <see cref="IEnumerable{T}"/> so that callers (notably Marten's
+    ///         <c>RichEventAppender</c> and <c>QuickEventAppender</c>) can pass
+    ///         the session's underlying <c>StreamAction</c> collection directly
+    ///         instead of materializing a new <c>List&lt;StreamAction&gt;</c> on
+    ///         every <c>SaveChangesAsync</c> call. Implementations that need
+    ///         to enumerate twice or take a count should call
+    ///         <c>streams.ToList()</c> once locally.
+    ///     </para>
+    ///     <para>
+    ///         Signature widened in JasperFx.Events 1.32 / Marten 9.0 — what
+    ///         was <c>IReadOnlyList&lt;StreamAction&gt;</c> is now
+    ///         <c>IEnumerable&lt;StreamAction&gt;</c>. Source-compatible for
+    ///         most consumers; a recompile is required.
+    ///     </para>
+    /// </remarks>
     /// <param name="operations"></param>
     /// <param name="streams"></param>
     /// <param name="cancellation"></param>
     /// <returns></returns>
-    Task ApplyAsync(TOperations operations, IReadOnlyList<StreamAction> streams,
+    Task ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams,
         CancellationToken cancellation);
 }

--- a/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
+++ b/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
@@ -67,7 +67,7 @@ public abstract class JasperFxEventProjectionBase<TOperations, TQuerySession> :
         return this;
     }
 
-    async Task IInlineProjection<TOperations>.ApplyAsync(TOperations operations, IReadOnlyList<StreamAction> streams, CancellationToken cancellation)
+    async Task IInlineProjection<TOperations>.ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams, CancellationToken cancellation)
     {
         var events = streams.SelectMany(x => x.Events).ToList();
         await EnrichEventsAsync(operations, events, cancellation);

--- a/src/JasperFx.Events/Projections/ProjectionWrapper.cs
+++ b/src/JasperFx.Events/Projections/ProjectionWrapper.cs
@@ -65,7 +65,7 @@ public class ProjectionWrapper<TOperations, TQuerySession> :
 
     public Type ProjectionType => _projection.GetType();
 
-    Task IInlineProjection<TOperations>.ApplyAsync(TOperations operations, IReadOnlyList<StreamAction> streams,
+    Task IInlineProjection<TOperations>.ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams,
         CancellationToken cancellation)
     {
         var events = streams.SelectMany(x => x.Events).ToList();

--- a/src/JasperFx/CodeGeneration/GenerationRules.cs
+++ b/src/JasperFx/CodeGeneration/GenerationRules.cs
@@ -130,6 +130,60 @@ public class GenerationRules
     {
         foreach (var assembly in WalkReferencedAssemblies.ForTypes(types).Distinct()) Assemblies.Fill(assembly);
     }
+
+    /// <summary>
+    ///     Returns a shallow clone of this <see cref="GenerationRules"/> with
+    ///     copied collections so mutating helpers like
+    ///     <see cref="ReferenceTypes"/>, <see cref="ReferenceAssembly"/>, or
+    ///     <see cref="AlwaysUseServiceLocationFor{T}"/> on the clone don't
+    ///     affect the source. Intended for callers that want to cache an
+    ///     expensive-to-build base configuration once and add per-call-site
+    ///     refinements without locking. <see cref="TypeLoadMode"/> and
+    ///     <see cref="SourceCodeWritingEnabled"/> are only re-applied on the
+    ///     clone when their *HasChanged tracking flags are set, so the clone
+    ///     starts out with the same has-changed view as the source.
+    /// </summary>
+    public GenerationRules Clone()
+    {
+        var clone = new GenerationRules
+        {
+            GeneratedNamespace = GeneratedNamespace,
+            GeneratedCodeOutputPath = GeneratedCodeOutputPath,
+            ApplicationAssembly = ApplicationAssembly,
+        };
+
+        if (TypeLoadModeHasChanged)
+        {
+            clone.TypeLoadMode = TypeLoadMode;
+        }
+
+        if (SourceCodeWritingEnabledHasChanged)
+        {
+            clone.SourceCodeWritingEnabled = SourceCodeWritingEnabled;
+        }
+
+        foreach (var assembly in Assemblies)
+        {
+            clone.Assemblies.Add(assembly);
+        }
+
+        foreach (var pair in Properties)
+        {
+            clone.Properties[pair.Key] = pair.Value;
+        }
+
+        foreach (var source in Sources)
+        {
+            clone.Sources.Add(source);
+        }
+
+        foreach (var policy in MethodPreCompilation)
+        {
+            clone.MethodPreCompilation.Add(policy);
+        }
+
+        return clone;
+    }
 }
 
 /// <summary>

--- a/src/JasperFx/Core/Reflection/GenericFactoryCache.cs
+++ b/src/JasperFx/Core/Reflection/GenericFactoryCache.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace JasperFx.Core.Reflection;
+
+/// <summary>
+/// Hot-path escape hatch for callers that today use
+/// <see cref="TypeExtensions.CloseAndBuildAs{T}(Type, object[], Type[])"/> or
+/// raw <see cref="Type.MakeGenericType"/> + <see cref="Activator.CreateInstance(Type, object?[])"/>
+/// per invocation. Both operations are AOT-unfriendly *and* allocate-heavy at
+/// steady state.
+/// </summary>
+/// <remarks>
+/// <para>
+///     <see cref="Build{T}(Type, Type, object?[])"/> caches by
+///     <c>(openType, typeArgs)</c>: the first call performs the
+///     <see cref="Type.MakeGenericType"/> walk and compiles a delegate that
+///     invokes the matching constructor on the closed type via
+///     <see cref="Expression.Lambda{TDelegate}(Expression, ParameterExpression[])"/>.
+///     Subsequent calls re-use the cached delegate and hit only a
+///     <see cref="ConcurrentDictionary{TKey,TValue}"/> lookup.
+/// </para>
+/// <para>
+///     The cache is process-wide and unbounded; intended for the
+///     "small finite set of closed types we'll keep using forever" shape
+///     (e.g. one entry per registered document type for Marten's LINQ
+///     handlers). Don't feed it user-generated open type tuples.
+/// </para>
+/// </remarks>
+public static class GenericFactoryCache
+{
+    private static readonly ConcurrentDictionary<(Type Open, Type Arg, int CtorArity), Func<object?[], object>> _cache1 = new();
+    private static readonly ConcurrentDictionary<(Type Open, Type Arg1, Type Arg2, int CtorArity), Func<object?[], object>> _cache2 = new();
+
+    /// <summary>
+    /// Construct an instance of <c>openType&lt;arg&gt;</c> using the constructor
+    /// whose arity matches <paramref name="ctorArgs"/>. Returns the result cast
+    /// to <typeparamref name="T"/>.
+    /// </summary>
+    public static T Build<T>(Type openType, Type arg, params object?[] ctorArgs)
+    {
+        var factory = _cache1.GetOrAdd(
+            (openType, arg, ctorArgs.Length),
+            static key => BuildFactory(key.Open.MakeGenericType(key.Arg), key.CtorArity));
+        return (T)factory(ctorArgs);
+    }
+
+    /// <summary>
+    /// Two-type-arg overload — construct <c>openType&lt;arg1, arg2&gt;</c>.
+    /// </summary>
+    public static T Build<T>(Type openType, Type arg1, Type arg2, params object?[] ctorArgs)
+    {
+        var factory = _cache2.GetOrAdd(
+            (openType, arg1, arg2, ctorArgs.Length),
+            static key => BuildFactory(key.Open.MakeGenericType(key.Arg1, key.Arg2), key.CtorArity));
+        return (T)factory(ctorArgs);
+    }
+
+    private static Func<object?[], object> BuildFactory(Type closedType, int ctorArity)
+    {
+        var ctor = closedType
+            .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == ctorArity);
+
+        if (ctor is null)
+        {
+            // Caller asked for a no-arg ctor when the type doesn't have one,
+            // or arity didn't match — fall back to Activator (which produces
+            // the same MissingMethodException Activator would have thrown
+            // before this cache existed).
+            return args => Activator.CreateInstance(closedType, args)!;
+        }
+
+        // (object?[] args) => (object) new ClosedType((TArg0)args[0], (TArg1)args[1], ...)
+        var argsParam = Expression.Parameter(typeof(object?[]), "args");
+        var parameters = ctor.GetParameters();
+        var ctorArgExprs = new Expression[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var indexer = Expression.ArrayIndex(argsParam, Expression.Constant(i));
+            ctorArgExprs[i] = Expression.Convert(indexer, parameters[i].ParameterType);
+        }
+
+        var newExpr = Expression.New(ctor, ctorArgExprs);
+        var castToObject = Expression.Convert(newExpr, typeof(object));
+        return Expression.Lambda<Func<object?[], object>>(castToObject, argsParam).Compile();
+    }
+}

--- a/src/JasperFx/Core/Reflection/TypeExtensions.cs
+++ b/src/JasperFx/Core/Reflection/TypeExtensions.cs
@@ -390,25 +390,37 @@ public static class TypeExtensions
     }
 
 
+    private const string CloseAndBuildAsAotMessage =
+        "CloseAndBuildAs uses Type.MakeGenericType + Activator.CreateInstance, neither of which is AOT-safe. " +
+        "Use the GenericFactoryCache delegate-factory escape hatch on hot paths, or pre-generate the closed types.";
+
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(CloseAndBuildAsAotMessage)]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(CloseAndBuildAsAotMessage)]
     public static T CloseAndBuildAs<T>(this Type openType, params Type[] parameterTypes)
     {
         var closedType = openType.MakeGenericType(parameterTypes);
         return (T)Activator.CreateInstance(closedType)!;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(CloseAndBuildAsAotMessage)]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(CloseAndBuildAsAotMessage)]
     public static T CloseAndBuildAs<T>(this Type openType, object ctorArgument, params Type[] parameterTypes)
     {
         var closedType = openType.MakeGenericType(parameterTypes);
         return (T)Activator.CreateInstance(closedType, ctorArgument)!;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(CloseAndBuildAsAotMessage)]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(CloseAndBuildAsAotMessage)]
     public static T CloseAndBuildAs<T>(this Type openType, object ctorArgument1, object ctorArgument2,
         params Type[] parameterTypes)
     {
         var closedType = openType.MakeGenericType(parameterTypes);
         return (T)Activator.CreateInstance(closedType, ctorArgument1, ctorArgument2)!;
     }
-    
+
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(CloseAndBuildAsAotMessage)]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(CloseAndBuildAsAotMessage)]
     public static T CloseAndBuildAs<T>(this Type openType, object ctorArgument1, object ctorArgument2, object ctorArgument3,
         params Type[] parameterTypes)
     {


### PR DESCRIPTION
Stacks four small additive changes that the Marten 9.0 long-lived branch depends on. Each commit stands alone and is targeted at a separate Marten umbrella issue ([#4294](https://github.com/JasperFx/marten/issues/4294)). Reviewing the commits in order is probably easier than reviewing the diff as a whole.

## Commits

1. **Widen `IInlineProjection<T>.ApplyAsync` streams to `IEnumerable<StreamAction>`** (8304f8d) — was `IReadOnlyList<StreamAction>`. Lets Marten's `RichEventAppender` and `QuickEventAppender` pass `session.WorkTracker.Streams` directly instead of allocating a fresh `List<StreamAction>` on every `SaveChangesAsync`. All shipped implementers were already a one-shot enumeration; only `JasperFxSingleStreamProjectionBase` needed a tiny change to materialize the filtered `Where().ToArray()` into a local before reading `.Length`. **Public-API breaking — consumers must recompile.** Companion to Marten [#4306](https://github.com/JasperFx/marten/issues/4306).

2. **Add `GenerationRules.Clone()`** (8482749) — additive shallow-clone helper with copied mutable collections (`Assemblies`, `Properties`, `Sources`, `MethodPreCompilation`). Lets callers cache an expensive-to-build base `GenerationRules` once and call `ReferenceTypes` / `ReferenceAssembly` on per-call clones without affecting the source. Marten 9.0's `CreateGenerationRules` cache holds a single base instance and hands each codegen entry point a `Clone()`. Companion to Marten [#4307](https://github.com/JasperFx/marten/issues/4307).

3. **Add `GenericFactoryCache`** (c126c35) — hot-path escape hatch for callers that today use `MakeGenericType` + `Activator.CreateInstance` per invocation. Caches by `(openType, typeArgs, ctorArity)` and populates a lazily-compiled `Func<object?[], object>` per closed type using `Expression.Lambda`. Marten's LINQ parser hot path was the motivating call site (`LinqQueryParser.BuildHandler`, `CollectionUsage.Includes`, `CollectionUsage.Compilation.processGroupJoin`). Tier-1 of [#191](https://github.com/JasperFx/jasperfx/issues/191); tier-2 (source-generated factories so even the first call avoids `MakeGenericType`) is deferred. Companion to Marten [#4308](https://github.com/JasperFx/marten/issues/4308).

4. **Annotate `CloseAndBuildAs<T>` with `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]`** (8b2f392) — non-breaking. The annotation surfaces real warnings in consuming projects under `<IsTrimmable>` or `<PublishAot>`, giving the Critter Stack a concrete punch list of call sites that need migration to `GenericFactoryCache` or source-generated factories. Companion to Marten [#4309](https://github.com/JasperFx/marten/issues/4309) (AOT-friendly tier 1).

## Versioning

These four together justify a JasperFx 1.32 minor bump (signature widening on `IInlineProjection<T>.ApplyAsync` is technically API-breaking; everything else is additive). Marten 9.0 will pin against 1.32 once this lands.

## Testing

Local CodegenTests pass on net8/9/10. JasperFx.Events builds and the downstream Marten 9.0 branch (which uses `nuke attach` to project-reference these changes locally) compiles clean and the `EventSourcingTests`, `DocumentDbTests`, `DaemonTests`, `LinqTests` and `CoreTests` matrices we've run are green modulo a handful of pre-existing cross-test-pollution flakes that also affect master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)