### PR TITLE
Defer aggregate cache compaction during composite projection execution

### DIFF
--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -95,18 +95,42 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             throw new AggregateException(exceptions);
         }
 
+        // Composite projections defer compaction until every stage has run so a downstream
+        // stage can read the upstream stage's in-flight entities without them being evicted
+        // out from under it. CompositeExecution calls CompactCachesAsync after all stages
+        // complete. See JasperFx/marten#4329.
+        if (range.BatchBehavior != BatchBehavior.Composite)
+        {
+            try
+            {
+                foreach (var cache in caches) cache.CompactIfNecessary();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error trying to compact aggregate caches for {ProjectionName}", Projection.Name);
+            }
+        }
+
+        await Projection.EndBatchAsync();
+
+        return batch;
+    }
+
+    public Task CompactCachesAsync()
+    {
         try
         {
-            foreach (var cache in caches) cache.CompactIfNecessary();
+            foreach (var pair in _caches.Enumerate())
+            {
+                pair.Value.CompactIfNecessary();
+            }
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Error trying to compact aggregate caches for {ProjectionName}", Projection.Name);
         }
 
-        await Projection.EndBatchAsync();
-
-        return batch;
+        return Task.CompletedTask;
     }
 
     private async Task processBatchAsync(CancellationToken cancellation, IProjectionBatch<TOperations, TQuerySession> batch, SliceGroup<TDoc, TId> group,

--- a/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
+++ b/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
@@ -101,6 +101,8 @@ public class GroupedProjectionExecution : ISubscriptionExecution
         return caching != null;
     }
 
+    public Task CompactCachesAsync() => _runner.CompactCachesAsync();
+
     private async Task<EventRange> groupEventRangeAsync(EventRange range, CancellationToken _)
     {
         if (_cancellation.IsCancellationRequested)

--- a/src/JasperFx.Events/Daemon/IGroupedProjectionRunner.cs
+++ b/src/JasperFx.Events/Daemon/IGroupedProjectionRunner.cs
@@ -13,11 +13,18 @@ public enum SliceBehavior
 public interface IGroupedProjectionRunner : IAsyncDisposable
 {
     SliceBehavior SliceBehavior { get; }
-    
+
     Task<IProjectionBatch> BuildBatchAsync(EventRange range, ShardExecutionMode mode, CancellationToken cancellation);
     bool TryBuildReplayExecutor(out IReplayExecutor executor);
 
     IEventSlicer Slicer { get; }
 
     ErrorHandlingOptions ErrorHandlingOptions(ShardExecutionMode mode);
+
+    /// <summary>
+    /// Apply CacheLimitPerTenant to any in-memory aggregate caches owned by this runner.
+    /// Composite projections defer this until all stages have run so that downstream stages
+    /// can read in-flight upstream entities without losing them to mid-batch eviction.
+    /// </summary>
+    Task CompactCachesAsync() => Task.CompletedTask;
 }

--- a/src/JasperFx.Events/Daemon/ISubscriptionExecution.cs
+++ b/src/JasperFx.Events/Daemon/ISubscriptionExecution.cs
@@ -28,6 +28,15 @@ public interface ISubscriptionExecution: IAsyncDisposable
     /// <typeparam name="TDoc"></typeparam>
     /// <returns></returns>
     bool TryGetAggregateCache<TId, TDoc>([NotNullWhen(true)] out IAggregateCaching<TId, TDoc>? caching);
+
+    /// <summary>
+    /// Compact (apply <see cref="AsyncOptions.CacheLimitPerTenant"/>) any in-memory aggregate
+    /// caches owned by this execution. Called by <see cref="Composite.CompositeExecution{TOperations,TQuerySession}"/>
+    /// once all stages of a composite projection batch have completed, so that each stage's cache
+    /// remains at full size for the duration of the composite batch and can be safely consulted by
+    /// downstream stages without dropping in-flight (uncommitted) entities.
+    /// </summary>
+    Task CompactCachesAsync() => Task.CompletedTask;
 }
 
 /// <summary>

--- a/src/JasperFx.Events/Projections/Composite/CompositeExecution.cs
+++ b/src/JasperFx.Events/Projections/Composite/CompositeExecution.cs
@@ -18,12 +18,24 @@ public class CompositeExecution<TOperations, TQuerySession> : ProjectionExecutio
         try
         {
             batch = await _store.StartProjectionBatchAsync(range, _database, Mode, _options, cancellationToken);
-            
+
             range.ActiveBatch = batch;
 
             foreach (var stage in _inners)
             {
                 await stage.ExecuteDownstreamAsync(range);
+            }
+
+            // Compact each child execution's aggregate caches now that every stage has run.
+            // BuildBatchAsync skipped per-stage compaction because downstream stages need to
+            // read the upstream's in-flight entities; we do it once here at the composite
+            // boundary instead. See JasperFx/marten#4329.
+            foreach (var stage in _inners)
+            {
+                foreach (var execution in stage.Executions)
+                {
+                    await execution.CompactCachesAsync();
+                }
             }
 
             return batch;


### PR DESCRIPTION
## Summary

Companion fix for [JasperFx/marten#4329](https://github.com/JasperFx/marten/issues/4329). When a composite projection's upstream stage finishes, its per-tenant `RecentlyUsedCache` was being compacted *before* downstream stages had a chance to read it. With a small `CacheLimitPerTenant` the compaction at end of stage 1 evicted entities that downstream stages were about to look up via `EnrichWith<T>().AddReferences()` or the new public `TryFindUpstreamCache<TId, T>`. Evicted ids fell through to `storage.LoadManyAsync`, which cannot see the upstream's queued in-flight writes — so the downstream lookup silently dropped them.

Reproducible from the Marten side by setting \`Options.CacheLimitPerTenant = 1\` on \`AppointmentProjection\` and running \`multi_stage_projections.end_to_end\` — \`AppointmentByExternalIdentifier\` ends up empty because nearly every stage-2 lookup misses both the cache and storage. See [the diagnosis comment](https://github.com/JasperFx/marten/issues/4329#issuecomment-4390826711) on #4329.

## What changes

Composite-aware compaction:

- \`AggregationRunner.BuildBatchAsync\` now skips end-of-batch \`CompactIfNecessary\` when \`range.BatchBehavior == BatchBehavior.Composite\`.
- New \`AggregationRunner.CompactCachesAsync\` iterates the per-tenant \`_caches\` and compacts each.
- New default-implemented \`Task CompactCachesAsync()\` on \`ISubscriptionExecution\` and \`IGroupedProjectionRunner\` (default = no-op) so existing callers/implementations don't need to change.
- \`GroupedProjectionExecution.CompactCachesAsync\` forwards to the runner.
- \`CompositeExecution.buildBatchWithNoSkippingAsync\` calls \`CompactCachesAsync\` on every child execution after all stages finish, restoring the per-tenant bound at the composite boundary.

Within a composite batch, every projection's cache stays at full size (one batch's worth of in-flight aggregates), then is compacted as a unit at composite end. Outside composites, behavior is unchanged.

## Test plan

- [x] All 235 \`EventTests\` pass on net8.0 / net9.0 / net10.0.
- [ ] End-to-end coverage lands in Marten via a follow-up integration test that runs \`multi_stage_projections.end_to_end\` with \`CacheLimitPerTenant = 1\` on the upstream — the same reproduction documented in the issue. (JasperFx-level unit-testing this would require building substantial AggregationRunner mock scaffolding for marginal additional confidence beyond the integration test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)