### PR TITLE
Descriptor types for CritterWatch HTTP graph (#84) and EF Core DbContext (#102)

### DIFF
--- a/src/JasperFx.Events/IHttpGraphUsageSource.cs
+++ b/src/JasperFx.Events/IHttpGraphUsageSource.cs
@@ -1,0 +1,37 @@
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events;
+
+/// <summary>
+/// Implemented by Wolverine.Http (and other HTTP integrations) to
+/// expose a diagnostic snapshot of the HTTP graph for monitoring tools
+/// (CritterWatch). Mirrors <see cref="IDocumentStoreUsageSource"/> on
+/// the HTTP side; lives in JasperFx.Events for the same reason — DI
+/// consumers (Wolverine's <c>ServiceCapabilities</c>) discover all
+/// shapes from one assembly.
+/// </summary>
+/// <remarks>
+/// Discovery interface only — the descriptor type
+/// (<see cref="HttpGraphUsage"/>) lives in JasperFx core because it
+/// carries no event-specific concepts.
+/// </remarks>
+public interface IHttpGraphUsageSource
+{
+    /// <summary>
+    /// Stable URI identifying this HTTP graph within the host process.
+    /// Common scheme is <c>wolverine-http://main</c>; multiple HTTP
+    /// graphs (rare today, but plausible long-term) carry their
+    /// registered name in the path.
+    /// </summary>
+    Uri Subject { get; }
+
+    /// <summary>
+    /// Build an <see cref="HttpGraphUsage"/> snapshot for this HTTP
+    /// graph. Receives the host service provider so the implementation
+    /// can resolve <c>IApiDescriptionGroupCollectionProvider</c> and
+    /// other ASP.NET Core diagnostic services. Returns
+    /// <see langword="null"/> when the graph can't produce a usage
+    /// description (e.g. transient initialization failure).
+    /// </summary>
+    Task<HttpGraphUsage?> TryCreateUsage(IServiceProvider services, CancellationToken token);
+}

--- a/src/JasperFx/Descriptors/AspNetEndpointDescriptor.cs
+++ b/src/JasperFx/Descriptors/AspNetEndpointDescriptor.cs
@@ -1,0 +1,60 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// Diagnostic mirror of a non-Wolverine ASP.NET Core endpoint —
+/// Minimal API, MVC controller action, Razor Page, SignalR hub method,
+/// or other route mapped via <c>EndpointDataSource</c>. Used to surface
+/// the full HTTP surface of a service in CritterWatch alongside the
+/// Wolverine.Http chains.
+/// </summary>
+/// <remarks>
+/// Wolverine.Http chains are NOT represented here — they get their
+/// own <see cref="HttpChainDescriptor"/> with richer detail. This
+/// descriptor covers everything else.
+/// </remarks>
+public class AspNetEndpointDescriptor : OptionsDescription
+{
+    /// <summary>
+    /// Stable id for the endpoint (hash of method+route+source) used in
+    /// the detail-page URL.
+    /// </summary>
+    public string EndpointId { get; set; } = "";
+
+    /// <summary>Raw route pattern — e.g. <c>"/health"</c>.</summary>
+    public string Route { get; set; } = "";
+
+    /// <summary>HTTP methods accepted by this endpoint.</summary>
+    public List<string> HttpMethods { get; set; } = new();
+
+    /// <summary>Display name from <c>EndpointNameMetadata</c>.</summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>
+    /// Discriminator describing the source of the endpoint. One of
+    /// <c>"MinimalApi"</c>, <c>"Mvc"</c>, <c>"RazorPages"</c>,
+    /// <c>"SignalR"</c>, <c>"StaticFile"</c>, <c>"Other"</c>.
+    /// </summary>
+    public string Source { get; set; } = "";
+
+    /// <summary>API description group name, when present.</summary>
+    public string? GroupName { get; set; }
+
+    /// <summary>OpenAPI tags applied to this endpoint.</summary>
+    public new List<string> Tags { get; set; } = new();
+
+    /// <summary>
+    /// Full OpenAPI shape, when discoverable through ApiExplorer or
+    /// <c>Microsoft.AspNetCore.OpenApi</c> document service. Null when
+    /// the endpoint is opaque to ApiExplorer (e.g. SignalR hubs).
+    /// </summary>
+    public OpenApiOperationDescriptor? OpenApi { get; set; }
+
+    /// <summary>True when the endpoint requires authorization.</summary>
+    public bool RequiresAuthorization { get; set; }
+
+    /// <summary>Authorization policy names applied via <c>[Authorize]</c>.</summary>
+    public List<string> AuthorizationPolicies { get; set; } = new();
+
+    /// <summary>Allowed roles applied via <c>[Authorize(Roles=...)]</c>.</summary>
+    public List<string> AllowedRoles { get; set; } = new();
+}

--- a/src/JasperFx/Descriptors/DbContextUsage.cs
+++ b/src/JasperFx/Descriptors/DbContextUsage.cs
@@ -123,4 +123,79 @@ public class DbContextUsage : OptionsDescription
     /// <c>"PendingMigrations"</c> when the bridge wants to surface them.
     /// </remarks>
     public int? PendingMigrationsCount { get; set; }
+
+    /// <summary>
+    /// <see langword="true"/> when this DbContext has been wired into
+    /// Wolverine's transactional outbox by way of
+    /// <c>MapWolverineEnvelopeStorage</c> on the model. When true, calls to
+    /// <c>SaveChangesAsync</c> publish queued outgoing messages atomically
+    /// with the domain write; when false the context is "just an
+    /// EF Core context" and any messaging happens on a separate connection.
+    /// Operators read this badge first when triaging missing-publish issues.
+    /// </summary>
+    public bool WolverineEnabled { get; set; }
+
+    /// <summary>
+    /// Wolverine transaction-middleware mode for this context — typically
+    /// <c>"Eager"</c> (an explicit transaction is opened up front) or
+    /// <c>"Lightweight"</c> (rely on <c>SaveChangesAsync</c> for atomicity).
+    /// <see langword="null"/> when the context isn't wired through
+    /// <c>UseEntityFrameworkCoreTransactions</c>; in that case Wolverine isn't
+    /// driving the transaction lifetime at all.
+    /// </summary>
+    public string? TransactionMode { get; set; }
+
+    /// <summary>
+    /// Tenancy strategy in operator vocabulary — one of <c>"Single"</c>
+    /// (single-database / single-tenant), <c>"ConnectionString"</c> (per-tenant
+    /// connection string sourced from Wolverine's tenant store), or
+    /// <c>"DbDataSource"</c> (per-tenant <c>DbDataSource</c>, used when
+    /// EF Core has to share a Marten-managed multi-tenant data source).
+    /// Drives which <see cref="DatabaseUsage.Cardinality"/> the bridge
+    /// reports.
+    /// </summary>
+    public string TenancyStyle { get; set; } = "Single";
+
+    /// <summary>
+    /// Whether and how this context publishes domain events to Wolverine —
+    /// <c>"None"</c> (no scraper registered),
+    /// <c>"OutgoingDomainEvents"</c> (the per-handler
+    /// <c>OutgoingDomainEvents</c> collection is the source), or
+    /// <c>"PerEntityType"</c> (one or more
+    /// <c>DomainEventScraper&lt;TEntity, TDomainEvent&gt;</c> are registered
+    /// for entity-level domain-event types). Operators investigating missed
+    /// publish events read this badge to confirm the integration shape.
+    /// </summary>
+    public string DomainEventsMode { get; set; } = "None";
+
+    /// <summary>
+    /// <see langword="true"/> when this context is wired through
+    /// <c>UseEntityFrameworkCoreWolverineManagedMigrations</c> — Wolverine's
+    /// resource-startup pipeline will create / migrate the database on its
+    /// own. <see langword="false"/> means schema management is the
+    /// application's responsibility (manual <c>dotnet ef database update</c>
+    /// or equivalent).
+    /// </summary>
+    public bool WolverineMigrations { get; set; }
+
+    /// <summary>
+    /// How Wolverine's outbox sits relative to this context's database
+    /// connection: <c>"Mapped"</c> (envelope storage shares the same
+    /// connection / transaction as the DbContext — the green-path setup),
+    /// <c>"ExternalConnection"</c> (Wolverine's outbox factory is registered
+    /// but the envelope tables live on a different connection), or
+    /// <c>"None"</c> (no outbox integration on this context). Operators
+    /// triaging outbox-related lag look here before expanding the per-entity
+    /// table.
+    /// </summary>
+    public string OutboxIntegration { get; set; } = "None";
+
+    /// <summary>
+    /// CLR identities of saga state types managed by this DbContext — any
+    /// <c>IEntityType</c> on the model whose CLR type derives from
+    /// Wolverine's <c>Saga</c> base class. Surfaced first-class so the
+    /// Storage tab can cross-link straight into the Sagas tab without
+    /// re-walking the entity collection.
+    /// </summary>
+    public List<TypeDescriptor> SagaTypes { get; set; } = new();
 }

