### PR TITLE
Wrap per-event in SG DetermineActionAsync overrides (closes #305)

### DIFF
--- a/src/EventTests/Projections/SingleStreamProjectionTests.cs
+++ b/src/EventTests/Projections/SingleStreamProjectionTests.cs
@@ -73,6 +73,46 @@ public class SingleStreamProjectionTests
         ex.InnerException!.Message.ShouldBe("poison pill");
     }
 
+    // Regression for #305: PR #304 wrapped the runtime adapter delegates but the
+    // *projection subclass* path bypasses those — when a partial projection has
+    // Apply + ShouldDelete, the SG emits a `DetermineActionAsync` override directly
+    // on the user class, so establishBuildActionAndEvolve sets
+    // `_buildAction = DetermineActionAsync` (the SG-emitted method) and the
+    // per-event wrap in tryUseAssemblyRegisteredEvolver is bypassed entirely.
+    // The Marten DaemonTests rebuild_the_projection_skip_failed_events failure was
+    // raw InvalidOperationException leaking up through the SG override directly to
+    // GroupedProjectionExecution.buildBatchWithSkipping, which only routes events
+    // for AggregateException-of-ApplyEventException. The SG-emitted DetermineActionAsync
+    // must wrap each event's switch body itself.
+    [Fact]
+    public async Task sg_determine_action_async_override_on_partial_projection_wraps_per_event()
+    {
+        var projection = new ProjectionWithFailingApplyAndShouldDelete();
+        projection.AssembleAndAssertValidity();
+
+        var events = new IEvent[]
+        {
+            new Event<AEvent>(new AEvent()) { Sequence = 10 },     // Create, fine
+            new Event<BEvent>(new BEvent()) { Sequence = 11 },     // poison Apply
+            new Event<AEvent>(new AEvent()) { Sequence = 12 }
+        };
+
+        var ex = await Should.ThrowAsync<ApplyEventException>(async () =>
+        {
+            await projection.DetermineActionAsync(
+                new FakeSession(),
+                null,
+                Guid.NewGuid(),
+                new NulloIdentitySetter<MyAggregate, Guid>(),
+                events,
+                CancellationToken.None);
+        });
+
+        ex.Event.Sequence.ShouldBe(11);
+        ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+        ex.InnerException!.Message.ShouldBe("You shall not pass!");
+    }
+
     [Theory]
     [InlineData(typeof(ConventionalPlusEvolve), "This projection can only use the override of 'Evolve' or conventional Apply/Create/ShouldDelete methods, but not both")]
     [InlineData(typeof(MultipleOverrides), "Only one of these methods can be overridden: Evolve, EvolveAsync")]
@@ -120,6 +160,18 @@ public class MultipleOverrides : SingleStreamProjection<MyAggregate, Guid>
 public partial class ConventionalProjection : SingleStreamProjection<MyAggregate, Guid>
 {
     public void Apply(AEvent e, MyAggregate a) => a.ACount++;
+}
+
+// Regression fixture for #305. Apply on BEvent throws. The SG sees ShouldDelete +
+// Apply on a partial projection subclass → emits a DetermineActionAsync override
+// directly on this class. That override's per-event switch body must now wrap the
+// thrown user exception as ApplyEventException carrying *that* event so the
+// daemon's buildBatchWithSkipping can route the poison event to the dead-letter queue.
+public partial class ProjectionWithFailingApplyAndShouldDelete : SingleStreamProjection<MyAggregate, Guid>
+{
+    public static MyAggregate Create(AEvent _) => new();
+    public void Apply(BEvent _, MyAggregate _2) => throw new InvalidOperationException("You shall not pass!");
+    public bool ShouldDelete(CEvent _) => false;
 }
 
 public class OverridesDetermineAction : SingleStreamProjection<MyAggregate, Guid>

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -939,6 +939,16 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("        var exists = snapshot != null;");
         sb.AppendLine("        foreach (var e in events)");
         sb.AppendLine("        {");
