### PR TITLE
Event-modeling descriptors + HWM diagnostics wire-format adds (unblocks CW#144 + CW#150 signals 2/3)

### DIFF
--- a/src/EventTests/Daemon/ShardStateTrackerTests.cs
+++ b/src/EventTests/Daemon/ShardStateTrackerTests.cs
@@ -89,4 +89,24 @@ public class ShardStateTrackerTests : IDisposable
             States.Add(value);
         }
     }
+
+    [Fact]
+    public void shard_state_skipped_events_count_defaults_to_null()
+    {
+        // CW#150 signal 3 semantics: null distinguishes "implementation hasn't
+        // populated it" from "zero skips have happened" — CritterWatch renders
+        // null as "n/a" not "0".
+        new ShardState("foo", 100).SkippedEventsCount.ShouldBeNull();
+    }
+
+    [Fact]
+    public void shard_state_skipped_events_count_round_trips()
+    {
+        var state = new ShardState(ShardState.HighWaterMark, 1_000_000)
+        {
+            SkippedEventsCount = 42L
+        };
+
+        state.SkippedEventsCount.ShouldBe(42L);
+    }
 }

--- a/src/EventTests/Descriptors/EventStoreUsageTests.cs
+++ b/src/EventTests/Descriptors/EventStoreUsageTests.cs
@@ -204,6 +204,26 @@ public class EventStoreUsageTests
         subscription.AgentUris[0].ShouldBe("event-subscriptions://marten/main/localhost.postgres/multi/one");
         subscription.AgentUris[1].ShouldBe("event-subscriptions://marten/main/localhost.postgres/multi/two");
     }
+
+    [Fact]
+    public void max_event_sequence_defaults_to_null()
+    {
+        // CW#150 signal 2 semantics: null means "not populated by this
+        // implementation" — CritterWatch renders that as "n/a" rather than 0.
+        new EventStoreUsage().MaxEventSequence.ShouldBeNull();
+        new EventStoreUsage(new Uri("marten://main"), new MyThing()).MaxEventSequence.ShouldBeNull();
+    }
+
+    [Fact]
+    public void max_event_sequence_round_trips()
+    {
+        var usage = new EventStoreUsage
+        {
+            MaxEventSequence = 123_456L
+        };
+
+        usage.MaxEventSequence.ShouldBe(123_456L);
+    }
 }
 
 public class MyThing

--- a/src/EventTests/EventModeling/AggregateDescriptorTests.cs
+++ b/src/EventTests/EventModeling/AggregateDescriptorTests.cs
@@ -1,0 +1,70 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+public class AggregateDescriptorTests
+{
+    private static readonly TypeDescriptor OrderType = TypeDescriptor.For(typeof(Order));
+    private static readonly TypeDescriptor PlacedEvent = TypeDescriptor.For(typeof(OrderPlaced));
+    private static readonly TypeDescriptor ShippedEvent = TypeDescriptor.For(typeof(OrderShipped));
+
+    [Fact]
+    public void positional_ctor_round_trips_inputs()
+    {
+        var descriptor = new AggregateDescriptor(
+            OrderType,
+            AggregateKind.WriteAggregate,
+            new[] { PlacedEvent, ShippedEvent });
+
+        descriptor.Type.ShouldBe(OrderType);
+        descriptor.Kind.ShouldBe(AggregateKind.WriteAggregate);
+        descriptor.AppliedEvents.Count.ShouldBe(2);
+        descriptor.AppliedEvents[0].ShouldBe(PlacedEvent);
+        descriptor.AppliedEvents[1].ShouldBe(ShippedEvent);
+    }
+
+    [Fact]
+    public void supports_empty_applied_events_list()
+    {
+        // The CW#144 generator emits an empty list when it can't statically
+        // resolve the apply set — the swim-lane renders this as "no events"
+        // rather than failing.
+        var descriptor = new AggregateDescriptor(
+            OrderType,
+            AggregateKind.BoundaryModel,
+            Array.Empty<TypeDescriptor>());
+
+        descriptor.AppliedEvents.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(AggregateKind.WriteAggregate)]
+    [InlineData(AggregateKind.ReadAggregate)]
+    [InlineData(AggregateKind.ConsistentAggregate)]
+    [InlineData(AggregateKind.BoundaryModel)]
+    public void accepts_all_four_kinds(AggregateKind kind)
+    {
+        var descriptor = new AggregateDescriptor(OrderType, kind, Array.Empty<TypeDescriptor>());
+        descriptor.Kind.ShouldBe(kind);
+    }
+
+    [Fact]
+    public void records_have_structural_equality()
+    {
+        var a = new AggregateDescriptor(OrderType, AggregateKind.WriteAggregate, new[] { PlacedEvent });
+        var b = new AggregateDescriptor(OrderType, AggregateKind.WriteAggregate, new[] { PlacedEvent });
+
+        // Records get structural equality on positional members for free.
+        // The collection-typed property compares by reference, not element
+        // sequence — pin the documented behavior so consumers aren't
+        // surprised by `Equals` returning false on equal-by-content lists.
+        a.ShouldBe(a);
+        a.Equals(b).ShouldBeFalse(); // different list instances
+    }
+
+    private record Order;
+    private record OrderPlaced;
+    private record OrderShipped;
+}

