### PR TITLE
OptionsDescription: Children + Sets as properties so JSON serializes them (#203)

### DIFF
--- a/src/CoreTests/Descriptors/OptionsDescriptionTests.cs
+++ b/src/CoreTests/Descriptors/OptionsDescriptionTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using JasperFx.Descriptors;
 using Shouldly;
 
@@ -14,7 +15,7 @@ public class OptionsDescriptionTests
         description.Sets["Children"] = children;
         children.SummaryColumns = ["a", "b"];
         children.Rows.Add(new OptionsDescription());
-        
+
         description.ShouldBeSerializable();
     }
 
@@ -24,6 +25,39 @@ public class OptionsDescriptionTests
         var description = new OptionsDescription(new SomeObject());
         description.Tags.ShouldContain("blue");
         description.Tags.ShouldContain("green");
+    }
+
+    [Fact]
+    public void children_and_sets_round_trip_through_default_json_options()
+    {
+        // Regression for #203 — `Children` and `Sets` were public fields, not
+        // properties. System.Text.Json with its default options walks properties
+        // only, so every [ChildDescription] and every AddChildSet(...) call was
+        // being silently dropped at the JSON boundary (e.g. Marten's
+        // EventGraph.MetadataConfig was invisible in CritterWatch).
+        var description = new OptionsDescription { Subject = "Parent" };
+
+        var child = new OptionsDescription { Subject = "Child" };
+        child.AddValue("Foo", 42);
+        description.Children["Inner"] = child;
+
+        var set = description.AddChildSet("Members");
+        set.Rows.Add(new OptionsDescription { Subject = "Row1" });
+        set.Rows.Add(new OptionsDescription { Subject = "Row2" });
+
+        // Default options — no IncludeFields = true override. This is what
+        // both Wolverine.SignalR (JsonSerializerOptions.Web) and TS-side
+        // codegen in CritterWatch effectively use.
+        var json = JsonSerializer.Serialize(description);
+        var round = JsonSerializer.Deserialize<OptionsDescription>(json);
+
+        round.ShouldNotBeNull();
+        round.Children.ShouldContainKey("Inner");
+        round.Children["Inner"].Subject.ShouldBe("Child");
+        round.Sets.ShouldContainKey("Members");
+        round.Sets["Members"].Rows.Count.ShouldBe(2);
+        round.Sets["Members"].Rows[0].Subject.ShouldBe("Row1");
+        round.Sets["Members"].Rows[1].Subject.ShouldBe("Row2");
     }
 }
 

--- a/src/JasperFx/Descriptors/OptionsDescription.cs
+++ b/src/JasperFx/Descriptors/OptionsDescription.cs
@@ -54,12 +54,19 @@ public class OptionsDescription
     public string Subject { get; set; } = null!;
     public List<OptionsValue> Properties { get; set; } = new();
 
-    public Dictionary<string, OptionsDescription> Children = new();
+    // #203: these were previously public *fields*, not properties. System.Text.Json
+    // (and the downstream TS generators) only walk properties by default — the result
+    // was that every [ChildDescription] and every AddChildSet(...) call was being
+    // silently dropped at the JSON boundary, e.g. Marten's EventGraph.MetadataConfig
+    // was invisible in CritterWatch even though the rendering pipeline was wired for
+    // it. Auto-property initializers carry over the prior field-init semantics, so
+    // call sites that mutate Children / Sets in place keep working unchanged.
+    public Dictionary<string, OptionsDescription> Children { get; set; } = new();
 
     /// <summary>
     /// Children "sets" of option descriptions
     /// </summary>
-    public Dictionary<string, OptionSet> Sets = new();
+    public Dictionary<string, OptionSet> Sets { get; set; } = new();
     
     // For serialization
 #pragma warning disable CS8618 


### PR DESCRIPTION
## Summary
- Convert \`OptionsDescription.Children\` and \`OptionsDescription.Sets\` from public **fields** to public **auto-properties**. The field initializers carry over verbatim, and no internal call site reassigns either member, so this is fully source-compatible.
- Add a regression test that round-trips a populated description through \`JsonSerializer\` with default options and asserts both \`Children\` and \`Sets\` entries survive.

Closes #203.

## Why this matters
\`System.Text.Json\`'s default options walk **properties only** — fields are skipped unless the caller sets \`IncludeFields = true\`. Wolverine.SignalR uses \`JsonSerializerOptions.Web\` with no override, and the TS-side \`OptionsDescription\` codegen in CritterWatch only sees properties either. Net effect: every \`[ChildDescription]\` property (e.g. Marten's \`EventGraph.MetadataConfig\`) and every \`AddChildSet(...)\` call was being silently dropped at the JSON boundary, even though CritterWatch's \`OptionsDescriptionView.vue\` already had Vue branches that would render them.

## Test plan
- [x] \`dotnet test src/CoreTests/CoreTests.csproj --filter "FullyQualifiedName~OptionsDescription"\` — 3/3 pass on net9.0 (existing 2 + new regression test)
- [x] grep -n internal callers of \`.Children = \` and \`.Sets = \` — none reassign

🤖 Generated with [Claude Code](https://claude.com/claude-code)