### PR TITLE
Restore per-event ApplyEventException seam in SG runtime adapters (closes #303)

### DIFF
--- a/src/EventTests/Projections/SingleStreamProjectionTests.cs
+++ b/src/EventTests/Projections/SingleStreamProjectionTests.cs
@@ -35,6 +35,44 @@ public class SingleStreamProjectionTests
         Should.NotThrow(() => projection.AssembleAndAssertValidity());
     }
 
+    // Regression for #303: pre-#276 the reflection path wrapped each Apply call in a
+    // try/catch keyed off RebuildErrors.SkipApplyErrors so the daemon could route just
+    // the poison event to the dead-letter queue. The SG-emitted IGeneratedSyncDetermineAction
+    // path processed the whole batch in one call, so a thrown Apply propagated as the raw
+    // user exception with no per-event seam. The runtime adapter now dispatches one event
+    // at a time and wraps each in ApplyEventException carrying *that* event's sequence,
+    // restoring the seam.
+    [Fact]
+    public async Task sg_determine_action_wraps_per_event_apply_failure_in_apply_event_exception()
+    {
+        var projection = new SingleStreamProjection<SelfAggregatingWithFailingApply, Guid>();
+        projection.AssembleAndAssertValidity();
+
+        // Three events: the first is fine (Create), the second is the poison pill (Apply
+        // throws), the third would otherwise succeed but execution stops at the poison.
+        var events = new IEvent[]
+        {
+            new Event<AEvent>(new AEvent()) { Sequence = 1 },
+            new Event<BEvent>(new BEvent()) { Sequence = 2 },  // poison
+            new Event<AEvent>(new AEvent()) { Sequence = 3 }
+        };
+
+        var ex = await Should.ThrowAsync<ApplyEventException>(async () =>
+        {
+            await projection.DetermineActionAsync(
+                new FakeSession(),
+                null,
+                Guid.NewGuid(),
+                new NulloIdentitySetter<SelfAggregatingWithFailingApply, Guid>(),
+                events,
+                CancellationToken.None);
+        });
+
+        ex.Event.Sequence.ShouldBe(2);
+        ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+        ex.InnerException!.Message.ShouldBe("poison pill");
+    }
+
     [Theory]
     [InlineData(typeof(ConventionalPlusEvolve), "This projection can only use the override of 'Evolve' or conventional Apply/Create/ShouldDelete methods, but not both")]
     [InlineData(typeof(MultipleOverrides), "Only one of these methods can be overridden: Evolve, EvolveAsync")]
@@ -138,6 +176,19 @@ public partial class SelfAggregatingWithShouldDelete
 
     public static SelfAggregatingWithShouldDelete Create(AEvent _) => new();
     public void Apply(BEvent _) => ACount++;
+    public bool ShouldDelete(CEvent _) => true;
+}
+
+// Self-aggregating fixture for #303 regression. Apply on BEvent throws — the daemon
+// rebuild flow needs the runtime to re-raise that as ApplyEventException carrying the
+// BEvent so SkipApplyErrors can dead-letter just that event. ShouldDelete is present
+// so the SG emits IGeneratedSyncDetermineAction (the path the issue targets).
+public partial class SelfAggregatingWithFailingApply
+{
+    public Guid Id { get; set; }
+
+    public static SelfAggregatingWithFailingApply Create(AEvent _) => new();
+    public void Apply(BEvent _) => throw new InvalidOperationException("poison pill");
     public bool ShouldDelete(CEvent _) => true;
 }
 

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.5</Version>
+        <Version>2.0.0-alpha.6</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -155,7 +155,21 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 {
                     foreach (var e in events)
                     {
-                        snapshot = evolver.Evolve(snapshot, id, e);
+                        try
+                        {
+                            snapshot = evolver.Evolve(snapshot, id, e);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Transient errors bubble for Polly to retry; non-transient
+                            // user errors get wrapped in ApplyEventException so the
+                            // daemon's SkipApplyErrors handler can route just the
+                            // offending event to the dead-letter queue. Matches the
+                            // semantics of the pre-#276 reflection path in
+                            // evolveDefaultAsync. See #303.
+                            if (ProjectionExceptions.IsExceptionTransient(ex)) throw;
+                            throw new ApplyEventException(e, ex);
+                        }
                     }
 
                     return new ValueTask<TDoc?>(snapshot);
@@ -170,7 +184,32 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 var evolver = (IGeneratedSyncDetermineAction<TDoc, TId>)Activator.CreateInstance(evolverType)!;
                 _generatedEvolverEventTypes = evolver.EventTypes;
                 _buildAction = (_, snapshot, id, _, events, _) =>
-                    new ValueTask<(TDoc?, ActionType)>(evolver.DetermineAction(snapshot, id, events));
+                {
+                    // Dispatch one event at a time so a poison-pill Apply can be wrapped
+                    // in ApplyEventException carrying *that* event. Bulk-dispatching the
+                    // whole batch through DetermineAction would lose the per-event seam
+                    // the daemon's SkipApplyErrors handler relies on (see #303). The
+                    // final action is whichever the last event produced — same outcome
+                    // as a single batch call because DetermineAction's per-event branches
+                    // are independent of the rest of the batch state apart from snapshot.
+                    var action = ActionType.Nothing;
+                    var single = new IEvent[1];
+                    foreach (var e in events)
+                    {
+                        single[0] = e;
+                        try
+                        {
+                            (snapshot, action) = evolver.DetermineAction(snapshot, id, single);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ProjectionExceptions.IsExceptionTransient(ex)) throw;
+                            throw new ApplyEventException(e, ex);
+                        }
+                    }
+
+                    return new ValueTask<(TDoc?, ActionType)>((snapshot, action));
+                };
                 _evolve = evolveDefaultAsync; // not used when _buildAction is set, but must be non-null
                 return true;
             }
