### PR TITLE
Annotate remaining AOT pillar tail in JasperFx (74 → 0 warnings)

### DIFF
--- a/src/JasperFx/CodeGeneration/CodeGenerationExtensions.cs
+++ b/src/JasperFx/CodeGeneration/CodeGenerationExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using JasperFx.CodeGeneration.Model;
@@ -37,6 +38,8 @@ public static class CodeGenerationExtensions
         return index.TryGetValue(fullName, out var type) ? type : null;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Indexes exported types of an assembly already loaded into the AppDomain. Used by FindPreGeneratedType to locate codegen output — types that aren't preserved by the consuming app's static graph wouldn't be reachable from FindPreGeneratedType callers anyway.")]
     private static IReadOnlyDictionary<string, Type> BuildExportedTypeIndex(Assembly assembly)
     {
         // ExportedTypes can contain duplicates only in pathological cases (forwarded

--- a/src/JasperFx/CodeGeneration/Expressions/LambdaDefinition.cs
+++ b/src/JasperFx/CodeGeneration/Expressions/LambdaDefinition.cs
@@ -49,6 +49,7 @@ public class LambdaDefinition
         return expression;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Compiles an expression tree via FastExpressionCompiler; the trimmer cannot reason about types reached only through the resulting delegate.")]
     public TFunc Compile<TFunc>() where TFunc : class
     {
         if (!Body.Any())

--- a/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
+++ b/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
@@ -36,7 +36,10 @@ public enum ReturnAction
 
 public class MethodCall : Frame
 {
-    public MethodCall(Type handlerType, string methodName) : this(handlerType, handlerType.GetMethod(methodName)!)
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("MethodCall reflects over handlerType.GetMethod(methodName); the requested method must survive trimming.")]
+    public MethodCall(
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)] Type handlerType,
+        string methodName) : this(handlerType, handlerType.GetMethod(methodName)!)
     {
     }
 
@@ -188,6 +191,8 @@ public class MethodCall : Frame
         return new MethodCall(typeof(T), method!);
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "Checks the return type against well-known framework Task / ValueTask shapes. type.Closes walks well-known interface hierarchies; user-defined task-like types satisfying this are themselves trim-preserved by their consuming context.")]
     private Type? correctedReturnType(Type type)
     {
         if (type == typeof(Task) || type == typeof(ValueTask) || type == typeof(void))
@@ -406,6 +411,8 @@ public class MethodCall : Frame
         return invokeMethod;
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+        Justification = "Checks Method.ReturnType against the well-known framework ValueTask / ValueTask<T> shapes. Trim-impact is bounded by framework types preserved by the runtime.")]
     private bool returnsValueTask()
     {
         return Method.ReturnType == typeof(ValueTask) || Method.ReturnType.Closes(typeof(ValueTask<>));

--- a/src/JasperFx/CodeGeneration/GeneratedAssembly.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedAssembly.cs
@@ -54,7 +54,12 @@ public class GeneratedAssembly
         _assemblies.Fill(assembly);
     }
 
-    public GeneratedType AddType(string typeName, Type baseType)
+    public GeneratedType AddType(
+        string typeName,
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors |
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods |
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)] Type baseType)
     {
         if (Assembly != null)
         {
@@ -76,6 +81,7 @@ public class GeneratedAssembly
         return generatedType;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Reads assembly.GetExportedTypes() to attach generated types into this GeneratedAssembly. AOT consumers loading pre-generated code rely on the source-generated type registry rather than this reflective scan.")]
     public void AttachAssembly(Assembly assembly)
     {
         var generated = assembly.GetExportedTypes().ToArray();

--- a/src/JasperFx/CodeGeneration/GeneratedType.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedType.cs
@@ -63,6 +63,7 @@ public class GeneratedType : IVariableSource, IGeneratedType
 
     public string? SourceCode { get; set; }
 
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
     public Type? CompiledType { get; private set; }
 
     public string FullName => $"{Namespace}.{TypeName}";
@@ -105,12 +106,19 @@ public class GeneratedType : IVariableSource, IGeneratedType
         Header = new MultiLineComment(text);
     }
 
-    public GeneratedType InheritsFrom<T>()
+    public GeneratedType InheritsFrom<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors |
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods |
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)] T>()
     {
         return InheritsFrom(typeof(T));
     }
 
-    public GeneratedType InheritsFrom(Type baseType)
+    public GeneratedType InheritsFrom(
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors |
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods |
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)] Type baseType)
     {
         var ctors = baseType.GetConstructors();
         if (ctors.Length > 1)
@@ -140,7 +148,9 @@ public class GeneratedType : IVariableSource, IGeneratedType
     }
 
 