--- a/src/JasperFx/Descriptors/EntityDescriptor.cs
+++ b/src/JasperFx/Descriptors/EntityDescriptor.cs
@@ -68,4 +68,108 @@ public class EntityDescriptor
     /// EF Core surfaces this through <c>IEntityType.GetViewName()</c>.
     /// </summary>
     public bool IsView { get; set; }
+
+    /// <summary>
+    /// <see langword="true"/> when the CLR entity type derives from
+    /// Wolverine's <c>Saga</c> base class. Surfaced per-entity so the
+    /// Storage tab can render saga rows with a chip linking out to the
+    /// dedicated Sagas tab without having to cross-reference
+    /// <see cref="DbContextUsage.SagaTypes"/>.
+    /// </summary>
+    public bool IsSaga { get; set; }
+
+    /// <summary>
+    /// <see langword="true"/> for EF Core "owned" entity types — types whose
+    /// table is logically a child of another entity's table and whose
+    /// lifetime is bound to the owner's. Operators staring at a long entity
+    /// list use this to fold owned types into their owner.
+    /// </summary>
+    public bool IsOwned { get; set; }
+
+    /// <summary>
+    /// All non-primary-key indexes EF Core has configured on this entity —
+    /// name, uniqueness, and the columns that make up the index. Matches
+    /// the per-document index list on <see cref="DocumentMappingDescriptor"/>
+    /// in operator weight: usually the first thing checked when investigating
+    /// a slow-query report.
+    /// </summary>
+    public List<IndexDescriptor> Indexes { get; set; } = new();
+
+    /// <summary>
+    /// All foreign-key relationships EF Core has configured on this entity.
+    /// Self-referencing FKs are filtered out by the bridge — they're noise
+    /// in the operator view and can be inferred from the entity name. The
+    /// bridge captures only the configuration shape (name + target table +
+    /// key columns); navigation properties don't ship through this snapshot.
+    /// </summary>
+    public List<ForeignKeyDescriptor> ForeignKeys { get; set; } = new();
+
+    /// <summary>
+    /// Resolved view name when <see cref="IsView"/> is <see langword="true"/>,
+    /// otherwise <see langword="null"/>. Sourced from
+    /// <c>IEntityType.GetViewName()</c>; lets operators distinguish the
+    /// underlying view from the entity name when those don't agree.
+    /// </summary>
+    public string? ViewName { get; set; }
+}
+
+/// <summary>
+/// Diagnostic mirror of a single EF Core index — name, uniqueness, and
+/// participating column names. Surfaced inside
+/// <see cref="EntityDescriptor.Indexes"/> so monitoring tools can render
+/// the per-entity index list without cracking open <c>IEntityType</c>.
+/// </summary>
+public class IndexDescriptor
+{
+    /// <summary>
+    /// Index name as configured on the model (or the EF Core convention-
+    /// generated name when the application didn't override it).
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// <see langword="true"/> when the index enforces a uniqueness constraint
+    /// — operators investigating duplicate-key write failures look here
+    /// first.
+    /// </summary>
+    public bool IsUnique { get; set; }
+
+    /// <summary>
+    /// Ordered list of column names participating in the index. Matches the
+    /// order EF Core configured them in — composite-index column order is
+    /// load-bearing for query planning, so the descriptor preserves it.
+    /// </summary>
+    public List<string> Columns { get; set; } = new();
+}
+
+/// <summary>
+/// Diagnostic mirror of a single EF Core foreign-key relationship — name,
+/// target table, and the columns on the source entity that carry the FK.
+/// Used inside <see cref="EntityDescriptor.ForeignKeys"/>.
+/// </summary>
+/// <remarks>
+/// Deliberately minimal: the bridge does NOT surface the navigation
+/// property names, on-delete behaviour, or the principal-key columns. The
+/// goal is to give operators a quick "this entity references that table"
+/// view, not to recreate <c>dotnet ef migrations script</c>.
+/// </remarks>
+public class ForeignKeyDescriptor
+{
+    /// <summary>
+    /// Foreign-key constraint name as configured on the model (or the
+    /// convention-generated name when the application didn't override it).
+    /// </summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>
+    /// Database table the foreign key points at — schema-qualified when
+    /// the target lives in a non-default schema, bare table name otherwise.
+    /// </summary>
+    public string TargetTable { get; set; } = "";
+
+    /// <summary>
+    /// Ordered column names on this entity's table that hold the foreign-key
+    /// values. Order matches the principal-key column order on the target.
+    /// </summary>
+    public List<string> KeyColumns { get; set; } = new();
 }

