### PR TITLE
Bump JasperFx → 2.0.0-alpha.11 and JasperFx.Events → 2.0.0-alpha.4

### DIFF
--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.3</Version>
+        <Version>2.0.0-alpha.4</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.10</Version>
+        <Version>2.0.0-alpha.11</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
Carries the AOT pillar Tier 1 work ([#213](https://github.com/JasperFx/jasperfx/issues/213)) that landed in #247 + #250 — `IsAotCompatible=true` on both packages, the CommandLine reflective surface annotated, and the AOT-clean smoke-test consumer in CI.

| Package | Old | New |
|---|---|---|
| `JasperFx` | 2.0.0-alpha.10 | 2.0.0-alpha.11 |
| `JasperFx.Events` | 2.0.0-alpha.3 | 2.0.0-alpha.4 |

Other packed packages (`JasperFx.RuntimeCompiler`, `JasperFx.SourceGeneration`, `JasperFx.Events.SourceGenerator`) keep their existing versions — nothing changed in those projects this cycle. `NugetPush` uses `EnableSkipDuplicate()`, so the re-pushed artifacts at unchanged versions are no-ops on nuget.org.

Once this merges I'll trigger the `JasperFx NuGet Manual Publish` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)