### PR TITLE
Bump JasperFx → 2.0.0-alpha.12 and JasperFx.Events → 2.0.0-alpha.5

### DIFF
--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.4</Version>
+        <Version>2.0.0-alpha.5</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.11</Version>
+        <Version>2.0.0-alpha.12</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
Carries the AOT pillar tail cleanup ([#213](https://github.com/JasperFx/jasperfx/issues/213)) that landed in #260, closing the remaining 74 IL warnings per TFM in JasperFx itself. With this release, JasperFx + JasperFx.Events compile clean under `IsAotCompatible=true` — downstream consumers (Marten 9, Wolverine 6, Polecat 4, Weasel 9) can adopt the new alphas and see the propagated annotations on JasperFx surfaces (TypeScanning, Hosting, Snapshots, CodeGeneration model + frames, OptionsDescription, etc.).

| Package | Old | New |
|---|---|---|
| `JasperFx` | 2.0.0-alpha.11 | **2.0.0-alpha.12** |
| `JasperFx.Events` | 2.0.0-alpha.4 | **2.0.0-alpha.5** |

`JasperFx.Events` itself didn't get direct changes, but the lockstep bump ensures consumers picking up alpha.12 also get the matching Events alpha. Per-area annotation work in `JasperFx.Events` deserves its own follow-up PR (~246 cascaded warnings as of #260); will be filed as a tracking issue once this release ships.

Other packed packages (`JasperFx.RuntimeCompiler`, `JasperFx.SourceGeneration`, `JasperFx.Events.SourceGenerator`) keep their current versions — nothing changed in those projects this cycle. `NugetPush` uses `EnableSkipDuplicate()`, so re-pushed artifacts at unchanged versions are no-ops.

Once this merges I'll trigger the `JasperFx NuGet Manual Publish` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)