### PR TITLE
Package metadata hygiene: PackageIcon + PackageReadmeFile (closes #221, #222)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,9 +4,10 @@
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>
-        <PackageIconUrl>https://raw.githubusercontent.com/JasperFx/jasperfx/refs/heads/main/logo.jpg</PackageIconUrl>
+        <PackageIcon>logo.jpg</PackageIcon>
         <PackageProjectUrl>http://github.com/jasperfx/jasperfx</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <ImplicitUsings>true</ImplicitUsings>
@@ -17,6 +18,20 @@
 
     <ItemGroup>
         <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.39" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <!-- Pack the shared repo-root logo into every IsPackable=true package
+         (NU5048 fix — replaces the deprecated PackageIconUrl from issue #221). -->
+    <ItemGroup Condition="'$(IsPackable)' != 'false'">
+        <None Include="$(MSBuildThisFileDirectory)logo.jpg" Pack="true" PackagePath="\" Visible="false" />
+    </ItemGroup>
+
+    <!-- Pack the per-project README.md when one exists. PackageReadmeFile is
+         set globally above (issue #222 fix); each packed project authors its
+         own README in its csproj directory. Non-packed projects (tests, demo
+         apps) don't need one. -->
+    <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/README.md')">
+        <None Include="README.md" Pack="true" PackagePath="\" Visible="false" />
     </ItemGroup>
 
 </Project>

--- a/src/JasperFx.Events.SourceGenerator/README.md
+++ b/src/JasperFx.Events.SourceGenerator/README.md
@@ -1,0 +1,22 @@
+# JasperFx.Events.SourceGenerator
+
+Roslyn source generator for fast aggregate projections in the [Critter Stack](https://jasperfx.net) event-store family. Produces zero-reflection projection metadata at compile time so Marten / Polecat projection registration doesn't pay the runtime cost of scanning aggregate types.
+
+Used by `JasperFx.Events`'s `SingleStreamProjection<TDoc, TId>` and `MultiStreamProjection<TDoc, TId>` registrations.
+
+## Install
+
+```xml
+<PackageReference Include="JasperFx.Events.SourceGenerator"
+                  PrivateAssets="all"
+                  OutputItemType="Analyzer"
+                  ReferenceOutputAssembly="false" />
+```
+
+Reference it as an analyzer/source-generator only — there's no runtime API. Generated code is invisible to consumers and shows up alongside your aggregate types under the `JasperFx.Events.Generated` namespace.
+
+## Documentation
+
+Full docs at [https://jasperfx.net](https://jasperfx.net).
+
+Repo: [github.com/JasperFx/jasperfx](https://github.com/JasperFx/jasperfx).

--- a/src/JasperFx.Events/README.md
+++ b/src/JasperFx.Events/README.md
@@ -1,0 +1,27 @@
+# JasperFx.Events
+
+Foundational event store abstractions and projection infrastructure for the [Critter Stack](https://jasperfx.net). Consumed by **Marten** (Postgres) and **Polecat** (SQL Server) so a projection or async-daemon scenario written against `JasperFx.Events` works across both products.
+
+Provides:
+
+- **Projections** — `ProjectionBase`, `IInlineProjection`, snapshot / single-stream / multi-stream variants, and the `SnapshotLifecycle` enum.
+- **Async daemon** — `AsyncShard`, `ISubscriptionExecution`, projection lifecycle and shard role semantics.
+- **Slicing & grouping** — `SliceGroup`, `EventSlice`, `IEventSlicer` for fan-out projection topologies.
+- **Event metadata** — `IEvent`, `IEventRegistry`, type registry primitives.
+- **Descriptors** — `EventStoreUsage` and friends, surfaced through `IEventStoreUsageSource` to monitoring tools (CritterWatch).
+
+## Quick start
+
+```csharp
+public class OrderProjection : SingleStreamProjection<Order, Guid>
+{
+    public Order Create(OrderPlaced e) => new(e.OrderId, e.Total);
+    public Order Apply(OrderShipped e, Order state) => state with { Shipped = true };
+}
+```
+
+## Documentation
+
+Full docs at [https://jasperfx.net](https://jasperfx.net).
+
+Repo: [github.com/JasperFx/jasperfx](https://github.com/JasperFx/jasperfx).

--- a/src/JasperFx.RuntimeCompiler/README.md
+++ b/src/JasperFx.RuntimeCompiler/README.md
@@ -1,0 +1,21 @@
+# JasperFx.RuntimeCompiler
+
+Roslyn-based runtime code-generation backend for the [Critter Stack](https://jasperfx.net). Compiles in-memory C# at runtime and loads the resulting assembly into the host process — used by Marten, Wolverine, and Polecat for dynamic code paths (LINQ compilation, message handlers, document storage).
+
+Installing this package is **opt-in**. Apps that pre-generate all code (`dotnet run -- codegen write`) and run in `TypeLoadMode.Static` can omit `JasperFx.RuntimeCompiler` entirely and ship without Roslyn in the production bundle — the foundation for `PublishAot=true` deployments.
+
+## Usage
+
+Register the runtime compiler service in DI to opt in:
+
+```csharp
+services.AddSingleton<IAssemblyGenerator, AssemblyGenerator>();
+```
+
+When `GenerationRules.TypeLoadMode` is `Dynamic` or `Auto`, codegen will route through `AssemblyGenerator` to compile in-memory.
+
+## Documentation
+
+Full docs at [https://jasperfx.net](https://jasperfx.net).
+
+Repo: [github.com/JasperFx/jasperfx](https://github.com/JasperFx/jasperfx).

--- a/src/JasperFx.SourceGeneration/README.md
+++ b/src/JasperFx.SourceGeneration/README.md
@@ -1,0 +1,22 @@
+# JasperFx.SourceGeneration
+
+Roslyn source generator for [JasperFx](https://jasperfx.net) CLI command discovery. Generates a compile-time command registry from `IJasperFxCommand<T>` implementations in the application assembly — eliminating runtime assembly scanning for `dotnet run -- <command>` lookups.
+
+Used by hosts that want fast cold-start CLI invocations (no reflection-based command discovery).
+
+## Install
+
+```xml
+<PackageReference Include="JasperFx.SourceGeneration"
+                  PrivateAssets="all"
+                  OutputItemType="Analyzer"
+                  ReferenceOutputAssembly="false" />
+```
+
+Reference it as an analyzer/source-generator only — there's no runtime API. The generated registry is consumed transparently by `JasperFx.CommandLine`.
+
+## Documentation
+
+Full docs at [https://jasperfx.net](https://jasperfx.net).
+
+Repo: [github.com/JasperFx/jasperfx](https://github.com/JasperFx/jasperfx).

--- a/src/JasperFx.SourceGenerator/README.md
+++ b/src/JasperFx.SourceGenerator/README.md
@@ -1,0 +1,20 @@
+# JasperFx.SourceGenerator
+
+Roslyn source generator for [JasperFx](https://jasperfx.net) `OptionsDescription` types. Generates `IDescribeMyself.ToDescription()` implementations at compile time, eliminating runtime reflection on options classes that surface in diagnostic snapshots (CritterWatch, etc.).
+
+## Install
+
+```xml
+<PackageReference Include="JasperFx.SourceGenerator"
+                  PrivateAssets="all"
+                  OutputItemType="Analyzer"
+                  ReferenceOutputAssembly="false" />
+```
+
+Reference it as an analyzer/source-generator only — there's no runtime API. Apply the `[GenerateDescription]` attribute to a class that implements `IDescribeMyself` and a `ToDescription()` method is generated.
+
+## Documentation
+
+Full docs at [https://jasperfx.net](https://jasperfx.net).
+
+Repo: [github.com/JasperFx/jasperfx](https://github.com/JasperFx/jasperfx).

--- a/src/JasperFx/README.md
+++ b/src/JasperFx/README.md
@@ -1,0 +1,35 @@
+# JasperFx
+
+Foundational helpers and command line support used by [JasperFx](https://jasperfx.net) and the [Critter Stack](https://jasperfx.net) projects (Marten, Wolverine, Polecat, Weasel).
+
+Provides:
+
+- **`JasperFx.CommandLine`** — a Spectre-Console-backed CLI framework (formerly the Oakton library), the host for `dotnet run -- <command>` style tooling.
+- **`JasperFx.CodeGeneration`** — Roslyn-backed runtime code generation, with pluggable `ITypeLoader` strategies (`Static` / `Dynamic` / `Auto`) for AOT-friendly deployments.
+- **`JasperFx.Core`** — reflection / type-scanning helpers, IoC primitives, the `GenericFactoryCache` hot-path delegate cache, and `RecentlyUsedCache` LRU.
+- **`JasperFx.MultiTenancy`** — shared tenant-id abstractions (`IHasTenantId`, `TenantId`, `TenantIdStyle`) consumed across the Critter Stack.
+- **`JasperFx.Descriptors`** — diagnostic descriptor types that products like CritterWatch use to render configuration / capability snapshots.
+
+## Quick start
+
+```csharp
+// CLI host
+return await new HostBuilder()
+    .ConfigureServices(services => services.AddJasperFxCommands())
+    .RunJasperFxCommandsAsync(args);
+```
+
+```csharp
+// Codegen
+var rules = new GenerationRules
+{
+    TypeLoadMode = TypeLoadMode.Static,
+    GeneratedNamespace = "MyApp.Generated"
+};
+```
+
+## Documentation
+
+Full docs at [https://jasperfx.net](https://jasperfx.net).
+
+Repo: [github.com/JasperFx/jasperfx](https://github.com/JasperFx/jasperfx).


### PR DESCRIPTION
Two NuGet hygiene issues closed together since they both touch `Directory.Build.props` pack-metadata.

## #221 — PackageIconUrl → PackageIcon

`PackageIconUrl` is deprecated (NU5048). Switched to packing the repo-root `logo.jpg` into every IsPackable=true package via `<PackageIcon>logo.jpg</PackageIcon>` + an MSBuild `<None>` include in Directory.Build.props. Image renders inline on the NuGet listing.

## #222 — PackageReadmeFile sweep

Every package push was emitting `warn : Readme missing`. Added a per-project `README.md` for each of the 6 packed projects (JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator, JasperFx.RuntimeCompiler, JasperFx.SourceGeneration, JasperFx.SourceGenerator). `<PackageReadmeFile>README.md</PackageReadmeFile>` declared globally; the conditional `<None>` include only fires when a project authored a README, so test/sample projects don't break.

## Test plan

- [x] `dotnet pack` on all 6 packed projects locally — no NU5048, no Readme warnings.
- [x] Inspected the produced nupkg: `logo.jpg` and `README.md` present at the package root, nuspec contains `<icon>logo.jpg</icon>` and `<readme>README.md</readme>`.
- [ ] CI green.