### PR TITLE
Annotate Core/IoC reflective surface for AOT (closes #253)

### DIFF
--- a/src/JasperFx/Core/IoC/AssemblyScanner.cs
+++ b/src/JasperFx/Core/IoC/AssemblyScanner.cs
@@ -304,6 +304,8 @@ public class AssemblyScanner : IAssemblyScanner
         TypeFinder = TypeRepository.FindTypes(_assemblies, type => _filter.Matches(type));
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Dispatches each IRegistrationConvention.ScanTypes call, which scans discovered types reflectively and constructs ServiceDescriptors.")]
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Open-generic conventions close types via MakeGenericType.")]
     public void ApplyRegistrations(IServiceCollection services)
     {
         foreach (var convention in Conventions) convention.ScanTypes(TypeFinder, services);

--- a/src/JasperFx/Core/IoC/DefaultConventionScanner.cs
+++ b/src/JasperFx/Core/IoC/DefaultConventionScanner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core.TypeScanning;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,8 @@ internal class DefaultConventionScanner : IRegistrationConvention
 
     public OverwriteBehavior Overwrites { get; set; } = OverwriteBehavior.NewType;
 
+    [RequiresUnreferencedCode("Convention scans types reflectively and constructs ServiceDescriptors; discovered types and their constructors must survive trimming.")]
+    [RequiresDynamicCode("Inherits the contract of IRegistrationConvention.ScanTypes.")]
     public void ScanTypes(TypeSet types, IServiceCollection services)
     {
         foreach (var type in types.FindTypes(TypeClassification.Concretes)
@@ -51,6 +54,8 @@ internal class DefaultConventionScanner : IRegistrationConvention
         return !hasMatch;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+        Justification = "Reads concreteType's interface list to find the matching I{Name} interface. Reachable only from ScanTypes which is annotated [RequiresUnreferencedCode]; trim-conscious callers either avoid convention scanning entirely or accept that registered types' interfaces survive trimming.")]
     public virtual Type? FindServiceType(Type concreteType)
     {
         var interfaceName = "I" + concreteType.Name;

--- a/src/JasperFx/Core/IoC/FindAllTypesFilter.cs
+++ b/src/JasperFx/Core/IoC/FindAllTypesFilter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Core.TypeScanning;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,8 @@ public class FindAllTypesFilter : IRegistrationConvention
         _lifetime = lifetime;
     }
 
+    [RequiresUnreferencedCode("Convention scans types reflectively for any implementor of _serviceType; discovered types and their constructors must survive trimming.")]
+    [RequiresDynamicCode("Open-generic _serviceType uses GenericConnectionScanner which closes types via MakeGenericType.")]
     void IRegistrationConvention.ScanTypes(TypeSet types, IServiceCollection services)
     {
         if (_serviceType.IsOpenGeneric())
@@ -32,11 +35,17 @@ public class FindAllTypesFilter : IRegistrationConvention
         }
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+        Justification = "type comes from convention-scan discovery; reachable only from ScanTypes which is annotated [RequiresUnreferencedCode]. The user invariant for convention-based registration is that discovered types' constructors survive trimming.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "Same as IL2070 — TypeExtensions.CanBeCreated has a [DAM(PublicConstructors)] constraint that propagates from the (un-annotated) convention-scan discovery surface.")]
     private bool Matches(Type type)
     {
         return type.CanBeCastTo(_serviceType) && type.GetConstructors().Any() && type.CanBeCreated();
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "type.FindFirstInterfaceThatCloses needs [DAM(Interfaces)]; type comes from convention-scan discovery. See Matches for the matching convention-scan justification.")]
     private static Type determineLeastSpecificButValidType(Type pluginType, Type type)
     {
         if (pluginType.IsGenericTypeDefinition && !type.IsOpenGeneric())

--- a/src/JasperFx/Core/IoC/FirstInterfaceConvention.cs
+++ b/src/JasperFx/Core/IoC/FirstInterfaceConvention.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Core.TypeScanning;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,8 @@ internal class FirstInterfaceConvention : IRegistrationConvention
         _lifetime = lifetime;
     }
 
+    [RequiresUnreferencedCode("Convention scans concrete types reflectively and registers each against its first non-IDisposable interface; discovered types and their constructors must survive trimming.")]
+    [RequiresDynamicCode("Inherits the contract of IRegistrationConvention.ScanTypes.")]
     public void ScanTypes(TypeSet types, IServiceCollection services)
     {
         foreach (var type in types.FindTypes(TypeClassification.Concretes).Where(x => x.GetConstructors().Any()))

--- a/src/JasperFx/Core/IoC/GenericConnectionScanner.cs
+++ b/src/JasperFx/Core/IoC/GenericConnectionScanner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Core.TypeScanning;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,8 @@ internal class GenericConnectionScanner : IRegistrationConvention
         }
     }
 
