### PR TITLE
UnknownTenantIdException: expose TenantId property + bump to 2.0.0-alpha.7

### DIFF
--- a/src/CoreTests/MultiTenancy/UnknownTenantIdExceptionTests.cs
+++ b/src/CoreTests/MultiTenancy/UnknownTenantIdExceptionTests.cs
@@ -1,0 +1,22 @@
+using JasperFx.MultiTenancy;
+using Shouldly;
+
+namespace CoreTests.MultiTenancy;
+
+public class UnknownTenantIdExceptionTests
+{
+    [Fact]
+    public void exposes_tenant_id_property()
+    {
+        // Regression for jasperfx#224 (multi-tenancy dedup slice). The exception
+        // previously embedded the tenant id in the message string only; consumers
+        // had to parse it back out. The TenantId property is the diagnostics
+        // surface that Polecat's now-removed local UnknownTenantException carried
+        // and that downstream callers expect when consuming the canonical
+        // JasperFx version.
+        var ex = new UnknownTenantIdException("acme-east");
+
+        ex.TenantId.ShouldBe("acme-east");
+        ex.Message.ShouldContain("acme-east");
+    }
+}

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.6</Version>
+        <Version>2.0.0-alpha.7</Version>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/src/JasperFx/MultiTenancy/UnknownTenantIdException.cs
+++ b/src/JasperFx/MultiTenancy/UnknownTenantIdException.cs
@@ -4,5 +4,16 @@ public class UnknownTenantIdException: Exception
 {
     public UnknownTenantIdException(string tenantId): base($"Unknown tenant id '{tenantId}'")
     {
+        TenantId = tenantId;
     }
+
+    /// <summary>
+    ///     The tenant id that could not be resolved. Exposed so consumers can
+    ///     <c>catch (UnknownTenantIdException ex) { ... ex.TenantId ... }</c>
+    ///     without parsing the message string. Added in 2.0.0-alpha.7 to close
+    ///     the diagnostics regression that the Polecat dedup audit (slice #224)
+    ///     surfaced — Polecat's now-removed local <c>UnknownTenantException</c>
+    ///     carried this getter.
+    /// </summary>
+    public string TenantId { get; }
 }


### PR DESCRIPTION
## Summary
- Add a public read-only \`TenantId\` property to \`JasperFx.MultiTenancy.UnknownTenantIdException\`. Single-arg ctor signature unchanged — now assigns the new property in addition to formatting the message.
- Bump JasperFx to 2.0.0-alpha.7.

## Why
From the multi-tenancy dedup audit ([jasperfx#224](https://github.com/JasperFx/jasperfx/issues/224)). When Polecat dropped its local \`Polecat.Exceptions.UnknownTenantException\` and adopted this canonical version, consumers lost the \`TenantId\` getter that the local exception carried — the id was only in the message string. \`catch (UnknownTenantIdException ex) { var id = ex.TenantId; ... }\` now Just Works without parsing the message back out.

## Test plan
- [x] \`dotnet test src/CoreTests/CoreTests.csproj --framework net9.0\` — 407/407 pass on net9.0 (the new \`UnknownTenantIdExceptionTests.exposes_tenant_id_property\` plus the existing 406)

🤖 Generated with [Claude Code](https://claude.com/claude-code)