### PR TITLE
[#297] AggregateEvolverGenerator codegen fixes from Marten Phase 2

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/JasperFx.Events.SourceGenerator.Tests.csproj
+++ b/src/JasperFx.Events.SourceGenerator.Tests/JasperFx.Events.SourceGenerator.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -75,7 +75,11 @@ internal sealed class CandidateInfo
     public INamedTypeSymbol? QuerySessionType { get; set; } // TQuerySession
     public List<ConventionalMethodInfo> Methods { get; set; } = new();
     public bool HasShouldDelete => Methods.Any(m => m.MethodName == "ShouldDelete");
-    public bool HasAnyAsync => Methods.Any(m => m.IsAsync);
+    // A method that takes IQuerySession can only run from the EvolveAsync /
+    // DetermineActionAsync path (the sync Evolve doesn't have a session to
+    // pass). Treat any session-taking handler as forcing the async dispatch
+    // path so the generated switch arm can bind `session` correctly. See #297.
+    public bool HasAnyAsync => Methods.Any(m => m.IsAsync || m.HasSession);
     public bool HasCreate => Methods.Any(m => m.MethodName == "Create");
     public bool HasDefaultConstructor { get; set; }
     public bool HasExistingParameterlessConstructor { get; set; } // On the projection class itself
@@ -594,7 +598,14 @@ internal static class AggregateAnalyzer
             var param = parameters[i];
             var paramType = param.Type;
 
-            if (SymbolEqualityComparer.Default.Equals(paramType, aggregateType) && !isOnAggregate)
+            // A parameter whose type is the aggregate type is the aggregate
+            // slot. For projection-side methods (!isOnAggregate) this is the
+            // shape `Apply(SomeEvent, TAggregate)`. For self-aggregating
+            // methods we also accept the same shape via static helpers
+            // (e.g. `static TAggregate Apply(SomeEvent, TAggregate current)`
+            // on a record). Without this branch the second param falls
+            // through to the "unrecognized parameter" bail below. See #297.
+            if (SymbolEqualityComparer.Default.Equals(paramType, aggregateType))
             {
                 aggregateSeen = true;
                 if (eventType == null)
@@ -637,6 +648,18 @@ internal static class AggregateAnalyzer
                     foundAggregateFirst = true;
                 else
                     foundAggregateFirst = false;
+            }
+            else
+            {
+                // An unrecognized parameter that comes after we've already
+                // identified the event type — e.g. `Apply(AEvent, MyAggregate, IDocumentOperations)`
+                // on a SingleStreamProjection where IDocumentOperations isn't a
+                // supported convention slot. Bail rather than emit a garbled
+                // dispatcher (CS1503 cascades from this). Runtime validation
+                // already covers these "invalid signature" shapes — letting
+                // the SG opt out preserves that behavior without breaking the
+                // build. See #297.
+                return null;
             }
         }
 
@@ -721,13 +744,18 @@ internal static class AggregateAnalyzer
             var fullName = current.ConstructedFrom.ToDisplayString();
             if (fullName.StartsWith(AggregationProjectionBaseFullName + "<"))
             {
-                if (current.TypeArguments.Length >= 4)
+                if (current.TypeArguments.Length >= 4
+                    && current.TypeArguments[0] is INamedTypeSymbol docType
+                    && current.TypeArguments[1] is INamedTypeSymbol idType
+                    && current.TypeArguments[3] is INamedTypeSymbol querySessionType)
                 {
-                    return (
-                        (INamedTypeSymbol)current.TypeArguments[0],
-                        (INamedTypeSymbol)current.TypeArguments[1],
-                        (INamedTypeSymbol)current.TypeArguments[3]
-                    );
+                    // Only return concrete (INamedTypeSymbol) instantiations. An
+                    // open generic base — e.g. `class MyBase<T> : SingleStreamProjection<T, Guid>`
+                    // declared inside the JasperFx.Events runtime library itself —
+                    // has TypeParameterSymbol type arguments which can't be cast
+                    // to INamedTypeSymbol and previously crashed the SG with
+                    // InvalidCastException. See #297.
+                    return (docType, idType, querySessionType);
                 }
             }
 
