### PR TITLE
Codegen CLI: enforce ServiceLocationPolicy per file (#227)

### DIFF
--- a/src/CodegenTests/DynamicCodeBuilderTests.cs
+++ b/src/CodegenTests/DynamicCodeBuilderTests.cs
@@ -1,0 +1,165 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace CodegenTests;
+
+public class DynamicCodeBuilderTests
+{
+    // #227: the three CLI codegen entry points (preview / write / test) used to
+    // bypass the AssertServiceLocationsAreAllowed hook that downstream consumers
+    // (Wolverine, Marten) rely on to enforce ServiceLocationPolicy.NotAllowed at
+    // generation time. The runtime compile path (DynamicTypeLoader.Initialize)
+    // already called the hook; only the CLI paths were silently dropping it.
+    // These tests assert each entry point now invokes the hook once per ICodeFile
+    // that produced at least one ServiceLocationReport.
+
+    [Fact]
+    public void generate_all_code_invokes_assertion_per_file()
+    {
+        var recorder = new RecordingFile("Alpha");
+        var source = new FakeServiceVariableSource(reportName: "needs-lookup");
+        var builder = BuildWithCollection(recorder, source);
+
+        builder.GenerateAllCode();
+
+        recorder.AssertionCalls.ShouldBe(1);
+        recorder.LastReports.ShouldNotBeNull();
+        recorder.LastReports!.Length.ShouldBe(1);
+    }
+
+    [Fact]
+    public void generate_code_for_namespace_invokes_assertion_per_file()
+    {
+        var recorder = new RecordingFile("Beta");
+        var source = new FakeServiceVariableSource(reportName: "needs-lookup");
+        var builder = BuildWithCollection(recorder, source);
+
+        builder.GenerateCodeFor("RecordedNamespace");
+
+        recorder.AssertionCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void try_build_and_compile_all_invokes_assertion_per_file()
+    {
+        var recorder = new RecordingFile("Gamma");
+        var source = new FakeServiceVariableSource(reportName: "needs-lookup");
+        var builder = BuildWithCollection(recorder, source);
+
+        builder.TryBuildAndCompileAll((_, _) => { });
+
+        recorder.AssertionCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public void no_assertion_when_no_service_locations_reported()
+    {
+        var recorder = new RecordingFile("Delta");
+        var source = new FakeServiceVariableSource(reportName: null);
+        var builder = BuildWithCollection(recorder, source);
+
+        builder.GenerateAllCode();
+        builder.TryBuildAndCompileAll((_, _) => { });
+
+        recorder.AssertionCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public void no_assertion_when_collection_does_not_use_services()
+    {
+        var recorder = new RecordingFile("Epsilon");
+        var source = new FakeServiceVariableSource(reportName: "needs-lookup");
+        var builder = new DynamicCodeBuilder(
+            new ServiceCollection().BuildServiceProvider(),
+            new ICodeFileCollection[] { new ServicelessCollection(recorder) })
+        {
+            ServiceVariableSource = source
+        };
+
+        builder.GenerateAllCode();
+
+        recorder.AssertionCalls.ShouldBe(0);
+    }
+
+    private static DynamicCodeBuilder BuildWithCollection(RecordingFile file, IServiceVariableSource source)
+    {
+        return new DynamicCodeBuilder(
+            new ServiceCollection().BuildServiceProvider(),
+            new ICodeFileCollection[] { new RecordingCollection(file) })
+        {
+            ServiceVariableSource = source
+        };
+    }
+
+    private sealed class RecordingFile : ICodeFile
+    {
+        public RecordingFile(string fileName) { FileName = fileName; }
+
+        public string FileName { get; }
+        public int AssertionCalls { get; private set; }
+        public ServiceLocationReport[]? LastReports { get; private set; }
+
+        public void AssembleTypes(GeneratedAssembly assembly)
+        {
+            assembly.AddType(FileName + "Type", typeof(object));
+        }
+
+        public Task<bool> AttachTypes(GenerationRules rules, System.Reflection.Assembly assembly,
+            IServiceProvider? services, string containingNamespace) => Task.FromResult(false);
+
+        public bool AttachTypesSynchronously(GenerationRules rules, System.Reflection.Assembly assembly,
+            IServiceProvider? services, string containingNamespace) => false;
+
+        public void AssertServiceLocationsAreAllowed(ServiceLocationReport[] reports, IServiceProvider? services)
+        {
+            AssertionCalls++;
+            LastReports = reports;
+        }
+    }
+
+    private sealed class RecordingCollection : ICodeFileCollectionWithServices
+    {
+        private readonly ICodeFile _file;
+        public RecordingCollection(ICodeFile file) { _file = file; }
+        public string ChildNamespace => "RecordedNamespace";
+        public GenerationRules Rules { get; } = new("RecordedNamespace");
+        public IReadOnlyList<ICodeFile> BuildFiles() => new[] { _file };
+    }
+
+    private sealed class ServicelessCollection : ICodeFileCollection
+    {
+        private readonly ICodeFile _file;
+        public ServicelessCollection(ICodeFile file) { _file = file; }
+        public string ChildNamespace => "Serviceless";
+        public GenerationRules Rules { get; } = new("Serviceless");
+        public IReadOnlyList<ICodeFile> BuildFiles() => new[] { _file };
+    }
+
+    private sealed class FakeServiceVariableSource : IServiceVariableSource
+    {
+        private readonly string? _reportName;
+
+        public FakeServiceVariableSource(string? reportName) { _reportName = reportName; }
+
+        public bool Matches(Type type) => false;
+        public JasperFx.CodeGeneration.Model.Variable Create(Type type) => throw new NotSupportedException();
+        public bool TryFindKeyedService(Type type, string key, out JasperFx.CodeGeneration.Model.Variable? variable)
+        { variable = null; return false; }
+        public void ReplaceVariables(IMethodVariables method) { }
+        public void StartNewType() { }
+        public void StartNewMethod() { }
+
+        public ServiceLocationReport[] ServiceLocations()
+        {
+            if (_reportName == null) return Array.Empty<ServiceLocationReport>();
+            return new[]
+            {
+                new ServiceLocationReport(
+                    new ServiceDescriptor(typeof(object), typeof(object), ServiceLifetime.Scoped),
+                    _reportName)
+            };
+        }
+    }
+}

--- a/src/JasperFx/CodeGeneration/DynamicCodeBuilder.cs
+++ b/src/JasperFx/CodeGeneration/DynamicCodeBuilder.cs
@@ -114,13 +114,25 @@ public class DynamicCodeBuilder
 
                 var exportDirectory = collection.ToExportDirectory(directory);
 
+                var withServices = collection is ICodeFileCollectionWithServices;
+                var services = withServices ? ServiceVariableSource : null;
 
                 foreach (var file in collection.BuildFiles())
                 {
                     var generatedAssembly = collection.StartAssembly(collection.Rules);
                     file.AssembleTypes(generatedAssembly);
 
-                    var code = collection is ICodeFileCollectionWithServices ? generatedAssembly.GenerateCode(ServiceVariableSource) : generatedAssembly.GenerateCode(null);
+                    var code = generatedAssembly.GenerateCode(services);
+
+                    // #227: enforce ServiceLocationPolicy per-file, matching the
+                    // runtime compile path in DynamicTypeLoader.Initialize. The
+                    // CLI codegen paths (preview / write / test) historically
+                    // bypassed this hook, so a host setting
+                    // ServiceLocationPolicy.NotAllowed got the expected
+                    // InvalidServiceLocationException at runtime but a clean
+                    // "all generated" result from the CLI.
+                    assertServiceLocationsAllowed(file, services);
+
                     var fileName = Path.Combine(exportDirectory, file.FileName.Replace(" ", "_") + ".cs");
                     File.WriteAllText(fileName, code);
                     onFileWritten(fileName);
@@ -141,12 +153,20 @@ public class DynamicCodeBuilder
                 $"Missing {nameof(ICodeFileCollection.ChildNamespace)} for {collection}");
         }
 
-        var @namespace = collection.ToNamespace(collection.Rules);
+        // #227: per-file generation + per-file ServiceLocationPolicy enforcement,
+        // matching the runtime compile path's per-ICodeFile granularity.
+        // ServiceCollectionServerVariableSource resets _serviceLocations on every
+        // StartNewMethod / StartNewType call, so the only point where we can
+        // observe a file's reports is right after its own GenerateCode finishes —
+        // which means we have to iterate files independently rather than batching
+        // them all into a single GeneratedAssembly the way this method used to.
+        var withServices = collection is ICodeFileCollectionWithServices;
+        var services = withServices ? ServiceVariableSource : null;
 
-        var generatedAssembly = new GeneratedAssembly(collection.Rules, @namespace);
-        var files = collection.BuildFiles();
-        foreach (var file in files)
+        var writer = new StringWriter();
+        foreach (var file in collection.BuildFiles())
         {
+            var generatedAssembly = collection.StartAssembly(collection.Rules);
             try
             {
                 file.AssembleTypes(generatedAssembly);
@@ -155,12 +175,14 @@ public class DynamicCodeBuilder
             {
                 throw new CodeGenerationException(file, e);
             }
+
+            var code = generatedAssembly.GenerateCode(services);
+            assertServiceLocationsAllowed(file, services);
+
+            writer.WriteLine(code);
         }
 
-        // This was important. Each source code collection should explicitly opt into using IoC services rather
-        // than making that automatic
-        var services = collection is ICodeFileCollectionWithServices ? ServiceVariableSource : null;
-        return generatedAssembly.GenerateCode(services);
+        return writer.ToString();
     }
 
     /// <summary>
@@ -172,17 +194,42 @@ public class DynamicCodeBuilder
     {
         foreach (var collection in Collections)
         {
-            var generatedAssembly = collection.AssembleTypes(collection.Rules);
+            // #227: iterate per ICodeFile so we can enforce ServiceLocationPolicy
+            // at file granularity (matching DynamicTypeLoader.Initialize). The
+            // previous batched-per-collection compile silently bypassed the
+            // policy hook because ServiceLocations() resets on every
+            // StartNewMethod, leaving only the last-method-of-last-file's
+            // reports visible at the end of a batched compile.
+            var withServices = collection is ICodeFileCollectionWithServices;
+            var services = withServices ? ServiceVariableSource : null;
 
-            try
+            foreach (var file in collection.BuildFiles())
             {
-                withAssembly(generatedAssembly, ServiceVariableSource);
-            }
-            catch (Exception e)
-            {
-                throw new GeneratorCompilationFailureException(collection, e);
+                var generatedAssembly = collection.StartAssembly(collection.Rules);
+                file.AssembleTypes(generatedAssembly);
+
+                try
+                {
+                    withAssembly(generatedAssembly, services);
+                }
+                catch (Exception e)
+                {
+                    throw new GeneratorCompilationFailureException(collection, e);
+                }
+
+                assertServiceLocationsAllowed(file, services);
             }
         }
+    }
+
+    private void assertServiceLocationsAllowed(ICodeFile file, IServiceVariableSource? services)
+    {
+        if (services == null) return;
+
+        var reports = services.ServiceLocations();
+        if (reports.Length == 0) return;
+
+        file.AssertServiceLocationsAreAllowed(reports, Services);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Refactor all three CLI codegen entry points (\`preview\` / \`write\` / \`test\`) to iterate per \`ICodeFile\` and invoke the \`AssertServiceLocationsAreAllowed\` hook per file after its own \`GenerateCode\`.
- Add \`DynamicCodeBuilderTests\` covering all three paths plus the no-services-collection and no-reports negative cases.

Closes #227.

## Why
\`ServiceCollectionServerVariableSource\` resets its \`_serviceLocations\` buffer on every \`StartNewMethod\` / \`StartNewType\`. So a file's reports are only observable for the brief window right after its own \`GenerateCode\` finishes. The previous batched-per-collection logic in \`generateCode\` (preview path) and \`TryBuildAndCompileAll\` (test path) discarded every file's reports except the last one's, which meant the policy hook never fired even when the code clearly used service location.

The runtime compile path in \`DynamicTypeLoader.Initialize\` already iterates per file and was the only path that enforced the policy. A host with \`ServiceLocationPolicy.NotAllowed\` got the expected \`InvalidServiceLocationException\` at runtime but a clean \"all generated\" result from any of the CLI commands.

## What changes
- \`WriteGeneratedCode\` — already per-file; just added the hook invocation.
- \`generateCode\` (preview) — refactored from batched-per-collection to per-file. Output gains multiple \`// <auto-generated/>\` headers (one per file). Still readable and now matches the on-disk layout produced by \`codegen write\` exactly.
- \`TryBuildAndCompileAll\` — refactored to per-file. \`withAssembly\` callback fires once per file. Only caller is \`GenerateCodeCommand\` itself (verified zero direct callers across Wolverine + Marten).

## Test plan
- [x] \`dotnet test src/CodegenTests\` — 338/338 pass on net9.0 (333 existing + 5 new in \`DynamicCodeBuilderTests\`)
- [x] \`dotnet test src/CommandLineTests\` — 280/280 pass on net9.0
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)