### PR TITLE
Skip flaky RecentlyUsedCache LRU-order tests (#231)

### DIFF
--- a/src/CoreTests/RecentlyUsedCacheTests.cs
+++ b/src/CoreTests/RecentlyUsedCacheTests.cs
@@ -36,7 +36,11 @@ public class RecentlyUsedCacheTests
         theCache.Contains(id).ShouldBeTrue();
     }
 
-    [Fact]
+    [Fact(Skip = "Tracks jasperfx#231 — flaky on net9.0 CI (~10%) because the cache's "
+              + "eviction order depends on DateTimeOffset.UtcNow resolution; 110 stores in a "
+              + "tight loop produce many same-tick timestamps and the LRU order becomes "
+              + "ImHashMap-enumeration-dependent. Re-enable once #231 swaps the timestamp "
+              + "for an Interlocked.Increment counter (deterministic LRU).")]
     public void compact_moves_off_the_first_ones()
     {
         var items = new List<Item>();
@@ -58,7 +62,8 @@ public class RecentlyUsedCacheTests
         theCache.Count.ShouldBe(theCache.Limit);
     }
 
-    [Fact]
+    [Fact(Skip = "Tracks jasperfx#231 — same DateTimeOffset.UtcNow resolution issue as "
+              + "compact_moves_off_the_first_ones above. Re-enable once #231 lands.")]
     public void request_item_resets()
     {
         var items = new List<Item>();


### PR DESCRIPTION
Stops CI eating reruns on a known flake until [#231](https://github.com/JasperFx/jasperfx/issues/231) lands the deterministic-counter fix.

Two tests skipped:
- compact_moves_off_the_first_ones
- request_item_resets

Both depend on DateTimeOffset.UtcNow having distinct ticks for items stored in a tight loop — runtime can't guarantee that at sub-microsecond resolution, so the LRU eviction order becomes ImHashMap-enumeration-dependent and the assertions flake nondeterministically (~10% on net9.0 CI).

The other RecentlyUsedCacheTests (get_the_same_value_back, contains, concurrent_store_does_not_lose_entries) continue to exercise core correctness + the alpha.4 thread-safety fix. Skips come off when #231 lands.