### PR TITLE
Set IsAotCompatible=true on JasperFx + JasperFx.Events (#213)

### DIFF
--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -4,6 +4,11 @@
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
         <Version>2.0.0-alpha.3</Version>
+        <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
+             reflective surface that isn't already annotated surfaces during our own
+             build. JasperFx.csproj carries the same flag — together they're the
+             punch-list source for the AOT pillar. -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -4,6 +4,11 @@
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
         <Version>2.0.0-alpha.10</Version>
+        <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
+             reflective public surface that isn't already annotated with
+             [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]
+             surfaces during our own build rather than downstream consumers'. -->
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">


### PR DESCRIPTION
First deliverable on the [AOT compliance pillar](https://github.com/JasperFx/jasperfx/issues/213) for the Critter Stack 2026 wave. Sets `IsAotCompatible=true` on the two foundational packages so the IL2026 / IL2070 / IL2075 / IL3050 analyzers run against our own build. Reflective surfaces that still need `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]` / `[DynamicallyAccessedMembers]` annotations surface here, not in downstream consumers' CI.

## Surface

```xml
<!-- src/JasperFx/JasperFx.csproj, src/JasperFx.Events/JasperFx.Events.csproj -->
<IsAotCompatible>true</IsAotCompatible>
```

## Behavior

- Build succeeds on both projects. No new errors.
- All four CI test projects pass locally on `net9.0` + `net10.0`:
  - `CoreTests` — 407 passed
  - `EventTests` — 255 passed
  - `CodegenTests` — 366 passed
  - `CommandLineTests` — 280 passed
- The trimming / AOT analyzer now emits a punch-list of warnings against reflective surfaces. These are tracking-only — none of them are new bugs, they're prior reflective code that the analyzer can now see because it's enabled.

## Initial fallout (net9.0 baseline; net10.0 mirrors)

**JasperFx — 236 warnings**

| Area | Warnings | Notes |
|---|---|---|
| `Core/Reflection` | 64 | `ValueTypeInfo`, `GenericFactoryCache`, `TypeExtensions` |
| `CodeGeneration/Services` + misc | 54 | `ServiceProviderPlan`, `ServiceFamily`, `ArrayPlan`, `GeneratedType`, `Snapshots/SnapshotGate` |
| `CommandLine/*` | 46 | `CommandFactory`, `Parsing/*`, `Internal`, `DependencyInjectionCommandCreator` — **scope of follow-up B** |
| `Core/IoC` | 30 | `GenericConnectionScanner`, `DefaultConventionScanner`, `ImplementationMap` |
| `ServiceContainer.cs` | 16 | Closed-generic registration paths |
| `Core/TypeScanning` | 10 | `AssemblyFinder`, `AssemblyTypes` |
| `JasperFxOptions.cs` | 6 | |
| Misc | 10 | `Resources`, `Environment`, `Descriptors`, `CommandLineHostingExtensions` |

**JasperFx.Events — 134 warnings**

| Area | Warnings | Notes |
|---|---|---|
| `Projections/EventProjectionApplication.cs` | 30 | Method-table reflection |
| `Aggregation/*` | 60 | `JasperFxAggregationProjectionBase`, `AggregateApplication.{Register,Creating,ShouldDelete,Applies}`, `CreateMethodCollection`, `ApplyMethodCollection`, `AggregateVersioning` |
| `Internals/MethodCollection.cs`, `IEventRegistry.cs` | 12 | |
| Misc | 16 | `Daemon`, `CommandLine`, `StreamAction`, `Tags`, `ReflectionExtensions` |

## Why this lands flag-only

Per the pillar definition, the goal is **either** AOT-clean **or** every dynamic surface annotated with precise `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]`. Annotating ~370 warning sites in a single PR would be unreviewable; each slice is naturally a follow-up.

Immediate next steps (separate PRs, tracked under #213):

- **`JasperFx.CommandLine` audit** — assembly-scanning for `IJasperFxCommand`, ~46 warnings. Already queued as the next pillar deliverable.
- **AOT-clean smoke-test consumer project in CI** — pins the build green per slice once annotated.
- **Per-slice annotation passes** for `Core/Reflection`, `Core/IoC`, `Aggregation`, `Projections` — best filed as follow-up issues against #213 so they can be tackled independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)