--- a/src/JasperFx/Descriptors/HttpChainDescriptor.cs
+++ b/src/JasperFx/Descriptors/HttpChainDescriptor.cs
@@ -1,0 +1,137 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// Diagnostic mirror of a single Wolverine.Http chain. One row per
+/// (method + route) — versioned variants collapse into a single
+/// descriptor with <see cref="ApiVersion"/> describing the range.
+/// </summary>
+/// <remarks>
+/// Source code is not snapshotted into this descriptor — it stays
+/// on-demand via the existing <c>RequestHandlerSourceCode</c> round-
+/// trip (the HttpChainDetail page lazy-fetches when the operator opens
+/// the Generated Code tab).
+/// </remarks>
+public class HttpChainDescriptor : OptionsDescription
+{
+    /// <summary>
+    /// Stable hash of (HTTP method + route + operation id) used in the
+    /// detail-page URL. Survives chain rebuild as long as the route
+    /// stays put.
+    /// </summary>
+    public string ChainId { get; set; } = "";
+
+    /// <summary>Raw route pattern — e.g. <c>"/orders/{id}"</c>.</summary>
+    public string Route { get; set; } = "";
+
+    /// <summary>
+    /// HTTP methods this chain answers — typically a single entry, but
+    /// e.g. <c>MapMethods</c> can wire multiple verbs.
+    /// </summary>
+    public List<string> HttpMethods { get; set; } = new();
+
+    /// <summary>Optional ASP.NET Core route name.</summary>
+    public string? RouteName { get; set; }
+
+    /// <summary>Endpoint order — affects route ranking.</summary>
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Display name (typically <c>Type.Method</c>). Falls back to the
+    /// generated file name when no explicit name is set.
+    /// </summary>
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>
+    /// Operation id — derived from <c>Type.Method</c> by default; set
+    /// explicitly via <c>WolverineHttpMethodAttribute.OperationId</c>.
+    /// </summary>
+    public string OperationId { get; set; } = "";
+
+    /// <summary>
+    /// True when the operation id was set explicitly (versus derived).
+    /// </summary>
+    public bool HasExplicitOperationId { get; set; }
+
+    /// <summary>Endpoint summary (OpenAPI <c>summary</c>).</summary>
+    public string? EndpointSummary { get; set; }
+
+    /// <summary>Endpoint description (OpenAPI <c>description</c>).</summary>
+    public string? EndpointDescription { get; set; }
+
+    /// <summary>Full name of the handler type.</summary>
+    public string EndpointTypeFullName { get; set; } = "";
+
+    /// <summary>Method name on the handler.</summary>
+    public string MethodName { get; set; } = "";
+
+    /// <summary>Compact method signature, e.g. <c>Get(Guid id)</c>.</summary>
+    public string MethodSignature { get; set; } = "";
+
+    /// <summary>Request-body type, when the chain consumes one.</summary>
+    public TypeDescriptor? RequestType { get; set; }
+
+    /// <summary>Resource (response) type, when not <c>void</c>.</summary>
+    public TypeDescriptor? ResourceType { get; set; }
+
+    /// <summary>True when the chain accepts <c>application/x-www-form-urlencoded</c> / <c>multipart/form-data</c>.</summary>
+    public bool IsFormData { get; set; }
+
+    /// <summary>True when the chain returns 204 No Content.</summary>
+    public bool NoContent { get; set; }
+
+    /// <summary>True when the chain requires the Wolverine outbox (i.e. depends on <c>IMessageBus</c> / <c>MessageContext</c>).</summary>
+    public bool RequiresOutbox { get; set; }
+
+    /// <summary>
+    /// Content-negotiation mode as a string — <c>"Loose"</c> /
+    /// <c>"Strict"</c>.
+    /// </summary>
+    public string? ConnegMode { get; set; }
+
+    /// <summary>
+    /// Service-provider source mode as a string — <c>"IsolatedAndScoped"</c>
+    /// / <c>"FromHttpContext"</c>.
+    /// </summary>
+    public string? ServiceProviderSource { get; set; }
+
+    /// <summary>
+    /// Required tenancy mode as a string — <c>"None"</c> / <c>"Required"</c>
+    /// / <c>"Optional"</c>. Null when not declared on the chain.
+    /// </summary>
+    public string? TenancyMode { get; set; }
+
+    /// <summary>
+    /// API version metadata — declared version, deprecation flag, range
+    /// when collapsed across version clones.
+    /// </summary>
+    public ApiVersionDescriptor? ApiVersion { get; set; }
+
+    /// <summary>OpenAPI tags applied to this chain.</summary>
+    public new List<string> Tags { get; set; } = new();
+
+    /// <summary>Middleware steps in apply order.</summary>
+    public List<MiddlewareStepDescriptor> Middleware { get; set; } = new();
+
+    /// <summary>Postprocessor steps in apply order.</summary>
+    public List<MiddlewareStepDescriptor> Postprocessors { get; set; } = new();
+
+    /// <summary>
+    /// Cascading message types this chain may publish — the
+    /// non-resource members of <c>MethodCall.Creates</c>. Frontend
+    /// renders these as clickable chips into the messaging detail page.
+    /// </summary>
+    public List<TypeDescriptor> CascadingMessageTypes { get; set; } = new();
+
+    /// <summary>Service dependencies the chain resolves at runtime.</summary>
+    public List<TypeDescriptor> ServiceDependencies { get; set; } = new();
+
+    /// <summary>Full OpenAPI shape of the operation, when discoverable.</summary>
+    public OpenApiOperationDescriptor? OpenApi { get; set; }
+
+    /// <summary>
+    /// True when the chain is marked transactional via
+    /// <c>[Transactional]</c> attribute or runtime policy, surfacing the
+    /// Q8-#102 transactional override.
+    /// </summary>
+    public bool IsTransactional { get; set; }
+}