+    [RequiresUnreferencedCode("Convention scans types reflectively, closes open generics via MakeGenericType, and constructs ServiceDescriptors. Open-generic implementations and their public constructors must survive trimming.")]
+    [RequiresDynamicCode("addConcretionsThatCouldBeClosed calls Type.MakeGenericType.")]
     public void ScanTypes(TypeSet types, IServiceCollection services)
     {
         foreach (var type in types.AllTypes())
@@ -63,6 +66,12 @@ internal class GenericConnectionScanner : IRegistrationConvention
         return "Connect all implementations of open generic type " + _openType.FullNameInCode();
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "ServiceDescriptor ctor with the closed concreteType; reachable only from ScanTypes which is annotated [RequiresUnreferencedCode]. The open-generic concretion's public constructors must survive trimming for convention-based registration to work.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055:DynamicallyAccessedMembers",
+        Justification = "Closes an open generic via MakeGenericType. The caller is annotated [RequiresDynamicCode] at ScanTypes.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Closes an open generic via MakeGenericType. The caller is annotated [RequiresDynamicCode] at ScanTypes.")]
     private void addConcretionsThatCouldBeClosed(Type @interface, IServiceCollection services)
     {
         _concretions.Where(x => x.IsOpenGeneric())

--- a/src/JasperFx/Core/IoC/IRegistrationConvention.cs
+++ b/src/JasperFx/Core/IoC/IRegistrationConvention.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.TypeScanning;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -6,10 +7,21 @@ namespace JasperFx.Core.IoC;
 #region sample_IRegistrationConvention
 
 /// <summary>
-///     Used to create custom type scanning conventions
+///     Used to create custom type scanning conventions.
 /// </summary>
+/// <remarks>
+///     Convention-based registration walks types discovered from loaded assemblies
+///     and constructs <see cref="ServiceDescriptor"/>s from them. The trimmer cannot
+///     reason statically about which types survive, and any <c>MakeGenericType</c>
+///     used by an open-generic convention needs runtime code generation. AOT-publishing
+///     apps should either avoid convention-based registration entirely (use explicit
+///     <c>services.AddSingleton&lt;TService, TImpl&gt;()</c> calls) or substitute a
+///     source-generated registration manifest.
+/// </remarks>
 public interface IRegistrationConvention
 {
+    [RequiresUnreferencedCode("Scans TypeSet for types matching the convention and constructs ServiceDescriptors reflectively. Discovered types and their constructors must survive trimming.")]
+    [RequiresDynamicCode("Open-generic conventions close types via MakeGenericType, which requires runtime code generation.")]
     void ScanTypes(TypeSet types, IServiceCollection services);
 }
 

--- a/src/JasperFx/Core/IoC/ImplementationMap.cs
+++ b/src/JasperFx/Core/IoC/ImplementationMap.cs
@@ -1,4 +1,5 @@
-﻿using JasperFx.Core.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core.Reflection;
 using JasperFx.Core.TypeScanning;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,6 +14,8 @@ internal class ImplementationMap : IRegistrationConvention
         _lifetime = lifetime;
     }
 
