### PR TITLE
Lift FetchForWritingByTags<T> + IEventBoundary<T> to JasperFx.Events (#270)

### DIFF
--- a/src/JasperFx.Events/IEventStoreOperations.cs
+++ b/src/JasperFx.Events/IEventStoreOperations.cs
@@ -16,8 +16,6 @@ namespace JasperFx.Events;
 ///
 /// Intentionally excluded from this version of the contract:
 /// <list type="bullet">
-///   <item><c>FetchForWritingByTags&lt;T&gt;(EventTagQuery)</c> — returns a product-specific
-///   <c>IEventBoundary&lt;T&gt;</c>. Lifted in a follow-up once Polecat reaches DCB parity.</item>
 ///   <item><c>StreamLatestJson&lt;T&gt;(...)</c> — Marten-specific JSON-passthrough optimization.</item>
 /// </list>
 /// </remarks>
@@ -277,6 +275,19 @@ public interface IEventStoreOperations : IEventOperations, IQueryEventStore
     /// Query events by tag and aggregate them into type T using a live fold.
     /// </summary>
     Task<T?> AggregateByTagsAsync<T>(EventTagQuery query, CancellationToken cancellation = default) where T : class;
+
+    /// <summary>
+    /// Fetch every event matching the tag query, aggregate them into <typeparamref name="T"/>,
+    /// and return a writable <see cref="IEventBoundary{T}"/> that enforces Dynamic
+    /// Consistency Boundary (DCB) checking. Additional events appended via the
+    /// boundary are routed to the appropriate stream(s) by tag; at
+    /// <c>SaveChangesAsync()</c> time the consuming product asserts that no new
+    /// events matching the tag query have been written past
+    /// <see cref="IEventBoundary{T}.LastSeenSequence"/>, throwing a product-specific
+    /// DCB concurrency exception if the boundary has shifted.
+    /// </summary>
+    Task<IEventBoundary<T>> FetchForWritingByTags<T>(EventTagQuery query,
+        CancellationToken cancellation = default) where T : class;
 
     // Natural-key (strong-typed-id) fetch overloads ---------------------------------------------
 

--- a/src/JasperFx.Events/Tags/IEventBoundary.cs
+++ b/src/JasperFx.Events/Tags/IEventBoundary.cs
@@ -1,0 +1,70 @@
+namespace JasperFx.Events.Tags;
+
+/// <summary>
+///     Writable handle returned by
+///     <see cref="IEventStoreOperations.FetchForWritingByTags{T}(EventTagQuery, CancellationToken)"/>
+///     for Dynamic Consistency Boundary (DCB) workflows. Unlike
+///     <see cref="IEventStream{T}"/>, which is pinned to a single stream, an
+///     <see cref="IEventBoundary{T}"/> spans every stream whose events match
+///     the boundary's tag query: the events are aggregated into
+///     <typeparamref name="T"/>, additional events can be appended via
+///     <see cref="AppendOne"/> / <see cref="AppendMany(object[])"/>, and the
+///     consuming product asserts at <c>SaveChangesAsync()</c> time that no
+///     new events matching the tag query have been written since
+///     <see cref="LastSeenSequence"/>.
+///     <para>
+///     Lifted from Marten's <c>Marten.Events.Dcb.IEventBoundary&lt;T&gt;</c>
+///     and Polecat's <c>Polecat.Events.Dcb.IEventBoundary&lt;T&gt;</c> into
+///     <c>JasperFx.Events.Tags</c> per the dedupe pillar
+///     (<see href="https://github.com/JasperFx/jasperfx/issues/214"/>). Each
+///     product retains its own concrete <c>EventBoundary&lt;T&gt;</c> behind
+///     this contract — only the shape is shared.
+///     </para>
+/// </summary>
+/// <typeparam name="T">
+///     The aggregate type built from the events matching the tag query.
+///     Constrained to <c>class</c> to match the rest of the lifted
+///     aggregate-handler surface (<see cref="IEventStream{T}"/> et al.).
+/// </typeparam>
+public interface IEventBoundary<out T> where T : class
+{
+    /// <summary>
+    ///     The current aggregate state built from the events matching the
+    ///     tag query. Null when no matching events were found.
+    /// </summary>
+    T? Aggregate { get; }
+
+    /// <summary>
+    ///     The highest event sequence number observed when the boundary was
+    ///     established. The consuming product uses this as the consistency
+    ///     marker — if any event matching the tag query has been appended
+    ///     past <see cref="LastSeenSequence"/> by the time the boundary is
+    ///     committed, the save fails with a DCB concurrency exception.
+    /// </summary>
+    long LastSeenSequence { get; }
+
+    /// <summary>
+    ///     The events loaded by the tag query, ordered by sequence.
+    /// </summary>
+    IReadOnlyList<IEvent> Events { get; }
+
+    /// <summary>
+    ///     Append a single event to the boundary. The event must carry tags
+    ///     (set explicitly via <c>WithTag()</c> or inferred from public
+    ///     properties at append time) so the product-specific compactor can
+    ///     route it to the appropriate stream.
+    /// </summary>
+    void AppendOne(object @event);
+
+    /// <summary>
+    ///     Append multiple events to the boundary. Each event must carry
+    ///     tags — see <see cref="AppendOne"/>.
+    /// </summary>
+    void AppendMany(params object[] events);
+
+    /// <summary>
+    ///     Append multiple events to the boundary. Each event must carry
+    ///     tags — see <see cref="AppendOne"/>.
+    /// </summary>
+    void AppendMany(IEnumerable<object> events);
+}


### PR DESCRIPTION
## Summary

- New `IEventBoundary<out T>` in `JasperFx.Events.Tags`. Identical shape to Marten's `Marten.Events.Dcb.IEventBoundary<T>` and Polecat's `Polecat.Events.Dcb.IEventBoundary<T>` (Aggregate / LastSeenSequence / Events / AppendOne / AppendMany). Constrained `where T : class` to match the rest of the lifted aggregate-handler surface (`IEventStream<T>` et al).
- New `FetchForWritingByTags<T>(EventTagQuery, CancellationToken)` on `IEventStoreOperations`, returning the lifted `IEventBoundary<T>`.
- Removes the "intentionally excluded" carve-out for this method from the `IEventStoreOperations` XML remarks — only `StreamLatestJson<T>` remains intentionally Marten-only.

Resolves #270. Stacks on the dedupe-pillar foundation (#268).

## Coordination

[polecat#80](https://github.com/JasperFx/polecat/issues/80) is now closed — Polecat has DCB write-side parity with Marten. Both products have a real concrete `EventBoundary<T>` ready to switch over to the lifted contract when they pin the next JasperFx.Events alpha.

## Test plan

- [x] `dotnet build src/JasperFx.Events/JasperFx.Events.csproj -c Release` — 0 errors
- [x] `dotnet test src/EventTests/EventTests.csproj -c Release` — 254/254 passing on both net9.0 and net10.0
- [ ] Polecat adopts the lifted `IEventBoundary<T>` (drops `Polecat.Events.Dcb.IEventBoundary<T>`)
- [ ] Marten 9 adopts the lifted contract (drops `Marten.Events.Dcb.IEventBoundary<T>`)

Generated with Claude Code.