--- a/src/JasperFx/Descriptors/HttpGraphUsage.cs
+++ b/src/JasperFx/Descriptors/HttpGraphUsage.cs
@@ -1,0 +1,106 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// Diagnostic snapshot of a Wolverine.HTTP graph for a single service —
+/// the parallel of <see cref="DocumentStoreUsage"/> on the HTTP side.
+/// Surfaces the operationally-interesting Wolverine.Http configuration
+/// (route prefix, antiforgery defaults, namespace prefixes, applied
+/// policies, middleware types, tenant detection strategies, API
+/// versioning enablement) plus the full per-chain inventory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire-format-neutral — no <c>Microsoft.OpenApi</c> types cross the
+/// SignalR boundary. OpenAPI shape is captured via the descriptor sub-
+/// records (<see cref="OpenApiOperationDescriptor"/>,
+/// <see cref="OpenApiSchemaDescriptor"/>) which are pure DTOs.
+/// </para>
+/// <para>
+/// Populated by <c>IHttpGraphUsageSource</c> implementations registered
+/// in DI (currently a single source inside <c>Wolverine.Http</c> that
+/// auto-registers when <c>MapWolverineEndpoints()</c> is called).
+/// </para>
+/// </remarks>
+public class HttpGraphUsage : OptionsDescription
+{
+    /// <summary>
+    /// Stable URI identifying this HTTP graph within the host process —
+    /// e.g. <c>wolverine-http://main</c>.
+    /// </summary>
+    public Uri SubjectUri { get; set; } = null!;
+
+    /// <summary>
+    /// Service name (mirrors <c>ServiceCapabilities</c>) so frontend
+    /// can correlate when it merges across services.
+    /// </summary>
+    public string ServiceName { get; set; } = "";
+
+    /// <summary>
+    /// Version of the Wolverine.Http assembly that produced this snapshot.
+    /// </summary>
+    public string? WolverineHttpVersion { get; set; }
+
+    /// <summary>
+    /// <c>WolverineHttpOptions.WarmUpRoutes</c> mode as a string —
+    /// <c>"Eager"</c> / <c>"Lazy"</c> / etc.
+    /// </summary>
+    public string? WarmUpRoutes { get; set; }
+
+    /// <summary>
+    /// <c>WolverineHttpOptions.ServiceProviderSource</c> as a string.
+    /// </summary>
+    public string? ServiceProviderSource { get; set; }
+
+    /// <summary>
+    /// True when antiforgery is auto-applied to form/file endpoints.
+    /// </summary>
+    public bool AutoAntiforgeryOnFormEndpoints { get; set; }
+
+    /// <summary>
+    /// Global route prefix applied to every chain — e.g. <c>"/api"</c>.
+    /// Null when no prefix policy is configured.
+    /// </summary>
+    public string? GlobalRoutePrefix { get; set; }
+
+    /// <summary>
+    /// Namespace-prefix policies — narrow per-namespace prefix overrides
+    /// applied through <c>RoutePrefixPolicy</c>.
+    /// </summary>
+    public List<NamespacePrefixDescriptor> NamespacePrefixes { get; set; } = new();
+
+    /// <summary>
+    /// Names of resource-writer policies in apply order — e.g.
+    /// <c>EmptyBody204Policy</c>, <c>StatusCodePolicy</c>,
+    /// <c>JsonResourceWriterPolicy</c>.
+    /// </summary>
+    public List<string> ResourceWriterPolicyNames { get; set; } = new();
+
+    /// <summary>
+    /// Names of <c>IChainPolicy</c> implementations in apply order.
+    /// </summary>
+    public List<string> PolicyNames { get; set; } = new();
+
+    /// <summary>
+    /// Type names of middleware that may apply across the graph (the
+    /// <c>WolverineHttpOptions.Middleware</c> registry).
+    /// </summary>
+    public List<string> MiddlewareTypes { get; set; } = new();
+
+    /// <summary>
+    /// Names of tenant-detection strategies registered on the graph.
+    /// </summary>
+    public List<string> TenantDetectionStrategies { get; set; } = new();
+
+    /// <summary>
+    /// True when <c>WolverineHttpOptions.ApiVersioning</c> is set.
+    /// </summary>
+    public bool ApiVersioningEnabled { get; set; }
+
+    /// <summary>
+    /// Per-chain descriptors — the heart of the snapshot. Versioned
+    /// chains are collapsed into a single descriptor with
+    /// <see cref="HttpChainDescriptor.ApiVersion"/> describing the
+    /// version range.
+    /// </summary>
+    public List<HttpChainDescriptor> Chains { get; set; } = new();
+}

