### PR TITLE
Fix SG sync DetermineActionAsync ValueTask wrap on snapshot==null branch

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -311,6 +311,75 @@ namespace EventTests.Projections
         allGenerated.ShouldContain("global::EventTests.Projections.DayEvent");
     }
 
+    // Regression for the sync `DetermineActionAsync` override emit: when a
+    // partial projection has both an `Apply` (sync) and a `ShouldDelete`
+    // method, the SG emits a sync method returning `ValueTask<(TDoc?, ActionType)>`
+    // but the `snapshot == null` early-return path used to emit a raw tuple
+    //
+    //   return exists ? (null, ActionType.Delete) : (null, ActionType.Nothing);
+    //
+    // instead of wrapping it in `new ValueTask<...>(...)`, producing CS8135
+    // ("Tuple with 2 elements cannot be converted to type 'ValueTask<...>'")
+    // in downstream compilations. The async path was correct (async state
+    // machine wraps the tuple) — only the sync branch was broken.
+    [Fact]
+    public void partial_projection_with_should_delete_compiles_sync_path()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class StringQuest
+{
+    public string Id { get; set; } = """";
+    public int Members { get; set; }
+}
+
+public class StartQuest { }
+public class JoinQuest { }
+public class EndQuest { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+
+public partial class StringQuestProjection : SingleStreamProjection<StringQuest, string>
+{
+    public static StringQuest Create(IEvent<StartQuest> e) => new StringQuest();
+    public void Apply(JoinQuest e, StringQuest q) { q.Members++; }
+    public bool ShouldDelete(EndQuest e) => true;
+}
+";
+        var diagnostics = CompileWithGenerator(source);
+
+        // Filter to CS8135 (the bug's compile error): "Tuple with N elements
+        // cannot be converted to type 'ValueTask<...>'". Stub-setup errors
+        // from the minimal test fixture (CS0311 etc. on the stub
+        // SingleStreamProjection<,>) are pre-existing and don't relate to the
+        // generated code — mirroring the filtering pattern used by the
+        // CS0426 regression test for #288.
+        var valueTaskTupleErrors = diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "CS8135")
+            .Select(d => d.GetMessage())
+            .ToArray();
+
+        valueTaskTupleErrors.ShouldBeEmpty();
+
+        // Spot-check that the generated sync DetermineActionAsync wraps the
+        // snapshot==null tuple in a ValueTask<>, so a future regression that
+        // accidentally compiles some other way still trips this assertion.
+        var (_, generatedSources) = RunGenerator(source);
+        var allGenerated = string.Join("\n", generatedSources);
+        allGenerated.ShouldContain("public override global::System.Threading.Tasks.ValueTask<(global::Test.StringQuest?,");
+        allGenerated.ShouldContain("new global::System.Threading.Tasks.ValueTask<(global::Test.StringQuest?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Delete))");
+    }
+
     [Fact]
     public void skips_type_with_constructor_event_parameter()
     {

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -789,13 +789,16 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("        }");
         sb.AppendLine();
         sb.AppendLine("        if (snapshot == null)");
-        sb.AppendLine($"            return exists ? (null, global::JasperFx.Events.Daemon.ActionType.Delete) : (null, global::JasperFx.Events.Daemon.ActionType.Nothing);");
         if (!isAsync)
         {
+            // Sync-path DetermineActionAsync returns ValueTask<(...)> directly; wrap the tuple.
+            sb.AppendLine($"            return exists ? new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Delete)) : new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Nothing));");
             sb.AppendLine($"        return new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((snapshot, global::JasperFx.Events.Daemon.ActionType.Store));");
         }
         else
         {
+            // Async method body — bare tuple is implicitly wrapped by the async state machine.
+            sb.AppendLine($"            return exists ? (null, global::JasperFx.Events.Daemon.ActionType.Delete) : (null, global::JasperFx.Events.Daemon.ActionType.Nothing);");
             sb.AppendLine($"        return (snapshot, global::JasperFx.Events.Daemon.ActionType.Store);");
         }
         sb.AppendLine("    }");

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.3</Version>
+        <Version>2.0.0-alpha.4</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

`JasperFx.Events.SourceGenerator` alpha.3 emits invalid C# for partial projections that combine sync `Apply` + `ShouldDelete` methods. The generated sync `DetermineActionAsync` override has return type `ValueTask<(TDoc?, ActionType)>`, but the `snapshot == null` early-return path emits a raw tuple:

```csharp
return exists ? (null, ActionType.Delete) : (null, ActionType.Nothing);
```

That's valid in an `async` method (the state machine wraps it), but produces **CS8135** (`Tuple with 2 elements cannot be converted to type 'ValueTask<...>'`) in the sync path. The very next line — the `Store` return — already had the correct `new ValueTask<>(...)` wrap conditional on `!isAsync`; the early-return needed the same conditional.

## Repro

Surfaced by Polecat's #276 Phase 3 adoption work — 3 Polecat test projections trip this:
- `StringQuestPartyProjection` (`SingleStreamProjection<StringQuestParty, string>` — sync Apply + ShouldDelete)
- `QuestPartyProjection` (`SingleStreamProjection<QuestParty, Guid>` — same shape)
- `DeletableAggregate` (self-aggregating with ShouldDelete — same emitter)

Minimum repro added as `AggregateEvolverGeneratorTests.partial_projection_with_should_delete_compiles_sync_path`, using the existing `CompileWithGenerator` helper and filtering to **CS8135** (mirrors the CS0426 filter pattern from the #288 regression test).

## Fix

In `EvolverCodeEmitter.EmitDetermineActionAsyncOverride`, branch the snapshot==null return on `isAsync` — same way the existing `Store` return already branched:

```diff
 sb.AppendLine("        if (snapshot == null)");
-sb.AppendLine($"            return exists ? (null, ActionType.Delete) : (null, ActionType.Nothing);");
 if (!isAsync)
 {
+    sb.AppendLine($"            return exists ? new ValueTask<...>((null, ActionType.Delete)) : new ValueTask<...>((null, ActionType.Nothing));");
     sb.AppendLine($"        return new ValueTask<...>((snapshot, ActionType.Store));");
 }
 else
 {
+    sb.AppendLine($"            return exists ? (null, ActionType.Delete) : (null, ActionType.Nothing);");
     sb.AppendLine($"        return (snapshot, ActionType.Store);");
 }
```

(`EmitSelfAggregatingDetermineAction` at line 961 emits the same pattern but returns a bare tuple from a non-async method, so it's correct as-is and not modified.)

## Verification

- ✅ New test fails on alpha.3 (3 CS8135 diagnostics)
- ✅ New test passes with this fix
- ✅ Full `JasperFx.Events.SourceGenerator.Tests` suite: **9 passed, 0 failed**

## Commits

1. `1446d30` — Fix + regression test
2. `fb3de01` — Bump `JasperFx.Events.SourceGenerator` 2.0.0-alpha.3 → 2.0.0-alpha.4

## Test plan

- [x] New SG regression test (`partial_projection_with_should_delete_compiles_sync_path`) passes
- [x] Full SG test suite passes
- [ ] Downstream verification: Polecat#276 Phase 3 tests build clean against `JasperFx.Events.SourceGenerator 2.0.0-alpha.4` (blocked on alpha.4 publish — Polecat PR will follow)

References JasperFx/jasperfx#276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)