@@ -185,7 +224,15 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 {
                     foreach (var e in events)
                     {
-                        snapshot = await evolver.EvolveAsync(snapshot, id, e, session!, ct);
+                        try
+                        {
+                            snapshot = await evolver.EvolveAsync(snapshot, id, e, session!, ct);
+                        }
+                        catch (Exception ex)
+                        {
+                            if (ProjectionExceptions.IsExceptionTransient(ex)) throw;
+                            throw new ApplyEventException(e, ex);
+                        }
                     }
 
                     return snapshot;

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.12</Version>
+        <Version>2.0.0-alpha.13</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-alpha.1</Version>
+        <Version>5.0.0-alpha.2</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-alpha.2</Version>
+        <Version>2.0.0-alpha.3</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.2</Version>
+        <Version>2.0.0-alpha.3</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.13</Version>
+        <Version>2.0.0-alpha.14</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
## Summary
Restores pre-#276 dead-letter semantics for source-generated dispatcher paths. **Closes #303.**

Pre-#276 the reflection-based path wrapped each individual `Apply` call in a `try`/`catch` so the daemon's `SkipApplyErrors` handler could isolate a single poison-pill event and route it to the dead-letter queue without aborting the whole batch. After #276 the source-generated adapters in `tryUseAssemblyRegisteredEvolver` (JasperFx.Events 2.0.0-alpha.x) lost that seam:

- `IGeneratedSyncEvolver` iterated events but didn't wrap thrown user exceptions in `ApplyEventException`.
- `IGeneratedSyncDetermineAction` was worse — it bulk-dispatched the whole batch through a single `DetermineAction(snapshot, id, events)` call, so even per-event wrapping wouldn't know which event threw.
- `IGeneratedAsyncEvolver` had the same gap as the sync evolver.

## What changed
Issue's option 1 — runtime change, no SG redesign. All three adapters now match the `evolveDefaultAsync` / `evolveDefault` semantics from `JasperFxAggregationProjectionBase.Runtime.cs:14-62`:

- Each evolver call is wrapped in `try`/`catch`. Transient exceptions (per `ProjectionExceptions.IsExceptionTransient`) bubble up so Polly can retry. Everything else is rethrown as `ApplyEventException(thatEvent, ex)`.
- `IGeneratedSyncDetermineAction` switches from bulk batch dispatch to a per-event loop. A single-element `IEvent[]` is re-used across iterations to avoid per-event allocations on the rebuild hot path. The final action is whichever the last event produced — semantically equivalent to the bulk call because the SG-emitted body's per-event branches don't depend on un-processed events earlier in the batch.

## Test plan
- [x] `dotnet test src/EventTests/...` — 259/259 on net9.0 and net10.0 (was 258 + 1 new).
- [x] `dotnet test src/JasperFx.Events.SourceGenerator.Tests/...` — 14/14.
- [x] New regression `sg_determine_action_wraps_per_event_apply_failure_in_apply_event_exception` verified red without this fix, green with it. Three-event batch with poison `BEvent` at sequence 2; asserts the thrown `ApplyEventException` carries `Event.Sequence == 2` and `InnerException` matches the user throw.
- [ ] Downstream: re-enable `DaemonTests.Resiliency.rebuilds_with_serialization_or_poison_pill_events.rebuild_the_projection_skip_failed_events` on the Marten side once a new alpha publishes.

## Version bumps (every packable project)
| Package | From | To |
|---|---|---|
| JasperFx | 2.0.0-alpha.13 | 2.0.0-alpha.14 |
| JasperFx.Events | 2.0.0-alpha.12 | 2.0.0-alpha.13 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.5 | 2.0.0-alpha.6 |
| JasperFx.SourceGenerator | 2.0.0-alpha.2 | 2.0.0-alpha.3 |
| JasperFx.SourceGeneration | 2.0.0-alpha.2 | 2.0.0-alpha.3 |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.1 | 5.0.0-alpha.2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)