@@ -1060,15 +1088,39 @@ internal static class AggregateAnalyzer
 
     private static bool HasLambdaRegistrations(TypeDeclarationSyntax classDecl)
     {
+        // Only ProjectEvent / CreateEvent / DeleteEvent invocations that *take
+        // an argument* (a handler / predicate lambda) opt the projection out of
+        // SG dispatch — those were the inline-lambda APIs JasperFx 2.0 removed.
+        // The parameterless variant `DeleteEvent<T>()` is still a supported way
+        // to declare delete-on events from the constructor and must NOT block
+        // dispatcher emission. See #297. A plain substring match on the body
+        // (previous implementation) misclassified `DeleteEvent<T>()` as a
+        // lambda registration and silently skipped dispatcher emission.
         var constructors = classDecl.Members.OfType<ConstructorDeclarationSyntax>();
         foreach (var ctor in constructors)
         {
             if (ctor.Body == null) continue;
-            var text = ctor.Body.ToFullString();
-            foreach (var name in LambdaMethodNames)
+            foreach (var invocation in ctor.Body.DescendantNodes().OfType<InvocationExpressionSyntax>())
             {
-                if (text.Contains(name))
-                    return true;
+                if (invocation.ArgumentList.Arguments.Count == 0) continue;
+
+                var simpleName = invocation.Expression switch
+                {
+                    MemberAccessExpressionSyntax m => m.Name,
+                    GenericNameSyntax g => g,
+                    IdentifierNameSyntax i => (SimpleNameSyntax?)i,
+                    _ => null
+                };
+
+                var name = (simpleName as GenericNameSyntax)?.Identifier.ValueText
+                           ?? (simpleName as IdentifierNameSyntax)?.Identifier.ValueText;
+
+                if (name == null) continue;
+
+                foreach (var lambdaName in LambdaMethodNames)
+                {
+                    if (name == lambdaName) return true;
+                }
             }
         }
 
@@ -1091,7 +1143,21 @@ internal static class AggregateAnalyzer
                 .FirstOrDefault(p => p.Name == "Id");
 
             if (idProp?.Type is INamedTypeSymbol idType)
+            {
+                // Unwrap `Nullable<T>` so `public PaymentId? Id { get; }` resolves
+                // to PaymentId (the runtime TId) instead of `Nullable<PaymentId>`.
+                // The runtime closes `SingleStreamProjection<TDoc, TId>` over the
+                // unwrapped struct type, so a generated evolver keyed on the
+                // nullable wrapper would never match. See #297.
+                if (idType.IsGenericType
+                    && idType.ConstructedFrom.ToDisplayString() == "System.Nullable<T>"
+                    && idType.TypeArguments.Length == 1
+                    && idType.TypeArguments[0] is INamedTypeSymbol unwrappedId)
+                {
+                    return unwrappedId;
+                }
                 return idType;
+            }
         }
 
         // 2. Check for [AggregateIdentity(typeof(...))]
@@ -1109,11 +1175,40 @@ internal static class AggregateAnalyzer
 
     private static bool HasParameterlessConstructor(INamedTypeSymbol type)
     {
+        // A type with `required` members can't be constructed with `new T()` even
+        // when a parameterless constructor exists — the compiler emits CS9035 unless
+        // every required member is initialized at the call site (or the ctor is
+        // annotated with [SetsRequiredMembers]). Treat "has required members" the
+        // same as "no usable parameterless ctor" so the SG doesn't emit
+        // `var s = new T(); Apply(data, s);` for these aggregates. See #297.
+        if (HasRequiredMembers(type)) return false;
+
         // If no explicit constructors, there's an implicit default
         var constructors = type.InstanceConstructors;
         if (constructors.Length == 0) return true;
 
         return constructors.Any(c => c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
+    }
+
+    private static bool HasRequiredMembers(INamedTypeSymbol type)
+    {
+        // Walk the inheritance chain — a required member on a base class still
+        // forces the derived `new T()` to initialize it.
+        for (INamedTypeSymbol? current = type;
+             current is not null && current.SpecialType != SpecialType.System_Object;
+             current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                switch (member)
+                {
+                    case IPropertySymbol prop when prop.IsRequired:
+                    case IFieldSymbol field when field.IsRequired:
+                        return true;
+                }
+            }
+        }
+        return false;
     }
 
     /// <summary>
