### PR TITLE
Fix CultureNotFoundException in ProjectionGraph.IsAssemblyKnownToHaveNoEvolvers under invariant-globalization mode

### DIFF
--- a/src/JasperFx.Events/Projections/ProjectionGraph.cs
+++ b/src/JasperFx.Events/Projections/ProjectionGraph.cs
@@ -425,7 +425,31 @@ public abstract class ProjectionGraph<TProjection, TOperations, TQuerySession> :
     /// </summary>
     private static bool IsAssemblyKnownToHaveNoEvolvers(Assembly assembly)
     {
-        var name = assembly.GetName().Name;
+        // assembly.GetName() walks AssemblyName.GetLocale() under the hood, which
+        // calls CultureInfo.GetCultureInfo(name). Under globalization-invariant
+        // mode (e.g. `<InvariantGlobalization>true</InvariantGlobalization>`,
+        // which is implied by NativeAOT publishing) any culture-tagged satellite
+        // assembly with a non-invariant name like "pt-br" causes that lookup to
+        // throw CultureNotFoundException. Use Assembly.FullName instead — it's
+        // pre-cached, doesn't go through CultureInfo, and the simple name is
+        // always the first comma-separated token. Wrap in try/catch as a
+        // belt-and-braces guard for any other exotic loader behaviour: failing
+        // to recognise the assembly as "known empty" just falls through to the
+        // GetCustomAttributes path, which already has its own try/catch.
+        // See https://aka.ms/GlobalizationInvariantMode.
+        string? name;
+        try
+        {
+            var fullName = assembly.FullName;
+            if (string.IsNullOrEmpty(fullName)) return false;
+            var commaIndex = fullName.IndexOf(',');
+            name = commaIndex < 0 ? fullName : fullName.Substring(0, commaIndex);
+        }
+        catch
+        {
+            return false;
+        }
+
         if (name == null) return false;
 
         return name.StartsWith("System", StringComparison.Ordinal)


### PR DESCRIPTION
## Problem
`Assembly.GetName().Name`, used by the cold-start prefilter in `DiscoverGeneratedEvolvers`, walks `AssemblyName.GetLocale()` → `CultureInfo.GetCultureInfo(name)` under the hood. Under globalization-invariant mode (`<InvariantGlobalization>true</InvariantGlobalization>` — implied by `<PublishAot>true</PublishAot>`) any culture-tagged satellite assembly (e.g. `pt-br`) makes that lookup throw `CultureNotFoundException`. The result for downstream consumers is a crash on `DocumentStore..ctor` (or the equivalent host-build entry point):

```
System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode.
See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name') pt-br is an invalid culture identifier.
   at CultureInfo System.Globalization.CultureInfo.GetCultureInfo(string name)
   at CultureInfo System.Reflection.RuntimeAssembly.GetLocale()
   at AssemblyName System.Reflection.RuntimeAssembly.GetName(bool copiedName)
   at bool JasperFx.Events.Projections.ProjectionGraph.IsAssemblyKnownToHaveNoEvolvers(Assembly assembly)
   at void JasperFx.Events.Projections.ProjectionGraph.DiscoverGeneratedEvolvers(params Assembly[] assemblies)
```

Reported today against Marten's cold-start optimization changes.

## Fix
Use `Assembly.FullName` and split on the first comma to get the simple name. `FullName` is pre-cached on the runtime assembly and doesn't traverse `CultureInfo`. Wrap in `try/catch` as a belt-and-braces guard for exotic loader behaviour — failing to recognise an assembly as "known empty" just falls through to the existing `GetCustomAttributes` path that has its own `try/catch`.

## Test plan
- [x] `dotnet build src/JasperFx.Events/JasperFx.Events.csproj` clean
- A precise unit-level repro requires `<InvariantGlobalization>true</InvariantGlobalization>` plus a loaded satellite assembly, which is hard to wire up in a portable test rig — covered instead by the existing prefilter tests + this fix's defensive try/catch fallback. Will follow up if anyone has a clean way to harness the invariant-mode case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)