### PR TITLE
Fix tryUseAssemblyRegisteredEvolver guard for IGeneratedSyncDetermineAction (closes #298)

### DIFF
--- a/src/EventTests/Projections/SingleStreamProjectionTests.cs
+++ b/src/EventTests/Projections/SingleStreamProjectionTests.cs
@@ -22,6 +22,19 @@ public class SingleStreamProjectionTests
         Activator.CreateInstance(type).As<ProjectionBase>().AssembleAndAssertValidity();
     }
 
+    // Regression for #298: tryUseAssemblyRegisteredEvolver was short-circuiting on
+    // HasShouldDeleteMethods() BEFORE checking IGeneratedSyncDetermineAction, even though
+    // that interface is exactly what the SG emits for self-aggregating docs with
+    // ShouldDelete and handles the ShouldDelete arm internally. Result: registering
+    // SingleStreamProjection<SelfAggregatingWithShouldDelete, Guid> threw
+    // InvalidProjectionException at AssembleAndAssertValidity time.
+    [Fact]
+    public void self_aggregating_with_should_delete_binds_via_assembly_registered_determine_action_evolver()
+    {
+        var projection = new SingleStreamProjection<SelfAggregatingWithShouldDelete, Guid>();
+        Should.NotThrow(() => projection.AssembleAndAssertValidity());
+    }
+
     [Theory]
     [InlineData(typeof(ConventionalPlusEvolve), "This projection can only use the override of 'Evolve' or conventional Apply/Create/ShouldDelete methods, but not both")]
     [InlineData(typeof(MultipleOverrides), "Only one of these methods can be overridden: Evolve, EvolveAsync")]
@@ -115,9 +128,22 @@ public partial class OverridesEnrichEventsAsyncWithConventionalApply : SingleStr
     public void Apply(AEvent e, MyAggregate a) => a.ACount++;
 }
 