@@ -1165,7 +1260,8 @@ internal static class AggregateAnalyzer
     /// </summary>
     public static CandidateInfo? AnalyzeRefersToAggregate(
         INamedTypeSymbol aggregateType,
-        CancellationToken ct)
+        CancellationToken ct,
+        INamedTypeSymbol? identityTypeHint = null)
     {
         if (IsProjectionBase(aggregateType)) return null;
 
@@ -1204,7 +1300,7 @@ internal static class AggregateAnalyzer
         if (methods.Count == 0) return null;
         if (HasEventParameterConstructor(aggregateType)) return null;
 
-        var inferredId = InferIdentityType(aggregateType);
+        var inferredId = InferIdentityType(aggregateType) ?? identityTypeHint;
         if (inferredId == null) return null;
 
         return new CandidateInfo

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -100,9 +100,23 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
     /// </summary>
     private static readonly HashSet<string> SnapshotRegistrationNames = new()
     {
+        // Registration APIs that close `SingleStreamProjection<T, TId>` over T:
         "Snapshot",
         "LiveStreamAggregation",
         "SingleStreamProjection",
+
+        // Per-call APIs on Marten's IEventStore / IEventStream surface. These
+        // also internally construct `SingleStreamProjection<T, TId>` and need
+        // a generated dispatcher for T. Adding them here lets a user who only
+        // calls e.g. `theSession.Events.AggregateStreamAsync<MyAgg>(streamId)`
+        // (without ever registering MyAgg via `Snapshot<T>(...)`) still get a
+        // dispatcher. See #297.
+        "AggregateStreamAsync",
+        "AggregateStream",
+        "AggregateStreamToLastKnownAsync",
+        "FetchLatest",
+        "FetchForWriting",
+        "FetchForExclusiveWriting",
     };
 
     /// <summary>
@@ -146,7 +160,13 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         if (generic.TypeArgumentList.Arguments.Count != 1) return null;
 
         var typeArgSyntax = generic.TypeArgumentList.Arguments[0];
-        if (ctx.SemanticModel.GetSymbolInfo(typeArgSyntax, ct).Symbol is not INamedTypeSymbol aggregateType)
+        var aggregateSymbol = ctx.SemanticModel.GetSymbolInfo(typeArgSyntax, ct).Symbol;
+        // Skip generic helper methods (e.g. a user wrapper that forwards
+        // `Snapshot<T>(...)` for arbitrary T) — the type arg is an open
+        // TypeParameterSymbol, not a concrete aggregate. Trying to cast
+        // it to INamedTypeSymbol threw InvalidCastException at compile time
+        // and aborted the whole SG run for that compilation. See #297.
+        if (aggregateSymbol is not INamedTypeSymbol aggregateType)
             return null;
 
         // Resolve the invoked method and require it to be defined on a JasperFx.Events
@@ -159,7 +179,35 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
 
         if (!IsKnownSnapshotApi(method)) return null;
 
-        return AggregateAnalyzer.AnalyzeRefersToAggregate(aggregateType, ct);
+        // Some call sites carry a stream identity argument (e.g.
+        // `AggregateStreamAsync<MyAgg>(streamId, ...)` or
+        // `FetchForWriting<MyAgg>(streamId, ...)`). When the aggregate type
+        // itself has no Id property and no [AggregateIdentity] attribute,
+        // we fall back to the first non-trivially-typed positional argument's
+        // compile-time type as the TId hint. This covers anonymous-aggregate
+        // live aggregation patterns common in tests:
+        //
+        //     theSession.Events.AggregateStreamAsync<CountOfLetters>(streamId);
+        //
+        // — where CountOfLetters has Apply methods but no Id of its own. See #297.
+        INamedTypeSymbol? idHint = null;
+        foreach (var arg in invocation.ArgumentList.Arguments)
+        {
+            var argType = ctx.SemanticModel.GetTypeInfo(arg.Expression, ct).Type;
+            if (argType is INamedTypeSymbol named && IsLikelyStreamIdType(named))
+            {
+                idHint = named;
+                break;
+            }
+        }
+
+        return AggregateAnalyzer.AnalyzeRefersToAggregate(aggregateType, ct, idHint);
+    }
+
+    private static bool IsLikelyStreamIdType(INamedTypeSymbol type)
+    {
+        var name = type.ToDisplayString();
+        return name is "System.Guid" or "string" or "System.String";
     }
 
     private static bool IsKnownSnapshotApi(IMethodSymbol method)
@@ -247,12 +295,29 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
             }
         }
 
-        // Pipeline 3: only for types not already handled by pipelines 1 or 2
+        // Pipeline 3: emit one dispatcher per unique (TDoc, TId) pair that
+        // Pipelines 1/2 didn't already cover. An aggregate without its own
+        // Id property (e.g. `CountOfLetters` used only via
+        // `AggregateStreamAsync<T>(streamId)`) can be invoked with multiple
+        // stream identity types in the same compilation — a Guid stream in
+        // one test, a string stream in another. We need one dispatcher per
+        // (TDoc, TId) so the runtime's `[GeneratedEvolver]` attribute scan
+        // finds the matching `IGeneratedSyncEvolver<TDoc, TId>` for each
+        // configured StreamIdentity. Many call sites can share the same
+        // (TDoc, TId) — emit once per unique pair so the SG doesn't trip
+        // the "hintName must be unique" guard. See #297.
+        var pipeline3Pairs = new System.Collections.Generic.HashSet<string>();
         foreach (var info in snapshots)
         {
             if (info == null) continue;
-            var key = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            if (seen.Add(key))
+            var classKey = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            // Skip aggregates whose closed-shape evolver was already covered
+            // by Pipelines 1/2 — those don't depend on call-site TId hints.
+            if (seen.Contains(classKey)) continue;
+
+            var idKey = info.IdentityType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? "";
+            var pairKey = $"{classKey}::{idKey}";
+            if (pipeline3Pairs.Add(pairKey))
             {
                 Execute(spc, info);
             }
@@ -317,6 +382,23 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         return $"{fullName}{suffix}.g.cs";
     }
 