--- a/src/EventTests/EventModeling/HandlerRelationshipDescriptorTests.cs
+++ b/src/EventTests/EventModeling/HandlerRelationshipDescriptorTests.cs
@@ -1,0 +1,67 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+public class HandlerRelationshipDescriptorTests
+{
+    private static readonly TypeDescriptor Handler = TypeDescriptor.For(typeof(PlaceOrderHandler));
+    private static readonly TypeDescriptor Command = TypeDescriptor.For(typeof(PlaceOrder));
+    private static readonly TypeDescriptor Aggregate = TypeDescriptor.For(typeof(Order));
+    private static readonly TypeDescriptor PlacedEvent = TypeDescriptor.For(typeof(OrderPlaced));
+    private static readonly TypeDescriptor ShippedEvent = TypeDescriptor.For(typeof(OrderShipped));
+
+    [Fact]
+    public void positional_ctor_round_trips_inputs()
+    {
+        var descriptor = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            new[] { PlacedEvent, ShippedEvent },
+            Aggregate);
+
+        descriptor.HandlerType.ShouldBe(Handler);
+        descriptor.MessageType.ShouldBe(Command);
+        descriptor.EmittedEvents.Count.ShouldBe(2);
+        descriptor.EmittedEvents[0].ShouldBe(PlacedEvent);
+        descriptor.EmittedEvents[1].ShouldBe(ShippedEvent);
+        descriptor.TargetAggregate.ShouldBe(Aggregate);
+    }
+
+    [Fact]
+    public void target_aggregate_is_optional()
+    {
+        // Stateless handlers don't load an aggregate snapshot; the generator
+        // emits null for TargetAggregate so the swim-lane knows not to draw
+        // the aggregate arrow.
+        var descriptor = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            new[] { PlacedEvent },
+            TargetAggregate: null);
+
+        descriptor.TargetAggregate.ShouldBeNull();
+    }
+
+    [Fact]
+    public void supports_empty_emitted_events_list()
+    {
+        // Handlers that don't emit events still have a useful relationship
+        // entry — the swim-lane renders the command-to-handler edge even
+        // when no events come back.
+        var descriptor = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            Array.Empty<TypeDescriptor>(),
+            TargetAggregate: null);
+
+        descriptor.EmittedEvents.ShouldBeEmpty();
+    }
+
+    private record Order;
+    private record PlaceOrder;
+    private record OrderPlaced;
+    private record OrderShipped;
+    private record PlaceOrderHandler;
+}

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -84,6 +84,20 @@ public class EventStoreUsage : OptionsDescription
     public List<EventTypeDescriptor> RegisteredEventTypes { get; set; } = new();
 
     /// <summary>
+    /// Highest event sequence currently persisted in the underlying event-store
+    /// table — <c>max(sequence) FROM mt_streams</c> in Marten, the
+    /// <c>pc_events</c> equivalent in Polecat. Different from the
+    /// HighWaterMark (which is the max-safe-to-read sequence async readers
+    /// can trust): this is the absolute physical maximum.
+    ///
+    /// Null when the implementation hasn't populated it — CritterWatch
+    /// renders that as "n/a" rather than zero. The gap between this and
+    /// the HighWaterMark is what surfaces CritterWatch#150 signal 2
+    /// ("HWM is behind the actual max event sequence").
+    /// </summary>
+    public long? MaxEventSequence { get; set; }
+
+    /// <summary>
     /// Populates AgentUris on each async SubscriptionDescriptor based on the
     /// agent URI pattern: {agentScheme}://{identity.Type}/{identity.Name}/{databaseId}/{shardName.RelativeUrl}
     /// </summary>