--- a/src/JasperFx/Descriptors/MiddlewareStepDescriptor.cs
+++ b/src/JasperFx/Descriptors/MiddlewareStepDescriptor.cs
@@ -1,0 +1,64 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// One ordered step in a chain's middleware / postprocessor pipeline.
+/// </summary>
+public class MiddlewareStepDescriptor
+{
+    /// <summary>Type that owns the step (handler / middleware / policy).</summary>
+    public string TypeFullName { get; set; } = "";
+
+    /// <summary>Method name within the owning type.</summary>
+    public string MethodName { get; set; } = "";
+
+    /// <summary>
+    /// Step kind — <c>"Middleware"</c>, <c>"Postprocessor"</c>,
+    /// <c>"Validation"</c>, <c>"Audit"</c>, etc. Used for visual
+    /// grouping in the Pipeline tab.
+    /// </summary>
+    public string Kind { get; set; } = "";
+
+    /// <summary>
+    /// Compact display string for the row (e.g.
+    /// <c>"OrderHandler.Before(Order)"</c>).
+    /// </summary>
+    public string Description { get; set; } = "";
+}
+
+/// <summary>
+/// Narrow per-namespace prefix applied via Wolverine's
+/// <c>RoutePrefixPolicy</c>.
+/// </summary>
+public class NamespacePrefixDescriptor
+{
+    /// <summary>Namespace this prefix targets — e.g. <c>"Api.V2"</c>.</summary>
+    public string Namespace { get; set; } = "";
+
+    /// <summary>Route prefix to apply — e.g. <c>"/v2"</c>.</summary>
+    public string Prefix { get; set; } = "";
+}
+
+/// <summary>
+/// API-version metadata for a chain — declared version, deprecation,
+/// and (when collapsed across version clones) the version range.
+/// </summary>
+public class ApiVersionDescriptor
+{
+    /// <summary>String form of the declared version — e.g. <c>"2"</c>, <c>"2024-01-01"</c>.</summary>
+    public string? Version { get; set; }
+
+    /// <summary>True when the chain is marked version-neutral.</summary>
+    public bool IsNeutral { get; set; }
+
+    /// <summary>True when the chain (or this version of it) is deprecated.</summary>
+    public bool IsDeprecated { get; set; }
+
+    /// <summary>Sunset date when configured.</summary>
+    public DateTimeOffset? Sunset { get; set; }
+
+    /// <summary>
+    /// All versions covered by this chain when version clones have been
+    /// collapsed. Frontend renders one chip per entry.
+    /// </summary>
+    public List<string> Versions { get; set; } = new();
+}