+    /// <summary>
+    /// Self-aggregating evolvers emitted via Pipeline 3 (Snapshot/LiveStream/
+    /// AggregateStreamAsync call sites) can target the same aggregate with
+    /// multiple TId types depending on the configured StreamIdentity. Include
+    /// TId in the hint name so two emissions for the same TDoc but different
+    /// TId (e.g. `CountOfLetters` with Guid AND string) don't trip the
+    /// "hintName must be unique" guard. See #297.
+    /// </summary>
+    private static string SafeSelfAggregatingHintName(CandidateInfo info, string suffix)
+    {
+        var typeName = info.ClassSymbol.ToDisplayString();
+        var idName = info.IdentityType?.ToDisplayString() ?? string.Empty;
+        var combined = (typeName + "_" + idName)
+            .Replace('<', '_').Replace('>', '_').Replace(',', '_').Replace(' ', '_').Replace('.', '_');
+        return $"{combined}{suffix}.g.cs";
+    }
+
     private static void EmitPartialProjection(SourceProductionContext context, CandidateInfo info)
     {
         if (info.Methods.Count == 0) return;
@@ -356,7 +438,7 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         }
 
         var source = EvolverCodeEmitter.EmitSelfAggregatingEvolveEvolver(info);
-        context.AddSource(SafeHintName(info.ClassSymbol, "EvolveEvolver"), source);
+        context.AddSource(SafeSelfAggregatingHintName(info, "EvolveEvolver"), source);
     }
 
     private static void EmitSelfAggregating(SourceProductionContext context, CandidateInfo info)
@@ -384,6 +466,6 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         }
 
         var source = EvolverCodeEmitter.EmitSelfAggregatingEvolver(info);
-        context.AddSource(SafeHintName(info.ClassSymbol, "Evolver"), source);
+        context.AddSource(SafeSelfAggregatingHintName(info, "Evolver"), source);
     }
 }

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -39,7 +39,7 @@ internal static class EvolverCodeEmitter
         var containingTypes = GetContainingTypes(info.ClassSymbol);
         foreach (var container in containingTypes)
         {
-            sb.AppendLine($"partial class {container.Name}{ContainerTypeParams(container)}");
+            sb.AppendLine($"partial {ContainerKeyword(container)} {container.Name}{ContainerTypeParams(container)}");
             sb.AppendLine("{");
         }
 
@@ -88,6 +88,23 @@ internal static class EvolverCodeEmitter
         return "<" + string.Join(", ", container.TypeParameters.Select(t => t.Name)) + ">";
     }
 
+    /// <summary>
+    /// Returns the type-declaration keyword that matches the user's source.
+    /// Required when a projection class is nested inside a record (a fairly
+    /// common pattern, e.g. `record Foo { partial class Projector ... }`)
+    /// — emitting `partial class Foo` against a `partial record Foo` fails
+    /// the build with CS0102 ("already contains a definition").
+    /// </summary>
+    private static string ContainerKeyword(INamedTypeSymbol container)
+    {
+        if (container.IsRecord)
+        {
+            return container.TypeKind == TypeKind.Struct ? "record struct" : "record";
+        }
+
+        return container.TypeKind == TypeKind.Struct ? "struct" : "class";
+    }
+
     private static void EmitConstructorWithIncludeTypes(StringBuilder sb, CandidateInfo info, string className)
     {
         var eventTypes = info.Methods.Select(m => Fqn(m.EventType)).Distinct().ToList();
@@ -123,7 +140,7 @@ internal static class EvolverCodeEmitter
         var containingTypes = GetContainingTypes(info.ClassSymbol);
         foreach (var container in containingTypes)
         {
-            sb.AppendLine($"partial class {container.Name}{ContainerTypeParams(container)}");
+            sb.AppendLine($"partial {ContainerKeyword(container)} {container.Name}{ContainerTypeParams(container)}");
             sb.AppendLine("{");
         }
 
@@ -179,7 +196,7 @@ internal static class EvolverCodeEmitter
         var containingTypes = GetContainingTypes(info.ClassSymbol);
         foreach (var container in containingTypes)
         {
-            sb.AppendLine($"partial class {container.Name}{ContainerTypeParams(container)}");
+            sb.AppendLine($"partial {ContainerKeyword(container)} {container.Name}{ContainerTypeParams(container)}");
             sb.AppendLine("{");
         }
 
@@ -312,8 +329,48 @@ internal static class EvolverCodeEmitter
         }
     }
 
