### PR TITLE
Bump all JasperFx alphas for cross-stack release

### DIFF
--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.8</Version>
+        <Version>2.0.0-alpha.9</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.15</Version>
+        <Version>2.0.0-alpha.16</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-alpha.4</Version>
+        <Version>5.0.0-alpha.5</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-alpha.5</Version>
+        <Version>2.0.0-alpha.6</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.5</Version>
+        <Version>2.0.0-alpha.6</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.16</Version>
+        <Version>2.0.0-alpha.17</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
Coordinated alpha bump for the Critter Stack 2026 wave. Polecat 4 and Marten 9 have unreleased items waiting on the next JasperFx publish — this cuts a fresh set so they can re-pin and ship.

## Bump matrix

| Package | Was | Now |
|---|---|---|
| `JasperFx` | `2.0.0-alpha.16` | `2.0.0-alpha.17` |
| `JasperFx.Events` | `2.0.0-alpha.15` | `2.0.0-alpha.16` |
| `JasperFx.Events.SourceGenerator` | `2.0.0-alpha.8` | `2.0.0-alpha.9` |
| `JasperFx.RuntimeCompiler` | `5.0.0-alpha.4` | `5.0.0-alpha.5` |
| `JasperFx.SourceGeneration` | `2.0.0-alpha.5` | `2.0.0-alpha.6` |
| `JasperFx.SourceGenerator` | `2.0.0-alpha.5` | `2.0.0-alpha.6` |

`JasperFx.RuntimeCompiler` stays on the **5.x line** (active continuation of the 4.x lineage). The parallel `2.0.x` series on NuGet is the stale alternative — do not pin that downstream (see Marten commit `44dc48425` for the precedent fix).

## Test plan

- [x] `dotnet build jasperfx.sln -c Release` clean (0 errors)
- [ ] After merge: trigger NuGet publish workflow_dispatch to push the six packages
- [ ] After publish lands on NuGet: downstream re-pins begin (Marten / Polecat / Wolverine foundation re-pin chip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)