--- a/src/JasperFx/Descriptors/OpenApiOperationDescriptor.cs
+++ b/src/JasperFx/Descriptors/OpenApiOperationDescriptor.cs
@@ -1,0 +1,128 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// Wire-format-neutral mirror of an OpenAPI operation — i.e. the
+/// shape of one HTTP endpoint as it would be described in a Swagger /
+/// OpenAPI document. No <c>Microsoft.OpenApi</c> types cross the
+/// SignalR boundary; this descriptor and its companion sub-records are
+/// pure DTOs.
+/// </summary>
+public class OpenApiOperationDescriptor
+{
+    /// <summary>Operation id — corresponds to OpenAPI <c>operationId</c>.</summary>
+    public string OperationId { get; set; } = "";
+
+    /// <summary>OpenAPI <c>summary</c>.</summary>
+    public string? Summary { get; set; }
+
+    /// <summary>OpenAPI <c>description</c>.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>True when the operation is marked <c>deprecated</c> in OpenAPI.</summary>
+    public bool Deprecated { get; set; }
+
+    /// <summary>OpenAPI <c>tags</c>.</summary>
+    public List<string> Tags { get; set; } = new();
+
+    /// <summary>Path / query / header / cookie parameters.</summary>
+    public List<OpenApiParameterDescriptor> Parameters { get; set; } = new();
+
+    /// <summary>Request body, when the operation accepts one.</summary>
+    public OpenApiRequestBodyDescriptor? RequestBody { get; set; }
+
+    /// <summary>
+    /// Responses keyed by status code as a string (<c>"200"</c>,
+    /// <c>"default"</c>, etc.) so the wire format mirrors OpenAPI.
+    /// </summary>
+    public Dictionary<string, OpenApiResponseDescriptor> Responses { get; set; } = new();
+
+    /// <summary>Security schemes that apply to this operation.</summary>
+    public List<OpenApiSecurityDescriptor> Security { get; set; } = new();
+}
+
+/// <summary>
+/// One parameter on an operation — corresponds to a single OpenAPI
+/// <c>parameter</c> entry.
+/// </summary>
+public class OpenApiParameterDescriptor
+{
+    /// <summary>Parameter name as it appears on the wire.</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>One of <c>"path"</c>, <c>"query"</c>, <c>"header"</c>, <c>"cookie"</c>.</summary>
+    public string In { get; set; } = "";
+
+    public string? Description { get; set; }
+    public bool Required { get; set; }
+    public bool Deprecated { get; set; }
+
+    /// <summary>Schema describing the parameter shape.</summary>
+    public OpenApiSchemaDescriptor? Schema { get; set; }
+
+    /// <summary>Example value, when supplied.</summary>
+    public object? Example { get; set; }
+}
+
+/// <summary>
+/// Request body — keyed by media type, each carrying its own schema.
+/// </summary>
+public class OpenApiRequestBodyDescriptor
+{
+    public string? Description { get; set; }
+    public bool Required { get; set; }
+
+    /// <summary>
+    /// Media-type → media-type-object mapping. Mirrors OpenAPI's
+    /// <c>content</c> keyed dictionary.
+    /// </summary>
+    public Dictionary<string, OpenApiMediaTypeDescriptor> Content { get; set; } = new();
+}
+
+/// <summary>
+/// Single response entry — one per status code on the parent
+/// <see cref="OpenApiOperationDescriptor.Responses"/>.
+/// </summary>
+public class OpenApiResponseDescriptor
+{
+    public string? Description { get; set; }
+
+    /// <summary>Media-type → media-type-object mapping.</summary>
+    public Dictionary<string, OpenApiMediaTypeDescriptor> Content { get; set; } = new();
+
+    /// <summary>Response headers keyed by header name.</summary>
+    public Dictionary<string, OpenApiSchemaDescriptor> Headers { get; set; } = new();
+}
+
+/// <summary>
+/// A single media-type entry — wraps a schema + an optional example.
+/// </summary>
+public class OpenApiMediaTypeDescriptor
+{
+    public OpenApiSchemaDescriptor? Schema { get; set; }
+    public object? Example { get; set; }
+}
+
+/// <summary>
+/// Security requirement — the OpenAPI security descriptor knits a
+/// scheme name to the scope set the operation needs.
+/// </summary>
+public class OpenApiSecurityDescriptor
+{
+    /// <summary>
+    /// Scheme name — corresponds to a key under the document's
+    /// <c>components.securitySchemes</c>.
+    /// </summary>
+    public string SchemeName { get; set; } = "";
+
+    /// <summary>
+    /// Type of the scheme — <c>"http"</c>, <c>"apiKey"</c>,
+    /// <c>"oauth2"</c>, <c>"openIdConnect"</c>.
+    /// </summary>
+    public string SchemeType { get; set; } = "";
+
+    /// <summary>OAuth2 flow when relevant — <c>"implicit"</c>, <c>"password"</c>, etc.</summary>
+    public string? Flow { get; set; }
+
+    /// <summary>Required scopes for this operation.</summary>
+    public List<string> Scopes { get; set; } = new();
+}