--- a/src/JasperFx.Events/EventModeling/AggregateDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/AggregateDescriptor.cs
@@ -1,0 +1,61 @@
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Kind discriminator for <see cref="AggregateDescriptor"/>. Mirrors the four
+/// aggregate-marker attributes the CritterWatch source generator scans for
+/// (per CritterWatch#143 / #144).
+/// </summary>
+public enum AggregateKind
+{
+    /// <summary>
+    /// Type carries <c>[WriteAggregate]</c> — a Wolverine aggregate-handler
+    /// target. Commands handled by such a type produce events that the
+    /// aggregate also applies.
+    /// </summary>
+    WriteAggregate,
+
+    /// <summary>
+    /// Type carries <c>[ReadAggregate]</c> — Wolverine loads the current
+    /// aggregate snapshot before the handler runs but doesn't manage event
+    /// persistence on the way out.
+    /// </summary>
+    ReadAggregate,
+
+    /// <summary>
+    /// Type carries <c>[ConsistentAggregate]</c> — a write-aggregate
+    /// variant that requires the "always enforce consistency" flag, raising
+    /// concurrency exceptions on stale versions.
+    /// </summary>
+    ConsistentAggregate,
+
+    /// <summary>
+    /// Type carries <c>[BoundaryModel]</c> — a read model that crosses a
+    /// service / bounded-context boundary, surfaced separately on the
+    /// Event Modeling swim-lane.
+    /// </summary>
+    BoundaryModel,
+}
+
+/// <summary>
+/// Diagnostic descriptor for an aggregate-shaped type that the CritterWatch
+/// source generator (CritterWatch#144) finds in the consuming application.
+/// One descriptor per CLR type annotated with one of the four aggregate-
+/// marker attributes; emitted into the per-project
+/// <c>CritterWatchAppManifest</c> as <c>static readonly</c> data and merged
+/// at runtime by <c>Wolverine.CritterWatch</c> into the unified
+/// <see cref="EventModelDescriptor"/> the swim-lane consumes.
+/// </summary>
+/// <param name="Type">CLR type carrying the aggregate marker.</param>
+/// <param name="Kind">Which of the four marker attributes the type carries.</param>
+/// <param name="AppliedEvents">
+///     Event types the aggregate consumes via its <c>Apply</c> / <c>When</c>
+///     methods (write/consistent kinds) or that the read model is keyed off
+///     (read/boundary kinds), in declaration order. Empty when the
+///     generator can't statically resolve the apply set.
+/// </param>
+public sealed record AggregateDescriptor(
+    TypeDescriptor Type,
+    AggregateKind Kind,
+    IReadOnlyList<TypeDescriptor> AppliedEvents);

--- a/src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs
@@ -1,0 +1,40 @@
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Diagnostic descriptor for one handler's contribution to the
+/// event-model graph. Captures the static command→events relationship the
+/// CritterWatch swim-lane (CritterWatch#143 / #147) needs to render arrows
+/// between commands, handlers, aggregates, and downstream events.
+/// </summary>
+/// <remarks>
+/// One descriptor per handler chain the CritterWatch source generator
+/// (CritterWatch#144) discovers via the standard Wolverine handler-discovery
+/// conventions, plus the saga-subclass + <c>yield return new SomeEvent(...)</c>
+/// patterns called out in the issue body. Emitted into the per-project
+/// <c>CritterWatchAppManifest</c> as <c>static readonly</c> data; runtime
+/// aggregation across all loaded <c>CritterWatchAppManifest</c> partials
+/// produces the unified <see cref="EventModelDescriptor"/> the swim-lane
+/// consumes.
+/// </remarks>
+/// <param name="HandlerType">CLR type of the handler class.</param>
+/// <param name="MessageType">CLR type of the message the handler accepts.</param>
+/// <param name="EmittedEvents">
+///     Event types the handler's body emits (cascading message return,
+///     <c>yield return</c>, <c>slice.PublishMessage</c>, etc.), in source order.
+///     Entries with a null underlying type identity correspond to <c>yield return</c>
+///     calls the generator couldn't statically resolve — rendered as a
+///     <c>?</c> placeholder on the swim-lane rather than failing the build.
+/// </param>
+/// <param name="TargetAggregate">
+///     When the handler is keyed to an aggregate type (<c>[WriteAggregate]</c>,
+///     <c>[ReadAggregate]</c>, <c>[ConsistentAggregate]</c>, <c>[BoundaryModel]</c>),
+///     the aggregate's CLR type. Null for stateless handlers that don't load
+///     an aggregate snapshot.
+/// </param>
+public sealed record HandlerRelationshipDescriptor(
+    TypeDescriptor HandlerType,
+    TypeDescriptor MessageType,
+    IReadOnlyList<TypeDescriptor> EmittedEvents,
+    TypeDescriptor? TargetAggregate);

--- a/src/JasperFx.Events/Projections/ShardState.cs
+++ b/src/JasperFx.Events/Projections/ShardState.cs
@@ -99,6 +99,22 @@ public class ShardState
     /// </summary>
     public long? CriticalBehindThreshold { get; set; }
 
