### PR TITLE
Annotate JasperFx.Events Projections cluster for AOT (#262, slice 2/4)

### DIFF
--- a/src/JasperFx.Events/Projections/CodeGenerationExtensions.cs
+++ b/src/JasperFx.Events/Projections/CodeGenerationExtensions.cs
@@ -1,9 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.CommandLine;
 using JasperFx.Core.Reflection;
 
 namespace JasperFx.Events.Projections;
 
+[UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
+    Justification = "Class-level: parameter receiving DAM-annotated Type from reflective lookup of method/event types. Both source and target preserved at the registration boundary.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+    Justification = "Class-level: assigns reflective Type results to DAM-annotated targets (TypeExtensions.Closes / GetGenericArguments). Source preserved at registration.")]
 public static class CodeGenerationExtensions
 {
     public static Type? UnwrapEventType(this Type type)

--- a/src/JasperFx.Events/Projections/Composite/ProjectionStage.cs
+++ b/src/JasperFx.Events/Projections/Composite/ProjectionStage.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using JasperFx.Events.Subscriptions;
@@ -5,6 +6,8 @@ using Microsoft.Extensions.Logging;
 
 namespace JasperFx.Events.Projections.Composite;
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: OptionsDescription(this) reads PublicProperties on subject's runtime type for diagnostic rendering only. The runtime stage subclass is preserved via its registration; missing properties degrade the diagnostic readout gracefully.")]
 public class ProjectionStage<TOperations, TQuerySession>(int order)
     where TOperations : TQuerySession, IStorageOperations
 {

--- a/src/JasperFx.Events/Projections/ContainerScoped/ScopedAggregationWrapper.cs
+++ b/src/JasperFx.Events/Projections/ContainerScoped/ScopedAggregationWrapper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using JasperFx.Events.Aggregation;
 using JasperFx.Events.Daemon;
@@ -15,6 +16,8 @@ namespace JasperFx.Events.Projections.ContainerScoped;
 /// <typeparam name="TId"></typeparam>
 /// <typeparam name="TOperations"></typeparam>
 /// <typeparam name="TQuerySession"></typeparam>
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument flow on the IoC wrapper. TSource/TDoc/TId/TOperations/TQuerySession are preserved by the IoC registration of the projection on the caller side.")]
 public class ScopedAggregationWrapper<TSource, TDoc, TId, TOperations, TQuerySession> :
     ProjectionSourceWrapperBase<TSource, TOperations, TQuerySession>, IJasperFxProjection<TOperations>,
     IAggregateProjection

--- a/src/JasperFx.Events/Projections/EventProjectionApplication.cs
+++ b/src/JasperFx.Events/Projections/EventProjectionApplication.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using FastExpressionCompiler;
@@ -13,6 +14,18 @@ public interface IEntityStorage<TOperations>
     void Store<T>(TOperations ops, T entity) where T : notnull;
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: discovers Project/Create handlers on the projection type via reflection and compiles delegates via Expression trees + FastExpressionCompiler. The projection and event types are preserved by the registered projection boundary on the caller side. AOT consumers should rely on JasperFx.Events.SourceGenerator-emitted projection helpers per the AOT publishing guide.")]
+[UnconditionalSuppressMessage("Trimming", "IL2062:DynamicallyAccessedMembers",
+    Justification = "Class-level: passes event-type Type values resolved reflectively to TypeExtensions.Closes(...). Event types preserved at registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+    Justification = "Class-level: assigns reflective Type/MethodInfo results to DAM-annotated targets when building handler delegates. Source types preserved at registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+    Justification = "Class-level: PublicMethods/PublicProperties access via Type returned by other reflection calls. Source preserved at registration.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic method parameter receives Type values obtained reflectively (eventType). Event types preserved at registration.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: handler discovery uses Type.MakeGenericType / MethodInfo.MakeGenericMethod + FastExpressionCompiler.CompileFast — runtime code generation. AOT consumers rely on the source-generated projection helpers.")]
 public class EventProjectionApplication<TOperations>
 {
     private readonly IEntityStorage<TOperations> _entity;
@@ -300,6 +313,10 @@ public class EventProjectionApplication<TOperations>
             MethodInfo method);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Nested-class-level: builds handler delegates via FastExpressionCompiler.CompileFast — RUC. AOT consumers rely on the source-generated projection helpers per the AOT publishing guide.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Nested-class-level: Type.MakeGenericType + CompileFast — runtime code generation.")]
     internal class CreatorBuilder<T> : ICreatorBuilder where T : notnull
     {
         public Func<TOperations, IEvent, CancellationToken, ValueTask> Build<TOperations>(IEntityStorage<TOperations> entityStorage,

--- a/src/JasperFx.Events/Projections/InvalidEventToStartAggregateException.cs
+++ b/src/JasperFx.Events/Projections/InvalidEventToStartAggregateException.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 
 namespace JasperFx.Events.Projections;
 
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: error-message formatter uses Type.MakeGenericType to render IEvent<TEvent> in a diagnostic — runtime code generation. This is on the exception path only; never executes during normal AOT-published code paths.")]
 public class InvalidEventToStartAggregateException : Exception
 {
     public static string ToMessage(Type aggregateType, Type projectionType, Type eventType)

--- a/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
+++ b/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
@@ -13,6 +13,8 @@ namespace JasperFx.Events.Projections;
 /// </summary>
 /// <typeparam name="TOperations"></typeparam>
 /// <typeparam name="TQuerySession"></typeparam>
+[UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",
+    Justification = "Class-level: GetType().GetMethod(...) for self-introspection of overridden methods. The concrete projection subclass is preserved by its registration on the caller side.")]
 public abstract class JasperFxEventProjectionBase<TOperations, TQuerySession> :
     ProjectionBase,
     IProjectionSource<TOperations, TQuerySession>,

--- a/src/JasperFx.Events/Projections/ProjectionGraph.cs
+++ b/src/JasperFx.Events/Projections/ProjectionGraph.cs
@@ -12,7 +12,9 @@ using JasperFx.Events.Subscriptions;
 
 namespace JasperFx.Events.Projections;
 
-public abstract class ProjectionGraph<TProjection, TOperations, TQuerySession> : DaemonSettings 
+[UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
+    Justification = "Class-level: reflects on registered projection Type values via TypeExtensions.Closes(...). The projection types are preserved at the registration boundary on the caller side.")]
+public abstract class ProjectionGraph<TProjection, TOperations, TQuerySession> : DaemonSettings
     where TOperations : TQuerySession, IStorageOperations
     where TProjection : IJasperFxProjection<TOperations>
 {

--- a/src/JasperFx.Events/Projections/ReflectionExtensions.cs
+++ b/src/JasperFx.Events/Projections/ReflectionExtensions.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace JasperFx.Events.Projections;
 
+[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+    Justification = "Class-level: GetMethod on the projection Type. The projection type is preserved at the registration boundary on the caller side.")]
 internal static class ReflectionExtensions
 {
     /// <summary>


### PR DESCRIPTION
## Summary

Second slice in the JasperFx.Events AOT propagation cleanup (#262), following the Aggregation slice (#264).

`EventProjectionApplication` and its supporting types reflect on projection / event types to build handler delegates via Expression trees + `FastExpressionCompiler.CompileFast`. The projection and event types are preserved at the registered projection boundary on the caller side. AOT consumers should rely on `JasperFx.Events.SourceGenerator`-emitted helpers per the AOT publishing guide.

Applied class-level `[UnconditionalSuppressMessage]`:

| File | Codes |
|---|---|
| `Projections/EventProjectionApplication` (outer + nested `CreatorBuilder<T>`) | IL2026/IL2062/IL2072/IL2075/IL2087/IL3050 |
| `Projections/ProjectionGraph` | IL2072 |
| `Projections/JasperFxEventProjectionBase` | IL2075 |
| `Projections/CodeGenerationExtensions` | IL2067/IL2072 |
| `Projections/ReflectionExtensions` | IL2070 |
| `Projections/ContainerScoped/ScopedAggregationWrapper` | IL2087 |
| `Projections/Composite/ProjectionStage` | IL2026 (`OptionsDescription` diagnostic) |
| `Projections/InvalidEventToStartAggregateException` | IL3050 (error-message formatter on the exception path) |

## Warning delta

`JasperFx.Events.csproj` IL warnings on this branch: **240 → 176 (-64)**.

## Slicing plan (from #262)

- [x] Aggregation slice (#264) — -110 warnings
- [x] **Projection slice (this PR)** — -64 warnings
- [ ] Tags/EventSlice/StreamAction/IEvent slice (~34 warnings)
- [ ] MultiStream + CodeGenerationExtensions tail (~remaining)

## Test plan

- [x] \`dotnet build src/JasperFx.Events/JasperFx.Events.csproj -c Debug\` — 0 errors, -64 IL warnings
- [x] \`dotnet build src/EventTests/EventTests.csproj -c Debug\` — 0 errors
- [ ] CI passes

Refs #262 #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)