### PR TITLE
Populate SkippedEventsCount in tracker + fix MaxEventSequence xmldoc (closes #281)

### DIFF
--- a/src/EventTests/Daemon/ShardStateTrackerTests.cs
+++ b/src/EventTests/Daemon/ShardStateTrackerTests.cs
@@ -66,6 +66,34 @@ public class ShardStateTrackerTests : IDisposable
     }
 
     [Fact]
+    public async Task mark_skipping_populates_skipped_events_count()
+    {
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        await theTracker.MarkSkippingAsync(100, 105);
+
+        await theTracker.Complete();
+
+        var state = observer.States.Last();
+        state.SkippedEventsCount.ShouldBe(5L);
+    }
+
+    [Fact]
+    public async Task mark_skipping_with_no_advance_leaves_skipped_events_count_null()
+    {
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        await theTracker.MarkSkippingAsync(100, 100);
+
+        await theTracker.Complete();
+
+        var state = observer.States.Last();
+        state.SkippedEventsCount.ShouldBeNull();
+    }
+
+    [Fact]
     public void default_state_action_is_update()
     {
         new ShardState("foo", 22L)

--- a/src/JasperFx.Events/Daemon/ShardStateTracker.cs
+++ b/src/JasperFx.Events/Daemon/ShardStateTracker.cs
@@ -84,7 +84,13 @@ public class ShardStateTracker: IObservable<ShardState>, IObserver<ShardState>, 
     
     public ValueTask MarkSkippingAsync(long lastKnownGoodHighWaterMark, long newHighWaterMark)
     {
-        return PublishAsync(new ShardState(ShardState.HighWaterMark, newHighWaterMark){PreviousGoodMark = lastKnownGoodHighWaterMark, Action = ShardAction.Skipped});
+        var skipped = newHighWaterMark - lastKnownGoodHighWaterMark;
+        return PublishAsync(new ShardState(ShardState.HighWaterMark, newHighWaterMark)
+        {
+            PreviousGoodMark = lastKnownGoodHighWaterMark,
+            Action = ShardAction.Skipped,
+            SkippedEventsCount = skipped > 0 ? skipped : null
+        });
     }
 
     /// <summary>

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -85,7 +85,7 @@ public class EventStoreUsage : OptionsDescription
 
     /// <summary>
     /// Highest event sequence currently persisted in the underlying event-store
-    /// table — <c>max(sequence) FROM mt_streams</c> in Marten, the
+    /// table — <c>SELECT max(seq_id) FROM {schema}.mt_events</c> in Marten, the
     /// <c>pc_events</c> equivalent in Polecat. Different from the
     /// HighWaterMark (which is the max-safe-to-read sequence async readers
     /// can trust): this is the absolute physical maximum.


### PR DESCRIPTION
Two-part follow-up to #279.

## Summary

- **`ShardStateTracker.MarkSkippingAsync`** now populates `ShardState.SkippedEventsCount` with `newHighWaterMark - lastKnownGoodHighWaterMark`, leaving it `null` when the delta is non-positive so CritterWatch can keep rendering "n/a" vs. "0" distinctly.
- **`EventStoreUsage.MaxEventSequence`** xmldoc corrected — the Marten shape is `SELECT max(seq_id) FROM {schema}.mt_events`, not `max(sequence) FROM mt_streams`. Doc-only change.

## Tests

Added two cases to `ShardStateTrackerTests`:
- `mark_skipping_populates_skipped_events_count` — `MarkSkippingAsync(100, 105)` ⇒ `SkippedEventsCount == 5`
- `mark_skipping_with_no_advance_leaves_skipped_events_count_null` — `MarkSkippingAsync(100, 100)` ⇒ `SkippedEventsCount == null`

`dotnet build jasperfx.sln` clean, `dotnet test src/EventTests` 270/270 pass.

## Cross-link / follow-up (not in this PR)

Once this lands and JasperFx.Events alpha.10 is published:
- **Marten** can remove `src/Marten/Events/Daemon/HighWater/SkippedEventsCountObserver.cs` (the workaround that back-filled `SkippedEventsCount` from observed `ShardState`s).
- **Polecat** can remove its equivalent observer, if one was added.

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)