### PR TITLE
ScopedContainerCreation: gate await-using on AsyncMode.AsyncTask (#228)

### DIFF
--- a/src/CodegenTests/Services/ScopedContainerCreationTests.cs
+++ b/src/CodegenTests/Services/ScopedContainerCreationTests.cs
@@ -1,0 +1,48 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using Shouldly;
+
+namespace CodegenTests.Services;
+
+public class ScopedContainerCreationTests
+{
+    private static string Emit(AsyncMode mode)
+    {
+        var method = new GeneratedMethod("Foo", typeof(string))
+        {
+            AsyncMode = mode
+        };
+
+        var writer = new SourceWriter();
+        new ScopedContainerCreation().GenerateCode(method, writer);
+        return writer.Code();
+    }
+
+    [Fact]
+    public void emits_async_using_only_for_async_task_methods()
+    {
+        // AsyncTask is the only AsyncMode that produces an `async ReturnType`
+        // method declaration (see GeneratedMethod.determineReturnExpression),
+        // so it's the only mode where `await using` is valid in the body.
+        Emit(AsyncMode.AsyncTask)
+            .ShouldContain("await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();");
+    }
+
+    [Theory]
+    [InlineData(AsyncMode.None)]
+    [InlineData(AsyncMode.ReturnFromLastNode)]
+    [InlineData(AsyncMode.ReturnCompletedTask)]
+    public void emits_sync_using_for_non_async_task_methods(AsyncMode mode)
+    {
+        // Regression for #228 — previously the check was `AsyncMode != None`,
+        // which incorrectly emitted `await using` in `ReturnFromLastNode` and
+        // `ReturnCompletedTask` methods. Those methods return a Task but their
+        // *declaration* has no `async` keyword, so `await using` in their
+        // body is CS4032 / CS1996.
+        var code = Emit(mode);
+        code.ShouldContain("using var serviceScope = _serviceScopeFactory.CreateScope();");
+        code.ShouldNotContain("await using");
+        code.ShouldNotContain("CreateAsyncScope");
+    }
+}

--- a/src/JasperFx/CodeGeneration/Services/ScopedContainerCreation.cs
+++ b/src/JasperFx/CodeGeneration/Services/ScopedContainerCreation.cs
@@ -24,7 +24,15 @@ internal class ScopedContainerCreation : SyncFrame
 
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
-        if (method.AsyncMode != AsyncMode.None)
+        // #228: gate the `await using` emission on AsyncMode == AsyncTask
+        // (not `!= None`). `ReturnFromLastNode` and `ReturnCompletedTask`
+        // both have non-async method *declarations* (no `async` keyword)
+        // that just return a Task — emitting `await using` in those bodies
+        // is a CS4032/CS1996 compile error. AsyncTask is the only mode that
+        // also produces the `async ReturnType` declaration (see
+        // GeneratedMethod.determineReturnExpression), so it's the only mode
+        // where `await using` is valid.
+        if (method.AsyncMode == AsyncMode.AsyncTask)
         {
             writer.Write(
                 $"await using var {Scope.Usage} = {Factory.Usage}.{nameof(ServiceProviderServiceExtensions.CreateAsyncScope)}();");


### PR DESCRIPTION
## Summary
- Tighten the async-emission branch in \`ScopedContainerCreation.GenerateCode\` from \`method.AsyncMode != AsyncMode.None\` to \`method.AsyncMode == AsyncMode.AsyncTask\`. \`AsyncTask\` is the only mode that produces an \`async ReturnType\` *declaration* (via \`GeneratedMethod.determineReturnExpression\`), so it's the only mode where \`await using\` in the body is valid.
- Add unit tests (\`ScopedContainerCreationTests\`) covering all four AsyncMode values.

Closes #228.

## Why not the issue's Approach 1 (mark the frame AsyncFrame)?
I tried it. Three pre-existing \`BruteForceTests\` failed with CS1983 because:
- \`BruteForceTests\` builds a \`ServiceAssertion.Build()\` method whose \`ReturnType\` is the service interface itself (e.g. \`IUsesScopedLambda\`).
- Marking \`ScopedContainerCreation\` as AsyncFrame promotes the method's AsyncMode to AsyncTask.
- That emits \`async IUsesScopedLambda Build()\` — CS1983 (\"return type of async method must be Task-like\").

Promoting AsyncMode without also promoting ReturnType is a downstream-consumer responsibility (e.g. Wolverine HTTP's HttpChain would need to wrap \`IResult\` → \`Task<IResult>\`). The frame can't do that on its own. The defensive condition-tightening in this PR is correct in both directions:
- If downstream promotes ReturnType + AsyncMode correctly → we emit \`await using\` (async-disposable scope).
- If downstream doesn't promote → we emit sync \`using\` (still valid, just gives up the IAsyncDisposable cleanup path on scope teardown).

The downstream Wolverine.Http promotion fix (\`HttpChain.AssembleTypes\` mirroring \`HandlerChain.AssembleTypes\`) is still wanted separately, but is no longer blocking — the JasperFx side is now safe regardless.

## Test plan
- [x] New \`ScopedContainerCreationTests\` — 4/4 pass (AsyncTask, None, ReturnFromLastNode, ReturnCompletedTask)
- [x] Full \`dotnet test src/CodegenTests\` — 337/337 pass on net9.0 (including the \`BruteForceTests\` that the AsyncFrame approach would have broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)