### PR TITLE
Bump JasperFx.Events to 2.0.0-alpha.9 (publishes #279)

### DIFF
--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.8</Version>
+        <Version>2.0.0-alpha.9</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the


### PR DESCRIPTION
## Summary

Bumps JasperFx.Events from `2.0.0-alpha.8` to `2.0.0-alpha.9` to publish the additive surface that merged in [#279](https://github.com/JasperFx/jasperfx/pull/279):

- `AggregateDescriptor` + `AggregateKind` enum + `HandlerRelationshipDescriptor` (in `JasperFx.Events.EventModeling`) — unblocks [CritterWatch#144](https://github.com/JasperFx/CritterWatch/issues/144) source generator.
- `EventStoreUsage.MaxEventSequence` (`long?`, default null) — unblocks [CritterWatch#150 signal 2](https://github.com/JasperFx/CritterWatch/issues/150) ("HWM is behind the actual max event sequence").
- `ShardState.SkippedEventsCount` (`long?`, default null) — unblocks CritterWatch#150 signal 3 ("High Water Agent skipped events").

## What this PR does NOT do

NuGet publish is **manual `workflow_dispatch`** — this PR only flags the version on `main`. You trigger the publish when ready.

## Downstream sequencing after publish

1. Marten + Polecat each bump their `JasperFx.Events` pin to `2.0.0-alpha.9` and populate `MaxEventSequence` + `SkippedEventsCount` in their next alpha cuts.
2. CritterWatch bumps its pin, extends the wire-layer `Wolverine.CritterWatch.Messages.Outbound.ShardStateSnapshot` DTO to carry `SkippedEventsCount` through to the frontend, then renders signals 2 + 3 on the Projections page alongside the already-shipped signal 1.
3. CritterStackScalability picks up the new alpha in its next coordinated pin bump.
4. The `CritterWatch.SourceGeneration` project (CW#144) can now reference `AggregateDescriptor` + `HandlerRelationshipDescriptor`.

## Test plan

- [ ] CI green
- [ ] After merge: trigger the JasperFx publish workflow
- [ ] Verify `JasperFx.Events 2.0.0-alpha.9` lands on nuget.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)
