### PR TITLE
SG: walk inheritance chain when discovering Apply/Create/ShouldDelete and Id (closes #295)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -543,6 +543,93 @@ public class Registration
         generatedSources.Length.ShouldBe(1);
     }
 
+    // Regression for https://github.com/JasperFx/jasperfx/issues/295 — DiscoverMethodsOnType
+    // and InferIdentityType used to enumerate direct members only, so an aggregate that
+    // inherited Apply/Create/Id from a user base class was invisible to the SG. The
+    // analyzer now walks the inheritance chain (stopping at framework bases) so an evolver
+    // is still emitted.
+    [Fact]
+    public void discovers_inherited_apply_create_and_id_on_self_aggregating_type()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public class Bumped { }
+public class Started { public Guid Id { get; set; } }
+
+public abstract class CounterBase
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+
+    public void Apply(Bumped _) { Count++; }
+}
+
+public class Counter : CounterBase
+{
+    public static Counter Create(Started e) => new() { Id = e.Id };
+}
+";
+        var (_, generatedSources) = RunGenerator(source);
+
+        // The aggregate is `Counter`; Apply + Id come from CounterBase. Before #295 the SG
+        // saw no methods and no Id directly on Counter and skipped it entirely. After the
+        // inheritance walk the evolver is emitted, keyed on Counter, with both Apply
+        // (from the base) and Create (from the derived) dispatched.
+        generatedSources.Length.ShouldBeGreaterThan(0);
+        var counterEvolver = generatedSources.FirstOrDefault(s => s.Contains("CounterEvolver"));
+        counterEvolver.ShouldNotBeNull();
+
+        counterEvolver!.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.Counter)");
+
+        // Both event types should appear in the dispatch:
+        counterEvolver.ShouldContain("global::Test.Bumped");
+        counterEvolver.ShouldContain("global::Test.Started");
+    }
+
+    // Verifies the inheritance walk respects the override/new resolution rule: a derived
+    // declaration with the same signature wins over the base declaration, matching how the
+    // language itself dispatches. Without the dedupe, both would land in the result list
+    // and the emitter would generate duplicate case branches.
+    [Fact]
+    public void inherited_apply_is_shadowed_by_derived_override_with_same_signature()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public class Bumped { }
+
+public class BaseCounter
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+
+    public virtual void Apply(Bumped _) { Count++; }
+}
+
+public class DerivedCounter : BaseCounter
+{
+    public override void Apply(Bumped _) { Count += 10; }
+}
+";
+        var diagnostics = CompileWithGenerator(source);
+
+        // Duplicate `case Test.Bumped:` branches would surface as CS0152 (the switch already
+        // contains a case for that label) on the generated code.
+        var dupCaseErrors = diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "CS0152")
+            .Select(d => d.GetMessage())
+            .ToArray();
+
+        dupCaseErrors.ShouldBeEmpty();
+    }
+
     [Fact]
     public void skips_type_with_constructor_event_parameter()
     {

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -496,22 +496,56 @@ internal static class AggregateAnalyzer
         bool isOnAggregate,
         List<ConventionalMethodInfo> results)
     {
-        var members = searchType.GetMembers();
-        foreach (var member in members)
+        // Walk the inheritance chain so aggregates / projections that inherit
+        // Apply/Create/ShouldDelete from a user base class still get those
+        // methods dispatched. Stop at System.Object and at any framework base
+        // (ProjectionBase / JasperFxAggregationProjectionBase /
+        // JasperFxEventProjectionBase) so we don't slurp framework internals.
+        // See https://github.com/JasperFx/jasperfx/issues/295.
+        var seenSignatures = new HashSet<string>();
+        for (INamedTypeSymbol? current = searchType;
+             current is not null
+             && current.SpecialType != SpecialType.System_Object
+             && !IsFrameworkBase(current);
+             current = current.BaseType)
         {
-            if (member is not IMethodSymbol method) continue;
-            if (method.MethodKind != MethodKind.Ordinary) continue;
-            if (method.Name is not ("Apply" or "Create" or "ShouldDelete")) continue;
-            if (HasJasperFxIgnoreAttribute(method)) continue;
-            // Skip non-public methods - we can't call them from generated code
-            if (method.DeclaredAccessibility != Accessibility.Public) continue;
-
-            var info = AnalyzeMethod(method, aggregateType, isOnAggregate);
-            if (info != null)
+            foreach (var member in current.GetMembers())
             {
-                results.Add(info);
+                if (member is not IMethodSymbol method) continue;
+                if (method.MethodKind != MethodKind.Ordinary) continue;
+                if (method.Name is not ("Apply" or "Create" or "ShouldDelete")) continue;
+                if (HasJasperFxIgnoreAttribute(method)) continue;
+                // Skip non-public methods - we can't call them from generated code
+                if (method.DeclaredAccessibility != Accessibility.Public) continue;
+
+                // Walking derived → base, the first sighting of a given signature wins.
+                // That gives a derived `override` or `new` declaration priority over
+                // the base-class declaration with the same signature, matching the
+                // language's own method-resolution behavior.
+                if (!seenSignatures.Add(SignatureKey(method))) continue;
+
+                var info = AnalyzeMethod(method, aggregateType, isOnAggregate);
+                if (info != null)
+                {
+                    results.Add(info);
+                }
             }
         }
+    }
+
+    private static bool IsFrameworkBase(INamedTypeSymbol type)
+    {
+        var fullName = type.ConstructedFrom?.ToDisplayString() ?? type.ToDisplayString();
+        return fullName.StartsWith(ProjectionBaseFullName, StringComparison.Ordinal)
+               || fullName.StartsWith(AggregationProjectionBaseFullName, StringComparison.Ordinal)
+               || fullName.StartsWith(EventProjectionBaseFullName, StringComparison.Ordinal);
+    }
+
+    private static string SignatureKey(IMethodSymbol method)
+    {
+        return method.Name + "("
+               + string.Join(",", method.Parameters.Select(p => p.Type.ToDisplayString()))
+               + ")";
     }
 
     private static ConventionalMethodInfo? AnalyzeMethod(
@@ -1043,13 +1077,22 @@ internal static class AggregateAnalyzer
 
     public static INamedTypeSymbol? InferIdentityType(INamedTypeSymbol classSymbol)
     {
-        // 1. Check for Id property
-        var idProp = classSymbol.GetMembers()
-            .OfType<IPropertySymbol>()
-            .FirstOrDefault(p => p.Name == "Id");
+        // 1. Check for an Id property — walk the inheritance chain so aggregates that
+        // inherit Id from a user base class are still recognized. Stop at framework
+        // bases and at System.Object. See #295.
+        for (INamedTypeSymbol? current = classSymbol;
+             current is not null
+             && current.SpecialType != SpecialType.System_Object
+             && !IsFrameworkBase(current);
+             current = current.BaseType)
+        {
+            var idProp = current.GetMembers()
+                .OfType<IPropertySymbol>()
+                .FirstOrDefault(p => p.Name == "Id");
 
-        if (idProp?.Type is INamedTypeSymbol idType)
-            return idType;
+            if (idProp?.Type is INamedTypeSymbol idType)
+                return idType;
+        }
 
         // 2. Check for [AggregateIdentity(typeof(...))]
         var attr = classSymbol.GetAttributes()


### PR DESCRIPTION
## Summary
Follow-up to [#294](https://github.com/JasperFx/jasperfx/pull/294). That PR added Pipeline 3 (Snapshot<T>() call-site discovery), but the analyzer's method/property enumeration was still direct-only — an aggregate whose Apply/Create/ShouldDelete (or `Id` property) lived on a user base class was invisible to the SG even after Pipeline 3 routed the call site through `AnalyzeRefersToAggregate`. **Closes #295.**

## Why
Concrete shape that #294 alone didn't unblock:
```csharp
public abstract class CounterBase
{
    public Guid Id { get; set; }
    public void Apply(Bumped _) { /* ... */ }
}
public class Counter : CounterBase
{
    public static Counter Create(Started e) => new() { Id = e.Id };
}
```
Before this PR, `DiscoverMethodsOnType(Counter, ...)` enumerated `Counter`'s direct members only — found `Create` but missed `Apply`, and `InferIdentityType(Counter)` returned null because `Id` lives on the base. Net result: no evolver emitted for `Counter`, runtime throws `InvalidProjectionException` at first event-store touch.

## What changed
- `DiscoverMethodsOnType` now walks the `BaseType` chain, stopping at `System.Object` and at framework bases (`ProjectionBase` / `JasperFxAggregationProjectionBase` / `JasperFxEventProjectionBase`) so framework internals aren't slurped into the generated dispatcher.
- New `IsFrameworkBase` helper centralizes the framework-base check using the existing `*FullName` constants already defined at the top of `AggregateAnalyzer`.
- Signature-keyed dedupe (`SignatureKey`) keeps a derived `override` or `new` declaration in priority over the base it shadows — walking derived → base, first sighting wins, matching language resolution.
- `InferIdentityType` gets the same inheritance walk for the `Id` property. The `[AggregateIdentity(typeof(...))]` attribute path is left direct-only; that attribute is typically applied at the leaf aggregate type and Roslyn's `GetAttributes()` doesn't carry inherited attributes anyway.

## Test plan
- [x] `dotnet build src/JasperFx.Events.SourceGenerator/...` — clean
- [x] `dotnet test src/JasperFx.Events.SourceGenerator.Tests/...` — 14/14 pass (was 12 + 2 new)
- [x] `dotnet test src/EventTests/...` — 257/257 on net9.0 and net10.0
- [x] `discovers_inherited_apply_create_and_id_on_self_aggregating_type` verified red without the inheritance walk, green with it.
- [x] `inherited_apply_is_shadowed_by_derived_override_with_same_signature` guards against a future regression where the inheritance walk forgets to dedupe (CS0152 "switch contains same label" would surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)