### PR TITLE
Bump JasperFx.Events to 2.0.0-alpha.10 (publishes #282 / closes #281)

### DIFF
--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.9</Version>
+        <Version>2.0.0-alpha.10</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the


### PR DESCRIPTION
Publishes the SkippedEventsCount populate fix + MaxEventSequence xmldoc fix from #282. After this lands and the publish workflow runs, Marten can drop its SkippedEventsCountObserver workaround.