### PR TITLE
Annotate ServiceContainer reflective surface for AOT (closes #254)

### DIFF
--- a/src/JasperFx/IServiceContainer.cs
+++ b/src/JasperFx/IServiceContainer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration.Frames;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,7 +26,9 @@ public interface IServiceContainer
     /// <param name="provider"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    T QuickBuild<T>();
+    [RequiresUnreferencedCode("QuickBuild reflects over T's public constructors and resolves [FromKeyedServices] parameters by closing IFinder<TParameter> via CloseAndBuildAs.")]
+    [RequiresDynamicCode("CloseAndBuildAs uses MakeGenericType + Activator.CreateInstance on IFinder<TParameter>.")]
+    T QuickBuild<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>();
 
     /// <summary>
     /// Polyfill to make IServiceProvider work like Lamar's ability
@@ -34,8 +37,10 @@ public interface IServiceContainer
     /// <param name="provider"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    object QuickBuild(Type concreteType);
-    
+    [RequiresUnreferencedCode("QuickBuild reflects over concreteType's public constructors and resolves [FromKeyedServices] parameters by closing IFinder<TParameter> via CloseAndBuildAs.")]
+    [RequiresDynamicCode("CloseAndBuildAs uses MakeGenericType + Activator.CreateInstance on IFinder<TParameter>.")]
+    object QuickBuild([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type concreteType);
+
     IServiceProvider Services { get; }
     T GetInstance<T>();
     IReadOnlyList<T> GetAllInstances<T>();

--- a/src/JasperFx/ServiceContainer.cs
+++ b/src/JasperFx/ServiceContainer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Services;
@@ -74,6 +75,8 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
         return DefaultFor(typeof(T));
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "Builds a transient self-binding ServiceDescriptor for each MethodCall.HandlerType so Wolverine can wire constructor dependencies into generated code. Handler types are reached from Wolverine's IHandlerDiscovery surface, which is itself an annotated reflective entry point — handler types preserve their public constructors transitively, and a missing public ctor surfaces as the explicit NotSupportedException below rather than as a silent runtime failure.")]
     public IEnumerable<Frame> TryCreateConstructorFrames(IEnumerable<MethodCall> calls)
     {
         if (calls.All(x => x.Method.IsStatic)) return new List<Frame>();
@@ -206,6 +209,8 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
         return false;
     }
     
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "The IsPublic + IsConcrete branch below auto-registers a self-binding ServiceDescriptor for public concrete types that weren't explicitly registered. Public concrete types reached via the family lookup either come from typeof(T) (compiler-preserved) or from user-supplied registrations whose constructors the user must keep alive. A missing public ctor at activation time surfaces from ConstructorPlan.TryBuildPlan as an InvalidPlan, not a silent failure.")]
     private ServiceFamily findFamily(Type serviceType)
     {
         if (_families.TryFind(serviceType, out var family)) return family;
@@ -287,7 +292,7 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
         return findFamily(serviceType).Services.Select(descriptor => PlanFor(descriptor, trail)).ToArray();
     }
 
-    public object BuildFromType(Type concreteType)
+    public object BuildFromType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type concreteType)
     {
         var constructor = concreteType.GetConstructors().Single();
         var dependencies = constructor.GetParameters().Select(x => _provider.GetService(x.ParameterType)).ToArray();
@@ -306,11 +311,13 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
     /// <param name="provider"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public T QuickBuild<T>()
+    [RequiresUnreferencedCode("QuickBuild reflects over T's public constructors and resolves [FromKeyedServices] parameters by closing IFinder<TParameter> via CloseAndBuildAs. The trimmer may remove types reached only through that closure.")]
+    [RequiresDynamicCode("CloseAndBuildAs uses MakeGenericType + Activator.CreateInstance on IFinder<TParameter>.")]
+    public T QuickBuild<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>()
     {
         return (T)QuickBuild(typeof(T));
     }
-    
+
     /// <summary>
     /// Polyfill to make IServiceProvider work like Lamar's ability
     /// to create unknown concrete types
@@ -318,7 +325,9 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
     /// <param name="provider"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public object QuickBuild(Type concreteType)
+    [RequiresUnreferencedCode("QuickBuild reflects over concreteType's public constructors and resolves [FromKeyedServices] parameters by closing IFinder<TParameter> via CloseAndBuildAs. The trimmer may remove types reached only through that closure.")]
+    [RequiresDynamicCode("CloseAndBuildAs uses MakeGenericType + Activator.CreateInstance on IFinder<TParameter>.")]
+    public object QuickBuild([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type concreteType)
     {
         var constructor = concreteType.GetConstructors().Single();
         var args = constructor
@@ -329,7 +338,7 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
                 {
                     return typeof(IFinder<>).CloseAndBuildAs<IFinder>(x.ParameterType).Find(_provider, att.Key.ToString());
                 }
-                
+
                 return _provider.GetService(x.ParameterType);
             })
             .ToArray();


### PR DESCRIPTION
Fourth AOT-pillar slice (jasperfx#213) — closes #254.

16 IL warnings per TFM in \`ServiceContainer.cs\` → **0**, with one matching annotation pair on \`IServiceContainer\` to keep IL2046 quiet across the impl boundary.

## Annotations

| Member | Annotation |
|---|---|
| \`IServiceContainer.QuickBuild<T>()\` + impl | \`[RequiresUnreferencedCode]\` + \`[RequiresDynamicCode]\` + \`[DAM(PublicConstructors)] T\` |
| \`IServiceContainer.QuickBuild(Type concreteType)\` + impl | same shape, \`[DAM(PublicConstructors)]\` on \`concreteType\` |
| \`ServiceContainer.BuildFromType(Type concreteType)\` | \`[DAM(PublicConstructors)]\` on \`concreteType\` (not on interface, so interface stays untouched) |

## Suppressed with justification

| Method | Why |
|---|---|
| \`TryCreateConstructorFrames(IEnumerable<MethodCall>)\` | IL2067 at the \`ServiceDescriptor\` self-binding for each \`MethodCall.HandlerType\`. Handler types reach this method from Wolverine's annotated \`IHandlerDiscovery\` surface; a missing ctor surfaces as the explicit \`NotSupportedException\` below, not a silent failure. |
| \`findFamily(Type)\` | IL2067 at the auto-self-binding branch for public concrete types not explicitly registered. Reached either from \`typeof(T)\` (compiler-preserved) or from user registrations whose ctors the user must keep alive. \`ConstructorPlan.TryBuildPlan\` returns \`InvalidPlan\` on missing ctors. |

## Effect on the punch list

```
Before (after #247 + #250):  JasperFx total per TFM 188
After this PR:               JasperFx total per TFM 172  (-16)
```

Remaining slices:

| Issue | Area | Warnings |
|---|---|---|
| #252 | Core/Reflection | 64 |
| #253 | Core/IoC | 30 |
| #255 | CodeGeneration/Services | 22 |
| — | Core/TypeScanning | 10 |
| — | CodeGeneration/Snapshots | 8 |
| — | CodeGeneration/GeneratedType.cs | 8 |
| — | JasperFxOptions.cs | 6 |
| — | misc tail | ~24 |

## Verification

- \`CoreTests\` — 407/407 pass on net9.0 + net10.0
- \`SmokeTestAot\` — build clean, program exits 0

Closes #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)