+    /// <summary>
+    /// Count of event sequences the HighWater agent has flagged as skipped.
+    /// Implementations decide whether this is cumulative (running total over
+    /// the lifetime of the daemon) or most-recent (events skipped in the
+    /// current <see cref="ShardAction.Skipped"/> publication) — both reach
+    /// the same operator conclusion: "this projection skipped some events".
+    /// Null when the implementation hasn't populated it — CritterWatch
+    /// renders null as "n/a" rather than 0 to distinguish "no skips
+    /// reported" from "zero skips have happened".
+    ///
+    /// Surfaces CritterWatch#150 signal 3 ("High Water Agent skipped
+    /// events"). Daemon-emitted; only meaningful on the HighWaterMark
+    /// shard.
+    /// </summary>
+    public long? SkippedEventsCount { get; set; }
+
     public override string ToString()
     {
         return $"{nameof(ShardName)}: {ShardName}, {nameof(Sequence)}: {Sequence}, {nameof(Action)}: {Action}";


### PR DESCRIPTION
## Summary

Combined **Phase 1 β + γ** of the refreshed Critter Stack 2026 plan. Pure additive JasperFx.Events changes that unblock downstream CritterWatch features without coupling to any other in-flight work. No breaking changes; no existing call sites disturbed.

## β — AggregateDescriptor + HandlerRelationshipDescriptor

**Unblocks [CritterWatch#144](https://github.com/JasperFx/CritterWatch/issues/144)** (the licensed Roslyn source generator). The issue body assumes these types live in `JasperFx.Descriptors` per the closed jasperfx#209, but only `EventModelSliceDescriptor` exists today. Without them the source generator can't emit the per-project `CritterWatchAppManifest` static-readonly collections.

- `src/JasperFx.Events/EventModeling/AggregateDescriptor.cs` — sealed record + `AggregateKind` enum (`WriteAggregate`, `ReadAggregate`, `ConsistentAggregate`, `BoundaryModel`). Captures `Type` + `AppliedEvents`.
- `src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs` — sealed record: `HandlerType`, `MessageType`, `EmittedEvents` (with nulls for yield-return calls the generator can't statically resolve), `TargetAggregate` (nullable for stateless handlers).

Both records sit next to `EventModelSliceDescriptor` and use `TypeDescriptor` from `JasperFx.Descriptors` for identity, matching the established pattern.

## γ — HWM diagnostics wire-format

**Unblocks [CritterWatch#150 signals 2 + 3](https://github.com/JasperFx/CritterWatch/issues/150)** (the HWM diagnostic indicators deferred when signal 1 shipped earlier today — both needed new wire fields here).

- **`EventStoreUsage.MaxEventSequence`** (`long?`, default null) — absolute physical maximum sequence in the event store, separate from the HighWaterMark which is the max-safe-to-read. CritterWatch signal 2 renders the gap. Marten and Polecat populate from `max(sequence) FROM mt_streams` / the `pc_events` equivalent.
- **`ShardState.SkippedEventsCount`** (`long?`, default null) — count of events the HighWater agent has flagged as skipped. Implementations decide cumulative-vs-most-recent semantics. Daemon-emitted; only meaningful on the HighWaterMark shard. CritterWatch signal 3 renders.

Both fields are nullable so CritterWatch can distinguish "not populated by this implementation" from concrete zero — `null` renders as "n/a", which is the right UX for downstream consumers that haven't adopted the new alpha yet.

## Tests

14 new unit tests in `src/EventTests/`:

- `EventModeling/AggregateDescriptorTests.cs` — positional ctor round-trip, empty applied-events list, all four kinds, structural-equality semantics (records compare lists by reference — pinned).
- `EventModeling/HandlerRelationshipDescriptorTests.cs` — round-trip, optional `TargetAggregate`, empty `EmittedEvents` list.
- `Descriptors/EventStoreUsageTests.cs` — `MaxEventSequence` defaults to null on both ctors, round-trips.
- `Daemon/ShardStateTrackerTests.cs` — `SkippedEventsCount` defaults to null, round-trips.

## Verified locally (net9.0)

- `dotnet build jasperfx.sln` — 0 errors, no new warnings
- `dotnet test src/EventTests/EventTests.csproj` — **268/268 passing** (up from 254; 14 new tests, no regressions)

## Downstream sequencing after merge

1. Publish JasperFx.Events `2.0.0-alpha.9`.
2. Bump pin in Marten + Polecat; both populate `MaxEventSequence` (Marten 9 / Polecat 4 alpha).
3. Bump pin in CritterWatch; extend its `Wolverine.CritterWatch.Messages.Outbound.ShardStateSnapshot` DTO to carry `SkippedEventsCount` through to the frontend.
4. CritterWatch frontend renders signals 2 + 3 alongside signal 1 (shipped today in CW#172).
5. The `CritterWatch.SourceGeneration` project (CW#144) can now reference `AggregateDescriptor` + `HandlerRelationshipDescriptor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
