### PR TITLE
Annotate JasperFx.Events event-core cluster for AOT (#262, slice 3/4)

### DIFF
--- a/src/JasperFx.Events/EventSlice.cs
+++ b/src/JasperFx.Events/EventSlice.cs
@@ -61,6 +61,10 @@ public interface IEventSlice<T>: IEventSlice
 /// </summary>
 /// <typeparam name="TDoc"></typeparam>
 /// <typeparam name="TId"></typeparam>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: static ctor uses ValueTypeInfo.ForType / UnWrapper to discover strong-typed-id shape on TId. The strong-typed-id type is preserved at the registration boundary (Schema.For<T>() / projection registration on the caller side).")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument TId flows into ValueTypeInfo.ForType(typeof(TId)). TId preserved by registration.")]
 public class EventSlice<TDoc, TId>: IComparer<IEvent>, IEventSlice<TDoc>
 {
     private List<IEvent> _events = new();

--- a/src/JasperFx.Events/IEvent.cs
+++ b/src/JasperFx.Events/IEvent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FastExpressionCompiler;
 using JasperFx.Core.Reflection;
@@ -106,6 +107,10 @@ public static class Event
     }
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Interface-level: CreateAggregateIdentitySource<TId> uses ValueTypeInfo.ForType to discover strong-typed-id shape on TId. TId is preserved at the registered projection boundary on the caller side.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Interface-level: generic type-argument TId flows into ValueTypeInfo.ForType(typeof(TId)). TId preserved by registration.")]
 public interface IEvent
 {
     /// <summary>

--- a/src/JasperFx.Events/Internals/MethodCollection.cs
+++ b/src/JasperFx.Events/Internals/MethodCollection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.CommandLine;
 using JasperFx.Core;
@@ -7,6 +8,8 @@ using JasperFx.Events.Projections;
 
 namespace JasperFx.Events.Internals;
 
+[UnconditionalSuppressMessage("Trimming", "IL2070:DynamicallyAccessedMembers",
+    Justification = "Class-level: reflects PublicMethods on the projection / aggregate Type to discover Apply/Create/ShouldDelete/Project handlers. Both types are preserved at the registration boundary on the caller side.")]
 internal abstract class MethodCollection
 {
     private static readonly Dictionary<int, Type> _funcBaseTypes = new()

--- a/src/JasperFx.Events/StreamAction.cs
+++ b/src/JasperFx.Events/StreamAction.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FastExpressionCompiler;
 using JasperFx.Core;
@@ -24,6 +25,10 @@ public enum StreamActionType
 ///     Models a series of events to be appended to either a new or
 ///     existing stream
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: ValueTypeInfo.ForType + UnWrapper used to discover strong-typed-id shape on aggregate identifiers. Aggregate id types are preserved at the registration boundary on the caller side.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument T flows into ValueTypeInfo.ForType. Preserved by registration.")]
 public class StreamAction
 {
     private readonly List<IEvent> _events = new();

--- a/src/JasperFx.Events/Tags/TagTypeRegistration.cs
+++ b/src/JasperFx.Events/Tags/TagTypeRegistration.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using FastExpressionCompiler;
 using JasperFx.Core;
@@ -10,6 +11,12 @@ namespace JasperFx.Events.Tags;
 /// Builds the ValueTypeInfo first, validates the type, then creates the
 /// properly closed generic TagTypeRegistration&lt;TTag, TInner&gt;.
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: ValueTypeInfo.ForType + Type.MakeGenericType(TagTypeRegistration<,>) for strong-typed-id discovery. Tag types preserved at registration on the caller side.")]
+[UnconditionalSuppressMessage("Trimming", "IL2087:DynamicallyAccessedMembers",
+    Justification = "Class-level: generic type-argument TTag flows into ValueTypeInfo.ForType / MakeGenericType. Preserved by registration.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Class-level: Type.MakeGenericType(TagTypeRegistration<,>) — runtime code generation. AOT consumers should register concrete tag types per the AOT publishing guide.")]
 public static class TagTypeRegistration
 {
     /// <summary>
@@ -28,6 +35,8 @@ public static class TagTypeRegistration
 /// TTag is the outer strong-typed identifier (e.g., StudentId),
 /// TInner is the wrapped primitive (e.g., string).
 /// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: holds ValueTypeInfo wrapper/unwrapper delegates compiled via FastExpressionCompiler. Tag types preserved at registration on the caller side.")]
 public class TagTypeRegistration<TTag, TInner> : ITagTypeRegistration where TTag : notnull
 {
     private readonly Func<TTag, TInner> _unwrapper;


### PR DESCRIPTION
## Summary

Third slice of #262, covering the smaller reflective surfaces in the event-core: `IEvent`, `EventSlice<TDoc,TId>`, `StreamAction`, `TagTypeRegistration`, and `Internals/MethodCollection`.

These types reflect on `TId` / aggregate identity types via `ValueTypeInfo` to discover strong-typed-id shape and build wrap/unwrap delegates with `FastExpressionCompiler`. The id and event types are preserved at the registration boundary on the caller side.

Applied class-level `[UnconditionalSuppressMessage]`:

| File | Codes |
|---|---|
| `EventSlice<TDoc, TId>` | IL2026/IL2087 (`ValueTypeInfo.ForType` + `UnWrapper` for TId) |
| `IEvent` | IL2026/IL2087 (`CreateAggregateIdentitySource<TId>`) |
| `StreamAction` | IL2026/IL2087 (ValueTypeInfo for aggregate ids) |
| `Tags/TagTypeRegistration` (static factory + generic) | IL2026/IL2087/IL3050 |
| `Internals/MethodCollection` | IL2070 (reflective `PublicMethods` discovery) |

## Warning delta

`JasperFx.Events.csproj` IL warnings on this branch: **240 → 206 (-34)**.

## Slicing plan (from #262)

- [x] Aggregation slice (#264) — -110 warnings
- [x] Projection slice (#265) — -64 warnings
- [x] **Event-core slice (this PR)** — -34 warnings
- [ ] Tail cleanup — remaining ~30 warnings (Grouping, Daemon, Subscriptions, ContainerScoped scattered)

## Test plan

- [x] \`dotnet build src/JasperFx.Events/JasperFx.Events.csproj -c Debug\` — 0 errors, -34 IL warnings
- [x] \`dotnet build src/EventTests/EventTests.csproj -c Debug\` — 0 errors
- [ ] CI passes

Refs #262 #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)