### PR TITLE
Bump JasperFx to 2.0.0-alpha.10 + regression test for wolverine#2719

### DIFF
--- a/src/CodegenTests/Bugs/Bug_244_scoped_session_compiles_in_non_async_method.cs
+++ b/src/CodegenTests/Bugs/Bug_244_scoped_session_compiles_in_non_async_method.cs
@@ -1,0 +1,81 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.RuntimeCompiler;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace CodegenTests.Bugs;
+
+/// <summary>
+/// Reproduces JasperFx/wolverine#2719: when a generated method requires
+/// service location (via the <c>ScopedContainerCreation</c> dependency
+/// frame inserted to satisfy a service-located parameter referenced by a
+/// downstream <see cref="MethodCall"/>) AND the method is otherwise fully
+/// synchronous, the generated code historically combined
+/// <c>await using var serviceScope</c> with a non-async method declaration
+/// (no <c>async</c> keyword on the return type), producing CS4032 / CS1996
+/// compile failures.
+///
+/// JasperFx PR #238 (commit 7dc7f0e) gated the <c>await using</c> emission
+/// on <see cref="AsyncMode.AsyncTask"/>, which should keep this scenario
+/// compilable — sync method body should get <c>using var scope = CreateScope()</c>
+/// instead. This test verifies that gate via a full codegen → compile cycle
+/// using the real <see cref="ServiceCollectionServerVariableSource"/>.
+/// </summary>
+public class Bug_244_scoped_session_compiles_in_non_async_method
+{
+    public interface IBugHandler
+    {
+        Task DoStuff();
+    }
+
+    public interface IServiceLocatedDependency;
+    public class ServiceLocatedDependency : IServiceLocatedDependency;
+
+    public static class ServiceConsumer
+    {
+        public static void UseTheService(IServiceLocatedDependency dep)
+        {
+            dep.ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public void compiles_when_method_is_sync_but_has_service_location()
+    {
+        // Opaque lambda-factory registration with Scoped lifetime — this is
+        // the exact "requires service location" shape from #2719's repro
+        // (`AddScoped<IGlobalUserContext>(sp => new GlobalUserContext())`).
+        var services = new ServiceCollection();
+        services.AddScoped<IServiceLocatedDependency>(_ => new ServiceLocatedDependency());
+
+        var graph = new ServiceContainer(services, services.BuildServiceProvider());
+        var source = new ServiceCollectionServerVariableSource(graph);
+        source.StartNewType();
+        source.StartNewMethod();
+
+        var assembly = new GeneratedAssembly(new GenerationRules());
+        var type = assembly.AddType("ScopedSyncHandler", typeof(IBugHandler));
+        var method = type.MethodFor(nameof(IBugHandler.DoStuff));
+
+        // The sync method call needs IServiceLocatedDependency. Because the
+        // registration is an opaque lambda factory with Scoped lifetime,
+        // JasperFx will resolve via ScopedContainerCreation + GetServiceFromScopedContainerFrame.
+        method.Frames.Add(new MethodCall(typeof(ServiceConsumer), nameof(ServiceConsumer.UseTheService)));
+
+        var generator = new AssemblyGenerator();
+        generator.ReferenceAssembly(typeof(IServiceLocatedDependency).Assembly);
+        var code = assembly.GenerateCode(source);
+        generator.Generate(code);  // Throws on compile failure.
+
+        // Method declaration must NOT have `async` since no frame is actually async.
+        // Body must use sync `using` (the JasperFx#238 fix) not `await using`.
+        type.SourceCode.ShouldNotBeNull();
+        type.SourceCode.ShouldNotContain("async ");
+        type.SourceCode.ShouldNotContain("await using");
+        type.SourceCode.ShouldContain("using var serviceScope = _serviceScopeFactory.CreateScope();");
+    }
+}

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.9</Version>
+        <Version>2.0.0-alpha.10</Version>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">


### PR DESCRIPTION
## Summary

- Bumps \`JasperFx\` to \`2.0.0-alpha.10\`.
- Adds an integration-level regression test that pins the fix from #238 (commit \`7dc7f0e\` — gate \`ScopedContainerCreation\`'s \`await using\` emission on \`AsyncMode.AsyncTask\`) at the full codegen → compile cycle, not just the \`Emit()\` unit test.

## Why

The existing \`ScopedContainerCreationTests\` verify the \`Emit()\` method in isolation by hard-coding \`AsyncMode\`. The new test mirrors the exact scenario from [JasperFx/wolverine#2719](https://github.com/JasperFx/wolverine/issues/2719):

- A non-async method (returns \`Task\`, no \`async\` keyword)
- An opaque lambda-factory registration with \`Scoped\` lifetime — exactly the "requires service location" shape \`AddScoped<T>(sp => new ...)\`
- A \`MethodCall\` that references the service-located dependency

Before #238, this scenario produced \`CS4032\` / \`CS1996\` compile failures because the generated body had \`await using\` in a method declared without \`async\`. After #238, the gate emits sync \`using var serviceScope = _serviceScopeFactory.CreateScope();\` for non-\`AsyncTask\` methods.

The test goes through the full \`ServiceCollectionServerVariableSource\` → \`ServiceContainer\` → \`AssemblyGenerator.Generate\` path that Wolverine's HTTP and message-handler codegen uses, so it pins the fix at the integration level where wolverine#2719 surfaced.

## Test plan

- [x] \`dotnet test src/CodegenTests/CodegenTests.csproj --framework net9.0 --filter "Bug_244"\` passes locally
- [ ] CI green
- [ ] After merge: trigger \`on-manual-do-nuget-publish.yml\` to push \`JasperFx 2.0.0-alpha.10\` to NuGet so Wolverine can pin it

🤖 Generated with [Claude Code](https://claude.com/claude-code)