### PR TITLE
Expose SliceGroup.TryFindUpstreamCache for downstream projection enrichment

### DIFF
--- a/src/EventTests/Projections/SliceGroupTests.cs
+++ b/src/EventTests/Projections/SliceGroupTests.cs
@@ -252,6 +252,63 @@ public class SliceGroupTests : IProjectionStorage<User, string>, IStorageOperati
     }
 
     [Fact]
+    public void try_find_upstream_cache_returns_false_when_no_upstream()
+    {
+        theGroup.TryFindUpstreamCache<string, User>(out var cache).ShouldBeFalse();
+        cache.ShouldBeNull();
+    }
+
+    [Fact]
+    public void try_find_upstream_cache_returns_per_tenant_cache_from_matching_upstream()
+    {
+        var execution = Substitute.For<ISubscriptionExecution>();
+        var caching = Substitute.For<IAggregateCaching<string, User>>();
+        var perTenantCache = Substitute.For<IAggregateCache<string, User>>();
+        caching.CacheFor(StorageConstants.DefaultTenantId).Returns(perTenantCache);
+
+        execution
+            .TryGetAggregateCache<string, User>(out Arg.Any<IAggregateCaching<string, User>?>())
+            .Returns(call =>
+            {
+                call[0] = caching;
+                return true;
+            });
+
+        theGroup.Upstream.Add(execution);
+
+        theGroup.TryFindUpstreamCache<string, User>(out var cache).ShouldBeTrue();
+        cache.ShouldBeSameAs(perTenantCache);
+    }
+
+    [Fact]
+    public void try_find_upstream_cache_walks_past_non_matching_upstream_executions()
+    {
+        var noMatch = Substitute.For<ISubscriptionExecution>();
+        var match = Substitute.For<ISubscriptionExecution>();
+
+        noMatch
+            .TryGetAggregateCache<string, User>(out Arg.Any<IAggregateCaching<string, User>?>())
+            .Returns(false);
+
+        var caching = Substitute.For<IAggregateCaching<string, User>>();
+        var perTenantCache = Substitute.For<IAggregateCache<string, User>>();
+        caching.CacheFor(StorageConstants.DefaultTenantId).Returns(perTenantCache);
+        match
+            .TryGetAggregateCache<string, User>(out Arg.Any<IAggregateCaching<string, User>?>())
+            .Returns(call =>
+            {
+                call[0] = caching;
+                return true;
+            });
+
+        theGroup.Upstream.Add(noMatch);
+        theGroup.Upstream.Add(match);
+
+        theGroup.TryFindUpstreamCache<string, User>(out var cache).ShouldBeTrue();
+        cache.ShouldBeSameAs(perTenantCache);
+    }
+
+    [Fact]
     public async Task enrich_with_using_entity_query()
     {
         var id1 = AddSlice("AAABCCDDDD", "Bill");

--- a/src/JasperFx.Events/Grouping/SliceGroup.cs
+++ b/src/JasperFx.Events/Grouping/SliceGroup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Daemon;
@@ -183,6 +184,29 @@ public class SliceGroup<TDoc, TId> : IEventGrouping<TId> where TId : notnull
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Try to find the in-memory aggregate cache for an upstream stage of a composite projection
+    /// that produces entities of type <typeparamref name="TEntity"/> keyed by
+    /// <typeparamref name="TEntityId"/>. Useful inside <see cref="EnrichWith{TEntity}"/> /
+    /// <c>EnrichUsingEntityQuery</c> callbacks when the calling stage needs to read the in-flight
+    /// (uncommitted) output of an upstream stage by id without going to the database — a SQL query
+    /// in the same composite batch will not see those writes until the batch flushes.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>false</c> when no upstream stage of this composite is registered as producing
+    /// entities of type <typeparamref name="TEntity"/>. Returns <c>true</c> with a per-tenant cache
+    /// otherwise; callers should still treat the cache as a hint and fall back to other resolution
+    /// strategies when <see cref="IAggregateCache{TKey,TItem}.TryFind"/> misses.
+    /// </remarks>
+    public bool TryFindUpstreamCache<TEntityId, TEntity>(
+        [NotNullWhen(true)] out IAggregateCache<TEntityId, TEntity>? cache)
+        where TEntityId : notnull
+        where TEntity : notnull
+    {
+        cache = findCache<TEntityId, TEntity>();
+        return cache != null;
     }
 
     public class EntityStep<TEntity>(SliceGroup<TDoc, TId> parent, IStorageOperations session, bool disposeAfterUse = false)


### PR DESCRIPTION
## Summary

Companion change for [JasperFx/marten#4329](https://github.com/JasperFx/marten/issues/4329).

A composite projection runs all of its stages against a single in-memory \`IProjectionBatch\` that flushes to the database **once**, after every stage completes. Document writes produced by stage 1 are still queued in memory while stage 2 enriches, so a SQL query in a downstream stage cannot see them — a trap that's easy to fall into when writing custom \`EnrichUsingEntityQuery\` callbacks.

\`SliceGroup<TDoc, TId>\` already has a private \`findCache<TEntityId, TEntity>()\` helper that walks \`Upstream\` and pulls the upstream stage's in-memory aggregate cache for entities of type \`TEntity\`. This is the mechanism the \`EnrichWith<T>().AddReferences()\` chain uses to read in-flight upstream output without going to SQL.

This PR exposes that lookup as a public API so custom enrichment callbacks (especially inside \`EnrichUsingEntityQuery\`) can do the same lookup for arbitrary upstream entity types — not only the \`TEntity\` of the enclosing \`EnrichWith<T>\`.

\`\`\`csharp
public bool TryFindUpstreamCache<TEntityId, TEntity>(
    [NotNullWhen(true)] out IAggregateCache<TEntityId, TEntity>? cache);
\`\`\`

Returns \`false\` when no upstream stage of the composite is producing entities of that type. Otherwise, returns a per-tenant cache backed by the upstream stage's in-memory aggregate cache.

## Test plan

- [x] 3 new unit tests in \`SliceGroupTests\`: empty \`Upstream\`, single matching upstream, walks past non-matching upstreams.
- [x] All 71 \`EventTests/Projections\` tests pass on net8.0 / net9.0 / net10.0.
- [x] No change to existing internal \`findCache\` callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)