### PR TITLE
Bump JasperFx to 2.0.0-alpha.9

### DIFF
--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.8</Version>
+        <Version>2.0.0-alpha.9</Version>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">


### PR DESCRIPTION
Ships the codegen snapshot invalidation contract (#243 Phase 1) — `SnapshotFingerprint` / `SnapshotVerdict` / `SnapshotGate`. Unblocks Phase 2 in [marten#4370](https://github.com/JasperFx/marten/issues/4370) and [wolverine#2728](https://github.com/JasperFx/wolverine/issues/2728).