-    public GeneratedType Implements(Type type)
+    public GeneratedType Implements(
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
     {
         if (!type.GetTypeInfo().IsInterface)
         {
@@ -155,7 +165,8 @@ public class GeneratedType : IVariableSource, IGeneratedType
         return this;
     }
 
-    public GeneratedType Implements<T>()
+    public GeneratedType Implements<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(
+        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)] T>()
     {
         return Implements(typeof(T));
     }
@@ -272,6 +283,8 @@ public class GeneratedType : IVariableSource, IGeneratedType
         foreach (var @interface in Interfaces) yield return @interface;
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+        Justification = "Assigns CompiledType (which has [DAM(PublicConstructors)]) from a runtime types lookup. The candidate types come from GeneratedAssembly.AttachAssembly's GetExportedTypes call which is itself annotated [RequiresUnreferencedCode] — the constructor preservation is owned at that boundary.")]
     public Type? FindType(IEnumerable<Type> types)
     {
         CompiledType = types.SingleOrDefault(x => x.FullName == FullName);
@@ -320,6 +333,7 @@ public class GeneratedType : IVariableSource, IGeneratedType
         return (T)Activator.CreateInstance(CompiledType, arguments)!;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls Setter.SetInitialValue which uses GetType().GetProperty reflectively on the supplied object.")]
     public void ApplySetterValues(object builtObject)
     {
         if (builtObject.GetType() != CompiledType)

--- a/src/JasperFx/CodeGeneration/Model/Setter.cs
+++ b/src/JasperFx/CodeGeneration/Model/Setter.cs
@@ -87,6 +87,7 @@ public class Setter : Variable
         throw new NotSupportedException();
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Reflectively sets a property by name on the supplied @object; @object's runtime type's properties must survive trimming.")]
     public void SetInitialValue(object @object)
     {
         if (InitialValue == null || Type != SetterType.ReadWrite)

--- a/src/JasperFx/CodeGeneration/Model/Variable.cs
+++ b/src/JasperFx/CodeGeneration/Model/Variable.cs
@@ -161,7 +161,7 @@ public class Variable
     /// </summary>
     public IList<Variable> Dependencies { get; } = new List<Variable>();
 
-    public static Variable[] VariablesForProperties<T>(string rootArgName)
+    public static Variable[] VariablesForProperties<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(string rootArgName)
     {
         return typeof(T).GetTypeInfo().GetProperties().Where(x => x.CanRead)
             .Select(x => new Variable(x.PropertyType, $"{rootArgName}.{x.Name}"))
@@ -183,6 +183,8 @@ public class Variable
         return variableName.Replace('<', '_').Replace('>', '_').Replace(".", "_").TrimEnd('_');
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "argType.IsEnumerable() needs [DAM(Interfaces)] from TypeExtensions; the call site is internal naming convention only — failure mode is a cosmetic variable-name fallback, not a runtime correctness issue.")]
     public static string DefaultArgName(Type argType)
     {
         if (argType.IsArray)

--- a/src/JasperFx/CodeGeneration/Services/ServiceCollectionServerVariableSource.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceCollectionServerVariableSource.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +23,8 @@ because at least one dependency is directly using IServiceProvider or has an opa
         _services = (ServiceContainer?)services;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "IServiceVariableSource.Matches(Type) doesn't carry DAM on its Type parameter, so this impl can't propagate the [DAM(PublicConstructors)] constraint that ServiceContainer.CouldResolve needs. The codegen-Variable resolution path is reached only from compiled-handler discovery where the candidate types come from typeof(T) expressions or already-registered ServiceDescriptors — both carry constructor preservation via their own surface.")]
     public bool Matches(Type type)
     {
         return _services.CouldResolve(type);

--- a/src/JasperFx/CodeGeneration/Snapshots/SnapshotGate.cs
+++ b/src/JasperFx/CodeGeneration/Snapshots/SnapshotGate.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -76,6 +77,8 @@ public static class SnapshotGate
     ///     (the <c>Internal/Generated</c>-style directory). Must exist; this method
     ///     does not create it.
     /// </param>
+    [RequiresUnreferencedCode("Uses System.Text.Json.JsonSerializer.Deserialize<SnapshotFingerprint>. AOT-publishing consumers should wrap this call with their own STJ source-generator context, or hand-deserialize the fingerprint file.")]
+    [RequiresDynamicCode("System.Text.Json.JsonSerializer.Deserialize uses runtime code generation for non-source-generated types.")]
     public static SnapshotFingerprint? Read(string generatedFolder)
     {
         if (string.IsNullOrWhiteSpace(generatedFolder)) return null;
@@ -103,6 +106,8 @@ public static class SnapshotGate
     ///     if it doesn't exist. Overwrites any prior fingerprint atomically (writes
     ///     to a temp file then moves into place).
     /// </summary>
+    [RequiresUnreferencedCode("Uses System.Text.Json.JsonSerializer.Serialize. AOT-publishing consumers should wrap this call with their own STJ source-generator context, or hand-serialize the fingerprint.")]
+    [RequiresDynamicCode("System.Text.Json.JsonSerializer.Serialize uses runtime code generation for non-source-generated types.")]
     public static void Write(string generatedFolder, SnapshotFingerprint fingerprint)
     {
         if (string.IsNullOrWhiteSpace(generatedFolder))

--- a/src/JasperFx/CommandLine/CommandFactory.cs
+++ b/src/JasperFx/CommandLine/CommandFactory.cs
@@ -300,7 +300,8 @@ public class CommandFactory : ICommandFactory
         _commandTypes[CommandNameFor(type)] = type;
     }
 
-    public static bool IsJasperFxCommandType(Type type)
+    public static bool IsJasperFxCommandType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type)
     {
         if (!type.IsConcrete())
         {
@@ -447,6 +448,8 @@ public class CommandFactory : ICommandFactory
         Justification = "JasperFx.Generated.DiscoveredCommands is emitted by JasperFx.SourceGenerator into the consuming app as ordinary code; the lookup degrades safely to the reflective fallback if the generator is not enabled.")]
     [UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
         Justification = "Same as IL2026 — DiscoveredCommands.CommandTypes is generated source code in the consuming assembly.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+        Justification = "Types come from JasperFx.Generated.DiscoveredCommands.CommandTypes which is emitted by the source generator with full interface metadata preserved.")]
     internal bool TryRegisterFromGeneratedManifest()
     {
         // Look for the generated DiscoveredCommands class in all loaded assemblies

--- a/src/JasperFx/CommandLine/Descriptions/ConfigurationPreview.cs
+++ b/src/JasperFx/CommandLine/Descriptions/ConfigurationPreview.cs
@@ -13,6 +13,7 @@ internal class ConfigurationPreview : SystemPartBase
         _configuration = configuration;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Override of SystemPartBase.WriteToConsole — see base for trim notes.")]
     public override Task WriteToConsole()
     {
         if (!(_configuration is IConfigurationRoot root))

--- a/src/JasperFx/CommandLine/Descriptions/DescribeCommand.cs
+++ b/src/JasperFx/CommandLine/Descriptions/DescribeCommand.cs
@@ -15,6 +15,8 @@ namespace JasperFx.CommandLine.Descriptions;
 [Description("Writes out a description of your running application to either the console or a file")]
 public class DescribeCommand : JasperFxAsyncCommand<DescribeInput>
 {
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Dev-time `describe` CLI command. Dispatches part.WriteToConsole() on each ISystemPart, which is annotated [RequiresUnreferencedCode] for diagnostic reflection over arbitrary host components. The describe command is dev-time / Roslyn-path tooling, not part of an AOT-published binary.")]
     public override async Task<bool> Execute(DescribeInput input)
     {
         using var host = input.BuildHost();
@@ -102,7 +104,15 @@ public class DescribeCommand : JasperFxAsyncCommand<DescribeInput>
             AnsiConsole.Write(rule);
             AnsiConsole.WriteLine();
 
+            // Dev-time describe CLI. ISystemPart.WriteToConsole is annotated
+            // [RequiresUnreferencedCode] for diagnostic reflection over arbitrary
+            // host components; the describe command is dev-time / Roslyn-path
+            // tooling, not part of an AOT-published binary. The suppression on
+            // the enclosing method doesn't propagate through the async state
+            // machine to this call site.
+#pragma warning disable IL2026
             await part.WriteToConsole();
+#pragma warning restore IL2026
 
             Console.WriteLine();
             Console.WriteLine();
@@ -119,6 +129,7 @@ public class AboutThisAppPart : SystemPartBase
         _host = host;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Override of SystemPartBase.WriteToConsole — see base for trim notes.")]
     public override Task WriteToConsole()
     {
         var table = new Table
@@ -150,8 +161,7 @@ public class ReferencedAssemblies : SystemPartBase
     {
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-        Justification = "Diagnostic-only describe command. Trimmed assemblies simply drop from the listed output; nothing branches on the value.")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Override of SystemPartBase.WriteToConsole — also calls Assembly.GetReferencedAssemblies(). Diagnostic-only describe command; trimmed assemblies drop from the output.")]
     public override Task WriteToConsole()
     {
         var description = new TextualDisplay("Referenced Assemblies");

--- a/src/JasperFx/CommandLine/Descriptions/ISystemPart.cs
+++ b/src/JasperFx/CommandLine/Descriptions/ISystemPart.cs
@@ -16,11 +16,12 @@ public interface ISystemPart
     ///     A descriptive title to be shown in the rendered output
     /// </summary>
     string Title { get; }
-    
+
     Uri SubjectUri { get; }
-    
+
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Default implementation derives an OptionsDescription via reflection over the runtime type's public properties; consumers writing custom system-part descriptions reflectively must keep their properties alive.")]
     Task WriteToConsole();
-    
+
     ValueTask<IReadOnlyList<IStatefulResource>> FindResources();
 
     Task AssertEnvironmentAsync(IServiceProvider services, EnvironmentCheckResults results, CancellationToken token);
@@ -37,6 +38,7 @@ public abstract class SystemPartBase : ISystemPart
         SubjectUri = subjectUri;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Derives an OptionsDescription via reflection over this instance's runtime type's public properties.")]
     public virtual Task WriteToConsole()
     {
         var description = OptionsDescription.For(this);

--- a/src/JasperFx/Core/IoC/AssemblyScanner.cs
+++ b/src/JasperFx/Core/IoC/AssemblyScanner.cs
@@ -209,11 +209,13 @@ public class AssemblyScanner : IAssemblyScanner
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the application base directory via AssemblyFinder.FindAssemblies.")]
     public void AssembliesFromApplicationBaseDirectory()
     {
         AssembliesFromApplicationBaseDirectory(a => true);
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the application base directory via AssemblyFinder.FindAssemblies.")]
     public void AssembliesFromApplicationBaseDirectory(Func<Assembly, bool> assemblyFilter)
     {
         var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter);
@@ -227,6 +229,7 @@ public class AssemblyScanner : IAssemblyScanner
     /// <param name="scanner"></param>
     /// <param name="assemblyFilter"></param>
     /// <param name="includeExeFiles"></param>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the application base directory via AssemblyFinder.FindAssemblies, including *.exe files.")]
     public void AssembliesAndExecutablesFromApplicationBaseDirectory(Func<Assembly, bool>? assemblyFilter = null)
     {
         var assemblies = AssemblyFinder.FindAssemblies(assemblyFilter, true);
@@ -235,6 +238,7 @@ public class AssemblyScanner : IAssemblyScanner
     }
 
     [Obsolete("It is very strongly recommended to use the overload with an Assembly filter to improve performance")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies, including *.exe files.")]
     public void AssembliesAndExecutablesFromPath(string path)
     {
         var assemblies = AssemblyFinder.FindAssemblies(a => true, path,
@@ -244,6 +248,7 @@ public class AssemblyScanner : IAssemblyScanner
     }
 
     [Obsolete("It is very strongly recommended to use the overload with an Assembly filter to improve performance")]
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies.")]
     public void AssembliesFromPath(string path)
     {
         var assemblies = AssemblyFinder.FindAssemblies(a => true, path,
@@ -252,6 +257,7 @@ public class AssemblyScanner : IAssemblyScanner
         foreach (var assembly in assemblies) Assembly(assembly);
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies, including *.exe files.")]
     public void AssembliesAndExecutablesFromPath(string path,
         Func<Assembly, bool> assemblyFilter)
     {
@@ -262,6 +268,7 @@ public class AssemblyScanner : IAssemblyScanner
         foreach (var assembly in assemblies) Assembly(assembly);
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies.")]
     public void AssembliesFromPath(string path,
         Func<Assembly, bool> assemblyFilter)
     {
@@ -286,6 +293,7 @@ public class AssemblyScanner : IAssemblyScanner
         Conventions.Each(x => writer.WriteLine("* " + x));
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Builds a TypeSet via TypeRepository.FindTypes which enumerates Assembly.ExportedTypes.")]
     public void Start()
     {
         if (_hasScanned)

--- a/src/JasperFx/Core/IoC/IAssemblyScanner.cs
+++ b/src/JasperFx/Core/IoC/IAssemblyScanner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -181,7 +182,11 @@ public interface IAssemblyScanner
     void SingleImplementationsOfInterface(ServiceLifetime lifetime);
 
     void TheCallingAssembly();
+
+    [RequiresUnreferencedCode("Scans the application base directory via AssemblyFinder.FindAssemblies.")]
     void AssembliesFromApplicationBaseDirectory();
+
+    [RequiresUnreferencedCode("Scans the application base directory via AssemblyFinder.FindAssemblies.")]
     void AssembliesFromApplicationBaseDirectory(Func<Assembly, bool> assemblyFilter);
 
 
@@ -208,17 +213,22 @@ public interface IAssemblyScanner
     /// <param name="scanner"></param>
     /// <param name="assemblyFilter"></param>
     /// <param name="includeExeFiles"></param>
+    [RequiresUnreferencedCode("Scans the application base directory via AssemblyFinder.FindAssemblies, including *.exe files.")]
     void AssembliesAndExecutablesFromApplicationBaseDirectory(Func<Assembly, bool>? assemblyFilter = null);
 
     [Obsolete("It is very strongly recommended to use the overload with an Assembly filter to improve performance")]
+    [RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies, including *.exe files.")]
     void AssembliesAndExecutablesFromPath(string path);
 
     [Obsolete("It is very strongly recommended to use the overload with an Assembly filter to improve performance")]
+    [RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies.")]
     void AssembliesFromPath(string path);
 
+    [RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies, including *.exe files.")]
     void AssembliesAndExecutablesFromPath(string path,
         Func<Assembly, bool> assemblyFilter);
 
+    [RequiresUnreferencedCode("Scans the given path via AssemblyFinder.FindAssemblies.")]
     void AssembliesFromPath(string path,
         Func<Assembly, bool> assemblyFilter);
 

--- a/src/JasperFx/Core/TypeScanning/AssemblyFinder.cs
+++ b/src/JasperFx/Core/TypeScanning/AssemblyFinder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Loader;
 
@@ -25,6 +26,7 @@ public static class AssemblyFinder
     /// <param name="filter">Allow list filter of assemblies to scan</param>
     /// <param name="includeExeFiles">Optionally include *.exe files</param>
     /// <returns></returns>
+    [RequiresUnreferencedCode("FindAssemblies scans the application base directory for assemblies and inspects their referenced-assembly graph. The trimmer cannot statically reason about which types those assemblies contribute; AOT-publishing apps should rely on explicit assembly references and source-generated type lists instead.")]
     public static IEnumerable<Assembly> FindAssemblies(Action<string> logFailure, Func<Assembly, bool> filter,
         bool includeExeFiles)
     {
@@ -48,6 +50,7 @@ public static class AssemblyFinder
     /// <param name="logFailure">Take an action when an assembly file could not be loaded</param>
     /// <param name="includeExeFiles">Optionally include *.exe files</param>
     /// <returns></returns>
+    [RequiresUnreferencedCode("FindAssemblies scans the given path for assemblies and inspects their referenced-assembly graph. The trimmer cannot statically reason about which types those assemblies contribute; AOT-publishing apps should rely on explicit assembly references and source-generated type lists instead.")]
     public static IEnumerable<Assembly> FindAssemblies(Func<Assembly, bool> filter, string assemblyPath,
         Action<string> logFailure, bool includeExeFiles)
     {
@@ -117,6 +120,7 @@ public static class AssemblyFinder
     /// <param name="filter"></param>
     /// <param name="includeExeFiles"></param>
     /// <returns></returns>
+    [RequiresUnreferencedCode("FindAssemblies scans the application base directory and inspects the referenced-assembly graph. AOT-publishing apps should rely on explicit assembly references and source-generated type lists.")]
     public static IEnumerable<Assembly> FindAssemblies(Func<Assembly, bool>? filter,
         bool includeExeFiles = false)
     {
@@ -128,8 +132,12 @@ public static class AssemblyFinder
 
 internal interface IJasperFxAssemblyLoadContext
 {
+    [RequiresUnreferencedCode("Loads an assembly the trimmer hasn't seen statically.")]
     Assembly LoadFromStream(Stream assembly);
+
     Assembly LoadFromAssemblyName(AssemblyName assemblyName);
+
+    [RequiresUnreferencedCode("Loads an assembly the trimmer hasn't seen statically.")]
     Assembly LoadFromAssemblyPath(string assemblyName);
 }
 
@@ -142,6 +150,7 @@ internal sealed class AssemblyLoadContextWrapper : IJasperFxAssemblyLoadContext
         _ctx = ctx;
     }
 
+    [RequiresUnreferencedCode("Wraps AssemblyLoadContext.LoadFromStream, which loads an assembly the trimmer hasn't seen statically.")]
     public Assembly LoadFromStream(Stream assembly)
     {
         return _ctx.LoadFromStream(assembly);
@@ -152,6 +161,7 @@ internal sealed class AssemblyLoadContextWrapper : IJasperFxAssemblyLoadContext
         return _ctx.LoadFromAssemblyName(assemblyName);
     }
 
+    [RequiresUnreferencedCode("Wraps AssemblyLoadContext.LoadFromAssemblyPath, which loads an assembly the trimmer hasn't seen statically.")]
     public Assembly LoadFromAssemblyPath(string assemblyName)
     {
         return _ctx.LoadFromAssemblyPath(assemblyName);

--- a/src/JasperFx/Core/TypeScanning/AssemblyTypes.cs
+++ b/src/JasperFx/Core/TypeScanning/AssemblyTypes.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core.Reflection;
 
@@ -20,6 +21,7 @@ public class AssemblyTypes
     public readonly AssemblyShelf OpenTypes = new();
 
 
+    [RequiresUnreferencedCode("Enumerates Assembly.ExportedTypes. AOT-publishing apps should construct AssemblyTypes via the (name, typeSource) overload with an explicit type list rather than scanning at runtime.")]
     public AssemblyTypes(Assembly assembly) : this(assembly.FullName!, () => assembly.ExportedTypes)
     {
     }

--- a/src/JasperFx/Core/TypeScanning/TypeQuery.cs
+++ b/src/JasperFx/Core/TypeScanning/TypeQuery.cs
@@ -23,6 +23,7 @@ public class TypeQuery
         return assembly.FindTypes(_classification).Where(type => Includes.Matches(type) && !Excludes.Matches(type));
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Routes through TypeRepository.ForAssembly which enumerates Assembly.ExportedTypes.")]
     public IEnumerable<Type> Find(IEnumerable<Assembly> assemblies)
     {
         return assemblies.Select(TypeRepository.ForAssembly)

--- a/src/JasperFx/Core/TypeScanning/TypeRepository.cs
+++ b/src/JasperFx/Core/TypeScanning/TypeRepository.cs
@@ -51,6 +51,7 @@ public static class TypeRepository
     /// </summary>
     /// <param name="assembly"></param>
     /// <returns></returns>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Builds an AssemblyTypes via AssemblyTypes(Assembly) which enumerates Assembly.ExportedTypes.")]
     public static AssemblyTypes ForAssembly(Assembly assembly)
     {
         if (_assemblies.TryFind(assembly, out var types))
@@ -70,6 +71,7 @@ public static class TypeRepository
     /// <param name="assemblies"></param>
     /// <param name="filter"></param>
     /// <returns></returns>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Routes through ForAssembly which enumerates Assembly.ExportedTypes.")]
     public static TypeSet FindTypes(IEnumerable<Assembly> assemblies, Func<Type, bool>? filter = null)
     {
         return new TypeSet(assemblies.Select(ForAssembly), filter);
@@ -83,6 +85,7 @@ public static class TypeRepository
     /// <param name="classification"></param>
     /// <param name="filter"></param>
     /// <returns></returns>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Routes through ForAssembly which enumerates Assembly.ExportedTypes.")]
     public static IEnumerable<Type> FindTypes(IEnumerable<Assembly> assemblies,
         TypeClassification classification, Func<Type, bool>? filter = null)
     {
@@ -96,6 +99,7 @@ public static class TypeRepository
     }
 
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Routes through ForAssembly which enumerates Assembly.ExportedTypes.")]
     public static IEnumerable<Type> FindTypes(Assembly? assembly, TypeClassification classification,
         Func<Type, bool>? filter = null)
     {

--- a/src/JasperFx/Descriptors/DatabaseDescriptor.cs
+++ b/src/JasperFx/Descriptors/DatabaseDescriptor.cs
@@ -13,10 +13,12 @@ public class DatabaseDescriptor : OptionsDescription
     {
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Inherits the OptionsDescription ctor's reflective property read of subject's runtime type.")]
     public DatabaseDescriptor(object subject) : base(subject)
     {
     }
-    
+
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Inherits the OptionsDescription ctor's reflective property read of subject's runtime type.")]
     public DatabaseDescriptor(object subject, Uri subjectUri) : base(subject)
     {
         SubjectUri = subjectUri;

--- a/src/JasperFx/Descriptors/OptionsDescription.cs
+++ b/src/JasperFx/Descriptors/OptionsDescription.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
 
@@ -24,6 +25,7 @@ public class OptionsDescription
     /// </summary>
     /// <param name="subject"></param>
     /// <returns></returns>
+    [RequiresUnreferencedCode("Derives an OptionsDescription via reflection over subject's public properties when subject doesn't implement IDescribeMyself.")]
     public static OptionsDescription For(object subject)
     {
         if (subject is IDescribeMyself describeMyself) return describeMyself.ToDescription();
@@ -80,11 +82,13 @@ public class OptionsDescription
         return $"{nameof(Subject)}: {Subject}";
     }
 
+    [RequiresUnreferencedCode("Reads subject.GetType().GetProperties() to build a diagnostic description. Properties of subject's runtime type must survive trimming for the description to be complete; missing properties are silently omitted (this surface is diagnostic-only).")]
     public OptionsDescription(object subject)
     {
         readProperties(subject);
     }
 
+    [RequiresUnreferencedCode("Reads subject.GetType().GetProperties() reflectively.")]
     private void readProperties(object subject)
     {
         if (subject == null)
@@ -162,6 +166,7 @@ public class OptionsDescription
         return set;
     }
     
+    [RequiresUnreferencedCode("Builds child OptionsDescriptions via reflection over each child's public properties when the child doesn't implement IDescribeMyself.")]
     public OptionSet AddChildSet(string name, IEnumerable<object> children)
     {
         var set = AddChildSet(name);

--- a/src/JasperFx/Environment/EnvironmentCheckExtensions.cs
+++ b/src/JasperFx/Environment/EnvironmentCheckExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -10,7 +11,7 @@ public static class EnvironmentCheckExtensions
     ///     JasperFx environment checks when running <c>dotnet run -- check-env</c>.
     /// </summary>
     /// <typeparam name="T">The IHealthCheck implementation type</typeparam>
-    public static IServiceCollection CheckEnvironmentHealthCheck<T>(this IServiceCollection services) where T : class, IHealthCheck
+    public static IServiceCollection CheckEnvironmentHealthCheck<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IHealthCheck
     {
         services.AddSingleton<IHealthCheck, T>();
         return services;
@@ -33,6 +34,7 @@ public static class EnvironmentCheckExtensions
     /// <param name="services"></param>
     /// <param name="description"></param>
     /// <param name="test"></param>
+    [RequiresUnreferencedCode("AddJasperFx scans entry/extension assemblies for IJasperFxCommand types.")]
     public static void CheckEnvironment(this IServiceCollection services,
         string description,
         Func<IServiceProvider, CancellationToken, Task> test)
@@ -47,6 +49,7 @@ public static class EnvironmentCheckExtensions
     /// <param name="services"></param>
     /// <param name="description"></param>
     /// <param name="action"></param>
+    [RequiresUnreferencedCode("Routes through AddJasperFx which scans assemblies for IJasperFxCommand types.")]
     public static void CheckEnvironment(this IServiceCollection services, string description,
         Action<IServiceProvider> action)
     {
@@ -65,6 +68,7 @@ public static class EnvironmentCheckExtensions
     /// <param name="description"></param>
     /// <param name="action"></param>
     /// <typeparam name="T"></typeparam>
+    [RequiresUnreferencedCode("Routes through AddJasperFx which scans assemblies for IJasperFxCommand types.")]
     public static void CheckEnvironment<T>(this IServiceCollection services, string description, Action<T?> action) where T: notnull
     {
         services.CheckEnvironment(description, (s, c) =>
@@ -83,6 +87,7 @@ public static class EnvironmentCheckExtensions
     /// <param name="description"></param>
     /// <param name="action"></param>
     /// <typeparam name="T"></typeparam>
+    [RequiresUnreferencedCode("Routes through AddJasperFx which scans assemblies for IJasperFxCommand types.")]
     public static void CheckEnvironment<T>(this IServiceCollection services, string description,
         Func<T?, CancellationToken, Task> action) where T: notnull
     {
@@ -96,6 +101,7 @@ public static class EnvironmentCheckExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <param name="path"></param>
+    [RequiresUnreferencedCode("AddJasperFx scans entry/extension assemblies for IJasperFxCommand types.")]
     public static void CheckThatFileExists(this IServiceCollection services, string path)
     {
         services.AddJasperFx(opts => opts.RequireFile(path));
@@ -111,6 +117,7 @@ public static class EnvironmentCheckExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <typeparam name="T"></typeparam>
+    [RequiresUnreferencedCode("Routes through CheckEnvironment which calls AddJasperFx.")]
     public static void CheckServiceIsRegistered<T>(this IServiceCollection services) where T: notnull
     {
         services.CheckEnvironment($"Service {typeof(T).FullName} should be registered", s => s.GetRequiredService<T>());
@@ -122,6 +129,7 @@ public static class EnvironmentCheckExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <param name="serviceType"></param>
+    [RequiresUnreferencedCode("Routes through CheckEnvironment which calls AddJasperFx.")]
     public static void CheckServiceIsRegistered(this IServiceCollection services, Type serviceType)
     {
         services.CheckEnvironment($"Service {serviceType.FullName} should be registered",

--- a/src/JasperFx/JasperFxAssemblyAttribute.cs
+++ b/src/JasperFx/JasperFxAssemblyAttribute.cs
@@ -20,7 +20,8 @@ public class JasperFxAssemblyAttribute : Attribute
     ///     commands
     /// </summary>
     /// <param name="extensionType"></param>
-    public JasperFxAssemblyAttribute(Type extensionType)
+    public JasperFxAssemblyAttribute(
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type extensionType)
     {
         if (extensionType.HasDefaultConstructor() && extensionType.CanBeCastTo<IServiceRegistrations>())
         {

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -16,6 +16,7 @@ namespace JasperFx;
 
 public class JasperFxOptions : SystemPartBase
 {
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks assembly.GetReferencedAssemblies() and loads each by name. AOT-publishing apps statically reference their dependencies; the JasperFx-tool detection here is for the dotnet-tool flow which is dev-time.")]
     public static bool HasReferenceToJasperFxTool(Assembly assembly)
     {
         var names = assembly.GetReferencedAssemblies();
@@ -118,6 +119,7 @@ public class JasperFxOptions : SystemPartBase
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls DetermineCallingAssembly when no explicit application assembly is supplied — walks the call stack via StackTrace + StackFrame.GetMethod().")]
     private void establishApplicationAssembly(string? assemblyName)
     {
         if (assemblyName.IsNotEmpty())
@@ -139,6 +141,7 @@ public class JasperFxOptions : SystemPartBase
         }
     }
     
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the call stack via StackTrace + StackFrame.GetMethod() to determine the calling assembly. AOT-publishing apps should call SetApplicationProject(Assembly) explicitly.")]
     internal static Assembly? DetermineCallingAssembly()
     {
         if (HasReferenceToJasperFxTool(Assembly.GetEntryAssembly())) return Assembly.GetEntryAssembly();
@@ -252,6 +255,7 @@ public class JasperFxOptions : SystemPartBase
         set => _autoResolveProjectRoot = value;
     }
 
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Calls establishApplicationAssembly when ApplicationAssembly is unset; the fallback walks the call stack to determine the calling assembly.")]
     internal void ReadHostEnvironment(IHostEnvironment environment)
     {
         if (GeneratedCodeOutputPath == null)

--- a/src/JasperFx/JasperFxServiceCollectionExtensions.cs
+++ b/src/JasperFx/JasperFxServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class JasperFxServiceCollectionExtensions
     /// <param name="configure"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CritterStackDefaults wires AddJasperFx, which scans entry/extension assemblies for IJasperFxCommand types via Assembly.GetExportedTypes(). Apps targeting trim/AOT should pre-register commands via the source-generated DiscoveredCommands manifest.")]
     public static IServiceCollection CritterStackDefaults(this IServiceCollection services,
         Action<JasperFxOptions> configure)
     {
@@ -36,6 +37,7 @@ public static class JasperFxServiceCollectionExtensions
     /// <param name="services"></param>
     /// <param name="configure">Optional configuration of the JasperFxDefaults for resource management</param>
     /// <returns></returns>
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans entry/extension assemblies for IJasperFxCommand types via Assembly.GetExportedTypes(). Apps targeting trim/AOT should pre-register commands via the source-generated DiscoveredCommands manifest.")]
     public static IServiceCollection AddJasperFx(this IServiceCollection services, Action<JasperFxOptions>? configure = null)
     {
         // It's actually important to do this as close as possible to this call

--- a/src/JasperFx/Resources/ResourcesCommand.cs
+++ b/src/JasperFx/Resources/ResourcesCommand.cs
@@ -94,6 +94,8 @@ public class ResourcesCommand : JasperFxAsyncCommand<ResourceInput>
         return ResourceExecutor.FindResources(host.Services, input.TypeFlag, input.NameFlag);
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Spectre.Console.AnsiConsole.WriteException is invoked only on the error-display path of a dev-time CLI command (resources init/apply/clear). The dev-time CLI is the canonical Roslyn path; AOT-publishing apps don't run resource commands as part of their AOT binary.")]
     internal async Task<bool> ExecuteOnEach(string heading, IList<IStatefulResource> resources, CancellationToken token,
         string progressTitle, Func<IStatefulResource, Task<IRenderable>> execution)
     {

--- a/src/JasperFx/ServiceContainer.cs
+++ b/src/JasperFx/ServiceContainer.cs
@@ -165,9 +165,9 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
         return plan;
     }
 
-    public bool CouldResolve(Type type) => CouldResolve(type, new());
+    public bool CouldResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type) => CouldResolve(type, new());
 
-    public bool CouldResolve(Type type, List<ServiceDescriptor> trail)
+    public bool CouldResolve([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type, List<ServiceDescriptor> trail)
     {
         if (_defaults.TryFind(type, out var plan))
         {
@@ -209,6 +209,8 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
         return false;
     }
     
+    [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+        Justification = "The IsPublic + IsConcrete branch auto-registers a self-binding ServiceDescriptor for public concrete types that weren't explicitly registered. Public concrete types reached via the family lookup either come from typeof(T) (compiler-preserved) or from user-supplied registrations whose constructors the user must keep alive. A missing public ctor at activation time surfaces from ConstructorPlan.TryBuildPlan as an InvalidPlan, not a silent failure. (Re-applied here after merge resolution between PRs #256 and #257 dropped this attribute.)")]
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
         Justification = "Calls into ServiceFamily.Close for open-generic registration close-over. Open-generic registrations are themselves a dynamic-code feature; AOT-publishing apps should use closed-generic registrations or source-generated equivalents and won't reach this branch.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",


### PR DESCRIPTION
Final AOT-pillar cleanup pass for JasperFx ([#213](https://github.com/JasperFx/jasperfx/issues/213)). After PRs #256–#259 closed the four largest slices (`ServiceContainer`, `CodeGeneration/Services`, `Core/IoC`, `Core/Reflection`), 74 warnings per TFM remained across the long tail. This PR brings the JasperFx project to **0 IL warnings** with `IsAotCompatible=true` enabled.

## Effect

```
Before:  JasperFx total per TFM  74 warnings
After:   JasperFx total per TFM   0 warnings

Cumulative since #213 flag-flip:  236 → 0  (all addressed)
```

## Areas annotated

The tail spans the parts of JasperFx that weren't large enough to deserve dedicated per-area issues but still needed annotation work to close out the pillar:

| Area | Members touched |
|---|---|
| `Core/TypeScanning` | `AssemblyFinder.FindAssemblies` (×3), `IJasperFxAssemblyLoadContext` + impl, `AssemblyTypes(Assembly)`, `TypeRepository.ForAssembly`, `TypeRepository.FindTypes` (×3), `TypeQuery.Find` |
| `Core/IoC` | `AssemblyScanner.Start` + assembly-scan APIs; matching `IAssemblyScanner.AssembliesFrom*` annotations |
| Hosting + entry | `JasperFxOptions.HasReferenceToJasperFxTool`, `DetermineCallingAssembly`, `establishApplicationAssembly`, `ReadHostEnvironment`; `JasperFxServiceCollectionExtensions.AddJasperFx` + `CritterStackDefaults`; `EnvironmentCheckExtensions` (5 overloads) |
| `CodeGeneration/Snapshots/SnapshotGate` | `Read` / `Write` annotated `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` for STJ usage |
| `CodeGeneration/Frames/MethodCall` | `MethodCall(Type, string)` ctor annotated, `correctedReturnType` / `returnsValueTask` suppress for well-known Task types |
| `CodeGeneration/GeneratedAssembly` + `GeneratedType` | `AddType`, `AttachAssembly`, `CompiledType` property, `InheritsFrom<T>` / `<Type>`, `Implements<T>` / `(Type)`, `FindType`, `ApplySetterValues` |
| `CodeGeneration/Model` | `Setter.SetInitialValue`, `Variable.VariablesForProperties<T>`, `Variable.DefaultArgName` |
| `CodeGeneration/Expressions` | `LambdaDefinition.Compile<TFunc>` |
| `CodeGeneration/Services` | `ServiceCollectionServerVariableSource.Matches` suppress (IVariableSource contract doesn't carry DAM) |
| `Descriptors` | `OptionsDescription` ctor / `For()` / `readProperties`; `DatabaseDescriptor` ctors |
| `CommandLine/Descriptions` | `ISystemPart.WriteToConsole` annotated on interface; overrides in `ConfigurationPreview`, `DescribeCommand` (×2) |
| `CommandLine` | `CommandFactory.IsJasperFxCommandType` DAM, `TryRegisterFromGeneratedManifest` IL2072 suppress; `DescribeCommand.Execute` pragma over `WriteToConsole` async call |
| `Resources` | `ResourcesCommand.ExecuteOnEach` suppress IL3050 (Spectre on error-display path) |
| `JasperFxAssemblyAttribute` | ctor DAM annotation |
| `ServiceContainer` | `CouldResolve(Type)` DAM; re-applied IL2067 suppression on `findFamily` that was lost in the #256 + #257 merge resolution |

## Note on JasperFx.Events propagation

This PR brings the **JasperFx** project itself to 0 warnings. The annotations propagate into `JasperFx.Events`, which now surfaces ~246 warnings per TFM that weren't there before. That deserves its own focused PR + likely an issue under #213 — not included here to keep this review-able.

## Verification

- `CoreTests` — 407/407 pass on net9.0 + net10.0
- `CommandLineTests` — 280/280 pass on net9.0 + net10.0
- `CodegenTests` — 366/366 pass on net9.0 + net10.0
- `SmokeTestAot` — build clean, exits 0

This (mostly) closes the AOT pillar #213 for JasperFx itself. Events follow-up is queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
