### PR TITLE
AssemblyGenerator: tolerate missing referenced assemblies (#188)

### DIFF
--- a/src/JasperFx.RuntimeCompiler/AssemblyGenerator.cs
+++ b/src/JasperFx.RuntimeCompiler/AssemblyGenerator.cs
@@ -74,7 +74,35 @@ namespace JasperFx.RuntimeCompiler
 
 				foreach (var assemblyName in assembly.GetReferencedAssemblies())
 				{
-					var referencedAssembly = Assembly.Load(assemblyName);
+					// #188: GetReferencedAssemblies() reports every assembly listed
+					// in the manifest, including platform-conditional satellites that
+					// the consuming app may not have installed. Oracle.ManagedDataAccess
+					// is the motivating example — it references .Azure / .Aws / .Gcp /
+					// .Oci / .Kerberos / .ConfigFile, of which a given deployment
+					// typically pulls in zero or one. Letting that throw aborts the
+					// outer foreach and leaves the parent assembly's other (real)
+					// dependencies unreferenced, which then surfaces as cascading
+					// runtime-compile failures further downstream. Skip the missing
+					// satellite and continue — Roslyn will surface a real compile
+					// error if the codegen output actually depends on the missing type.
+					Assembly? referencedAssembly;
+					try
+					{
+						referencedAssembly = Assembly.Load(assemblyName);
+					}
+					catch (FileNotFoundException)
+					{
+						continue;
+					}
+					catch (FileLoadException)
+					{
+						continue;
+					}
+					catch (BadImageFormatException)
+					{
+						continue;
+					}
+
 					ReferenceAssembly(referencedAssembly);
 				}
 			}


### PR DESCRIPTION
## Summary
- Wrap the inner `Assembly.Load(assemblyName)` call inside `ReferenceAssembly()`'s recursion in its own `try` so a single missing satellite no longer aborts the outer assembly's reference setup. Catch the three plausible load failures (`FileNotFoundException`, `FileLoadException`, `BadImageFormatException`) and `continue` to the next referenced name.
- Oracle.ManagedDataAccess.Core was the motivating real-world case (manifest lists six platform satellites — Aws / Azure / ConfigFile / Gcp / Kerberos / Oci — of which a given deployment typically pulls in zero or one).

Closes #188.

## Why the previous code misbehaved
The outer `try/catch` wrapped the whole `foreach (var assemblyName in assembly.GetReferencedAssemblies())` loop, so the first missing satellite would:
1. Surface as a misleading log line pointing at the **parent** assembly (\"Could not make an assembly reference to Oracle.ManagedDataAccess...\")
2. Abort the rest of the loop, leaving the parent's other (installed) dependencies unreferenced — which then surfaced downstream as cryptic runtime-compile failures on Wolverine handler code.

## Test plan
- [x] `dotnet test src/CodegenTests/CodegenTests.csproj` — 333/333 pass on net9.0
- [x] Build clean (only the pre-existing nullability warnings in the broader codebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)