### PR TITLE
IJasperFxAggregateGrouper.Group: take IReadOnlyList<IEvent> (#201)

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
@@ -213,7 +213,7 @@ public abstract class JasperFxMultiStreamProjectionBase<TDoc, TId, TOperations, 
     /// </summary>
     /// <param name="func"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    public void CustomGrouping(Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> func)
+    public void CustomGrouping(Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> func)
     {
         if (_customSlicer != null)
         {

--- a/src/JasperFx.Events/Grouping/IEventSlicer.cs
+++ b/src/JasperFx.Events/Grouping/IEventSlicer.cs
@@ -69,25 +69,35 @@ public interface IEventSlicer<TDoc, TId, TQuerySession> where TId : notnull
 public interface IJasperFxAggregateGrouper<out TId, in TQuerySession>
 {
     /// <summary>
-    ///     Apply custom grouping rules to apply events to one or many aggregates
+    ///     Apply custom grouping rules to apply events to one or many aggregates.
+    ///     <para>
+    ///     #201: the parameter is <see cref="IReadOnlyList{T}"/> rather than
+    ///     <see cref="IEnumerable{T}"/> — implementations frequently need two or
+    ///     more passes over the same events (e.g. partition by type, then resolve
+    ///     related document IDs from the database), and <see cref="IEnumerable{T}"/>
+    ///     gave no guarantee re-iteration was safe or cheap, forcing every
+    ///     implementor to either eat the multi-enum warning or do a defensive
+    ///     <c>.ToList()</c>. The materialised <see cref="IReadOnlyList{T}"/>
+    ///     contract makes Count + indexed access first-class.
+    ///     </para>
     /// </summary>
     /// <param name="session"></param>
     /// <param name="events"></param>
     /// <param name="grouping"></param>
     /// <returns></returns>
-    Task Group(TQuerySession session, IEnumerable<IEvent> events, IEventGrouping<TId> grouping);
+    Task Group(TQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<TId> grouping);
 }
 
 internal class LambdaAggregateGrouper<TId, TQuerySession> : IJasperFxAggregateGrouper<TId, TQuerySession>
 {
-    private readonly Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> _func;
+    private readonly Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> _func;
 
-    public LambdaAggregateGrouper(Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> func)
+    public LambdaAggregateGrouper(Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> func)
     {
         _func = func;
     }
 
-    public Task Group(TQuerySession session, IEnumerable<IEvent> events, IEventGrouping<TId> grouping)
+    public Task Group(TQuerySession session, IReadOnlyList<IEvent> events, IEventGrouping<TId> grouping)
     {
         return _func(session, events, grouping);
     }
@@ -162,8 +172,8 @@ public class EventSlicer<TDoc, TId, TQuerySession>: IEventSlicer<TDoc, TId, TQue
     /// <summary>
     ///     Apply a custom event grouping strategy for events. This is additive to Identity() or Identities()
     /// </summary>
-    /// <param name="grouper"></param>
-    public EventSlicer<TDoc, TId, TQuerySession> CustomGrouping(Func<TQuerySession, IEnumerable<IEvent>, IEventGrouping<TId>, Task> func)
+    /// <param name="func"></param>
+    public EventSlicer<TDoc, TId, TQuerySession> CustomGrouping(Func<TQuerySession, IReadOnlyList<IEvent>, IEventGrouping<TId>, Task> func)
     {
         _lookupGroupers.Add(new LambdaAggregateGrouper<TId, TQuerySession>(func));
 


### PR DESCRIPTION
## Summary
- Promote the \`events\` parameter on \`IJasperFxAggregateGrouper<TId, TQuerySession>.Group\` from \`IEnumerable<IEvent>\` to \`IReadOnlyList<IEvent>\`.
- Mirror the change through the internal \`LambdaAggregateGrouper\`, the \`EventSlicer.CustomGrouping(Func<...>)\` overload, and the same overload on \`JasperFxMultiStreamProjectionBase\`.

Closes #201.

## Why
Implementations of \`IJasperFxAggregateGrouper\` frequently need two or more passes over the same event batch — partition by type first, then resolve related document IDs from the database. \`IEnumerable<IEvent>\` gave no guarantee re-iteration was safe or cheap, so static analysers (Rider, ReSharper, Roslyn) flagged it as possible-multiple-enumeration. \`IReadOnlyList<IEvent>\` makes \`Count\` + indexed access first-class.

The call site (\`EventSlicer.SliceAsync\`) already received the events as \`IReadOnlyList<IEvent>\` — the materialised list always existed; the interface was just hiding it.

## Breaking change
Yes — \`IJasperFxAggregateGrouper\` implementors need to update one parameter type in their \`Group\` method (no logic change). JasperFx 2.0 is a major bump, so a straight break is acceptable per the issue's \"Breaking change?\" discussion.

## Test plan
- [x] \`dotnet build src/JasperFx.Events/JasperFx.Events.csproj\` — clean (only pre-existing warnings)
- [x] \`dotnet test src/EventTests/EventTests.csproj --framework net9.0\` — 255/255 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)