+    [RequiresUnreferencedCode("Convention scans types reflectively and constructs ServiceDescriptors for any single-implementation interface; discovered types and their constructors must survive trimming.")]
+    [RequiresDynamicCode("Inherits the contract of IRegistrationConvention.ScanTypes.")]
     public void ScanTypes(TypeSet types, IServiceCollection services)
     {
         var interfaces = types.FindTypes(TypeClassification.Interfaces | TypeClassification.Closed)

--- a/src/JasperFx/Core/IoC/ScanningExploder.cs
+++ b/src/JasperFx/Core/IoC/ScanningExploder.cs
@@ -1,9 +1,12 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JasperFx.Core.IoC;
 
 internal static class ScanningExploder
 {
+    [RequiresUnreferencedCode("Drives AssemblyScanner.ApplyRegistrations, which dispatches IRegistrationConvention.ScanTypes for each registered convention.")]
+    [RequiresDynamicCode("Open-generic conventions close types via MakeGenericType.")]
     internal static (IServiceCollection, AssemblyScanner[]) ExplodeSynchronously(IServiceCollection services)
     {
         var scanners = new AssemblyScanner[0];
@@ -42,6 +45,8 @@ internal static class ScanningExploder
         return (registry, scanners);
     }
 
+    [RequiresUnreferencedCode("Drives AssemblyScanner.ApplyRegistrations, which dispatches IRegistrationConvention.ScanTypes for each registered convention.")]
+    [RequiresDynamicCode("Open-generic conventions close types via MakeGenericType.")]
     internal static Task<(IServiceCollection, AssemblyScanner[])> Explode(IServiceCollection services)
     {
         var scanners = Array.Empty<AssemblyScanner>();

--- a/src/JasperFx/Core/IoC/ServiceCollectionExtensions.cs
+++ b/src/JasperFx/Core/IoC/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JasperFx.Core.IoC;
 
@@ -18,6 +19,8 @@ public static class ServiceCollectionExtensions
     ///     Create an isolated type scanning registration policy
     /// </summary>
     /// <param name="scan"></param>
+    [RequiresUnreferencedCode("Scans assemblies for types matching the registered IRegistrationConventions and constructs ServiceDescriptors reflectively. AOT-publishing apps should use explicit registrations or a source-generated registration manifest instead of convention scanning.")]
+    [RequiresDynamicCode("Open-generic conventions close types via MakeGenericType.")]
     public static IServiceCollection Scan(this IServiceCollection services, Action<IAssemblyScanner> scan)
     {
         var finder = new AssemblyScanner(services);
@@ -73,7 +76,7 @@ public static class ServiceCollectionExtensions
     }
 
     public static ServiceDescriptor? AddType(this IServiceCollection services, Type serviceType,
-        Type implementationType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
         ServiceLifetime lifetime = ServiceLifetime.Transient)
     {
         var hasAlready = services.Any(x => x.Matches(serviceType, implementationType));

--- a/src/JasperFx/Core/IoC/TypeExtensions.cs
+++ b/src/JasperFx/Core/IoC/TypeExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 
@@ -5,22 +6,29 @@ namespace JasperFx.Core.IoC;
 
 internal static class TypeExtensions
 {
-    public static bool CanBeCreated(this Type type)
+    public static bool CanBeCreated(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] this Type type)
     {
         return type.IsConcrete() && type.GetConstructors().Any();
     }
 
 
-    public static Type FindFirstInterfaceThatCloses(this Type implementationType, Type templateType)
+    public static Type FindFirstInterfaceThatCloses(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type implementationType,
+        Type templateType)
     {
         return implementationType.FindInterfacesThatClose(templateType).FirstOrDefault()!;
     }
 
-    public static IEnumerable<Type> FindInterfacesThatClose(this Type pluggedType, Type templateType)
+    public static IEnumerable<Type> FindInterfacesThatClose(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type pluggedType,
+        Type templateType)
     {
         return rawFindInterfacesThatCloses(pluggedType, templateType).Distinct();
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+        Justification = "Recurses up BaseType chain to find matching interface closures. The caller chain enters from FindInterfacesThatClose which carries [DAM(Interfaces)] on the first parameter; base types beyond the entry point are walked best-effort and the trim impact is bounded by the entry-point annotation.")]
     private static IEnumerable<Type> rawFindInterfacesThatCloses(Type TPluggedType, Type templateType)
     {
         if (!TPluggedType.IsConcrete())


### PR DESCRIPTION
Second AOT-pillar slice (jasperfx#213) — closes #253.

30 IL warnings per TFM across 7 files in `Core/IoC` → **0**, plus matching propagation to `AssemblyScanner` / `ScanningExploder` / `ServiceCollectionExtensions.Scan` to keep IL2026 quiet across the public convention-registration surface.

## Why annotate (not just suppress)

Convention-scanning is fundamentally trim-hostile: `TypeSet` enumerates types from loaded assemblies, conventions register types by naming / interface patterns, and `ServiceDescriptor`s are constructed from runtime-discovered `Type`s. AOT-publishing apps should either avoid convention-based registration entirely (use explicit `services.AddSingleton<TService, TImpl>()`) or substitute a source-generated registration manifest.

## Public surface annotated

| Member | Annotation |
|---|---|
| `IRegistrationConvention.ScanTypes` | `[RUC]` + `[RDC]` |
| `ServiceCollectionExtensions.Scan(IServiceCollection, Action<IAssemblyScanner>)` | `[RUC]` + `[RDC]` |
| `ServiceCollectionExtensions.AddType(IServiceCollection, Type, Type, ServiceLifetime)` | `[DAM(PublicConstructors)]` on `implementationType` |
| `AssemblyScanner.ApplyRegistrations` | `[RUC]` + `[RDC]` |
| `FindAllTypesFilter.IRegistrationConvention.ScanTypes` | `[RUC]` + `[RDC]` (matches interface) |

## Implementations annotated (match interface)

`DefaultConventionScanner.ScanTypes`, `FirstInterfaceConvention.ScanTypes`, `ImplementationMap.ScanTypes`, `GenericConnectionScanner.ScanTypes` — all carry the matching `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]`.

## Internal helpers annotated

| Member | Annotation |
|---|---|
| `TypeExtensions.CanBeCreated(this Type)` | `[DAM(PublicConstructors)]` |
| `TypeExtensions.FindFirstInterfaceThatCloses(this Type, Type)` | `[DAM(Interfaces)]` |
| `TypeExtensions.FindInterfacesThatClose(this Type, Type)` | `[DAM(Interfaces)]` |

## Internal propagation

`ScanningExploder.Explode` + `ExplodeSynchronously` annotated with `[RUC]` + `[RDC]` to keep the convention-scan dispatch site quiet.

## Suppressed with justification

| Site | Why |
|---|---|
| `DefaultConventionScanner.FindServiceType` | IL2070 on `GetInterfaces()`. Reached only from `ScanTypes` which is annotated; user invariant for convention scanning is that registered types' interfaces survive trimming. |
| `GenericConnectionScanner.addConcretionsThatCouldBeClosed` | IL2055 + IL2067 + IL3050 on `MakeGenericType` + `ServiceDescriptor` ctor. The caller (`ScanTypes`) is annotated `[RDC]`. |
| `FindAllTypesFilter.Matches` + `determineLeastSpecificButValidType` | IL2070 + IL2067 on `type.GetConstructors()` + `FindFirstInterfaceThatCloses`. Convention-scan discovery surface. |
| `TypeExtensions.rawFindInterfacesThatCloses` | IL2070 on the recursive `BaseType` walk. Trim impact bounded by the entry-point `[DAM(Interfaces)]`. |

## Effect on the punch list

```
Before:  JasperFx total per TFM  188
After:   JasperFx total per TFM  158  (-30, this slice)
```

Remaining slices: #252 Core/Reflection (64), #254 ServiceContainer.cs (16, PR #256 in flight), #255 CodeGeneration/Services (22, PR #257 in flight), plus smaller tails.

## Verification

- `CoreTests` — 407/407 pass on net9.0 + net10.0
- `SmokeTestAot` — build clean, exits 0

Closes #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