--- a/src/JasperFx/Descriptors/OpenApiSchemaDescriptor.cs
+++ b/src/JasperFx/Descriptors/OpenApiSchemaDescriptor.cs
@@ -1,0 +1,65 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// Recursive description of an OpenAPI schema. Walks the full shape
+/// up to a configurable depth (depth-3 inline + <c>$ref</c> chip beyond
+/// — Q12) so cyclic types (linked-list nodes, tree nodes, owning
+/// document with self-reference) don't blow the wire format.
+/// </summary>
+/// <remarks>
+/// Wire-format-neutral. No <c>Microsoft.OpenApi</c> types involved —
+/// the discovery side flattens an <c>OpenApiSchema</c> into this DTO.
+/// Frontend renders lazily-expandable trees keyed by <see cref="Ref"/>
+/// once depth is exceeded.
+/// </remarks>
+public class OpenApiSchemaDescriptor
+{
+    /// <summary>OpenAPI <c>type</c> (<c>"object"</c>, <c>"string"</c>, <c>"integer"</c>, etc.).</summary>
+    public string? Type { get; set; }
+
+    /// <summary>OpenAPI <c>format</c> (<c>"int32"</c>, <c>"date-time"</c>, <c>"uuid"</c>, etc.).</summary>
+    public string? Format { get; set; }
+
+    /// <summary>OpenAPI <c>title</c>.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>OpenAPI <c>description</c>.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Required property names (when <see cref="Type"/> is <c>object</c>).</summary>
+    public List<string> Required { get; set; } = new();
+
+    /// <summary>Property name → schema. Empty for non-object types.</summary>
+    public Dictionary<string, OpenApiSchemaDescriptor> Properties { get; set; } = new();
+
+    /// <summary>Item schema for <c>array</c> types.</summary>
+    public OpenApiSchemaDescriptor? Items { get; set; }
+
+    /// <summary>OpenAPI <c>oneOf</c>.</summary>
+    public List<OpenApiSchemaDescriptor> OneOf { get; set; } = new();
+
+    /// <summary>OpenAPI <c>anyOf</c>.</summary>
+    public List<OpenApiSchemaDescriptor> AnyOf { get; set; } = new();
+
+    /// <summary>OpenAPI <c>allOf</c>.</summary>
+    public List<OpenApiSchemaDescriptor> AllOf { get; set; } = new();
+
+    /// <summary>OpenAPI <c>enum</c> values.</summary>
+    public List<object> Enum { get; set; } = new();
+
+    /// <summary>
+    /// <c>$ref</c> placeholder — set when expansion is truncated by the
+    /// depth limiter. The frontend renders this as a chip the operator
+    /// can click to fetch the full sub-tree on demand.
+    /// </summary>
+    public string? Ref { get; set; }
+
+    /// <summary>OpenAPI <c>nullable</c>.</summary>
+    public bool Nullable { get; set; }
+
+    /// <summary>OpenAPI <c>example</c>.</summary>
+    public object? Example { get; set; }
+
+    /// <summary>OpenAPI <c>default</c>.</summary>
+    public object? Default { get; set; }
+}


