### PR TITLE
Bump FastExpressionCompiler 5.3.0 → 5.4.1 + JasperFx 2.0.0-alpha.8

### DIFF
--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.7</Version>
+        <Version>2.0.0-alpha.8</Version>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FastExpressionCompiler" Version="5.3.0" />
+        <PackageReference Include="FastExpressionCompiler" Version="5.4.1" />
         <PackageReference Include="ImTools" Version="4.0.0"/>
         <PackageReference Include="Spectre.Console" Version="0.55.0" />
         <PackageReference Include="Polly.Core" Version="8.6.5" />


### PR DESCRIPTION
## Summary
- Bump \`FastExpressionCompiler\` 5.3.0 → 5.4.1 (latest stable).
- \`ImTools\` is already at the latest stable (4.0.0); the only newer is 5.0.0-preview-01 which is intentionally skipped.
- Bump \`JasperFx\` to 2.0.0-alpha.8.

## Scope across the wave

Only JasperFx core directly references these packages. Marten, Polecat, Weasel, and Wolverine all pull them in transitively through the JasperFx dependency, so they automatically pick up the bumps on their next JasperFx-pin update — no parallel PRs needed on those repos for this.

Pin map after alpha.8 lands:

| Repo | How it gets the bumps |
|---|---|
| JasperFx | direct (this PR) |
| Marten | next JasperFx pin bump (currently on alpha.6, scheduled for alpha.7+ shortly) |
| Polecat | next JasperFx pin bump (currently on alpha.7 via PR #61) |
| Weasel | not a direct consumer of these packages — no action |
| Wolverine | 6.0 cutover (currently on JasperFx 1.31.0; cutover bumps it past alpha.7) |

## Test plan
- [x] \`./build.sh test-core\` — 407/407 pass on net9.0
- [x] \`./build.sh test-codegen\` — 342/342 pass on net9.0 + net10.0
- [x] \`./build.sh test-events\` — clean
- [x] \`./build.sh test-command-line\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)