### PR TITLE
feat(codegen): AppendActivityEventFrame + MethodCall before/after activity events

### DIFF
--- a/src/CodegenTests/Frames/AppendActivityEventFrameTests.cs
+++ b/src/CodegenTests/Frames/AppendActivityEventFrameTests.cs
@@ -1,0 +1,59 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+using Shouldly;
+
+namespace CodegenTests.Frames;
+
+public class AppendActivityEventFrameTests
+{
+    [Fact]
+    public void emits_addEvent_using_fully_qualified_type_names()
+    {
+        var frame = new AppendActivityEventFrame("my.event");
+        var writer = new SourceWriter();
+
+        frame.GenerateCode(GeneratedMethod.ForNoArg("Foo"), writer);
+
+        var line = writer.Code().ReadLines().Single();
+        line.ShouldBe(
+            "System.Diagnostics.Activity.Current?.AddEvent(new System.Diagnostics.ActivityEvent(\"my.event\"));");
+    }
+
+    [Fact]
+    public void preserves_event_name_verbatim()
+    {
+        var frame = new AppendActivityEventFrame("wolverine.handler.started");
+
+        frame.EventName.ShouldBe("wolverine.handler.started");
+    }
+
+    [Fact]
+    public void rejects_null_event_name()
+    {
+        Should.Throw<ArgumentNullException>(() => new AppendActivityEventFrame(null!));
+    }
+
+    [Fact]
+    public void chains_to_next_frame()
+    {
+        var frame = new AppendActivityEventFrame("first");
+        frame.Next = new AppendActivityEventFrame("second");
+
+        var writer = new SourceWriter();
+        frame.GenerateCode(GeneratedMethod.ForNoArg("Foo"), writer);
+
+        var lines = writer.Code().ReadLines().ToArray();
+        lines.Length.ShouldBe(2);
+        lines[0].ShouldContain("\"first\"");
+        lines[1].ShouldContain("\"second\"");
+    }
+
+    [Fact]
+    public void declares_no_variables()
+    {
+        var frame = new AppendActivityEventFrame("anything");
+        frame.FindVariables(null!).ShouldBeEmpty();
+    }
+}

--- a/src/CodegenTests/MethodCall_generate_code.cs
+++ b/src/CodegenTests/MethodCall_generate_code.cs
@@ -356,6 +356,75 @@ public class MethodCall_generate_code
             "var (var red, var blue, var green) = await target.AsyncReturnTuple().ConfigureAwait(false);");
     }
 #endif
+
+    private const string ExpectedActivityEventLineFormat =
+        "System.Diagnostics.Activity.Current?.AddEvent(new System.Diagnostics.ActivityEvent(\"{0}\"));";
+
+    [Fact]
+    public void emits_activity_event_before_call_when_set()
+    {
+        var lines = WriteMethod(x => x.Go(), call => call.ActivityEventBeforeCall = "wolverine.handler.started");
+
+        lines.Length.ShouldBe(2);
+        lines[0].ShouldBe(string.Format(ExpectedActivityEventLineFormat, "wolverine.handler.started"));
+        lines[1].ShouldBe("target.Go();");
+    }
+
+    [Fact]
+    public void emits_activity_event_after_call_when_set()
+    {
+        var lines = WriteMethod(x => x.Go(), call => call.ActivityEventAfterCall = "wolverine.handler.finished");
+
+        lines.Length.ShouldBe(2);
+        lines[0].ShouldBe("target.Go();");
+        lines[1].ShouldBe(string.Format(ExpectedActivityEventLineFormat, "wolverine.handler.finished"));
+    }
+
+    [Fact]
+    public void emits_activity_events_around_call_when_both_set()
+    {
+        var lines = WriteMethod(x => x.Go(), call =>
+        {
+            call.ActivityEventBeforeCall = "before";
+            call.ActivityEventAfterCall = "after";
+        });
+
+        lines.Length.ShouldBe(3);
+        lines[0].ShouldBe(string.Format(ExpectedActivityEventLineFormat, "before"));
+        lines[1].ShouldBe("target.Go();");
+        lines[2].ShouldBe(string.Format(ExpectedActivityEventLineFormat, "after"));
+    }
+
+    [Fact]
+    public void no_activity_events_when_unset()
+    {
+        // Sanity check: the new properties default to null and must not emit
+        // any AddEvent calls when left untouched. Guards against an
+        // unconditional emission regression.
+        WriteMethod(x => x.Go()).Single().ShouldBe("target.Go();");
+    }
+
+    [Fact]
+    public void emits_activity_event_around_async_call_with_return_value()
+    {
+        // Verifies the before/after lines bracket the actual await line
+        // (not the variable assignment), matching the way callers expect
+        // ActivityEvents to flank a single observable invocation.
+        theMethod.AsyncMode = AsyncMode.AsyncTask;
+
+        var lines = WriteMethod(x => x.OtherAsync(null, null), call =>
+        {
+            call.Arguments[0] = Variable.For<Arg2>();
+            call.Arguments[1] = Variable.For<Arg3>();
+            call.ActivityEventBeforeCall = "before";
+            call.ActivityEventAfterCall = "after";
+        });
+
+        lines.Length.ShouldBe(3);
+        lines[0].ShouldBe(string.Format(ExpectedActivityEventLineFormat, "before"));
+        lines[1].ShouldBe("var arg1 = await target.OtherAsync(arg2, arg3).ConfigureAwait(false);");
+        lines[2].ShouldBe(string.Format(ExpectedActivityEventLineFormat, "after"));
+    }
 }
 
 public class Blue