+    /// <summary>
+    /// Picks one handler per event type so the generated switch doesn't emit
+    /// duplicate arms (CS8120). When the SG discovers both a projection-side
+    /// handler (e.g. `Bug4268ProductProjection.Apply(EventX, AggregateY)`)
+    /// AND an aggregate-side handler for the same event type (e.g.
+    /// `Bug4268Product.Apply(EventX)`), the projection-side handler wins —
+    /// the projection's method typically wraps / extends the aggregate's
+    /// behavior and is the user's intentional dispatch entry point. Ties on
+    /// IsOnAggregate break to the overload with more parameters (the more
+    /// specific signature). Final ordering puts more-derived event types
+    /// first so interface arms don't shadow concrete-class arms.
+    /// </summary>
+    private static List<ConventionalMethodInfo> CoalesceByEventType(IEnumerable<ConventionalMethodInfo> methods)
+    {
+        return methods
+            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
+            .Select(g => g
+                .OrderBy(m => m.IsOnAggregate)
+                .ThenByDescending(m => m.Symbol.Parameters.Length)
+                .First())
+            .OrderByDescending(m => GetTypeDepth(m.EventType))
+            .ToList();
+    }
+
     private static int GetTypeDepth(ITypeSymbol type)
     {
+        // Used to order `switch (e.Data)` arms so that more-derived types come
+        // before their base types / interfaces. C# pattern matching falls
+        // through to the first satisfied case; if `case IBase data` is emitted
+        // before `case Concrete data` and Concrete : IBase, the compiler flags
+        // the latter as unreachable (CS8120).
+        //
+        // Interfaces are pushed below every concrete class (negative key) so
+        // an interface arm always sinks below any class arm — including arms
+        // for classes that *don't* implement the interface, which is fine
+        // because order among unrelated types doesn't matter to correctness.
+        // Among interfaces, ones that extend more other interfaces sort first.
+        if (type.TypeKind == TypeKind.Interface)
+        {
+            return -1_000_000 + type.AllInterfaces.Length;
+        }
+
         int depth = 0;
         var current = type.BaseType;
         while (current != null)
@@ -433,7 +490,7 @@ internal static class EvolverCodeEmitter
 
         var aggregateFullName = Fqn(info.AggregateType!);
         var idFullName = Fqn(info.IdentityType!);
-        var evolverName = info.ClassSymbol.Name + "Evolver";
+        var evolverName = BuildUniqueEvolverName(info, "Evolver");
 
         // Assembly attributes must precede namespace declarations
         sb.AppendLine($"[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof({aggregateFullName}), typeof({GetFullyQualifiedEvolverName(info, evolverName)}))]");
@@ -486,7 +543,7 @@ internal static class EvolverCodeEmitter
         var evolve = info.EvolveMethod!;
         var aggregateFullName = Fqn(info.AggregateType!);
         var idFullName = Fqn(info.IdentityType!);
-        var evolverName = info.ClassSymbol.Name + "EvolveEvolver";
+        var evolverName = BuildUniqueEvolverName(info, "EvolveEvolver");
 
         // Assembly attribute for discovery
         sb.AppendLine($"[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof({aggregateFullName}), typeof({GetFullyQualifiedEvolverName(info, evolverName)}))]");
@@ -640,6 +697,40 @@ internal static class EvolverCodeEmitter
         return name.EndsWith("IQuerySession") || name.EndsWith("QuerySession");
     }
 
