### PR TITLE
Annotate CodeGeneration/Services reflective surface for AOT (closes #255)

### DIFF
--- a/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
@@ -8,6 +9,8 @@ namespace JasperFx.CodeGeneration.Services;
 
 internal class ArrayFamily : ServiceFamily
 {
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "ArrayFamily wraps a collection-shaped serviceType (T[] / IEnumerable<T> / IList<T> / IReadOnlyList<T>) — there is no real constructor to preserve. The placeholder ServiceDescriptor exists so the family has a Default; the actual code emission uses CreateArrayFrame to write `new T[]{...}` source literal, never reflection.")]
     public ArrayFamily(Type serviceType) : base(serviceType, [new ServiceDescriptor(serviceType, serviceType, ServiceLifetime.Scoped)])
     {
         ElementType = serviceType.GetElementType() ?? serviceType.GenericTypeArguments[0];

--- a/src/JasperFx/CodeGeneration/Services/ConstructorPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ConstructorPlan.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using JasperFx.CodeGeneration.Frames;
@@ -9,7 +10,8 @@ namespace JasperFx.CodeGeneration.Services;
 
 internal class ConstructorPlan : ServicePlan
 {
-    public static ConstructorInfo[] FindPublicConstructorCandidates(Type implementationType)
+    public static ConstructorInfo[] FindPublicConstructorCandidates(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
     {
         // The codegen cannot use any non-public types
         if (implementationType is { IsPublic: false, IsNestedPublic: false })

--- a/src/JasperFx/CodeGeneration/Services/ServiceFamily.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceFamily.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,12 +17,14 @@ internal class ServiceFamily
 
     public ServiceDescriptor? Default => Services.LastOrDefault(x => !x.IsKeyedService);
 
+    [RequiresUnreferencedCode("Closes an open-generic ServiceType / ImplementationType via MakeGenericType using user-supplied parameter types. The trimmer cannot statically reason about the closed shape; consumers depending on this path either accept the warning or replace open-generic registration with closed-generic / source-generated alternatives.")]
+    [RequiresDynamicCode("ServiceType.MakeGenericType + descriptor.ImplementationType.MakeGenericType require runtime code generation.")]
     public ServiceFamily Close(Type[] parameterTypes)
     {
         if (!ServiceType.IsOpenGeneric())
             throw new InvalidOperationException($"{ServiceType.FullNameInCode()} is not an open type");
         var serviceType = ServiceType.MakeGenericType(parameterTypes);
-        
+
         var candidates = Services.Where(x => x.ImplementationType != null).Select(open =>
         {
             try

--- a/src/JasperFx/CodeGeneration/Services/ServiceProviderPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceProviderPlan.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration.Model;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -7,9 +8,11 @@ internal class ServiceProviderFamily : ServiceFamily
 {
     public ServiceProviderFamily() : base(typeof(IServiceProvider), Array.Empty<ServiceDescriptor>())
     {
-        
+
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2111:DynamicallyAccessedMembers",
+        Justification = "The placeholder ServiceDescriptor here uses typeof(ServiceDescriptor) as a stand-in implementation type only to satisfy the ServiceDescriptor ctor's non-null contract — ServiceProviderPlan.CreateVariable throws NotImplementedException and the descriptor is never actually instantiated. The real IServiceProvider is bound by the host's DI container.")]
     public override ServicePlan? BuildDefaultPlan(ServiceContainer graph, List<ServiceDescriptor> trail)
     {
         return new ServiceProviderPlan(new ServiceDescriptor(typeof(IServiceProvider), typeof(ServiceDescriptor),
@@ -21,9 +24,11 @@ internal class ServiceScopeFactoryFamily : ServiceFamily
 {
     public ServiceScopeFactoryFamily() : base(typeof(IServiceScopeFactory), Array.Empty<ServiceDescriptor>())
     {
-        
+
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2111:DynamicallyAccessedMembers",
+        Justification = "The placeholder ServiceDescriptor here uses typeof(ServiceDescriptor) as a stand-in implementation type only to satisfy the ServiceDescriptor ctor's non-null contract — ServiceProviderPlan.CreateVariable throws NotImplementedException and the descriptor is never actually instantiated. The real IServiceScopeFactory is bound by the host's DI container.")]
     public override ServicePlan? BuildDefaultPlan(ServiceContainer graph, List<ServiceDescriptor> trail)
     {
         return new ServiceProviderPlan(new ServiceDescriptor(typeof(IServiceScopeFactory), typeof(ServiceDescriptor),

--- a/src/JasperFx/ServiceContainer.cs
+++ b/src/JasperFx/ServiceContainer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Services;
@@ -206,6 +207,10 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
         return false;
     }
     
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Calls into ServiceFamily.Close for open-generic registration close-over. Open-generic registrations are themselves a dynamic-code feature; AOT-publishing apps should use closed-generic registrations or source-generated equivalents and won't reach this branch.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Same as IL2026 — ServiceFamily.Close uses MakeGenericType, reached only via the open-generic registration path.")]
     private ServiceFamily findFamily(Type serviceType)
     {
         if (_families.TryFind(serviceType, out var family)) return family;


### PR DESCRIPTION
Third AOT-pillar slice (jasperfx#213) — closes #255.

22 IL warnings per TFM across 4 files in `CodeGeneration/Services` → **0**, plus one small ripple suppression at `ServiceContainer.findFamily` for the open-generic call into the now-annotated `ServiceFamily.Close`.

## Annotations

| Method | Annotation |
|---|---|
| `ConstructorPlan.FindPublicConstructorCandidates(Type implementationType)` | `[DAM(PublicConstructors)]` on `implementationType` — satisfies IL2070 at the `GetConstructors()` call. The call site in `TryBuildPlan` passes `descriptor.ImplementationType` / `KeyedImplementationType`, which already carry the matching DAM from MS DI. |
| `ServiceFamily.Close(Type[] parameterTypes)` | `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` — open-generic close uses `MakeGenericType` on `ServiceType` + each `ImplementationType`. Honest characterization. |

## Suppressed with justification

| Site | Why |
|---|---|
| `ServiceProviderFamily.BuildDefaultPlan` / `ServiceScopeFactoryFamily.BuildDefaultPlan` (IL2111) | The placeholder `typeof(ServiceDescriptor)` is never actually instantiated — `ServiceProviderPlan.CreateVariable` throws `NotImplementedException`; the real `IServiceProvider` / `IServiceScopeFactory` comes from the host's DI. |
| `ArrayFamily(Type serviceType)` (IL2067) | The placeholder `ServiceDescriptor` for collection-shaped types — no constructor is ever invoked, `CreateArrayFrame` emits `new T[]{…}` source literal. |
| `ServiceContainer.findFamily(Type)` (IL2026 + IL3050) | Inherited from the annotated `Close()` call at the open-generic close path. Open-generic registration is itself a dynamic-code feature; AOT-publishing apps avoid it. |

## Effect on the punch list

```
Before:  JasperFx total per TFM  188
After:   JasperFx total per TFM  166  (-22, this slice)
```

Remaining slices: #252 Core/Reflection (64), #253 Core/IoC (30), #254 ServiceContainer.cs (16, PR #256 in flight), plus smaller tails.

## Overlap with #254

This PR adds an `[UnconditionalSuppressMessage]` for IL2026 + IL3050 to `ServiceContainer.findFamily`. PR #256 (closes #254) adds a separate `[UnconditionalSuppressMessage]` for IL2067 to the same method. Whichever PR merges second will need a one-attribute textual rebase — the attributes themselves are non-conflicting.

## Verification

- `CoreTests` — 407/407 pass on net9.0 + net10.0
- `SmokeTestAot` — build clean, exits 0

Closes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
