### PR TITLE
Use IReadOnlyList for aggregate grouper events

### DIFF
--- a/src/EventStoreTests/Grouping/EventSlicerTests.cs
+++ b/src/EventStoreTests/Grouping/EventSlicerTests.cs
@@ -194,18 +194,23 @@ public class EventSlicerWithSessionTests
     public async Task slice_with_custom_grouping()
     {
         var slicer = new EventSlicer<SimpleAggregate, string, object>();
-        slicer.CustomGrouping((session, events, grouping) =>
+
+        var events = new TestEventSet();
+        var e1 = events.Added(1, "blue");
+        var e2 = events.Added(2, "green");
+        
+        slicer.CustomGrouping((session, page, grouping) =>
         {
-            foreach (var e in events)
+            page.Count.ShouldBe(2);
+            page[0].ShouldBe(e1);
+            page[1].ShouldBe(e2);
+
+            foreach (var e in page)
             {
                 grouping.AddEvent("all", e);
             }
             return Task.CompletedTask;
         });
-
-        var events = new TestEventSet();
-        var e1 = events.Added(1, "blue");
-        var e2 = events.Added(2, "green");
 
         var group = new SliceGroup<SimpleAggregate, string>();
         await slicer.SliceAsync(new object(), events.All, group);

--- a/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
@@ -213,7 +213,7 @@ public abstract class JasperFxMultiStreamProjectionBase<TDoc, TId, TOperations, 
     /// </summary>
     /// <param name="func"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    public void CustomGrouping(Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> func)
+    public void CustomGrouping(Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> func)
     {
         if (_customSlicer != null)
         {

--- a/src/JasperFx.Events/Grouping/IEventSlicer.cs
+++ b/src/JasperFx.Events/Grouping/IEventSlicer.cs
@@ -43,7 +43,7 @@ public interface IEventSlicer<TDoc, TId> where TId : notnull
     /// <summary>
     ///     This is called by the asynchronous projection runner
     /// </summary>
-    /// <param name="events">Enumerable of new events within the current event range (page) that is currently being processed by the projection</param>
+    /// <param name="events">List of new events within the current event range (page) that is currently being processed by the projection</param>
     /// <param name="grouping"></param>
     /// <returns></returns>
     ValueTask SliceAsync(IReadOnlyList<IEvent> events, SliceGroup<TDoc, TId> grouping);
@@ -54,7 +54,7 @@ public interface IEventSlicer<TDoc, TId, TQuerySession> where TId : notnull
     /// <summary>
     ///     This is called by the asynchronous projection runner
     /// </summary>
-    /// <param name="events">Enumerable of new events within the current event range (page) that is currently being processed by the projection</param>
+    /// <param name="events">List of new events within the current event range (page) that is currently being processed by the projection</param>
     /// <param name="grouping"></param>
     /// <returns></returns>
     ValueTask SliceAsync(TQuerySession session, IReadOnlyList<IEvent> events, SliceGroup<TDoc, TId> grouping);
@@ -75,19 +75,19 @@ public interface IJasperFxAggregateGrouper<out TId, in TQuerySession>
     /// <param name="events"></param>
     /// <param name="grouping"></param>
     /// <returns></returns>
-    Task Group(TQuerySession session, IEnumerable<IEvent> events, IEventGrouping<TId> grouping);
+    Task Group(TQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<TId> grouping);
 }
 
 internal class LambdaAggregateGrouper<TId, TQuerySession> : IJasperFxAggregateGrouper<TId, TQuerySession>
 {
-    private readonly Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> _func;
+    private readonly Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> _func;
 
-    public LambdaAggregateGrouper(Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> func)
+    public LambdaAggregateGrouper(Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> func)
     {
         _func = func;
     }
 
-    public Task Group(TQuerySession session, IEnumerable<IEvent> events, IEventGrouping<TId> grouping)
+    public Task Group(TQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<TId> grouping)
     {
         return _func(session, events, grouping);
     }
@@ -98,7 +98,7 @@ public class EventSlicer<TDoc, TId, TQuerySession>: IEventSlicer<TDoc, TId, TQue
 {
     private readonly List<IFanOutRule> _afterGroupingFanoutRules = new();
     private readonly List<IFanOutRule> _beforeGroupingFanoutRules = new();
-    private readonly List<Action<IEnumerable<IEvent>, IEventGrouping<TId>>> _groupers = new();
+    private readonly List<Action<IReadOnlyList<IEvent>, IEventGrouping<TId>>> _groupers = new();
     private readonly List<IJasperFxAggregateGrouper<TId, TQuerySession>> _lookupGroupers = new();
 
     public async ValueTask SliceAsync(TQuerySession session, IReadOnlyList<IEvent> events, SliceGroup<TDoc, TId> grouping)
@@ -163,7 +163,7 @@ public class EventSlicer<TDoc, TId, TQuerySession>: IEventSlicer<TDoc, TId, TQue
     ///     Apply a custom event grouping strategy for events. This is additive to Identity() or Identities()
     /// </summary>
     /// <param name="grouper"></param>
-    public EventSlicer<TDoc, TId, TQuerySession> CustomGrouping(Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> func)
+    public EventSlicer<TDoc, TId, TQuerySession> CustomGrouping(Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> func)
     {
         _lookupGroupers.Add(new LambdaAggregateGrouper<TId, TQuerySession>(func));
 


### PR DESCRIPTION
## Summary

- Change `IJasperFxAggregateGrouper.Group` to receive `IReadOnlyList<IEvent>` instead of `IEnumerable<IEvent>`.
- Update the lambda-based `CustomGrouping` overloads and adapter to preserve the materialized event page contract.
- Add test coverage that custom grouping callbacks can use `Count` and indexed access without allocating.

## Why

Aggregate grouping implementations may need to inspect the same event page more than once. Accepting `IReadOnlyList<IEvent>` makes it explicit that the events are already materialized and safe for repeated enumeration or indexed access.

Fixes #201