### PR TITLE
Remove no-consumer OaktonAsyncCommand / OaktonCommand shims (#273)

### DIFF
--- a/src/JasperFx/CommandLine/OaktonShims.cs
+++ b/src/JasperFx/CommandLine/OaktonShims.cs
@@ -14,15 +14,6 @@ using JasperFx.CommandLine;
 
 namespace Oakton;
 
-[Obsolete("Prefer JasperFxAsyncCommand")]
-public abstract class OaktonAsyncCommand<T> : JasperFxAsyncCommand<T>
-{
-    
-}
-
-[Obsolete("Prefer JasperFxCommand")]
-public abstract class OaktonCommand<T> : JasperFxCommand<T>{}
-
 [Obsolete("Prefer JasperFxEnvironment")]
 public static class OaktonEnvironment
 {


### PR DESCRIPTION
## Summary

Knocks out two of the three **"safe alone"** items from the [Obsolete] sweep punch list in [#273](https://github.com/JasperFx/jasperfx/issues/273):

- `OaktonAsyncCommand<T>` — empty `[Obsolete]` inheritor of `JasperFxAsyncCommand<T>`.
- `OaktonCommand<T>` — empty `[Obsolete]` inheritor of `JasperFxCommand<T>`.

Both are kept-for-the-rename shells with no behavior. Issue #273 flagged them as *"no consumers found, possibly safe alone"*; re-verified zero references across the local clones of Marten, Polecat, and Wolverine before removing:

```
$ grep -rn "OaktonAsyncCommand\|OaktonCommand\b" marten/src polecat/src wolverine/src
# (no output)
```

## What stays (and why)

The remaining Oakton compat shims in `OaktonShims.cs` still have downstream consumers in **sample / test programs** (Marten Helpdesk sample, Wolverine OpenTelemetry samples, etc.) and stay until those samples migrate:

- `OaktonEnvironment` → `JasperFxEnvironment`
- `CommandLineHostingExtensions.ApplyOaktonExtensions` → `ApplyJasperFxExtensions`
- `CommandLineHostingExtensions.RunOaktonCommands` → `RunJasperFxCommands`

Migrating those samples is the **OaktonShims removal last** step in #273's suggested ordering.

## Test plan

- [x] `src/JasperFx/JasperFx.csproj` builds clean on net9.0 + net10.0 (0 errors)
- [x] CommandLineTests 280/280 passing on net9.0
- [ ] CI green

## Refs

- Closes part of [#273](https://github.com/JasperFx/jasperfx/issues/273) — the `OaktonAsyncCommand` / `OaktonCommand` rows of the "Coordinated-removal candidates → Oakton compat shims" table that were flagged as no-consumer-safe.
- Companion PR [#277](https://github.com/JasperFx/jasperfx/pull/277) covers the same issue's "reclassify instead" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)