-public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, FakeOperations, FakeSession> where TDoc : notnull where TId : notnull
+// Self-aggregating fixture for #298 regression. Apply + Create + ShouldDelete on the
+// document type → SG emits IGeneratedSyncDetermineAction<SelfAggregatingWithShouldDelete, Guid>
+// (with the ShouldDelete arm baked into the switch) + [assembly: GeneratedEvolver(...)].
+public partial class SelfAggregatingWithShouldDelete
 {
-    protected SingleStreamProjection() : base()
+    public Guid Id { get; set; }
+    public int ACount { get; set; }
+
+    public static SelfAggregatingWithShouldDelete Create(AEvent _) => new();
+    public void Apply(BEvent _) => ACount++;
+    public bool ShouldDelete(CEvent _) => true;
+}
+
+public class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, FakeOperations, FakeSession> where TDoc : notnull where TId : notnull
+{
+    public SingleStreamProjection() : base()
     {
     }
 }

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -129,10 +129,13 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
     [MemberNotNullWhen(true, nameof(_evolve))]
     private bool tryUseAssemblyRegisteredEvolver()
     {
-        // Don't use a generated IGeneratedSyncEvolver when the projection has ShouldDelete methods,
-        // because the evolver only knows about Apply/Create on the aggregate type itself.
-        // ShouldDelete needs the full DetermineAction flow via AggregateApplication.
-        if (_application.HasShouldDeleteMethods()) return false;
+        // When the aggregate declares ShouldDelete methods, the IGeneratedSyncEvolver /
+        // IGeneratedAsyncEvolver shapes don't help — those only dispatch Apply/Create,
+        // and silently dropping the ShouldDelete arm would lose deletions. Those branches
+        // are skipped below. IGeneratedSyncDetermineAction *does* bake the ShouldDelete
+        // arm into its switch (see EvolverCodeEmitter.EmitSelfAggregatingDetermineAction)
+        // — that branch is always allowed.
+        var hasShouldDelete = _application.HasShouldDeleteMethods();
 
         var docType = typeof(TDoc);
 
@@ -144,9 +147,9 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
 
             var evolverType = attr.EvolverType;
 
-            // Check for IGeneratedSyncEvolver<TDoc, TId>
+            // Check for IGeneratedSyncEvolver<TDoc, TId> — Apply/Create only, no ShouldDelete arm
             var syncEvolverInterface = typeof(IGeneratedSyncEvolver<TDoc, TId>);
-            if (syncEvolverInterface.IsAssignableFrom(evolverType))
+            if (!hasShouldDelete && syncEvolverInterface.IsAssignableFrom(evolverType))
             {
                 var evolver = (IGeneratedSyncEvolver<TDoc, TId>)Activator.CreateInstance(evolverType)!;
                 _generatedEvolverEventTypes = evolver.EventTypes;
@@ -162,7 +165,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 return true;
             }
 
-            // Check for IGeneratedSyncDetermineAction<TDoc, TId>
+            // Check for IGeneratedSyncDetermineAction<TDoc, TId> — handles ShouldDelete natively
             var determineActionInterface = typeof(IGeneratedSyncDetermineAction<TDoc, TId>);
             if (determineActionInterface.IsAssignableFrom(evolverType))
             {
@@ -174,9 +177,9 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 return true;
             }
 
-            // Check for IGeneratedAsyncEvolver<TDoc, TId> (from Evolve/EvolveAsync on self-aggregating types)
+            // Check for IGeneratedAsyncEvolver<TDoc, TId> — Evolve/EvolveAsync on self-aggregating types, no ShouldDelete arm
             var asyncEvolverInterface = typeof(IGeneratedAsyncEvolver<TDoc, TId>);
-            if (asyncEvolverInterface.IsAssignableFrom(evolverType))
+            if (!hasShouldDelete && asyncEvolverInterface.IsAssignableFrom(evolverType))
             {
                 var evolver = (IGeneratedAsyncEvolver<TDoc, TId>)Activator.CreateInstance(evolverType)!;
                 _generatedEvolverEventTypes = evolver.EventTypes;


### PR DESCRIPTION
Closes #298.

## Summary

`JasperFxAggregationProjectionBase.tryUseAssemblyRegisteredEvolver` short-circuited on `HasShouldDeleteMethods()` **before** entering the loop that checks for `IGeneratedSyncDetermineAction<TDoc, TId>` — the very interface the SG emits for self-aggregating doc types with `ShouldDelete`, and which handles ShouldDelete natively. The guard was skipping its own escape hatch.

Surfaced during Polecat's adoption of `JasperFx.Events 2.0.0-alpha.11` ([JasperFx/polecat#109](https://github.com/JasperFx/polecat/pull/109)) — affected 3 doc types (`QuestParty`, `StringQuestParty`, `DeletableAggregate`) → ~25 cascaded `InvalidProjectionException` test failures.

## Fix

Move the `HasShouldDeleteMethods()` check from the early-exit into the per-interface branches, so it only blocks the two evolver shapes that genuinely can't dispatch ShouldDelete (`IGeneratedSyncEvolver`, `IGeneratedAsyncEvolver`):

```diff
-if (_application.HasShouldDeleteMethods()) return false;

+var hasShouldDelete = _application.HasShouldDeleteMethods();
 var docType = typeof(TDoc);
 var attrs = docType.Assembly.GetCustomAttributes<GeneratedEvolverAttribute>();
 foreach (var attr in attrs)
 {
-    if (syncEvolverInterface.IsAssignableFrom(evolverType)) { ... }
+    if (!hasShouldDelete && syncEvolverInterface.IsAssignableFrom(evolverType)) { ... }

     // IGeneratedSyncDetermineAction — handles ShouldDelete natively, always allowed
     if (determineActionInterface.IsAssignableFrom(evolverType)) { ... }

-    if (asyncEvolverInterface.IsAssignableFrom(evolverType)) { ... }
+    if (!hasShouldDelete && asyncEvolverInterface.IsAssignableFrom(evolverType)) { ... }
 }
```

## Regression test

`SingleStreamProjectionTests.self_aggregating_with_should_delete_binds_via_assembly_registered_determine_action_evolver` — fixture `SelfAggregatingWithShouldDelete` is a partial class with Apply + Create + ShouldDelete; the SG emits `IGeneratedSyncDetermineAction<SelfAggregatingWithShouldDelete, Guid>` + the assembly attribute; `AssembleAndAssertValidity` on the bare `SingleStreamProjection<SelfAggregatingWithShouldDelete, Guid>` now succeeds.

Verified the test **fails** on the pre-fix code (the original short-circuit) and **passes** with this change.

## Verification

- ✅ New regression test `self_aggregating_with_should_delete_binds_via_assembly_registered_determine_action_evolver` passes
- ✅ Full `EventTests` suite: **258 passed, 0 failed** (net9.0 + net10.0)
- ✅ Full `JasperFx.Events.SourceGenerator.Tests` suite: **14 passed, 0 failed**
- ✅ End-to-end against Polecat#109 via the `Polecat.AotSmoke` consumer project pointed at this branch via local ProjectReference — a bare `opts.Projections.Add<SingleStreamProjection<DeletableQuest, Guid>>(...)` registration where `DeletableQuest` has `ShouldDelete` now boots cleanly on net9.0 and net10.0 (pre-fix: `InvalidProjectionException` at DocumentStore construction)

## Suggested follow-up: cut SG/Events alpha

This fix lives in `JasperFx.Events` runtime (not the source generator), so a `JasperFx.Events 2.0.0-alpha.12` (or whatever the next alpha number is) needs to publish to unblock Polecat#109 downstream. No `JasperFx.Events.SourceGenerator` version bump needed — that package is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)