+    /// <summary>
+    /// Builds an evolver class name that includes the parent-type chain so two
+    /// aggregates with the same simple name (e.g. `Bug_2666.CounterWithCreate`
+    /// and `Bug_2528.CounterWithCreate`, common in xUnit test files where the
+    /// aggregate is nested inside the test class) don't collide on the
+    /// generated `CounterWithCreateEvolver` class name in the shared namespace.
+    /// See #297.
+    /// </summary>
+    private static string BuildUniqueEvolverName(CandidateInfo info, string suffix)
+    {
+        var prefix = new StringBuilder();
+        for (INamedTypeSymbol? container = info.ClassSymbol.ContainingType;
+             container is not null;
+             container = container.ContainingType)
+        {
+            prefix.Insert(0, container.Name + "_");
+        }
+
+        // When the same aggregate type can be registered against multiple
+        // stream-identity types (e.g. `AggregateStreamAsync<CountOfLetters>`
+        // with both Guid and string stream IDs), emit a separate evolver per
+        // TId. Include a sanitized TId tag in the name so the two evolvers
+        // don't collide in the same namespace. See #297.
+        var idTag = "";
+        if (info.IdentityType is { } id)
+        {
+            var idName = id.Name;
+            if (!string.IsNullOrEmpty(idName))
+                idTag = "_" + idName.Replace(".", "_").Replace("<", "_").Replace(">", "_").Replace(",", "_").Replace(" ", "");
+        }
+
+        return prefix.ToString() + info.ClassSymbol.Name + idTag + suffix;
+    }
+
     private static string GetFullyQualifiedEvolverName(CandidateInfo info, string evolverName)
     {
         var ns = info.ClassSymbol.ContainingNamespace;
@@ -667,8 +758,8 @@ internal static class EvolverCodeEmitter
         sb.AppendLine($"    public override {docType}? Evolve({docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e)");
         sb.AppendLine("    {");
 
-        var createMethods = info.Methods.Where(m => m.MethodName == "Create").ToList();
-        var applyMethods = info.Methods.Where(m => m.MethodName == "Apply").ToList();
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
 
         // Null snapshot branch
         sb.AppendLine("        if (snapshot == null)");
@@ -705,8 +796,8 @@ internal static class EvolverCodeEmitter
         sb.AppendLine($"        global::JasperFx.Events.IEvent e, global::System.Threading.CancellationToken cancellation)");
         sb.AppendLine("    {");
 
-        var createMethods = info.Methods.Where(m => m.MethodName == "Create").ToList();
-        var applyMethods = info.Methods.Where(m => m.MethodName == "Apply").ToList();
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
 
         sb.AppendLine("        if (snapshot == null)");
         sb.AppendLine("        {");
@@ -753,22 +844,36 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("            switch (e.Data)");
         sb.AppendLine("            {");
 
-        // ShouldDelete cases first
+        // ShouldDelete cases first — coalesce overloads sharing the same event
+        // type into a single switch arm so the compiler doesn't flag duplicate
+        // arms as unreachable (CS8120). Multiple ShouldDelete overloads on the
+        // same event type are OR'd together so the snapshot is dropped if any
+        // overload returns true.
         var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
-        foreach (var method in shouldDeleteMethods)
+        var shouldDeleteByEventType = shouldDeleteMethods
+            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
+            .OrderByDescending(g => GetTypeDepth(g.Key))
+            .ToList();
+        foreach (var group in shouldDeleteByEventType)
         {
-            var eventTypeName = Fqn(method.EventType);
+            var eventTypeName = Fqn(group.Key);
             var dataVar = "data";
             sb.AppendLine($"                case {eventTypeName} {dataVar}:");
-            sb.Append("                    if (snapshot != null && ");
-            EmitShouldDeleteCall(sb, method, dataVar);
-            sb.AppendLine(")");
+            sb.Append("                    if (snapshot != null && (");
+            bool first = true;
+            foreach (var method in group)
+            {
+                if (!first) sb.Append(" || ");
+                first = false;
+                EmitShouldDeleteCall(sb, method, dataVar);
+            }
+            sb.AppendLine("))");
             sb.AppendLine("                        snapshot = null;");
             sb.AppendLine("                    break;");
         }
 
-        // Create cases
-        var createMethods = info.Methods.Where(m => m.MethodName == "Create").ToList();
+        // Create cases — coalesce by event type, prefer projection-defined over aggregate-defined.
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
         foreach (var method in createMethods)
         {
             var eventTypeName = Fqn(method.EventType);
@@ -779,8 +884,8 @@ internal static class EvolverCodeEmitter
             sb.AppendLine("                    break;");
         }
 
-        // Apply cases
-        var applyMethods = info.Methods.Where(m => m.MethodName == "Apply").ToList();
+        // Apply cases — coalesce by event type.
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
         foreach (var method in applyMethods)
         {
             var eventTypeName = Fqn(method.EventType);
@@ -841,8 +946,13 @@ internal static class EvolverCodeEmitter
         var createMethods = info.Methods.Where(m => m.MethodName == "Create").ToList();
         var applyMethods = info.Methods.Where(m => m.MethodName == "Apply").ToList();
 
-        // Each event type gets one case
-        var allEventTypes = info.Methods.Select(m => m.EventType).Distinct<ITypeSymbol>(SymbolEqualityComparer.Default).ToList();
+        // Each event type gets one case. Sort more-derived types first so
+        // `case IBase data:` doesn't shadow `case Concrete data:` (CS8120).
+        var allEventTypes = info.Methods
+            .Select(m => m.EventType)
+            .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
+            .OrderByDescending(t => GetTypeDepth(t!))
+            .ToList();
 
         foreach (var eventType in allEventTypes)
         {
@@ -933,6 +1043,7 @@ internal static class EvolverCodeEmitter
             .Select(m => m.EventType)
             .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
             .Where(t => !handledDeleteTypes.Contains(t!))
+            .OrderByDescending(t => GetTypeDepth(t!))
             .ToList();
 
         foreach (var eventType in applyAndCreateTypes)
@@ -1164,16 +1275,21 @@ internal static class EvolverCodeEmitter
             }
             else
             {
+                // Sync method body inside the async dispatch path — `session` and
+                // `cancellation` are still in scope from the enclosing
+                // EvolveAsync / DetermineActionAsync method, so handler params
+                // that need them must still bind correctly. Pass
+                // includeSessionAndCancellation=true here. See #297.
                 if (method.ReturnsAggregate)
                 {
                     sb.Append($"{indent}    return ");
-                    EmitApplyCallExpression(sb, method, "data", "e", false);
+                    EmitApplyCallExpression(sb, method, "data", "e", true);
                     sb.AppendLine(";");
                 }
                 else
                 {
                     sb.Append($"{indent}    ");
-                    EmitApplyCallExpression(sb, method, "data", "e", false);
+                    EmitApplyCallExpression(sb, method, "data", "e", true);
                     sb.AppendLine(";");
                     sb.AppendLine($"{indent}    return snapshot;");
                 }
@@ -1271,14 +1387,15 @@ internal static class EvolverCodeEmitter
     private static void EmitShouldDeleteCall(StringBuilder sb, ConventionalMethodInfo method, string dataVar)
     {
         var args = BuildShouldDeleteArgs(method, dataVar);
+        var awaitKeyword = method.IsAsync ? "await " : "";
 
         if (method.IsOnAggregate)
         {
-            sb.Append($"snapshot.{method.MethodName}({args})");
+            sb.Append($"{awaitKeyword}snapshot.{method.MethodName}({args})");
         }
         else
         {
-            sb.Append($"{method.MethodName}({args})");
+            sb.Append($"{awaitKeyword}{method.MethodName}({args})");
         }
     }
 
@@ -1286,6 +1403,7 @@ internal static class EvolverCodeEmitter
     {
         var parts = new List<string>();
         var parameters = method.Symbol.Parameters;
+        var containingType = method.Symbol.ContainingType;
 
         foreach (var param in parameters)
         {
@@ -1299,6 +1417,23 @@ internal static class EvolverCodeEmitter
             else if (IsRawIEvent(paramType))
             {
                 parts.Add("e");
+            }
+            else if (SymbolEqualityComparer.Default.Equals(paramType, containingType))
+            {
+                // The aggregate itself, as a second/third parameter on a self-aggregating
+                // Apply/Create/ShouldDelete method — e.g.
+                //   public TAgg Apply(SomeEvent e, TAgg current) => ...;
+                // The previous emitter unconditionally fell through to `dataVar` for any
+                // non-IEvent parameter, generating `snapshot.Apply(data, data)` (CS1503).
+                parts.Add("snapshot");
+            }
+            else if (IsQuerySession(paramType))
+            {
+                parts.Add("session");
+            }
+            else if (IsCancellationToken(paramType))
+            {
+                parts.Add("cancellation");
             }
             else
             {
@@ -1332,14 +1467,20 @@ internal static class EvolverCodeEmitter
     {
         var args = BuildSelfAggregatingArgs(method, dataVar);
 
-        // Self-aggregating: method is on the aggregate instance
+        // Static Apply on a self-aggregating record (e.g.
+        //   public static TAgg Apply(SomeEvent e, TAgg current) => ...;
+        // ) — must be invoked as Type.Apply(...) not snapshot.Apply(...) (CS0176).
+        var receiver = method.IsStatic
+            ? Fqn(method.Symbol.ContainingType)
+            : "snapshot";
+
         if (method.ReturnsAggregate)
         {
-            sb.AppendLine($"snapshot = snapshot.{method.MethodName}({args});");
+            sb.AppendLine($"snapshot = {receiver}.{method.MethodName}({args});");
         }
         else
         {
-            sb.AppendLine($"snapshot.{method.MethodName}({args});");
+            sb.AppendLine($"{receiver}.{method.MethodName}({args});");
         }
     }
 
@@ -1347,7 +1488,10 @@ internal static class EvolverCodeEmitter
         string dataVar)
     {
         var args = BuildSelfAggregatingArgs(method, dataVar);
-        sb.Append($"snapshot.{method.MethodName}({args})");
+        var receiver = method.IsStatic
+            ? Fqn(method.Symbol.ContainingType)
+            : "snapshot";
+        sb.Append($"{receiver}.{method.MethodName}({args})");
     }
 
     // --- Argument builders ---
@@ -1451,6 +1595,14 @@ internal static class EvolverCodeEmitter
             else if (IsRawIEvent(paramType))
             {
                 parts.Add("e");
+            }
+            else if (IsQuerySession(paramType))
+            {
+                parts.Add("session");
+            }
+            else if (IsCancellationToken(paramType))
+            {
+                parts.Add("cancellation");
             }
             else
             {

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -718,10 +718,14 @@ internal static class EvolverCodeEmitter
         // When the same aggregate type can be registered against multiple
         // stream-identity types (e.g. `AggregateStreamAsync<CountOfLetters>`
         // with both Guid and string stream IDs), emit a separate evolver per
-        // TId. Include a sanitized TId tag in the name so the two evolvers
-        // don't collide in the same namespace. See #297.
+        // TId. Append a sanitized TId tag in the name so the two evolvers
+        // don't collide in the same namespace. Only needed when the aggregate
+        // *itself* doesn't determine TId via an Id property — when it does,
+        // Pipeline 1 emits a single dispatcher per TDoc and existing tests
+        // (and downstream consumers) reference the original
+        // `{Name}Evolver` class name. See #297.
         var idTag = "";
-        if (info.IdentityType is { } id)
+        if (info.IdentityType is { } id && !AggregateHasOwnIdentity(info))
         {
             var idName = id.Name;
             if (!string.IsNullOrEmpty(idName))
@@ -729,6 +733,35 @@ internal static class EvolverCodeEmitter
         }
 
         return prefix.ToString() + info.ClassSymbol.Name + idTag + suffix;
+    }
+
+    /// <summary>
+    /// True when the aggregate type itself locks in the TId (via an Id property
+    /// or [AggregateIdentity] attribute). False when the candidate's TId came
+    /// from a Pipeline 3 call-site hint and could conceivably vary by call site.
+    /// </summary>
+    private static bool AggregateHasOwnIdentity(CandidateInfo info)
+    {
+        if (info.AggregateType is null) return false;
+
+        for (INamedTypeSymbol? current = info.AggregateType;
+             current is not null && current.SpecialType != SpecialType.System_Object;
+             current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is IPropertySymbol prop && prop.Name == "Id")
+                    return true;
+            }
+
+            foreach (var attr in current.GetAttributes())
+            {
+                if (attr.AttributeClass?.Name is "AggregateIdentityAttribute" or "AggregateIdentity")
+                    return true;
+            }
+        }
+
+        return false;
     }
 
     private static string GetFullyQualifiedEvolverName(CandidateInfo info, string evolverName)

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Surfaced from porting Marten's test suite onto JasperFx.Events.SourceGenerator alpha.4 (#276 Phase 2). Tested by switching Marten to local ProjectReferences against this branch: **796 → 54 failures** in src/EventSourcingTests (95.5% pass rate).

This branch is based on top of \`fix/sg-discover-methods-walk-inheritance\` (#295), which is also still pending merge — please merge that one first, or merge into a base that includes it.

## Summary

Five classes of codegen bugs surfaced when consuming the SG from a real-world test corpus:

1. **Microsoft.CodeAnalysis.CSharp 4.3.0 → 4.8.0** — the 4.3.0 binary silently fails to load under the .NET 10 SDK Roslyn host. The analyzer never ran for any consuming project; this was masking every other bug below.

2. **Handler-argument binding** — the SG mis-bound positional arguments in several shapes:
   - Self-aggregating \`static T Apply(SomeEvent, T current)\` on records — second param was treated as "more event data" instead of the aggregate slot.
   - \`Apply(AEvent, T, IQuerySession)\` on projection subclasses — IQuerySession fell through to the event-data path (\`Apply(data, snapshot, data)\`).
   - \`Apply(AEvent, T, IDocumentOperations)\` — IDocumentOperations isn't a supported convention slot for SingleStreamProjection; the SG now skips such methods (validation tests cover the runtime side).

3. **Switch-arm ordering and dedup** — \`case IBase data:\` could be emitted before \`case Concrete data:\` where Concrete implements IBase, producing CS8120 unreachable cascades across event-type-hierarchy tests. \`CoalesceByEventType\` and depth-aware sorting fix both.

4. **Required-member aggregates / nullable Id properties** — \`new T()\` was emitted for record aggregates with \`required\` members (CS9035 cascade), and \`Nullable<PaymentId>\` Id properties confused TId inference. Fixed both.

5. **Pipeline 3 (call-site discovery) gaps**:
   - Only \`Snapshot\`/\`LiveStreamAggregation\`/\`SingleStreamProjection\` were recognized; added \`AggregateStreamAsync\`/\`FetchLatest\`/\`FetchForWriting\` and friends.
   - Anonymous aggregates with no Id property + \`AggregateStreamAsync<T>(streamId, …)\` now use the first Guid/string-typed argument as a TId hint.
   - Same aggregate with different TId at different call sites (Guid stream in one test, string stream in another) now gets one dispatcher per \`(TDoc, TId)\` pair, keyed in the hint name + evolver class name so the two emissions don't collide.

Plus several smaller fixes (static-vs-instance Apply emission, async-path session binding for sync-return handlers, partial-record keyword in nested-class chain, \`HasLambdaRegistrations\` no longer matches the kept parameterless \`DeleteEvent<T>()\`, \`FindAggregationProjectionBase\` pattern-matches instead of force-casting type arguments so generic helpers in JasperFx.Events itself don't crash the SG).

## Validation

Marten's src/EventSourcingTests (1,331 tests):
- Before this PR (alpha.4 NuGet): 796 failures, 529 passes.
- After this PR (project refs): 54 failures, 1,271 passes.

Remaining 54 failures are documented limitations — private \`Apply\` methods on aggregates (Bug_3665), and a handful of anonymous-aggregate \`Snapshot<T>\` registrations whose call sites carry no stream-id argument to infer TId from. Both are reasonable lines to draw at the SG layer.

## Test plan

- [ ] CI: existing JasperFx.Events.SourceGenerator.Tests pass.
- [ ] CI: existing JasperFx.Events runtime tests pass.
- [ ] Manual: pull marten PR on top of this branch and rerun src/EventSourcingTests — expect ~54 documented failures.

Closes #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)