+        // Per-event try/catch so a poison-pill Apply/Create/ShouldDelete is re-raised
+        // as ApplyEventException carrying *that* event. The daemon's buildBatchWithSkipping
+        // catch handler keys off ApplyEventException.Event.Sequence to route the failing
+        // event to the dead-letter queue — without this wrap the daemon sees the raw
+        // user exception and SkipApplyErrors can't isolate the offending event.
+        // Matches evolveDefaultAsync's semantics in JasperFxAggregationProjectionBase.Runtime.cs.
+        // Already-ApplyEventException-typed throws (e.g. user code raised it explicitly)
+        // propagate unchanged so we don't double-wrap. See #305.
+        sb.AppendLine("            try");
+        sb.AppendLine("            {");
         sb.AppendLine("            switch (e.Data)");
         sb.AppendLine("            {");
 
@@ -1029,6 +1039,16 @@ internal static class EvolverCodeEmitter
             sb.AppendLine("                    break;");
         }
 
+        sb.AppendLine("            }");
+        sb.AppendLine("            }");
+        sb.AppendLine("            catch (global::JasperFx.Events.Daemon.ApplyEventException)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw;");
+        sb.AppendLine("            }");
+        sb.AppendLine("            catch (global::System.Exception __ex)");
+        sb.AppendLine("                when (!global::JasperFx.Events.Projections.ProjectionExceptions.IsExceptionTransient(__ex))");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw new global::JasperFx.Events.Daemon.ApplyEventException(e, __ex);");
         sb.AppendLine("            }");
         sb.AppendLine("        }");
         sb.AppendLine();
@@ -1338,6 +1358,11 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("        var exists = snapshot != null;");
         sb.AppendLine("        foreach (var e in events)");
         sb.AppendLine("        {");
+        // Per-event try/catch (parallel to EmitDetermineActionAsyncOverride, same
+        // rationale — preserve the per-event seam for the daemon's dead-letter routing).
+        // See #305.
+        sb.AppendLine("            try");
+        sb.AppendLine("            {");
         sb.AppendLine("            switch (e.Data)");
         sb.AppendLine("            {");
 
@@ -1414,6 +1439,16 @@ internal static class EvolverCodeEmitter
             sb.AppendLine("                    break;");
         }
 
+        sb.AppendLine("            }");
+        sb.AppendLine("            }");
+        sb.AppendLine("            catch (global::JasperFx.Events.Daemon.ApplyEventException)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw;");
+        sb.AppendLine("            }");
+        sb.AppendLine("            catch (global::System.Exception __ex)");
+        sb.AppendLine("                when (!global::JasperFx.Events.Projections.ProjectionExceptions.IsExceptionTransient(__ex))");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw new global::JasperFx.Events.Daemon.ApplyEventException(e, __ex);");
         sb.AppendLine("            }");
         sb.AppendLine("        }");
         sb.AppendLine();

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.6</Version>
+        <Version>2.0.0-alpha.7</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -201,6 +201,13 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                         {
                             (snapshot, action) = evolver.DetermineAction(snapshot, id, single);
                         }
