### PR TITLE
Annotate JasperFx.Events Aggregation cluster for AOT (#262, slice 1/4)

### DIFF
--- a/src/JasperFx.Events/Aggregation/AggregateApplication.cs
+++ b/src/JasperFx.Events/Aggregation/AggregateApplication.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ImTools;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -6,6 +7,22 @@ using JasperFx.Events.Projections;
 
 namespace JasperFx.Events.Aggregation;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level (all partials): aggregate Create/Apply/ShouldDelete method discovery scans TAggregate / TProjection via reflection, and the discovered handlers may call methods annotated RUC. The aggregate type T flows in from caller registration where trimming preserves T. AOT consumers must register concrete aggregate types per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): reflects PublicMethods on the aggregate / projection Type to discover Create/Apply/ShouldDelete handlers. Type flows in from caller-side generic parameters that trimming sees.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): assigns the result of reflective method/property lookup to DAM-annotated targets when building handler delegates via Expression.Call/CompileFast. Source type is preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): accesses PublicProperties on event-data Type returned by other reflection calls (e.g. GetGenericArguments). Event types are preserved by IEvent<T> registration on the caller side.")]
+[UnconditionalSuppressMessage("Trimming", "IL2077:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): field/property of DAM-annotated type assigned from reflective lookups whose source type is preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): generic method parameter receives Type values obtained reflectively (e.g. eventType via IEvent.EventType / GetGenericArguments). Both source and target types are preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): generic class type argument flow at the aggregator instantiation point. TAggregate / TQuerySession are preserved by the registered projection boundary.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level (all partials): handler discovery uses Type.MakeGenericType / MethodInfo.MakeGenericMethod + FastExpressionCompiler.CompileFast — runtime code generation. AOT consumers should rely on the JasperFx.Events.SourceGenerator-emitted aggregator (covered by the AOT publishing guide).")]
 internal partial class AggregateApplication<TAggregate, TQuerySession> : IAggregator<TAggregate, TQuerySession>, IMetadataApplication
 {
     // This would be for external projections

--- a/src/JasperFx.Events/Aggregation/AggregateVersioning.cs
+++ b/src/JasperFx.Events/Aggregation/AggregateVersioning.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using FastExpressionCompiler;
@@ -23,6 +24,10 @@ public interface IAggregateVersioning<in T>
     void TrySetVersion(T aggregate, IEvent lastEvent);
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: reflects the aggregate's Version property via Expression-tree-based getters/setters compiled with FastExpressionCompiler. The aggregate type T is preserved by the registered projection boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument flow on the aggregator. T preserved by registration.")]
 public class AggregateVersioning<T> : IAggregateVersioning
 {
     private readonly Lazy<Action<T, IEvent>> _setValue;
@@ -150,6 +155,10 @@ public class AggregateVersioning<T> : IAggregateVersioning
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: same as the single-arg sibling — reflective Version member access via FastExpressionCompiler. T preserved by registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument flow on the aggregator. T preserved by registration.")]
 public class AggregateVersioning<T, TQuerySession> : AggregateVersioning<T>, IAggregateVersioning, IAggregateVersioning<T>, IAggregator<T, TQuerySession>
 {
     public AggregateVersioning(AggregationScope scope) : base(scope)

--- a/src/JasperFx.Events/Aggregation/ApplyMethodCollection.cs
+++ b/src/JasperFx.Events/Aggregation/ApplyMethodCollection.cs
@@ -1,8 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Internals;
 
 namespace JasperFx.Events.Aggregation;
 
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: Type.MakeGenericType for Task<T>.MakeGenericType(aggregateType) — runtime code generation. AOT consumers should rely on the source-generated evolver per the AOT publishing guide.")]
 internal class ApplyMethodCollection: MethodCollection
 {
     public static readonly string MethodName = "Apply";

--- a/src/JasperFx.Events/Aggregation/CreateMethodCollection.cs
+++ b/src/JasperFx.Events/Aggregation/CreateMethodCollection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.Core;
 using JasperFx.Core.Reflection;
@@ -5,6 +6,12 @@ using JasperFx.Events.Internals;
 
 namespace JasperFx.Events.Aggregation;
 
+[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+    Justification = "Class-level: scans constructors / public methods on aggregateType and projectionType to discover Create handlers. Both types are preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+    Justification = "Class-level: assigns reflective ConstructorInfo/MethodInfo results to DAM-annotated targets when building MethodSlot. Source types preserved at registration.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: Type.MakeGenericType for Task<T>.MakeGenericType(aggregateType) — runtime code generation. AOT consumers should rely on the source-generated evolver per the AOT publishing guide.")]
 internal class CreateMethodCollection: MethodCollection
 {
     public static readonly string MethodName = "Create";

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -13,6 +13,18 @@ using Microsoft.Extensions.Logging;
 
 namespace JasperFx.Events.Aggregation;
 
+[UnconditionalSuppressMessage("Trimming", "IL2065:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): reflects on `this.GetType()` / projection type for handler discovery. The concrete projection type is preserved by registration on the caller side.")]
+[UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): parameter receiving DAM-annotated Type from reflective lookup. Both source and target preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): reflects PublicMethods / PublicProperties on TDoc / projection Type for aggregation step discovery. Types preserved at registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): assigns reflective Type/MethodInfo results to DAM-annotated targets. Source types preserved at registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): PublicProperties access via Type returned by other reflection calls. Source preserved at registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2090:DynamicallyAccessedMembers",
+    Justification = "Class-level (all partials): generic type argument flow at base-class instantiation. TDoc/TId/TOperations/TQuerySession preserved by registration.")]
 public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOperations, TQuerySession>
     : ProjectionBase, IAggregateProjection, IAggregationSteps<TDoc, TQuerySession>,
         IProjectionSource<TOperations, TQuerySession>, ISubscriptionFactory<TOperations, TQuerySession>,

--- a/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Grouping;
@@ -5,6 +6,10 @@ using JasperFx.Events.Projections;
 
 namespace JasperFx.Events.Aggregation;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: inherits aggregation method discovery from JasperFxAggregationProjectionBase; reflective handler lookup propagates RUC. Aggregate/Id types preserved by registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic method parameter receives Type values obtained reflectively via inherited helpers. TDoc/TId preserved at registration.")]
 public abstract class JasperFxMultiStreamProjectionBase<TDoc, TId, TOperations, TQuerySession> :
     JasperFxAggregationProjectionBase<TDoc, TId, TOperations, TQuerySession>, IInlineProjection<TOperations>
     where TOperations : TQuerySession, IStorageOperations where TDoc : notnull where TId : notnull


### PR DESCRIPTION
## Summary

First of four slices that mirror the JasperFx-side cleanup pattern (#252-#255 + #260) on the JasperFx.Events side, tracked by #262.

The aggregator graph (`AggregateApplication` and friends) reflects `TAggregate` / `TProjection` to discover Create/Apply/ShouldDelete handlers, builds delegates via `Expression.Call` + `FastExpressionCompiler.CompileFast`, and threads event types via `IEvent<T>.MakeGenericType`. Both aggregate and event types are preserved at the registered projection boundary (caller-side generic parameters that trimming sees). AOT consumers should rely on the source-generated evolver from `JasperFx.Events.SourceGenerator` per the [AOT publishing guide](https://github.com/JasperFx/jasperfx/pull/263).

Applied class-level `[UnconditionalSuppressMessage]`:

| File | Codes |
|---|---|
| `Aggregation/AggregateApplication` (primary partial — covers Register/Creating/Applies/ShouldDelete) | IL2026/IL2070/IL2072/IL2075/IL2077/IL2087/IL2090/IL3050 |
| `Aggregation/JasperFxAggregationProjectionBase` | IL2065/IL2067/IL2070/IL2072/IL2075/IL2090 |
| `Aggregation/JasperFxMultiStreamProjectionBase` | IL2026/IL2087 |
| `Aggregation/CreateMethodCollection` | IL2070/IL2072/IL3050 |
| `Aggregation/ApplyMethodCollection` | IL3050 |
| `Aggregation/AggregateVersioning<T>` + `<T,TQuerySession>` | IL2026/IL2090 |

## Warning delta

`JasperFx.Events.csproj` IL warnings: **240 → 130 (-110)**.

## Slicing plan (from #262)

- [x] **Aggregation slice (this PR)** — Aggregation/*.cs (~110 warnings)
- [ ] Projection slice — `EventProjectionApplication.cs` (~72 warnings)
- [ ] Tags/EventSlice/StreamAction/IEvent slice (~34 warnings)
- [ ] MultiStream + CodeGenerationExtensions tail (~remaining)

## Test plan

- [x] `dotnet build src/JasperFx.Events/JasperFx.Events.csproj -c Debug` — 0 errors, -110 IL warnings
- [x] `dotnet build src/EventTests/EventTests.csproj -c Debug` — 0 errors
- [ ] CI passes

Refs #262 #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)