### PR TITLE
Lift IEventStream, session API + daemon contracts to JasperFx.Events …

### DIFF
--- a/docs/dedupe-namespace-table-2026.md
+++ b/docs/dedupe-namespace-table-2026.md
@@ -1,0 +1,94 @@
+# Critter Stack 2026 — Dedupe Namespace Movement Table
+
+Canonical reference for the dedupe pillar ([JasperFx#214](https://github.com/JasperFx/jasperfx/issues/214)) of the Critter Stack 2026 wave. Each row records a type whose home is moving as part of the Marten ↔ Polecat consolidation.
+
+**Marten 9, Polecat 4, and Wolverine 6 migration guides must reference this table** for the relocations relevant to their product. The intent is one canonical list rather than per-product re-statements of the same moves.
+
+Status legend:
+
+* ✅ **Landed in JFx.Events 2.0** — type exists at the new home, downstream products still own their own copy.
+* 🔄 **In flight** — design settled, awaiting product-side consumption PRs.
+* 🕓 **Pending** — design discussion still open (see footnotes / open questions).
+
+## JasperFx.Events 2.0 — new canonical home
+
+| Type | Old namespace(s) | New namespace | Status | Affects |
+|---|---|---|---|---|
+| `IEventStream<T>` | `Marten.Events` / `Polecat.Events` | `JasperFx.Events` | ✅ | Marten 9, Polecat 4, Wolverine 6 |
+| `ConcurrencyStyle` | `Wolverine.Marten` / `Wolverine.Polecat` | `JasperFx.Events` | ✅ | Wolverine 6 (and any consumer of the aggregate-handler workflow) |
+| `StreamState` | `Marten.Events` / `Polecat.Events` | `JasperFx.Events` (was already partially there; constructors aligned in 2.0) | ✅ | Marten 9, Polecat 4 |
+| `IEventFilter` | n/a (new contract) | `JasperFx.Events.Daemon` | ✅ | Marten 9, Polecat 4 — products satisfy by translating to their own filter representation |
+| `IProjectionDatabase` | n/a (new contract) | `JasperFx.Events.Daemon` | ✅ | Marten 9, Polecat 4 — minimal seam for coordinator |
+| `IDaemonChangeListener` (was Polecat's `IChangeListener`) | `Polecat` | `JasperFx.Events.Daemon` | ✅ | Polecat 4 (renamed from `IChangeListener` to avoid clash with Marten's session-level listener concept) |
+| `IQueryEventStore` (session read-side) | `Marten.Events` / `Polecat.Events` | `JasperFx.Events` | ✅ | Marten 9, Polecat 4 — LINQ-returning methods stay on each product's extending interface |
+| `IEventOperations` (session write-side basics) | `Marten.Events` / `Polecat.Events` (Polecat collapses w/ IEventStoreOperations) | `JasperFx.Events` | ✅ | Marten 9, Polecat 4. Polecat refactors its combined interface into the Marten 3-tier shape (`IQueryEventStore` + `IEventOperations` + `IEventStoreOperations`). |
+| `IEventStoreOperations` (aggregate-handler workflow) | `Marten.Events` / `Polecat.Events` | `JasperFx.Events` | ✅ | Marten 9, Polecat 4, Wolverine 6. Excluded from this round: `FetchForWritingByTags<T>` (DCB — blocked on Polecat DCB parity) and `StreamLatestJson<T>` (Marten-specific optimization). |
+| `IProjectionCoordinator`, `IProjectionCoordinator<T>` | `Marten.Events.Daemon.Coordination` | `JasperFx.Events.Daemon` | ✅ | Marten 9, Polecat 4. Non-generic interface lifted (depends on `Microsoft.Extensions.Hosting`, already a transitive dep of JFx core). Generic variant relaxed from `where T : IDocumentStore` to `where T : class` — products keep their own typed registrations. |
+| `IProjectionDistributor`, `IProjectionSet`, `ProjectionLockIds` | `Marten.Events.Daemon.Coordination` | `JasperFx.Events.Daemon` | ✅ | Marten 9, Polecat 4 — Polecat to add a distributor layer ([Polecat follow-up issue](#polecat-follow-up-issues)). Abstract base class for the three Solo/SingleTenant/MultiTenanted variants deferred to the consumption PR so it's designed against real call sites. |
+| Fetch planner family (`IFetchPlanner`, `IAggregateFetchPlan<TDoc,TId>`, `Async/Inline/Live/NaturalKeyFetchPlanner`) | `Marten.Events.Fetching` | `JasperFx.Events.Fetching` (new namespace) | 🔄 | Marten 9 source side; Polecat 4 adoption |
+| `NaturalKey*` runtime types (`NaturalKeyDefinition`, `NaturalKeyBuilder`) | already in JFx.Events | n/a | ✅ | Marten 9 / Polecat 4 should drop their copies |
+| `NaturalKeyProjection`, `NaturalKeyAttribute` | `Marten.Events.Aggregation` / `Polecat.Aggregation` | `JasperFx.Events.Aggregation` | 🔄 | Marten 9 source side; Polecat 4 adoption |
+| `StreamCompactingRequest<T>` + `CompactStreamAsync<T>` overloads | `Marten.Events` / `Polecat.Events.Protected` | `JasperFx.Events` | 🕓 | Data class plus the two `IEventOperations.CompactStreamAsync<T>` overloads. Execution is product-specific; lifting the data class is a follow-up PR. |
+| `IEventBoundary<T>`, `EventTagQuery` DCB write-side methods | `Marten.Events.Dcb` / `Polecat.Events.Dcb` | `JasperFx.Events.Tags` | 🕓 | Blocked on Polecat 4 DCB parity — see [Polecat follow-up issues](#polecat-follow-up-issues). `EventTagQuery` itself is already in `JasperFx.Events.Tags`. |
+
+## Weasel.Core 9.0 — new canonical home
+
+| Type | Old namespace(s) | New namespace | Status | Affects |
+|---|---|---|---|---|
+| Marten `IStorageOperation` family (`AppendEventOperationBase`, `QuickAppendEventsOperationBase`, `InsertStreamBase`, `UpdateStreamVersion`, `IncrementStreamVersionBy*`, `AssertStreamVersion*`, etc.) | `Marten` | `Weasel.Core` | 🔄 | Marten 9 + Weasel 9 (stated example in [JasperFx#214](https://github.com/JasperFx/jasperfx/issues/214) Rule 2) |
+| Marten event-table / stream-table DDL (`EventsTable`, `StreamsTable`, etc.) | `Marten.Events.Schema` | partially shared with Weasel; Marten retains Postgres-specific bits | 🔄 | Marten 9 + Weasel 9 |
+
+## Wolverine 6 — core promotion
+
+| Type | Old namespace(s) | New namespace | Status | Affects |
+|---|---|---|---|---|
+| `AggregateHandlerAttribute`, `AggregateHandling`, `LoadAggregateFrame`, `MissingAggregateCheckFrame`, `RegisterEventsFrame`, `EventStoreFrame`, `TagAggregateOtelFrame`, `BoundaryEventCapture`, `ReadAggregateAttribute`, `WriteAggregateAttribute`, `BoundaryModelAttribute`, `ConsistentAggregateAttribute`, `ConsistentAggregateHandlerAttribute` | `Wolverine.Marten` / `Wolverine.Polecat` | `Wolverine.Persistence.EventSourcing` | 🔄 | Wolverine 6 |
+| `IMartenOp` / `IPolecatOp` + 8 of 10 concrete ops (`StoreDoc<T>`, `StoreManyDocs<T>`, `InsertDoc<T>`, `UpdateDoc<T>`, `DeleteDoc<T>`, `DeleteDocWhere<T>`, `NoOp`) | `Wolverine.Marten` / `Wolverine.Polecat` | `Wolverine.Runtime.Persistence` (generic `Op<TSession,TDoc>` base) | 🔄 | Wolverine 6. Concrete factory wrappers (`MartenOps.X` / `PolecatOps.X`) may keep their old namespace with `[Obsolete]` aliases for one release. |
+| `StoreObjects`, `DeleteDocById<T>`, `StartStream<T>` | `Wolverine.Marten` / `Wolverine.Polecat` | TBD — divergence-blocked | 🕓 | Wolverine 6. See deep-dive findings on Q9. |
+| `IWolverineSubscription`, `BatchSubscription`, `WolverineSubscriptionRunner`, `ScopedWolverineSubscriptionRunner`, `InlineInvoker`, `InnerDataInvoker`, `NulloMessageInvoker`, `WolverineCallbackForCascadingMessages`, `PublishingRelay`, `EventRouter` | `Wolverine.Marten` / `Wolverine.Polecat` | `Wolverine.Persistence.EventSourcing` | 🔄 | Wolverine 6 |
+| `EventStoreAgents`, `EventSubscriptionAgent`, `EventSubscriptionAgentFamily`, `WolverineProjectionCoordinator` | `Wolverine.Marten` / `Wolverine.Polecat` | `Wolverine.Persistence.EventSourcing` | 🔄 | Wolverine 6 |
+| `UpdatedAggregate`, `UpdatedAggregate<T>` | `Wolverine.Marten` only | `Wolverine.Persistence.EventSourcing` (now available to Wolverine.Polecat too) | 🔄 | Wolverine 6 |
+| `IMartenOutbox` / `IPolecatOutbox` (interfaces are character-for-character identical) | `Wolverine.Marten` / `Wolverine.Polecat` | `Wolverine.Persistence` (one unified `IDocumentSessionOutbox`) | 🔄 | Wolverine 6. Product-specific aliases retained for one release. |
+| `OutboxedSessionFactory`, `OutboxedSessionFactoryGeneric`, `FlushOutgoingMessagesOnCommit`, `PublishIncomingEventsBeforeCommit` | `Wolverine.Marten` / `Wolverine.Polecat` | `Wolverine.Runtime.Persistence` — shared `OutboxedSessionFactory<TSession>` base | 🔄 | Wolverine 6 |
+| `MartenToWolverineMessageBatch` (and Polecat equivalent once it exists) | `Wolverine.Marten` only today | `Wolverine.Runtime.Persistence` | 🕓 | Blocked on Polecat projection-emit-messages capability — see [open question 4](#open-questions) |
+
+## Polecat follow-up issues
+
+Several rows above require Polecat 4 to gain capability it does not have today.
+These are tracked as separate Polecat issues so the JFx.Events 2.0 consumption
+PR in Polecat can land in pieces:
+
+1. **DCB parity with Marten (excluding HSTORE).** Polecat needs equivalents to Marten's `IEventBoundary<T>` + `FetchForWritingByTags<T>` + tag-table operations. Polecat already has `pc_event_tag_*` schema infrastructure; the query / operation surface is the gap. The Postgres-specific HSTORE storage mode stays Marten-side. Once this lands, `IEventBoundary<T>` and the DCB methods on `IEventStoreOperations` graduate to JFx.Events.
+2. **`StoreObjects(IEnumerable<object>)` on `IDocumentOperations`.** Polecat's `IDocumentOperations` lacks the bulk-store API, forcing `Wolverine.Polecat.PolecatOps.StoreObjects` into per-document reflection dispatch. Adding the method collapses the op to Marten's one-liner and removes the reflection from the hot path.
+3. **Tenant scoping for event-store operations.** Marten's `IMartenOp.StartStream<T>` wraps the session via `session.ForTenant(TenantId)` to scope event-stream operations to a tenant — but Polecat's `ITenantOperations` only exposes the read-only `IQueryEventStore`, so the equivalent wrap is impossible. Polecat needs an `ITenantOperations.Events` surface exposing the write side. (Marten's wrap is real code — confirmed by user.)
+4. **Distributor layer.** Polecat needs equivalents to Marten's `SoloProjectionDistributor` / `SingleTenantProjectionDistributor` / `MultiTenantedProjectionDistributor` so Polecat can run multi-node coordinated daemons the same way Marten does. The JFx.Events 2.0 interfaces (`IProjectionDistributor`, `IProjectionSet`, `ProjectionLockIds`) give the seam; the storage-specific bits (SQL Server `sp_getapplock` for the lock implementation, database enumeration through Polecat's tenancy) are the Polecat-side work.
+5. **`IMessageBatch` for projection-emitted messages.** Polecat 4 needs the equivalent of Marten's `MartenToWolverineMessageBatch` so projections can publish messages on commit. Without this, Wolverine's outbox is asymmetric between Marten and Polecat. Once it lands, the shared `OutboxedSessionFactory<TSession>` base in Wolverine 6 can absorb the projection-emit pathway.
+
+## Marten clean-up that the migration should pick up
+
+These are pre-existing items in Marten that are easier to fix during the relocation than as separate work:
+
+* **`Marten.IReadOnlyEventStore`** — already in JFx.Events but with a different shape than Marten's `IQueryEventStore` (uses the generic `EventQuery` / `PagedEvents` instead of Marten's per-query overloads, and has no consumers in either product). Decide during Marten 9 whether to retire it, merge it into `IQueryEventStore`, or keep it as the generic event-query surface alongside.
+
+## How to reference this table from a product migration guide
+
+In each of Marten 9, Polecat 4, Wolverine 6 migration guides, add a section that says (e.g.):
+
+```markdown
+## Type relocations from the Critter Stack 2026 dedupe pillar
+
+The shared substrate consolidation moved a number of types out of `Marten.*` /
+`Polecat.*` / `Wolverine.*` and into `JasperFx.Events` / `Weasel.Core` /
+`Wolverine.Persistence.*`. See the [canonical table][1] for the full list; the
+rows below are the relocations that directly affect this product.
+
+[1]: https://github.com/JasperFx/jasperfx/blob/main/docs/dedupe-namespace-table-2026.md
+
+- `IEventStream<T>` is now `JasperFx.Events.IEventStream<T>`. Existing
+  `Marten.Events.IEventStream<T>` / `Polecat.IEventStream<T>` remain as
+  inheriting interfaces with no new members; user code that imports
+  `using Marten.Events;` or `using Polecat;` keeps working.
+- ... (per-product rows here)
+```
+
+The intent is for each product migration guide to call out the relocations its users will *see in their code*, not to restate the full table.

--- a/src/JasperFx.Events/ConcurrencyStyle.cs
+++ b/src/JasperFx.Events/ConcurrencyStyle.cs
@@ -1,0 +1,22 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// How a FetchForWriting / aggregate-handler workflow should enforce concurrent access
+/// to an event stream while a handler is running.
+/// </summary>
+/// <remarks>
+/// Canonical home is JasperFx.Events so that Wolverine.Marten, Wolverine.Polecat, and any
+/// future event-store integration share one enum rather than each defining a private copy.
+/// </remarks>
+public enum ConcurrencyStyle
+{
+    /// <summary>
+    /// Check for concurrency violations optimistically at the point of committing the updated data.
+    /// </summary>
+    Optimistic,
+
+    /// <summary>
+    /// Try to attain an exclusive lock on the data behind the current aggregate.
+    /// </summary>
+    Exclusive
+}

--- a/src/JasperFx.Events/Daemon/IDaemonChangeListener.cs
+++ b/src/JasperFx.Events/Daemon/IDaemonChangeListener.cs
@@ -1,0 +1,35 @@
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Hook invoked after a daemon subscription batch has been committed to the underlying
+/// store. Use for fire-and-forget side effects that need to happen exactly once per
+/// successful batch — for example flushing webhooks or emitting telemetry once the
+/// projection write is durable.
+/// </summary>
+/// <remarks>
+/// Lifted from Polecat's <c>IChangeListener</c> as the canonical shape. Intentionally
+/// narrower than Marten's session-level <c>IDocumentSessionListener</c> / <c>IChangeListener</c>:
+/// this is purely a daemon post-batch signal and does not carry a change-set payload.
+/// </remarks>
+public interface IDaemonChangeListener
+{
+    /// <summary>
+    /// Invoked after the daemon has successfully committed a batch of events.
+    /// </summary>
+    Task AfterCommitAsync(CancellationToken token);
+}
+
+/// <summary>
+/// Null-object implementation of <see cref="IDaemonChangeListener"/>. Use as a default
+/// when no post-commit work is required.
+/// </summary>
+public sealed class NullDaemonChangeListener : IDaemonChangeListener
+{
+    public static readonly NullDaemonChangeListener Instance = new();
+
+    private NullDaemonChangeListener()
+    {
+    }
+
+    public Task AfterCommitAsync(CancellationToken token) => Task.CompletedTask;
+}

--- a/src/JasperFx.Events/Daemon/IEventFilter.cs
+++ b/src/JasperFx.Events/Daemon/IEventFilter.cs
@@ -1,0 +1,28 @@
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Data-shape filter that an event-store implementation can consult when loading or
+/// dispatching events. Lets a projection / subscription declare "only these event
+/// types" without forcing the loader to invent its own SQL fragment shape.
+/// </summary>
+/// <remarks>
+/// This is intentionally storage-agnostic — concrete event-store implementations
+/// translate <see cref="IEventFilter"/> into their own query language (Marten emits an
+/// <c>ISqlFragment</c>, Polecat builds a <c>dotnet_type</c> allowlist).
+/// </remarks>
+public interface IEventFilter
+{
+    /// <summary>
+    /// True when this filter does not restrict the event stream — the loader can skip
+    /// applying any predicate and return everything in the requested range.
+    /// </summary>
+    bool MatchesAnyEvent { get; }
+
+    /// <summary>
+    /// The set of event types this filter is willing to deliver. When
+    /// <see cref="MatchesAnyEvent"/> is true this collection is unused; otherwise the
+    /// loader is expected to restrict the result set to events whose runtime type
+    /// matches an entry in this collection.
+    /// </summary>
+    IReadOnlyCollection<Type> EventTypes { get; }
+}

--- a/src/JasperFx.Events/Daemon/IProjectionCoordinator.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionCoordinator.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Hosting;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Coordinates the projection daemons that run for an event store across one or more
+/// databases. Hosted as an <see cref="IHostedService"/> so the runtime can start and
+/// stop the daemons with the application lifetime, and pause/resume them at runtime
+/// for diagnostics or maintenance.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>Marten.Events.Daemon.Coordination.IProjectionCoordinator</c>
+/// as the canonical home. Concrete implementations remain product-specific so they can
+/// integrate with each event store's database resolution + tenancy model.
+/// </remarks>
+public interface IProjectionCoordinator : IHostedService
+{
+    /// <summary>
+    /// Returns the daemon running against the default/main database for this event store.
+    /// </summary>
+    IProjectionDaemon DaemonForMainDatabase();
+
+    /// <summary>
+    /// Returns the daemon running against the database with the given identifier.
+    /// Resolves the database lazily — implementations may need to open a connection
+    /// to discover databases that have not yet been observed.
+    /// </summary>
+    ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier);
+
+    /// <summary>
+    /// All daemons currently running across all databases known to this coordinator.
+    /// </summary>
+    ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync();
+
+    /// <summary>
+    /// Stops the coordinator's automatic restart logic and stops all running agents
+    /// across all daemons. Does not release any held locks. Use <see cref="ResumeAsync"/>
+    /// to restart.
+    /// </summary>
+    Task PauseAsync();
+
+    /// <summary>
+    /// Resumes the coordinator's automatic restart logic and restarts all agents across
+    /// all daemons. Intended to be paired with a prior <see cref="PauseAsync"/> call.
+    /// </summary>
+    Task ResumeAsync();
+}
+
+/// <summary>
+/// Marker variant of <see cref="IProjectionCoordinator"/> used to register multiple
+/// coordinators in DI when an application talks to more than one event store. The
+/// type parameter acts as a unique key for ancillary stores; it has no behavioral
+/// constraint of its own.
+/// </summary>
+/// <typeparam name="T">A marker type identifying which event store this coordinator manages.</typeparam>
+public interface IProjectionCoordinator<T> : IProjectionCoordinator where T : class
+{
+}

--- a/src/JasperFx.Events/Daemon/IProjectionDatabase.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDatabase.cs
@@ -1,0 +1,25 @@
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Minimal database identity contract consumed by projection-coordination plumbing.
+/// Lets shared coordinator code refer to a database by identifier and URI without
+/// pulling in Marten's <c>IMartenDatabase</c> or Polecat's session/database types.
+/// </summary>
+/// <remarks>
+/// Concrete event-store implementations satisfy this contract by wrapping their own
+/// database abstraction. The coordinator only ever needs the identifier (for shard
+/// addressing) and a URI for telemetry.
+/// </remarks>
+public interface IProjectionDatabase
+{
+    /// <summary>
+    /// Stable identifier for this database. In multi-tenant or multi-database setups
+    /// the coordinator uses this string to address a specific daemon.
+    /// </summary>
+    string Identifier { get; }
+
+    /// <summary>
+    /// A URI describing this database, primarily for telemetry / diagnostics output.
+    /// </summary>
+    Uri DatabaseUri { get; }
+}

--- a/src/JasperFx.Events/Daemon/IProjectionDistributor.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDistributor.cs
@@ -1,0 +1,79 @@
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Strategy for distributing projection shards across nodes in a deployment.
+/// Distributors are responsible for grouping shards into <see cref="IProjectionSet"/>s,
+/// acquiring exclusive leadership over a set via a distributed lock, and releasing
+/// that lock when work moves to another node.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>IProjectionDistributor</c>. Three storage-agnostic variants
+/// are expected:
+/// <list type="bullet">
+///   <item>Solo — single node, no locks (used when the application is known not to scale out).</item>
+///   <item>Single-tenant — multi-node, single tenant; one lock per shard.</item>
+///   <item>Multi-tenanted — multi-node, multi-tenant; locks are shard-aware per database.</item>
+/// </list>
+/// Lock acquisition itself is storage-specific (Postgres advisory locks, SQL Server
+/// application locks, etc.) and is provided by product-specific implementations
+/// behind this contract.
+/// </remarks>
+public interface IProjectionDistributor : IAsyncDisposable
+{
+    /// <summary>
+    /// Build the current view of which projection shards should run where. The
+    /// coordinator polls this regularly and asks for new locks accordingly.
+    /// </summary>
+    ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync();
+
+    /// <summary>
+    /// Apply an initial random jitter before polling, so multiple nodes coming up
+    /// at the same time do not collide on identical poll intervals.
+    /// </summary>
+    Task RandomWait(CancellationToken token);
+
+    /// <summary>
+    /// True when this distributor already holds the lock for the given set on this node.
+    /// </summary>
+    bool HasLock(IProjectionSet set);
+
+    /// <summary>
+    /// Attempt to acquire the distributed lock for this set on this node.
+    /// Returns false when another node holds the lock.
+    /// </summary>
+    Task<bool> TryAttainLockAsync(IProjectionSet set, CancellationToken token);
+
+    /// <summary>
+    /// Release the lock for this set.
+    /// </summary>
+    Task ReleaseLockAsync(IProjectionSet set);
+
+    /// <summary>
+    /// Release every lock this distributor holds. Used during coordinated shutdown
+    /// and pause/resume cycles.
+    /// </summary>
+    Task ReleaseAllLocks();
+}
+
+/// <summary>
+/// Helpers for computing the deterministic lock identifiers a multi-node deployment
+/// uses to negotiate shard ownership. The hash must be identical across nodes so two
+/// nodes asking the lock service for the "Trip:All:1" lock both ask for the same id.
+/// </summary>
+public static class ProjectionLockIds
+{
+    /// <summary>
+    /// Compute a deterministic lock id from a schema-qualified shard identity plus
+    /// a base lock id. Mirrors the hash pattern used by Marten's
+    /// <c>SingleTenantProjectionDistributor</c> so Marten and Polecat distributors
+    /// negotiate the same identifiers when migrated.
+    /// </summary>
+    public static int Compute(string schemaQualifier, ShardName shardName, int baseLockId)
+    {
+        ArgumentNullException.ThrowIfNull(shardName);
+        return Math.Abs($"{schemaQualifier}:{shardName.Identity}".GetDeterministicHashCode()) + baseLockId;
+    }
+}

--- a/src/JasperFx.Events/Daemon/IProjectionSet.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionSet.cs
@@ -1,0 +1,28 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// A group of projection shards that share a single lock — i.e. they're scheduled
+/// together as a unit by the projection coordinator. Each set targets exactly one
+/// database; multi-database deployments expose one set per database.
+/// </summary>
+public interface IProjectionSet
+{
+    /// <summary>
+    /// Stable, deterministic identifier used as the underlying lock key when this
+    /// set is scheduled. Distributed projection coordinators across nodes must
+    /// compute the same id for the same logical set so they negotiate the same lock.
+    /// </summary>
+    int LockId { get; }
+
+    /// <summary>
+    /// The database that this set's shards run against.
+    /// </summary>
+    IProjectionDatabase Database { get; }
+
+    /// <summary>
+    /// The shards in this set.
+    /// </summary>
+    IReadOnlyList<ShardName> Names { get; }
+}

--- a/src/JasperFx.Events/IEventOperations.cs
+++ b/src/JasperFx.Events/IEventOperations.cs
@@ -1,0 +1,144 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Write-side event-store API basics: append events to streams and start new streams.
+/// Canonical home for the surface that Marten's <c>IEventOperations</c> and
+/// Polecat's write-side event API share.
+/// </summary>
+/// <remarks>
+/// <see cref="IEventStoreOperations"/> extends this contract with the
+/// aggregate-handler workflow (FetchForWriting, WriteToAggregate, optimistic /
+/// exclusive concurrency, archive, etc.).
+/// </remarks>
+public interface IEventOperations
+{
+    /// <summary>
+    /// Append events in order to an existing stream by Guid identity.
+    /// </summary>
+    StreamAction Append(Guid stream, IEnumerable<object> events);
+
+    /// <summary>
+    /// Append events in order to an existing stream by Guid identity.
+    /// </summary>
+    StreamAction Append(Guid stream, params object[] events);
+
+    /// <summary>
+    /// Append events in order to an existing stream by string key.
+    /// </summary>
+    StreamAction Append(string stream, IEnumerable<object> events);
+
+    /// <summary>
+    /// Append events in order to an existing stream by string key.
+    /// </summary>
+    StreamAction Append(string stream, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream and verify that the maximum event id for the
+    /// stream matches the supplied expected version or the transaction is aborted.
+    /// </summary>
+    StreamAction Append(Guid stream, long expectedVersion, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream and verify that the maximum event id for the
+    /// stream matches the supplied expected version or the transaction is aborted.
+    /// </summary>
+    StreamAction Append(string stream, long expectedVersion, IEnumerable<object> events);
+
+    /// <summary>
+    /// Append events to an existing stream and verify that the maximum event id for the
+    /// stream matches the supplied expected version or the transaction is aborted.
+    /// </summary>
+    StreamAction Append(string stream, long expectedVersion, params object[] events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied Guid and append events to it.
+    /// Throws when a stream with the same identity already exists.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class;
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied Guid and append events to it.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, Guid id, IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied Guid and append events to it.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, Guid id, params object[] events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied string key and append events.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(string streamKey, IEnumerable<object> events) where TAggregate : class;
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied string key and append events.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class;
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied string key and append events.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, string streamKey, IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied string key and append events.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, string streamKey, params object[] events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied Guid and append events.
+    /// </summary>
+    StreamAction StartStream(Guid id, IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied Guid and append events.
+    /// </summary>
+    StreamAction StartStream(Guid id, params object[] events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied string key and append events.
+    /// </summary>
+    StreamAction StartStream(string streamKey, IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream based on a user-supplied string key and append events.
+    /// </summary>
+    StreamAction StartStream(string streamKey, params object[] events);
+
+    /// <summary>
+    /// Create a new event stream, assign a new Guid id, and append events to it.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class;
+
+    /// <summary>
+    /// Create a new event stream, assign a new Guid id, and append events to it.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(params object[] events) where TAggregate : class;
+
+    /// <summary>
+    /// Create a new event stream, assign a new Guid id, and append events to it.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream, assign a new Guid id, and append events to it.
+    /// </summary>
+    StreamAction StartStream(Type aggregateType, params object[] events);
+
+    /// <summary>
+    /// Create a new event stream, assign a new Guid id, and append events to it.
+    /// </summary>
+    StreamAction StartStream(IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream, assign a new Guid id, and append events to it.
+    /// </summary>
+    StreamAction StartStream(params object[] events);
+
+    // NOTE: CompactStreamAsync<T>(...) is intentionally not lifted here. Marten and Polecat
+    // each ship a public StreamCompactingRequest<T> with product-specific execution
+    // (against IDocumentOperations / IDocumentSession). Lifting that data class is a
+    // follow-up; until then each product exposes CompactStreamAsync on its own derived
+    // interface.
+}

--- a/src/JasperFx.Events/IEventStoreOperations.cs
+++ b/src/JasperFx.Events/IEventStoreOperations.cs
@@ -1,0 +1,302 @@
+using System.Linq.Expressions;
+using JasperFx.Events.Tags;
+
+namespace JasperFx.Events;
+
+/// <summary>
+/// Full session-level event-store API: read + write + the aggregate-handler workflow
+/// (FetchForWriting / WriteToAggregate / optimistic / exclusive concurrency / fetch
+/// latest / project latest / tag queries / natural-key fetches).
+/// </summary>
+/// <remarks>
+/// Canonical home of the surface that Marten's <c>IEventStoreOperations</c> and
+/// Polecat's combined <c>IEventOperations</c> share. Wolverine codegen targets this
+/// contract directly — both products' session types implement it so the aggregate
+/// handler frames don't need to be parameterized on a session generic.
+///
+/// Intentionally excluded from this version of the contract:
+/// <list type="bullet">
+///   <item><c>FetchForWritingByTags&lt;T&gt;(EventTagQuery)</c> — returns a product-specific
+///   <c>IEventBoundary&lt;T&gt;</c>. Lifted in a follow-up once Polecat reaches DCB parity.</item>
+///   <item><c>StreamLatestJson&lt;T&gt;(...)</c> — Marten-specific JSON-passthrough optimization.</item>
+/// </list>
+/// </remarks>
+public interface IEventStoreOperations : IEventOperations, IQueryEventStore
+{
+    /// <summary>
+    /// Helper to create an event wrapper as part of appending events when custom metadata is needed.
+    /// </summary>
+    IEvent BuildEvent(object data);
+
+    /// <summary>
+    /// Append events to an existing stream and verify that the maximum event id for the stream
+    /// matches the supplied expected version or the transaction is aborted.
+    /// </summary>
+    StreamAction Append(Guid stream, long expectedVersion, IEnumerable<object> events);
+
+    /// <summary>
+    /// Create a new event stream with a user-supplied Guid and append events to it.
+    /// </summary>
+    StreamAction StartStream<TAggregate>(Guid id, IEnumerable<object> events) where TAggregate : class;
+
+    /// <summary>
+    /// Append events to an existing stream with an optimistic concurrency check against
+    /// the existing version of the stream.
+    /// </summary>
+    Task AppendOptimistic(string streamKey, CancellationToken token, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an optimistic concurrency check against
+    /// the existing version of the stream.
+    /// </summary>
+    Task AppendOptimistic(string streamKey, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an optimistic concurrency check against
+    /// the existing version of the stream.
+    /// </summary>
+    Task AppendOptimistic(Guid streamId, CancellationToken token, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an optimistic concurrency check against
+    /// the existing version of the stream.
+    /// </summary>
+    Task AppendOptimistic(Guid streamId, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an exclusive lock against the stream until
+    /// this session is saved.
+    /// </summary>
+    Task AppendExclusive(string streamKey, CancellationToken token, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an exclusive lock against the stream until
+    /// this session is saved.
+    /// </summary>
+    Task AppendExclusive(string streamKey, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an exclusive lock against the stream until
+    /// this session is saved.
+    /// </summary>
+    Task AppendExclusive(Guid streamId, CancellationToken token, params object[] events);
+
+    /// <summary>
+    /// Append events to an existing stream with an exclusive lock against the stream until
+    /// this session is saved.
+    /// </summary>
+    Task AppendExclusive(Guid streamId, params object[] events);
+
+    /// <summary>
+    /// Mark a stream and all of its events as archived.
+    /// </summary>
+    void ArchiveStream(Guid streamId);
+
+    /// <summary>
+    /// Mark a stream and all of its events as archived.
+    /// </summary>
+    void ArchiveStream(string streamKey);
+
+    /// <summary>
+    /// Fetch the projected aggregate T by id with built-in optimistic concurrency checks
+    /// starting at the point the aggregate was fetched.
+    /// </summary>
+    Task<IEventStream<T>> FetchForWriting<T>(Guid id, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Fetch the projected aggregate T by id with built-in optimistic concurrency checks
+    /// starting at the point the aggregate was fetched.
+    /// </summary>
+    Task<IEventStream<T>> FetchForWriting<T>(string key, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Fetch projected aggregate T by id and expected, current version. Fails immediately
+    /// with a concurrency exception if the expectedVersion is stale.
+    /// </summary>
+    Task<IEventStream<T>> FetchForWriting<T>(Guid id, long expectedVersion, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Fetch projected aggregate T by id and expected, current version. Fails immediately
+    /// with a concurrency exception if the expectedVersion is stale.
+    /// </summary>
+    Task<IEventStream<T>> FetchForWriting<T>(string key, long expectedVersion, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Fetch projected aggregate T by id for exclusive writing.
+    /// </summary>
+    Task<IEventStream<T>> FetchForExclusiveWriting<T>(Guid id, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Fetch projected aggregate T by id for exclusive writing.
+    /// </summary>
+    Task<IEventStream<T>> FetchForExclusiveWriting<T>(string key, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream for the current version of the aggregate of type T.
+    /// Automatically persists the entire session.
+    /// </summary>
+    Task WriteToAggregate<T>(Guid id, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream for the current version of the aggregate of type T.
+    /// Automatically persists the entire session.
+    /// </summary>
+    Task WriteToAggregate<T>(Guid id, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream for the current version of the aggregate of type T.
+    /// Automatically persists the entire session.
+    /// </summary>
+    Task WriteToAggregate<T>(string id, Action<IEventStream<T>> writing, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream for the current version of the aggregate of type T.
+    /// Automatically persists the entire session.
+    /// </summary>
+    Task WriteToAggregate<T>(string id, Func<IEventStream<T>, Task> writing, CancellationToken cancellation = default)
+        where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream at a specific expected starting version.
+    /// </summary>
+    Task WriteToAggregate<T>(Guid id, int expectedVersion, Action<IEventStream<T>> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream at a specific expected starting version.
+    /// </summary>
+    Task WriteToAggregate<T>(Guid id, int expectedVersion, Func<IEventStream<T>, Task> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream at a specific expected starting version.
+    /// </summary>
+    Task WriteToAggregate<T>(string id, int expectedVersion, Action<IEventStream<T>> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Conditionally write to an event stream at a specific expected starting version.
+    /// </summary>
+    Task WriteToAggregate<T>(string id, int expectedVersion, Func<IEventStream<T>, Task> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Write exclusively to the stream for aggregate of type T. May time out if a lock
+    /// cannot be attained on the stream in time.
+    /// </summary>
+    Task WriteExclusivelyToAggregate<T>(Guid id, Action<IEventStream<T>> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Write exclusively to the stream for aggregate of type T. May time out if a lock
+    /// cannot be attained on the stream in time.
+    /// </summary>
+    Task WriteExclusivelyToAggregate<T>(string id, Action<IEventStream<T>> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Write exclusively to the stream for aggregate of type T. May time out if a lock
+    /// cannot be attained on the stream in time.
+    /// </summary>
+    Task WriteExclusivelyToAggregate<T>(Guid id, Func<IEventStream<T>, Task> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Write exclusively to the stream for aggregate of type T. May time out if a lock
+    /// cannot be attained on the stream in time.
+    /// </summary>
+    Task WriteExclusivelyToAggregate<T>(string id, Func<IEventStream<T>, Task> writing,
+        CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Advanced usage: register an operation with the current session to overwrite the
+    /// data or headers of an existing event.
+    /// </summary>
+    void OverwriteEvent(IEvent e);
+
+    /// <summary>
+    /// Fetch the projected aggregate T by id. Functions regardless of the projection
+    /// lifecycle — a lightweight, read-only counterpart to FetchForWriting.
+    /// </summary>
+    ValueTask<T?> FetchLatest<T>(Guid id, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Fetch the projected aggregate T by id. Functions regardless of the projection
+    /// lifecycle — a lightweight, read-only counterpart to FetchForWriting.
+    /// </summary>
+    ValueTask<T?> FetchLatest<T>(string id, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Fetch the projected aggregate T by id, including any events appended in this
+    /// session that have not yet been committed. For inline projections, the updated
+    /// document is also stored in the session so it will be persisted on the next
+    /// SaveChangesAsync call.
+    /// </summary>
+    ValueTask<T?> ProjectLatest<T>(Guid id, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Fetch the projected aggregate T by id, including any events appended in this
+    /// session that have not yet been committed.
+    /// </summary>
+    ValueTask<T?> ProjectLatest<T>(string id, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Replace event data at a specified spot in the event store without changing stream
+    /// identity or version. Replaces all header information with empty. Originally
+    /// intended for stream compacting.
+    /// </summary>
+    Guid CompletelyReplaceEvent<T>(long sequence, T eventBody) where T : class;
+
+    /// <summary>
+    /// Retroactively assign a tag to all events matching the given LINQ predicate. The
+    /// tag's type must be registered via the event registry. The operation is queued
+    /// and applied at SaveChangesAsync time.
+    /// </summary>
+    void AssignTagWhere(Expression<Func<IEvent, bool>> expression, object tag);
+
+    /// <summary>
+    /// Lightweight existence check: are there any events matching the given tag query?
+    /// Useful for DCB guard clauses.
+    /// </summary>
+    Task<bool> EventsExistAsync(EventTagQuery query, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Query events by their tags. Returns events matching any of the OR'd conditions
+    /// in the query, ordered by sequence id.
+    /// </summary>
+    Task<IReadOnlyList<IEvent>> QueryByTagsAsync(EventTagQuery query, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Query events by tag and aggregate them into type T using a live fold.
+    /// </summary>
+    Task<T?> AggregateByTagsAsync<T>(EventTagQuery query, CancellationToken cancellation = default) where T : class;
+
+    // Natural-key (strong-typed-id) fetch overloads ---------------------------------------------
+
+    /// <summary>
+    /// Fetch projected aggregate T by a natural key or any registered identifier type
+    /// with built-in optimistic concurrency checks.
+    /// </summary>
+    Task<IEventStream<T>> FetchForWriting<T, TId>(TId id, CancellationToken cancellation = default)
+        where T : class where TId : notnull;
+
+    /// <summary>
+    /// Fetch projected aggregate T by a natural key for exclusive writing with row-level locking.
+    /// </summary>
+    Task<IEventStream<T>> FetchForExclusiveWriting<T, TId>(TId id, CancellationToken cancellation = default)
+        where T : class where TId : notnull;
+
+    /// <summary>
+    /// Fetch the projected aggregate T by a natural key or any registered identifier
+    /// type. Lightweight, read-only counterpart to FetchForWriting.
+    /// </summary>
+    ValueTask<T?> FetchLatest<T, TId>(TId id, CancellationToken cancellation = default)
+        where T : class where TId : notnull;
+}

--- a/src/JasperFx.Events/IEventStream.cs
+++ b/src/JasperFx.Events/IEventStream.cs
@@ -1,0 +1,93 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Internal marker that lets the event-sourcing infrastructure advance the expected
+/// starting version on a stream handle without exposing the concrete type.
+/// </summary>
+internal interface IEventStream
+{
+    void TryFastForwardVersion();
+}
+
+/// <summary>
+/// A writable handle to an event stream and its currently-projected aggregate.
+/// Returned by FetchForWriting / FetchForExclusiveWriting on a session-bound event store.
+/// </summary>
+/// <remarks>
+/// Canonical home is JasperFx.Events. Marten and Polecat each expose product-specific
+/// re-exports / inheriting interfaces, but the shape is shared so that Wolverine codegen
+/// can target a single contract regardless of which event store is backing the handler.
+/// </remarks>
+public interface IEventStream<out T> where T : notnull
+{
+    /// <summary>
+    /// The projected aggregate state at the moment the stream was fetched, or null
+    /// if the stream does not yet exist.
+    /// </summary>
+    T? Aggregate { get; }
+
+    /// <summary>
+    /// The version of the stream at the moment it was fetched. Null when the stream
+    /// did not exist at fetch time.
+    /// </summary>
+    long? StartingVersion { get; }
+
+    /// <summary>
+    /// The expected version after the events queued on this handle are persisted —
+    /// equivalent to <see cref="StartingVersion"/> + the count of pending events.
+    /// Null when <see cref="StartingVersion"/> is null.
+    /// </summary>
+    long? CurrentVersion { get; }
+
+    /// <summary>
+    /// Cancellation token bound to the fetch operation that produced this handle.
+    /// Useful when async work needs to honor the same cancellation as the load.
+    /// </summary>
+    CancellationToken Cancellation { get; }
+
+    /// <summary>
+    /// The Guid identity of the stream, or Guid.Empty when the stream is keyed by string.
+    /// </summary>
+    Guid Id { get; }
+
+    /// <summary>
+    /// The string key of the stream, or null when the stream is keyed by Guid.
+    /// </summary>
+    string? Key { get; }
+
+    /// <summary>
+    /// Events that have been appended to this handle and will be persisted when the
+    /// session is saved.
+    /// </summary>
+    IReadOnlyList<IEvent> Events { get; }
+
+    /// <summary>
+    /// Append a single event to the stream.
+    /// </summary>
+    void AppendOne(object @event);
+
+    /// <summary>
+    /// Append multiple events to the stream.
+    /// </summary>
+    void AppendMany(params object[] events);
+
+    /// <summary>
+    /// Append multiple events to the stream.
+    /// </summary>
+    void AppendMany(IEnumerable<object> events);
+
+    /// <summary>
+    /// When true, the underlying event store will enforce an optimistic concurrency
+    /// check on this stream at save time even if no events are appended. Useful when
+    /// the handler decides not to emit events but still needs to assert the stream
+    /// version has not advanced since it was fetched.
+    /// </summary>
+    bool AlwaysEnforceConsistency { get; set; }
+
+    /// <summary>
+    /// Advance the expected starting version for optimistic concurrency checks to
+    /// the current version, so a single stream handle can be reused across multiple
+    /// units of work. Intended for very specific advanced scenarios.
+    /// </summary>
+    void TryFastForwardVersion();
+}

--- a/src/JasperFx.Events/IQueryEventStore.cs
+++ b/src/JasperFx.Events/IQueryEventStore.cs
@@ -1,0 +1,76 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Read-only event-store API as seen from a session. Canonical home for the surface
+/// that Marten's <c>IQueryEventStore</c> and Polecat's <c>IQueryEventStore</c> share.
+/// </summary>
+/// <remarks>
+/// LINQ-returning methods (<c>QueryRawEventDataOnly</c>, <c>QueryAllRawEvents</c>) are
+/// intentionally not part of this contract — they return product-specific queryable
+/// types and stay on each product's product-specific extension of this interface.
+/// </remarks>
+public interface IQueryEventStore
+{
+    /// <summary>
+    /// Fetch all of the events for the named stream.
+    /// </summary>
+    /// <param name="streamId">Stream identity (Guid).</param>
+    /// <param name="version">If set, queries for events up to and including this version.</param>
+    /// <param name="timestamp">If set, queries for events captured on or before this timestamp.</param>
+    /// <param name="fromVersion">If set, queries for events on or from this version.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task<IReadOnlyList<IEvent>> FetchStreamAsync(Guid streamId, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
+
+    /// <summary>
+    /// Fetch all of the events for the named stream by string key.
+    /// </summary>
+    Task<IReadOnlyList<IEvent>> FetchStreamAsync(string streamKey, long version = 0,
+        DateTimeOffset? timestamp = null, long fromVersion = 0, CancellationToken token = default);
+
+    /// <summary>
+    /// Perform a live aggregation of the raw events in this stream into a T object.
+    /// </summary>
+    Task<T?> AggregateStreamAsync<T>(Guid streamId, long version = 0, DateTimeOffset? timestamp = null,
+        T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Perform a live aggregation of the raw events in this stream into a T object.
+    /// </summary>
+    Task<T?> AggregateStreamAsync<T>(string streamKey, long version = 0, DateTimeOffset? timestamp = null,
+        T? state = null, long fromVersion = 0, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Perform a live aggregation but return the last known non-null version of the aggregate,
+    /// walking backwards through events if the aggregate is marked deleted at the current version.
+    /// </summary>
+    Task<T?> AggregateStreamToLastKnownAsync<T>(Guid streamId, long version = 0,
+        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Perform a live aggregation but return the last known non-null version of the aggregate,
+    /// walking backwards through events if the aggregate is marked deleted at the current version.
+    /// </summary>
+    Task<T?> AggregateStreamToLastKnownAsync<T>(string streamKey, long version = 0,
+        DateTimeOffset? timestamp = null, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Load a single event by its id, knowing the event type upfront.
+    /// </summary>
+    Task<IEvent<T>?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class;
+
+    /// <summary>
+    /// Load a single event by its id.
+    /// </summary>
+    Task<IEvent?> LoadAsync(Guid id, CancellationToken token = default);
+
+    /// <summary>
+    /// Fetch only the metadata about a stream by id.
+    /// </summary>
+    Task<StreamState?> FetchStreamStateAsync(Guid streamId, CancellationToken token = default);
+
+    /// <summary>
+    /// Fetch only the metadata about a stream by string key.
+    /// </summary>
+    Task<StreamState?> FetchStreamStateAsync(string streamKey, CancellationToken token = default);
+}

--- a/src/JasperFx.Events/StreamState.cs
+++ b/src/JasperFx.Events/StreamState.cs
@@ -1,12 +1,66 @@
 namespace JasperFx.Events;
 
+/// <summary>
+/// Metadata snapshot of an event stream.
+/// </summary>
 public class StreamState
 {
+    public StreamState()
+    {
+    }
+
+    public StreamState(Guid id, long version, Type? aggregateType,
+        DateTimeOffset lastTimestamp, DateTimeOffset created)
+    {
+        Id = id;
+        Version = version;
+        AggregateType = aggregateType;
+        LastTimestamp = lastTimestamp;
+        Created = created;
+    }
+
+    public StreamState(string key, long version, Type? aggregateType,
+        DateTimeOffset lastTimestamp, DateTimeOffset created)
+    {
+        Key = key;
+        Version = version;
+        AggregateType = aggregateType;
+        LastTimestamp = lastTimestamp;
+        Created = created;
+    }
+
+    /// <summary>
+    /// Identity of the stream when using Guid identity. <see cref="Guid.Empty"/> if the stream is string-keyed.
+    /// </summary>
     public Guid Id { get; set; }
+
+    /// <summary>
+    /// Identity of the stream when using string identity. Null if the stream is Guid-keyed.
+    /// </summary>
     public string? Key { get; set; }
+
+    /// <summary>
+    /// Current version of the stream in the database (the count of events).
+    /// </summary>
     public long Version { get; set; }
+
+    /// <summary>
+    /// If the stream was started tagged with an aggregate type, that type is reflected here. May be null.
+    /// </summary>
     public Type? AggregateType { get; set; }
+
+    /// <summary>
+    /// The last time this stream was appended to.
+    /// </summary>
     public DateTimeOffset LastTimestamp { get; set; }
+
+    /// <summary>
+    /// The time at which this stream was created.
+    /// </summary>
     public DateTimeOffset Created { get; set; }
+
+    /// <summary>
+    /// Is this event stream marked as archived.
+    /// </summary>
     public bool IsArchived { get; set; }
 }


### PR DESCRIPTION
…for dedupe pillar

Foundation drop for the Marten ↔ Polecat dedupe pillar (JasperFx#214). Adds the database-agnostic contracts both products will inherit so common event-sourcing logic stops living in two parallel implementations. Purely additive — nothing in Marten or Polecat changes yet.

JasperFx.Events:
- IEventStream<T> — writable stream handle (where T : notnull)
- IQueryEventStore — read-side session API (LINQ-returning methods stay product-specific since they return IMartenQueryable / IPolecatQueryable)
- IEventOperations — write-side basics (Append × 7, StartStream × 16)
- IEventStoreOperations — combined aggregate-handler workflow (FetchForWriting, WriteToAggregate, AppendOptimistic/Exclusive, FetchLatest, ProjectLatest, OverwriteEvent, AssignTagWhere, tag queries, natural-key fetches)
- ConcurrencyStyle — was duplicated in both Wolverine integrations

JasperFx.Events.Daemon:
- IEventFilter — storage-agnostic event-type allowlist
- IProjectionDatabase — minimal { Identifier; DatabaseUri } seam
- IDaemonChangeListener — post-batch hook (was Polecat's IChangeListener; renamed to avoid clash with Marten's session-level IChangeListener)
- IProjectionCoordinator + IProjectionCoordinator<T> — daemon control plane
- IProjectionDistributor + IProjectionSet + ProjectionLockIds — shard distribution contracts

Updates:
- StreamState gains the Marten/Polecat-compatible constructors so the existing class is drop-in for both products
- IEventStream<T> takes where T : notnull (matches Marten's broader shape; Polecat will adapt)

Excluded from this round (follow-ups):
- StreamCompactingRequest<T> + CompactStreamAsync<T> — execution is product-specific; lift the data class in a separate PR
- FetchForWritingByTags<T> returning IEventBoundary<T> — blocked on Polecat DCB parity
- StreamLatestJson<T> — Marten-specific JSON-passthrough optimization
- ProjectionDistributor abstract base + Solo/SingleTenant/MultiTenanted concretes — designed against real consumption call sites in the Marten 9 PR rather than guessed at the seams here

Companion: docs/dedupe-namespace-table-2026.md is the canonical reference that Marten 9 / Polecat 4 / Wolverine 6 migration guides will link to.

Refs JasperFx#214 (dedupe pillar), part of JasperFx#217 (Critter Stack 2026).