### PR TITLE
Stop daemon-internal cancellations from leaking into CatchUpAsync (closes #284)

### DIFF
--- a/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
+++ b/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
@@ -128,6 +128,11 @@ public class GroupedProjectionExecution : ISubscriptionExecution
 
             return range;
         }
+        catch when (_cancellation.IsCancellationRequested)
+        {
+            // Shard is being torn down — don't promote the cancellation to a critical failure.
+            return null!;
+        }
         catch (Exception e)
         {
             activity?.AddException(e);
@@ -182,6 +187,17 @@ public class GroupedProjectionExecution : ISubscriptionExecution
             }
 
             range.Agent.Metrics.UpdateProcessed(range.Size);
+        }
+        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+        {
+            // Daemon-internal cancellation (StopAllAsync / HardStopAsync / DisposeAsync fired the
+            // shard's CTS). Don't surface as a critical shard failure — matches the guard already
+            // used in applyBatchOperationsToDatabaseAsync and SubscriptionExecutionBase.executeRange.
+        }
+        catch when (_cancellation.IsCancellationRequested)
+        {
+            // Wrapped/aggregated cancellation (e.g. Npgsql 57014 surfaced through a non-OCE) that
+            // is really a side effect of the shard being torn down. Same rationale as above.
         }
         catch (Exception e)
         {

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -710,7 +710,11 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             var agent = buildAgentForShard(asyncShard);
             
             await agent.CatchUpAsync(HighWaterMark(), state, cancellation);
-            var exceptions = recorder.States.Select(x => x.Exception).Where(x => x != null).ToArray();
+            var exceptions = recorder.States
+                .Select(x => x.Exception)
+                .Where(x => x != null)
+                .Where(x => cancellation.IsCancellationRequested || !isCancellationNoise(x!))
+                .ToArray();
             if (exceptions.Length != 0)
             {
                 throw new AggregateException(exceptions!);
@@ -723,6 +727,18 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
         cts.CancelAfter(timeout);
         await CatchUpAsync(cts.Token);
+    }
+
+    private static bool isCancellationNoise(Exception exception)
+    {
+        if (exception is OperationCanceledException) return true;
+        if (exception is AggregateException aggregate)
+        {
+            return aggregate.InnerExceptions.Count > 0
+                   && aggregate.InnerExceptions.All(isCancellationNoise);
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary
- `GroupedProjectionExecution.processRangeAsync` (and `groupEventRangeAsync`) now short-circuit OCE / wrapped-OCE in their generic catch when the shard's private `_cancellation` CTS has fired, instead of pushing the noise through `ReportCriticalFailureAsync`. Mirrors the existing guards in `applyBatchOperationsToDatabaseAsync` and `SubscriptionExecutionBase.executeRange`.
- `JasperFxAsyncDaemon.CatchUpAsync` filters cancellation-shaped exceptions out of the aggregated `recorder.States` set when the inbound cancellation token was never cancelled (defense in depth, covers the `AggregateException`-of-`OCE` shape from the issue trace).

## Why
Per #284 (JasperFx-side follow-up to JasperFx/marten#4462): Marten's `ForceAllMartenDaemonActivityToCatchUpAsync` test helper calls `StopAllAsync()` immediately before `CatchUpAsync`. Daemon-internal cancellation of an in-flight batch build (Npgsql 57014 surfaced through `FetchProjectionStorageAsync`) was being recorded onto `ShardState.Exception`, aggregated at `JasperFxAsyncDaemon.cs:716`, and re-thrown — making the helper surface benign internal-cancellation as a misleading "exceptions should be empty but had 1 item" assertion. The user-supplied CT never fired, so this was always internal-lifecycle noise.

Matches fix-path (2) + (3) from the issue's suggested fixes.

## Test plan
- [x] `dotnet build src/JasperFx.Events/JasperFx.Events.csproj` — clean (216 pre-existing nullability warnings)
- [x] `dotnet test src/EventTests/EventTests.csproj` — 270/270 pass on net9.0 and net10.0
- [x] `dotnet test src/EventStoreTests/EventStoreTests.csproj` — 72/72 net9.0; 70/72 net10.0 (2 pre-existing `RecentlyUsedCacheTests` flakes unrelated to daemon code; pass in isolation on both `main` and this branch)
- [ ] Once merged + new JasperFx.Events alpha is published, Marten side can unskip `Bug_4441_force_catch_up_with_outbox.force_catch_up_invokes_message_batch_lifecycle_with_custom_outbox` (currently pointed at marten#4462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)