+                        catch (ApplyEventException)
+                        {
+                            // Already wrapped (either by the SG-emitted dispatcher
+                            // per #305 or by user code throwing it explicitly); pass
+                            // through unchanged so we don't double-wrap.
+                            throw;
+                        }
                         catch (Exception ex)
                         {
                             if (ProjectionExceptions.IsExceptionTransient(ex)) throw;
@@ -227,6 +234,13 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                         try
                         {
                             snapshot = await evolver.EvolveAsync(snapshot, id, e, session!, ct);
+                        }
+                        catch (ApplyEventException)
+                        {
+                            // Already wrapped (either by the SG-emitted dispatcher
+                            // per #305 or by user code throwing it explicitly); pass
+                            // through unchanged so we don't double-wrap.
+                            throw;
                         }
                         catch (Exception ex)
                         {

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.13</Version>
+        <Version>2.0.0-alpha.14</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-alpha.2</Version>
+        <Version>5.0.0-alpha.3</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-alpha.3</Version>
+        <Version>2.0.0-alpha.4</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.3</Version>
+        <Version>2.0.0-alpha.4</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.14</Version>
+        <Version>2.0.0-alpha.15</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
## Summary
Follow-up to [#304](https://github.com/JasperFx/jasperfx/pull/304). That PR fixed the runtime adapter delegates in `tryUseAssemblyRegisteredEvolver`, but there's a second SG-dispatch path the fix didn't reach: when a partial projection has `Apply` + `ShouldDelete` on a user subclass of `SingleStreamProjection<TDoc, TId>`, the SG emits a `DetermineActionAsync` **override** directly on the user class. At runtime `establishBuildActionAndEvolve` sets `_buildAction = DetermineActionAsync` (the SG-emitted method) and the `tryUseAssemblyRegisteredEvolver` adapter is bypassed entirely. **Closes #305.**

## Why
Marten's `rebuild_the_projection_skip_failed_events` failure stack trace points straight at `DaemonTests_Resiliency_SometimesFailingTripProjection.Evolver.g.cs:line 40` — the SG-emitted override. The raw `InvalidOperationException` leaked from there directly up to `GroupedProjectionExecution.buildBatchWithSkipping`, whose catch only filters `AggregateException` for inner `ApplyEventException`. With raw inners, `applyErrors` was empty, no events were skipped, the `while (batch == null && !cancellationToken.IsCancellationRequested)` loop retried forever, and the 60s shard timeout fired.

## What changed
Per-event `try`/`catch` + `ApplyEventException` wrap emitted inside both SG-emitted `DetermineAction*` bodies:

- `EmitDetermineActionAsyncOverride` — the partial-projection override (the path #305's stack trace hits).
- `EmitSelfAggregatingDetermineAction` — the standalone evolver class for self-aggregating types with `ShouldDelete`. Parallel hole, same root cause; the runtime adapter from #304 was wrapping at the call site, but with the SG also wrapping internally the per-event seam is consistent across both paths.

Each generated body now reads:
```csharp
foreach (var e in events)
{
    try
    {
        switch (e.Data) { ...user-method dispatch... }
    }
    catch (ApplyEventException) { throw; }
    catch (Exception __ex)
        when (!ProjectionExceptions.IsExceptionTransient(__ex))
    {
        throw new ApplyEventException(e, __ex);
    }
}
```

`ApplyEventException` is rethrown unchanged so user code that explicitly raises it doesn't get double-wrapped. Transient exceptions bubble for Polly retries, matching `evolveDefaultAsync`'s semantics.

The runtime-side adapters from #304 keep their per-event `try`/`catch` but now rethrow `ApplyEventException` as-is to avoid double-wrap now that the SG wraps internally.

## Test plan
- [x] `dotnet test src/EventTests/...` — 260/260 on net9.0 and net10.0 (was 259 + 1 new).
- [x] `dotnet test src/JasperFx.Events.SourceGenerator.Tests/...` — 14/14.
- [x] New regression `sg_determine_action_async_override_on_partial_projection_wraps_per_event` invokes the SG-emitted override directly on a partial projection with `Create + failing Apply + ShouldDelete`. Verified red without the `EmitDetermineActionAsyncOverride` change, green with it.
- [ ] Downstream: with this published, Marten's `rebuild_the_projection_skip_failed_events` should pass — the 5 `FailingEvent` instances per stream should produce 5 `DeadLetterEvent` rows in `mt_doc_deadletterevent`.

## Version bumps (every packable project)
| Package | From | To |
|---|---|---|
| JasperFx | 2.0.0-alpha.14 | 2.0.0-alpha.15 |
| JasperFx.Events | 2.0.0-alpha.13 | 2.0.0-alpha.14 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.6 | 2.0.0-alpha.7 |
| JasperFx.SourceGenerator | 2.0.0-alpha.3 | 2.0.0-alpha.4 |
| JasperFx.SourceGeneration | 2.0.0-alpha.3 | 2.0.0-alpha.4 |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.2 | 5.0.0-alpha.3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)