--- a/src/JasperFx/CodeGeneration/Frames/AppendActivityEventFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/AppendActivityEventFrame.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+
+namespace JasperFx.CodeGeneration.Frames;
+
+/// <summary>
+/// Codegen frame that appends an <see cref="ActivityEvent"/> to
+/// <see cref="Activity.Current"/> when an activity exists. Emits
+/// <c>System.Diagnostics.Activity.Current?.AddEvent(new System.Diagnostics.ActivityEvent("..."));</c>
+/// using fully qualified type names so the frame is safe to use from any
+/// generated assembly without depending on namespace imports.
+/// </summary>
+public class AppendActivityEventFrame : Frame
+{
+    private readonly string _eventName;
+
+    /// <param name="eventName">
+    /// Name of the activity event. Forwarded as a string literal into the generated
+    /// <see cref="ActivityEvent"/> constructor argument. The caller is responsible
+    /// for escaping any embedded double quotes.
+    /// </param>
+    public AppendActivityEventFrame(string eventName) : base(false)
+    {
+        _eventName = eventName ?? throw new ArgumentNullException(nameof(eventName));
+    }
+
+    /// <summary>
+    /// The event name that will be embedded into the generated code.
+    /// </summary>
+    public string EventName => _eventName;
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.Write(
+            $"{typeof(Activity).FullNameInCode()}.{nameof(Activity.Current)}?.AddEvent(new {typeof(ActivityEvent).FullNameInCode()}(\"{_eventName}\"));");
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain) => [];
+}

--- a/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
+++ b/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using System.Diagnostics;
+using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
@@ -120,6 +121,25 @@ public class MethodCall : Frame
     ///     How should the ReturnVariable handled within the generated code? Initialize is the default.
     /// </summary>
     public ReturnAction ReturnAction { get; set; } = ReturnAction.Initialize;
+
+    /// <summary>
+    /// Optional name of an <see cref="ActivityEvent"/> to append to the
+    /// current <see cref="Activity"/> immediately BEFORE this method is invoked.
+    /// When set, <see cref="GenerateCode"/> emits the equivalent of
+    /// <c>Activity.Current?.AddEvent(new ActivityEvent("..."))</c> using fully
+    /// qualified type names. No-op when the value is null or empty.
+    /// </summary>
+    public string? ActivityEventBeforeCall { get; set; }
+
+    /// <summary>
+    /// Optional name of an <see cref="ActivityEvent"/> to append to the
+    /// current <see cref="Activity"/> immediately AFTER this method is invoked
+    /// (success path; events are not emitted from a catch). When set,
+    /// <see cref="GenerateCode"/> emits the equivalent of
+    /// <c>Activity.Current?.AddEvent(new ActivityEvent("..."))</c> using fully
+    /// qualified type names. No-op when the value is null or empty.
+    /// </summary>
+    public string? ActivityEventAfterCall { get; set; }
     
     private IEnumerable<Variable> buildTupleCreateVariables()
     {
@@ -328,6 +348,11 @@ public class MethodCall : Frame
             writer.WriteComment(CommentText);
         }
 
