### PR TITLE
Codegen snapshot invalidation contract (#243 Phase 1)

### DIFF
--- a/src/CodegenTests/Snapshots/SnapshotGateTests.cs
+++ b/src/CodegenTests/Snapshots/SnapshotGateTests.cs
@@ -1,0 +1,212 @@
+using JasperFx.CodeGeneration.Snapshots;
+using Shouldly;
+
+namespace CodegenTests.Snapshots;
+
+/// <summary>
+///     Phase 1 of jasperfx#243 — the invalidation contract shared across
+///     codegen consumers (Marten, Wolverine, Polecat, etc.). These tests
+///     pin the public surface: persistence round-trip, the three-way verdict
+///     matrix, hash determinism, and the soft-fallback semantics around
+///     malformed / missing fingerprints.
+/// </summary>
+public class SnapshotGateTests : IDisposable
+{
+    private readonly string _folder;
+
+    public SnapshotGateTests()
+    {
+        _folder = Path.Combine(Path.GetTempPath(), "jasperfx-snapshot-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_folder);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_folder)) Directory.Delete(_folder, recursive: true);
+    }
+
+    private static SnapshotFingerprint NewFingerprint(string configHash = "deadbeef") =>
+        new(
+            ProductName: "test-product",
+            ProductVersion: "1.2.3",
+            JasperFxVersion: "2.0.0-alpha.8",
+            ConfigHash: configHash);
+
+    // ─── Read / Write round-trip ─────────────────────────────────────────
+
+    [Fact]
+    public void read_returns_null_when_folder_has_no_fingerprint()
+    {
+        SnapshotGate.Read(_folder).ShouldBeNull();
+    }
+
+    [Fact]
+    public void read_returns_null_when_folder_path_is_empty()
+    {
+        SnapshotGate.Read("").ShouldBeNull();
+        SnapshotGate.Read("   ").ShouldBeNull();
+    }
+
+    [Fact]
+    public void write_then_read_round_trips_every_field()
+    {
+        var written = NewFingerprint();
+        SnapshotGate.Write(_folder, written);
+
+        var read = SnapshotGate.Read(_folder);
+
+        read.ShouldNotBeNull();
+        read.ShouldBe(written);
+    }
+
+    [Fact]
+    public void write_creates_the_target_folder_if_it_does_not_exist()
+    {
+        var nested = Path.Combine(_folder, "nested", "subfolder");
+        SnapshotGate.Write(nested, NewFingerprint());
+
+        File.Exists(Path.Combine(nested, SnapshotGate.FingerprintFileName)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void write_overwrites_a_prior_fingerprint()
+    {
+        SnapshotGate.Write(_folder, NewFingerprint("first"));
+        SnapshotGate.Write(_folder, NewFingerprint("second"));
+
+        SnapshotGate.Read(_folder)!.ConfigHash.ShouldBe("second");
+    }
+
+    [Fact]
+    public void read_returns_null_when_persisted_file_is_malformed()
+    {
+        // Soft-fallback policy: an unreadable fingerprint is indistinguishable
+        // from "no fingerprint" for the consumer's purposes. Both produce
+        // FirstBoot, both regenerate, neither throws.
+        File.WriteAllText(
+            Path.Combine(_folder, SnapshotGate.FingerprintFileName),
+            "{ this is not valid json ");
+
+        SnapshotGate.Read(_folder).ShouldBeNull();
+    }
+
+    [Fact]
+    public void write_with_null_fingerprint_throws()
+    {
+        Should.Throw<ArgumentNullException>(() => SnapshotGate.Write(_folder, null!));
+    }
+
+    [Fact]
+    public void write_with_empty_folder_throws()
+    {
+        Should.Throw<ArgumentException>(() => SnapshotGate.Write("", NewFingerprint()));
+    }
+
+    // ─── Verify ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void verify_returns_FirstBoot_when_persisted_is_null()
+    {
+        SnapshotGate.Verify(NewFingerprint(), persisted: null)
+            .ShouldBe(SnapshotVerdict.FirstBoot);
+    }
+
+    [Fact]
+    public void verify_returns_Accept_when_every_field_matches()
+    {
+        var live = NewFingerprint();
+        var persisted = NewFingerprint();
+
+        SnapshotGate.Verify(live, persisted).ShouldBe(SnapshotVerdict.Accept);
+    }
+
+    [Theory]
+    [InlineData("product")]
+    [InlineData("version")]
+    [InlineData("jasperfx")]
+    [InlineData("config")]
+    [InlineData("schema")]
+    public void verify_returns_RejectAndRegenerate_when_any_field_differs(string differingField)
+    {
+        var live = NewFingerprint();
+        var persisted = differingField switch
+        {
+            "product" => live with { ProductName = "other-product" },
+            "version" => live with { ProductVersion = "9.9.9" },
+            "jasperfx" => live with { JasperFxVersion = "99.0.0" },
+            "config" => live with { ConfigHash = "0000000000000000" },
+            "schema" => live with { SchemaVersion = SnapshotGate.CurrentSchemaVersion + 1 },
+            _ => throw new ArgumentOutOfRangeException(nameof(differingField))
+        };
+
+        SnapshotGate.Verify(live, persisted).ShouldBe(SnapshotVerdict.RejectAndRegenerate);
+    }
+
+    [Fact]
+    public void verify_with_null_live_throws()
+    {
+        Should.Throw<ArgumentNullException>(() => SnapshotGate.Verify(null!, NewFingerprint()));
+    }
+
+    // ─── ComputeHash ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void compute_hash_is_deterministic()
+    {
+        SnapshotGate.ComputeHash("the same input")
+            .ShouldBe(SnapshotGate.ComputeHash("the same input"));
+    }
+
+    [Fact]
+    public void compute_hash_differs_for_different_inputs()
+    {
+        SnapshotGate.ComputeHash("input A")
+            .ShouldNotBe(SnapshotGate.ComputeHash("input B"));
+    }
+
+    [Fact]
+    public void compute_hash_returns_lowercase_hex_digest_of_expected_length()
+    {
+        // SHA-256 = 256 bits = 64 hex chars
+        var hash = SnapshotGate.ComputeHash("anything");
+
+        hash.Length.ShouldBe(64);
+        hash.ShouldAllBe(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+    }
+
+    [Fact]
+    public void compute_hash_with_null_input_throws()
+    {
+        Should.Throw<ArgumentNullException>(() => SnapshotGate.ComputeHash(null!));
+    }
+
+    // ─── Stability promises ──────────────────────────────────────────────
+
+    [Fact]
+    public void log_template_includes_documented_placeholders()
+    {
+        // The template is part of the public stability contract (per the
+        // jasperfx#243 design). Operators grep for it in logs to recognise
+        // the "snapshot rejected" path. If this test fails, you're about to
+        // break someone's log-monitoring rule — bump JasperFx to 3.0 first.
+        SnapshotGate.SnapshotRejectedLogTemplate.ShouldContain("{ProductName}");
+        SnapshotGate.SnapshotRejectedLogTemplate.ShouldContain("{Namespace}");
+        SnapshotGate.SnapshotRejectedLogTemplate.ShouldContain("{Reason}");
+        SnapshotGate.SnapshotRejectedLogTemplate.ShouldStartWith("JasperFx.Codegen: snapshot rejected");
+    }
+
+    [Fact]
+    public void fingerprint_filename_is_stable()
+    {
+        // Same stability promise as the log template — consumers and their
+        // build tooling key off this constant.
+        SnapshotGate.FingerprintFileName.ShouldBe("fingerprint.json");
+    }
+
+    [Fact]
+    public void schema_version_default_is_current()
+    {
+        new SnapshotFingerprint("p", "v", "j", "h")
+            .SchemaVersion.ShouldBe(SnapshotGate.CurrentSchemaVersion);
+    }
+}

--- a/src/JasperFx/CodeGeneration/Snapshots/SnapshotFingerprint.cs
+++ b/src/JasperFx/CodeGeneration/Snapshots/SnapshotFingerprint.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace JasperFx.CodeGeneration.Snapshots;
+
+/// <summary>
+///     Invalidation record persisted alongside pre-generated code by codegen consumers
+///     (Marten, Wolverine, Polecat, etc.). At boot, consumers compare a live-computed
+///     fingerprint against the persisted one via <see cref="SnapshotGate.Verify"/>; a
+///     mismatch triggers a soft fallback to the live discovery + codegen path.
+/// </summary>
+/// <param name="ProductName">
+///     Short, stable identifier for the consuming product — <c>"marten"</c>,
+///     <c>"wolverine"</c>, <c>"polecat"</c>, etc. Used in the rejection log signature
+///     so operators can tell which product invalidated.
+/// </param>
+/// <param name="ProductVersion">
+///     SemVer of the consuming product at the time the snapshot was written.
+///     Mismatch with the running version invalidates the snapshot — product
+///     authors may have changed how the snapshot is interpreted between versions.
+/// </param>
+/// <param name="JasperFxVersion">
+///     SemVer of JasperFx at the time the snapshot was written. Mismatch with the
+///     running version invalidates — codegen output shape may have shifted.
+/// </param>
+/// <param name="ConfigHash">
+///     Deterministic hash (typically SHA-256, via <see cref="SnapshotGate.ComputeHash"/>)
+///     of consumer-specific config inputs. Each consumer decides what goes in: registered
+///     types, projection registrations, serializer choice, transport URIs, etc. The hash
+///     is opaque to JasperFx — we only compare for equality.
+/// </param>
+/// <param name="SchemaVersion">
+///     Versioning of the <see cref="SnapshotFingerprint"/> shape itself. Bumped if this
+///     record's fields ever change. Mismatch is treated identically to any other
+///     mismatch — <see cref="SnapshotVerdict.RejectAndRegenerate"/>. Defaults to
+///     <see cref="SnapshotGate.CurrentSchemaVersion"/>.
+/// </param>
+/// <remarks>
+///     This record is the *entire* shared shape JasperFx requires across consumers in
+///     Phase 1 of jasperfx#243. Consumers own their snapshot-artifact format completely;
+///     JasperFx supplies only invalidation + the log signature.
+/// </remarks>
+public sealed record SnapshotFingerprint(
+    string ProductName,
+    string ProductVersion,
+    string JasperFxVersion,
+    string ConfigHash,
+    int SchemaVersion = SnapshotGate.CurrentSchemaVersion)
+{
+    /// <summary>
+    ///     Source-generation-friendly parameterless constructor. Required for
+    ///     <c>System.Text.Json</c> deserialisation on consumers that use a
+    ///     <see cref="JsonSerializerContext"/>; the positional record syntax
+    ///     above is the canonical authoring form.
+    /// </summary>
+    [JsonConstructor]
+    public SnapshotFingerprint() : this("", "", "", "", SnapshotGate.CurrentSchemaVersion)
+    {
+    }
+}

--- a/src/JasperFx/CodeGeneration/Snapshots/SnapshotGate.cs
+++ b/src/JasperFx/CodeGeneration/Snapshots/SnapshotGate.cs
@@ -1,0 +1,172 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace JasperFx.CodeGeneration.Snapshots;
+
+/// <summary>
+///     Phase 1 of jasperfx#243. The minimum shared surface across codegen consumers
+///     (Marten, Wolverine, Polecat, etc.) for pre-generated-code invalidation:
+///     a fingerprint persistence format, a verdict policy, and a stable log signature.
+/// </summary>
+/// <remarks>
+///     <para>
+///     What this is NOT: an opinion on artifact format, file layout beyond the
+///     fingerprint itself, or how a consumer enumerates / serialises its pre-computed
+///     boot state. Consumers own those calls completely. Phase 3 of jasperfx#243 may
+///     extract a shared <c>ISnapshotArtifact</c> if both Marten and Wolverine end up
+///     wanting one, but Phase 1 does not commit to that.
+///     </para>
+///     <para>
+///     <b>Soft fallback in every mode.</b> A persisted fingerprint that disagrees
+///     with the live one triggers <see cref="SnapshotVerdict.RejectAndRegenerate"/>;
+///     the consumer falls back to live codegen and re-persists. Hard-fail behaviour
+///     was rejected during the design (a stale snapshot in production should
+///     degrade gracefully, not refuse to boot).
+///     </para>
+///     <para>
+///     <b>The log template is a public stability promise.</b>
+///     <see cref="SnapshotRejectedLogTemplate"/> is what operators grep for in logs
+///     to recognise the "snapshot rejected, regenerating" path. Stable across
+///     JasperFx 2.x minor versions.
+///     </para>
+/// </remarks>
+public static class SnapshotGate
+{
+    /// <summary>
+    ///     Canonical filename for the persisted <see cref="SnapshotFingerprint"/>
+    ///     within a consumer's generated-code folder. One per
+    ///     <see cref="ICodeFileCollection"/> export directory.
+    /// </summary>
+    public const string FingerprintFileName = "fingerprint.json";
+
+    /// <summary>
+    ///     Current <see cref="SnapshotFingerprint.SchemaVersion"/>. Bumped if the
+    ///     record's shape ever changes; mismatched persisted values are treated as
+    ///     <see cref="SnapshotVerdict.RejectAndRegenerate"/>.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    ///     Structured-log message template emitted at
+    ///     <see cref="Microsoft.Extensions.Logging.LogLevel.Information"/> when a
+    ///     consumer's snapshot is rejected. Operators grep for this exact prefix
+    ///     when diagnosing slow first-boot-after-deploy. The template parameters
+    ///     are <c>{ProductName}</c>, <c>{Namespace}</c>, <c>{Reason}</c> — in
+    ///     that order.
+    /// </summary>
+    public const string SnapshotRejectedLogTemplate =
+        "JasperFx.Codegen: snapshot rejected ({ProductName}/{Namespace}), regenerating. Reason: {Reason}";
+
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    ///     Read the persisted fingerprint from a generated-code folder. Returns
+    ///     <see langword="null"/> if no fingerprint exists (first boot, cleared
+    ///     folder), or if the file is unreadable / malformed (treated as
+    ///     "no usable persisted fingerprint" — caller will get
+    ///     <see cref="SnapshotVerdict.FirstBoot"/> from <see cref="Verify"/>).
+    /// </summary>
+    /// <param name="generatedFolder">
+    ///     Absolute path to the consumer's generated-code folder
+    ///     (the <c>Internal/Generated</c>-style directory). Must exist; this method
+    ///     does not create it.
+    /// </param>
+    public static SnapshotFingerprint? Read(string generatedFolder)
+    {
+        if (string.IsNullOrWhiteSpace(generatedFolder)) return null;
+
+        var path = Path.Combine(generatedFolder, FingerprintFileName);
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<SnapshotFingerprint>(json, _serializerOptions);
+        }
+        catch (Exception)
+        {
+            // Corrupted / unreadable fingerprint is indistinguishable from "no
+            // fingerprint" for caller purposes — both result in regeneration on
+            // the next Verify call. Don't surface the read failure as an
+            // exception; the soft-fallback policy says boot continues.
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Persist a fingerprint to the generated-code folder. Creates the folder
+    ///     if it doesn't exist. Overwrites any prior fingerprint atomically (writes
+    ///     to a temp file then moves into place).
+    /// </summary>
+    public static void Write(string generatedFolder, SnapshotFingerprint fingerprint)
+    {
+        if (string.IsNullOrWhiteSpace(generatedFolder))
+            throw new ArgumentException("Generated folder path is required.", nameof(generatedFolder));
+        ArgumentNullException.ThrowIfNull(fingerprint);
+
+        Directory.CreateDirectory(generatedFolder);
+        var finalPath = Path.Combine(generatedFolder, FingerprintFileName);
+        var tempPath = finalPath + ".tmp";
+
+        var json = JsonSerializer.Serialize(fingerprint, _serializerOptions);
+        File.WriteAllText(tempPath, json);
+
+        // Atomic move so a partial write never leaves a corrupted fingerprint
+        // visible to a concurrently-booting process.
+        File.Move(tempPath, finalPath, overwrite: true);
+    }
+
+    /// <summary>
+    ///     Compare a live-computed fingerprint against a persisted one and return
+    ///     the verdict that drives the consumer's boot path.
+    /// </summary>
+    /// <param name="live">The freshly-computed fingerprint from the live boot path. Must not be null.</param>
+    /// <param name="persisted">
+    ///     The fingerprint read via <see cref="Read"/>, or <see langword="null"/>
+    ///     if no fingerprint existed.
+    /// </param>
+    /// <returns>
+    ///     <see cref="SnapshotVerdict.FirstBoot"/> if <paramref name="persisted"/> is null;
+    ///     <see cref="SnapshotVerdict.Accept"/> if every field matches;
+    ///     <see cref="SnapshotVerdict.RejectAndRegenerate"/> otherwise.
+    /// </returns>
+    public static SnapshotVerdict Verify(SnapshotFingerprint live, SnapshotFingerprint? persisted)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+
+        if (persisted is null) return SnapshotVerdict.FirstBoot;
+
+        // Record equality is by-value across every field — exactly what we want.
+        return live == persisted
+            ? SnapshotVerdict.Accept
+            : SnapshotVerdict.RejectAndRegenerate;
+    }
+
+    /// <summary>
+    ///     Compute a SHA-256 hash of a canonical-form string and return it as a
+    ///     lowercase hex digest. Convenience helper for <see cref="SnapshotFingerprint.ConfigHash"/>.
+    ///     Consumers are free to use any deterministic hash function they prefer —
+    ///     JasperFx only compares the resulting strings for equality.
+    /// </summary>
+    /// <param name="canonicalRepresentation">
+    ///     A deterministic string representation of the consumer's config inputs.
+    ///     The hash is only as stable as the canonicalisation; consumers must sort
+    ///     collections, normalise whitespace, etc. before calling this.
+    /// </param>
+    public static string ComputeHash(string canonicalRepresentation)
+    {
+        ArgumentNullException.ThrowIfNull(canonicalRepresentation);
+
+        var bytes = Encoding.UTF8.GetBytes(canonicalRepresentation);
+        var hash = SHA256.HashData(bytes);
+
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash) sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+}

--- a/src/JasperFx/CodeGeneration/Snapshots/SnapshotVerdict.cs
+++ b/src/JasperFx/CodeGeneration/Snapshots/SnapshotVerdict.cs
@@ -1,0 +1,39 @@
+namespace JasperFx.CodeGeneration.Snapshots;
+
+/// <summary>
+///     Result of <see cref="SnapshotGate.Verify"/>. The three values describe the
+///     three boot-time situations a consumer can be in regarding pre-generated
+///     snapshot artifacts.
+/// </summary>
+public enum SnapshotVerdict
+{
+    /// <summary>
+    ///     The live-computed fingerprint matches the persisted one. The consumer's
+    ///     snapshot artifacts can be trusted; skip the live discovery + codegen path.
+    /// </summary>
+    Accept,
+
+    /// <summary>
+    ///     No persisted fingerprint exists (first boot, or the generated folder was
+    ///     cleared). The consumer should run the live discovery + codegen path as
+    ///     normal and persist a fingerprint for the next boot. Not an error — this
+    ///     is the steady-state result on a fresh deployment.
+    /// </summary>
+    FirstBoot,
+
+    /// <summary>
+    ///     A persisted fingerprint exists but differs from the live-computed one.
+    ///     The consumer must fall back to the live discovery + codegen path
+    ///     (the snapshot artifacts cannot be trusted) and re-persist the
+    ///     fingerprint at the end of boot. This is logged via
+    ///     <see cref="SnapshotGate.SnapshotRejectedLogTemplate"/> at
+    ///     <see cref="Microsoft.Extensions.Logging.LogLevel.Information"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Soft-fallback is the policy in <i>every</i> mode, including production.
+    ///     A stale snapshot should degrade gracefully — the worst case is a
+    ///     slightly-slower first boot, not a refusal to start. Hard-fail behaviour
+    ///     was explicitly rejected during the jasperfx#243 design.
+    /// </remarks>
+    RejectAndRegenerate
+}


### PR DESCRIPTION
## Summary

Phase 1 of [#243](https://github.com/JasperFx/jasperfx/issues/243) — the minimum shared surface for pre-generated-code invalidation across codegen consumers (Marten, Wolverine, Polecat, …). What's actually shared between products is the fingerprint format, the invalidation policy, and the log signature; everything else stays product-specific until Phase 3 demonstrates that unification earns its weight.

## Public surface

\`JasperFx.CodeGeneration.Snapshots\`:

- **\`SnapshotFingerprint\`** (record) — \`ProductName\`, \`ProductVersion\`, \`JasperFxVersion\`, \`ConfigHash\`, \`SchemaVersion\`. Stable shape; mismatch on any field invalidates.
- **\`SnapshotVerdict\`** (enum) — \`Accept\` / \`FirstBoot\` / \`RejectAndRegenerate\`. Three values covering the three boot-time situations.
- **\`SnapshotGate\`** (static helper) — \`Read\` / \`Write\` / \`Verify\` / \`ComputeHash\`. Atomic-move write (temp-then-rename) so concurrent boots never see a partially-written fingerprint. \`Read\` returns null on malformed JSON (soft-fallback: indistinguishable from "no fingerprint" for the caller; both result in regeneration). SHA-256 via \`System.Security.Cryptography\` — no extra dependency.

## Public stability promises (pinned by tests)

| Promise | Test |
|---|---|
| \`FingerprintFileName == "fingerprint.json"\` | \`fingerprint_filename_is_stable\` |
| \`SnapshotRejectedLogTemplate\` contains \`{ProductName}\` / \`{Namespace}\` / \`{Reason}\` and starts with \`"JasperFx.Codegen: snapshot rejected"\` | \`log_template_includes_documented_placeholders\` |
| \`CurrentSchemaVersion == 1\` (default on \`SnapshotFingerprint\`) | \`schema_version_default_is_current\` |
| Verdict matrix: \`FirstBoot\` on null persisted; \`Accept\` on full match; \`RejectAndRegenerate\` on any of 5 field mismatches | \`verify_*\` suite |
| Soft-fallback on malformed persisted JSON (returns null, not throw) | \`read_returns_null_when_persisted_file_is_malformed\` |
| Atomic write — overwrites prior fingerprint cleanly | \`write_overwrites_a_prior_fingerprint\` |

## What this PR deliberately does NOT include

Per the [#243](https://github.com/JasperFx/jasperfx/issues/243) design (locked after [user discussion this session](https://github.com/JasperFx/jasperfx/issues/243#issue-body)):

- ❌ No \`ISnapshotArtifact\` / \`IHasSnapshotArtifacts\` interfaces — each consumer owns its artifact format
- ❌ No shared on-disk layout beyond \`fingerprint.json\`
- ❌ No persistence-format opinion (JSON / binary / source-generated constants — consumer's choice)
- ❌ No source-generator applicator

The \`ISnapshotArtifact\` extraction is deferred to **Phase 3**, contingent on both Marten and Wolverine Phase 2 artifact formats actually converging in practice.

## Verification

- \`dotnet build src/JasperFx/JasperFx.csproj\` — clean
- \`dotnet build src/CodegenTests/CodegenTests.csproj\` — clean
- \`dotnet test src/CodegenTests/CodegenTests.csproj --framework net9.0\` — **365/365 pass** (342 pre-existing + 23 new in \`SnapshotGateTests\`)

## Sequencing

After this lands and ships in JasperFx 2.0.0-alpha.9:
- **Phase 2-Marten** ([marten#4370](https://github.com/JasperFx/marten/issues/4370)) and **Phase 2-Wolverine** ([wolverine#2728](https://github.com/JasperFx/wolverine/issues/2728)) can begin in parallel
- Each product builds its canonical-input string, hashes via \`SnapshotGate.ComputeHash\` (or any hash they prefer), writes product-specific snapshot artifacts in whatever format suits its hot path, and routes invalidation through \`SnapshotGate\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)