### PR TITLE
RecentlyUsedCache: deterministic LRU via Interlocked counter (#231)

### DIFF
--- a/src/CoreTests/RecentlyUsedCacheTests.cs
+++ b/src/CoreTests/RecentlyUsedCacheTests.cs
@@ -36,11 +36,7 @@ public class RecentlyUsedCacheTests
         theCache.Contains(id).ShouldBeTrue();
     }
 
-    [Fact(Skip = "Tracks jasperfx#231 — flaky on net9.0 CI (~10%) because the cache's "
-              + "eviction order depends on DateTimeOffset.UtcNow resolution; 110 stores in a "
-              + "tight loop produce many same-tick timestamps and the LRU order becomes "
-              + "ImHashMap-enumeration-dependent. Re-enable once #231 swaps the timestamp "
-              + "for an Interlocked.Increment counter (deterministic LRU).")]
+    [Fact]
     public void compact_moves_off_the_first_ones()
     {
         var items = new List<Item>();
@@ -62,8 +58,7 @@ public class RecentlyUsedCacheTests
         theCache.Count.ShouldBe(theCache.Limit);
     }
 
-    [Fact(Skip = "Tracks jasperfx#231 — same DateTimeOffset.UtcNow resolution issue as "
-              + "compact_moves_off_the_first_ones above. Re-enable once #231 lands.")]
+    [Fact]
     public void request_item_resets()
     {
         var items = new List<Item>();

--- a/src/JasperFx/Core/RecentlyUsedCache.cs
+++ b/src/JasperFx/Core/RecentlyUsedCache.cs
@@ -84,7 +84,16 @@ public class RecentlyUsedCache<TKey, TItem>: IAggregateCache<TKey, TItem> where 
     // race is closed.
     private readonly object _lock = new();
     private ImHashMap<TKey, TItem> _items = ImHashMap<TKey, TItem>.Empty;
-    private ImHashMap<TKey, DateTimeOffset> _times = ImHashMap<TKey, DateTimeOffset>.Empty;
+
+    // #231: per-entry LRU tick. Previously a DateTimeOffset.UtcNow
+    // timestamp — non-deterministic for items stored in a tight loop
+    // (sub-µs clock resolution → ties → ImHashMap-enumeration-order
+    // bleed into the eviction set). Replaced with a strictly-increasing
+    // counter so insertion order maps 1:1 to LRU position regardless
+    // of wall-clock resolution. Counter is `long` — 2^63 entries before
+    // wraparound, which never happens in any realistic cache lifetime.
+    private ImHashMap<TKey, long> _times = ImHashMap<TKey, long>.Empty;
+    private long _tick;
 
     public int Limit = 100;
 
@@ -106,7 +115,7 @@ public class RecentlyUsedCache<TKey, TItem>: IAggregateCache<TKey, TItem> where 
         {
             if (_items.TryFind(key, out item))
             {
-                _times = _times.AddOrUpdate(key, DateTimeOffset.UtcNow);
+                _times = _times.AddOrUpdate(key, ++_tick);
                 return true;
             }
         }
@@ -120,7 +129,7 @@ public class RecentlyUsedCache<TKey, TItem>: IAggregateCache<TKey, TItem> where 
         lock (_lock)
         {
             _items = _items.AddOrUpdate(key, item);
-            _times = _times.AddOrUpdate(key, DateTimeOffset.UtcNow);
+            _times = _times.AddOrUpdate(key, ++_tick);
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `ImHashMap<TKey, DateTimeOffset> _times` with `ImHashMap<TKey, long> _times` + a strictly-increasing `long _tick` counter. `Store` and `TryFind` bump the counter under the existing `_lock`, so insertion / touch order maps 1:1 to LRU position regardless of wall-clock resolution.
- Un-skip the two LRU-order tests (`compact_moves_off_the_first_ones`, `request_item_resets`) that PR #232 had to gate behind `Skip` because the `DateTimeOffset.UtcNow`-based timestamps tied at sub-µs resolution and bled `ImHashMap`-enumeration order into the eviction set.

Closes #231.

## Test plan
- [x] `./build.sh test-core` — full CoreTests suite green
- [x] 20 consecutive runs of `RecentlyUsedCacheTests` all pass deterministically (vs the ~5-10% flake rate on the previous timestamp-based implementation)
- [x] `concurrent_store_does_not_lose_entries` (the #226 thread-safety regression test) still passes — the new counter is bumped under the existing `_lock`, so no new race surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)