+        if (ActivityEventBeforeCall.IsNotEmpty())
+        {
+            writeActivityEvent(writer, ActivityEventBeforeCall);
+        }
+
         var invokeMethod = InvocationCode(method);
 
         if (shouldWriteInUsingBlock(method))
@@ -343,6 +368,11 @@ public class MethodCall : Frame
             writer.Write($"{returnActionCode(method)}{invokeMethod};");
         }
 
+        if (ActivityEventAfterCall.IsNotEmpty())
+        {
+            writeActivityEvent(writer, ActivityEventAfterCall);
+        }
+
         // This is just to make the generated code a little
         // easier to read
         if (CommentText.IsNotEmpty())
@@ -351,6 +381,12 @@ public class MethodCall : Frame
         }
 
         Next?.GenerateCode(method, writer);
+    }
+
+    private static void writeActivityEvent(ISourceWriter writer, string eventName)
+    {
+        writer.Write(
+            $"{typeof(Activity).FullNameInCode()}.{nameof(Activity.Current)}?.AddEvent(new {typeof(ActivityEvent).FullNameInCode()}(\"{eventName}\"));");
     }
 
     private string invocationCode()


### PR DESCRIPTION
## Summary
Adds a reusable codegen primitive for appending an `ActivityEvent` to `Activity.Current` from generated code, plus two new properties on `MethodCall` that emit the same line immediately before and/or after the wrapped invocation. Both emit fully-qualified type names (`System.Diagnostics.Activity.Current?.AddEvent(new System.Diagnostics.ActivityEvent("…"))`) so they're safe to use from any generated assembly without depending on namespace imports.

### New surface

**`JasperFx.CodeGeneration.Frames.AppendActivityEventFrame`** — standalone reusable Frame:

```csharp
chain.Frames.Add(new AppendActivityEventFrame("wolverine.handler.started"));
```

**`MethodCall.ActivityEventBeforeCall` / `ActivityEventAfterCall`** — properties on the existing `MethodCall` frame:

```csharp
var call = MethodCall.For<Handler>(h => h.Handle(null!));
call.ActivityEventBeforeCall = "wolverine.handler.started";
call.ActivityEventAfterCall  = "wolverine.handler.finished";
```

Generated code (in both cases):

```csharp
System.Diagnostics.Activity.Current?.AddEvent(new System.Diagnostics.ActivityEvent("wolverine.handler.started"));
target.Handle(message);
System.Diagnostics.Activity.Current?.AddEvent(new System.Diagnostics.ActivityEvent("wolverine.handler.finished"));
```

The properties default to `null` and are no-ops when unset — zero impact on existing code paths.

### Use cases (downstream — landing in Wolverine after this releases)

- Wrap user-handler `MethodCall`s with `wolverine.handler.started` / `.finished` to bracket the actual user body with structured tracing events while leaving middleware unmarked.
- Wrap `FlushOutgoingMessages` and other transactional-middleware `SaveChangesAsync` `MethodCall`s with provider-agnostic outbox events so dashboards can read commit-vs-dispatch ordering off the span timeline.
- Drop standalone `AppendActivityEventFrame` instances anywhere in a frame chain when no `MethodCall` is being wrapped.

## Test plan
- [x] New `AppendActivityEventFrameTests` — verifies the emitted line shape, null guarding, frame chaining, and that the frame declares no variables (5 tests).
- [x] New tests in `MethodCall_generate_code` — before-only, after-only, both, default-null no-op, and the async + return-value case to confirm the events bracket the actual await line rather than the variable assignment (5 tests).
- [x] Full `CodegenTests` suite is **321/321 green** on net8.0, net9.0, net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)