### PR DESCRIPTION
## Summary
Adds two batches of descriptor types for CritterWatch's monitoring surface — both already in production use against the \`critterwatch\` branch and consumed by [JasperFx/CritterWatch#136](https://github.com/JasperFx/CritterWatch/pull/136) (DbContext) and [#137](https://github.com/JasperFx/CritterWatch/pull/137) (HTTP graph). This PR promotes them upstream so a coordinated NuGet release can ship them.

### \`767382f\` — DbContext + EntityDescriptor additions ([CritterWatch #102](https://github.com/JasperFx/CritterWatch/issues/102))

\`DbContextUsage\` gains seven first-class diagnostic fields:
- \`WolverineEnabled\`, \`TransactionMode\`, \`TenancyStyle\`, \`DomainEventsMode\`, \`WolverineMigrations\`, \`OutboxIntegration\`, \`SagaTypes\`

\`EntityDescriptor\` gains five fields:
- \`IsSaga\`, \`IsOwned\`, \`Indexes\` (full column lists), \`ForeignKeys\` (target table + key columns), \`ViewName\`

Plus new \`IndexDescriptor\` and \`ForeignKeyDescriptor\` types in the same namespace.

### \`22c30d7\` — HTTP descriptor types ([CritterWatch #84](https://github.com/JasperFx/CritterWatch/issues/84))

New types in \`JasperFx.Descriptors\`:
- \`HttpGraphUsage\` — service-level HTTP-graph snapshot (WolverineHttpOptions, policies, middleware, tenant-detection strategies, API versioning, route-warmup, per-chain list)
- \`HttpChainDescriptor\` — per-chain detail (route, methods, operation id, parameters, request/response types, middleware chain, cascading messages, ApiVersion / Sunset / Deprecation, OpenAPI block)
- \`AspNetEndpointDescriptor\` — for non-Wolverine ASP.NET Core endpoints (Minimal API, MVC, SignalR, etc.)
- \`OpenApiOperationDescriptor\` + sub-records (\`OpenApiSchemaDescriptor\`, \`OpenApiParameterDescriptor\`, \`OpenApiRequestBodyDescriptor\`, \`OpenApiResponseDescriptor\`, \`OpenApiSecurityDescriptor\`) — wire-format-neutral, no \`Microsoft.OpenApi\` types cross the SignalR boundary
- \`MiddlewareStepDescriptor\`, \`NamespacePrefixDescriptor\`, \`ApiVersionDescriptor\`

Plus \`IHttpGraphUsageSource\` discovery interface in \`JasperFx.Events\`.

## Test plan
- [x] \`jasperfx.sln\` builds 0 errors
- [x] All existing \`CoreTests\` pass — both commits are pure additions (no surface changes to existing types beyond appended properties on \`DbContextUsage\` / \`EntityDescriptor\` with safe defaults)
- [x] In active CritterWatch usage today (PR #136 + #137 against the \`critterwatch\` branch via submodule reference)

## Cross-stack context
This branch (\`critterwatch\`) is the integration branch CritterWatch consumes via git submodule + project reference per [CritterWatch PR #134](https://github.com/JasperFx/CritterWatch/pull/134). Merging this lets CritterWatch eventually swap the \`./jasperfx/\` submodule's project reference back to a NuGet PackageReference once the next JasperFx release ships.

A larger cross-stack feature plan ([CritterWatch master plan #148](https://github.com/JasperFx/CritterWatch/issues/148)) will pile additional descriptor work onto the same \`critterwatch\` branch after this lands.