### PR TITLE
Make CritterStackDefaults / AddJasperFx annotation-free for AOT consumers (closes #312)

### DIFF
--- a/src/JasperFx.AotSmoke/Program.cs
+++ b/src/JasperFx.AotSmoke/Program.cs
@@ -19,8 +19,10 @@
 //     context — Marten and Wolverine consumers wrap these with their own
 //     STJ context or pre-serialized strings)
 
+using JasperFx;
 using JasperFx.CodeGeneration.Snapshots;
 using JasperFx.Events;
+using Microsoft.Extensions.DependencyInjection;
 
 // --- SnapshotGate.ComputeHash / Verify ----------------------------------
 // Pure functions that compute SHA-256 over a canonical-input string and
@@ -67,6 +69,26 @@ if (evt.Data.Message != tenantEvt.Data.Message)
     Console.Error.WriteLine("Event.For<T> regression.");
     return 1;
 }
+
+// --- CritterStackDefaults / AddJasperFx --------------------------------
+// Regression for #312. These are the unified 2.0 codegen-mode entry points
+// the per-store opts.GeneratedCodeMode obsoletion recommends as replacement.
+// They previously carried [RequiresUnreferencedCode] which fired IL2026
+// for every IsAotCompatible consumer even when JasperFx.SourceGeneration
+// was wired — locking AOT consumers onto the obsolete per-store form.
+// The annotation has been pushed down to the inner fallback path that
+// only runs when the source-generated DiscoveredCommands manifest is absent.
+// Per the AOT publishing guide, set the application assembly explicitly
+// before calling CritterStackDefaults to short-circuit the stack-walk
+// fallback in JasperFxOptions.
+
+JasperFxOptions.RememberedApplicationAssembly = typeof(SampleEvent).Assembly;
+
+var services = new ServiceCollection();
+services.CritterStackDefaults(jfx =>
+{
+    jfx.ServiceName = "jasperfx-aot-smoke";
+});
 
 Console.WriteLine($"JasperFx AOT smoke OK — ConfigHash={hashA[..16]}…");
 return 0;

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.9</Version>
+        <Version>2.0.0-alpha.10</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.16</Version>
+        <Version>2.0.0-alpha.17</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-alpha.5</Version>
+        <Version>5.0.0-alpha.6</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-alpha.6</Version>
+        <Version>2.0.0-alpha.7</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.6</Version>
+        <Version>2.0.0-alpha.7</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/CommandLineHostingExtensions.cs
+++ b/src/JasperFx/CommandLineHostingExtensions.cs
@@ -113,9 +113,29 @@ public static class CommandLineHostingExtensions
         return args;
     }
 
-    [RequiresUnreferencedCode("Scans the entry/extension assemblies for IJasperFxCommand types via Assembly.GetExportedTypes().")]
+    /// <summary>
+    /// Populate <paramref name="factory"/> with the standard JasperFx command set:
+    /// built-in commands shipped with the framework, the application's own commands,
+    /// and commands contributed by extension assemblies.
+    /// </summary>
+    /// <remarks>
+    /// Tries the source-generated <c>DiscoveredCommands</c> manifest first and
+    /// short-circuits entirely when it's present — the manifest already covers
+    /// built-in + application + extension commands as a single trim-clean list.
+    /// Only the no-manifest fallback path is trim-unsafe; its
+    /// <see cref="CommandFactory.RegisterCommands(Assembly)"/> calls are suppressed
+    /// here with documented justification so AOT-compatible consumers don't see
+    /// IL2026 at the <c>CritterStackDefaults</c> / <c>AddJasperFx</c> call site.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Fallback assembly scan is only reached when the source-generated DiscoveredCommands manifest is absent. Consumers targeting trim/AOT wire JasperFx.SourceGeneration, which emits the manifest as ordinary code in the consuming assembly so RegisterCommands(Assembly) is never reached at runtime. Apps that omit the analyzer are by definition opting into the runtime-codegen path and accept the scan.")]
     internal static void ApplyFactoryDefaults(this CommandFactory factory, Assembly? applicationAssembly)
     {
+        if (factory.TryRegisterFromGeneratedManifest())
+        {
+            return;
+        }
+
         factory.RegisterCommands(typeof(RunCommand).GetTypeInfo().Assembly);
 
         if (applicationAssembly != null)

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.17</Version>
+        <Version>2.0.0-alpha.18</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]

--- a/src/JasperFx/JasperFxServiceCollectionExtensions.cs
+++ b/src/JasperFx/JasperFxServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.CommandLine;
 using JasperFx.CommandLine.Descriptions;
@@ -19,7 +20,16 @@ public static class JasperFxServiceCollectionExtensions
     /// <param name="configure"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("CritterStackDefaults wires AddJasperFx, which scans entry/extension assemblies for IJasperFxCommand types via Assembly.GetExportedTypes(). Apps targeting trim/AOT should pre-register commands via the source-generated DiscoveredCommands manifest.")]
+    /// <remarks>
+    /// This method is annotation-free for trim/AOT consumers: the only trim-unsafe
+    /// work is the assembly-scan fallback in <see cref="CommandFactory.RegisterCommands(Assembly)"/>,
+    /// which is gated behind the source-generated <c>DiscoveredCommands</c> manifest
+    /// (emitted by the <c>JasperFx.SourceGeneration</c> analyzer). When the manifest
+    /// is present at runtime, registration is fully trim-clean. When it is absent,
+    /// the fallback path still works for runtime-codegen apps but will emit IL2026
+    /// at the inner <c>RegisterCommands</c> call site. See <see cref="CommandLineHostingExtensions.ApplyFactoryDefaults"/>
+    /// for the manifest-first short-circuit.
+    /// </remarks>
     public static IServiceCollection CritterStackDefaults(this IServiceCollection services,
         Action<JasperFxOptions> configure)
     {
@@ -30,14 +40,18 @@ public static class JasperFxServiceCollectionExtensions
 
         return services.AddJasperFx(configure);
     }
-    
+
     /// <summary>
     /// Configure JasperFx and Critter Stack tool behavior for resource management at runtime
     /// </summary>
     /// <param name="services"></param>
     /// <param name="configure">Optional configuration of the JasperFxDefaults for resource management</param>
     /// <returns></returns>
-    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Scans entry/extension assemblies for IJasperFxCommand types via Assembly.GetExportedTypes(). Apps targeting trim/AOT should pre-register commands via the source-generated DiscoveredCommands manifest.")]
+    /// <remarks>
+    /// Annotation-free for trim/AOT — see the remarks on <see cref="CritterStackDefaults"/>.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Two reachable RUC call sites are stack-walk fallbacks that only execute when the consumer hasn't pre-set the application assembly: DetermineCallingAssembly is guarded by `RememberedApplicationAssembly == null`, and ReadHostEnvironment's establishApplicationAssembly fallback is guarded by `ApplicationAssembly == null`. AOT consumers are expected to call `JasperFxOptions.SetApplicationProject(typeof(Program).Assembly)` before AddJasperFx per the AOT publishing guide, which short-circuits both fallbacks. Apps that omit that call are by definition on the runtime-codegen path. See docs/codegen/aot.md.")]
     public static IServiceCollection AddJasperFx(this IServiceCollection services, Action<JasperFxOptions>? configure = null)
     {
         // It's actually important to do this as close as possible to this call


### PR DESCRIPTION
## Summary
`CritterStackDefaults` — the unified 2.0 codegen-mode entry point the per-store `opts.GeneratedCodeMode` obsoletion recommends as the replacement — carried `[RequiresUnreferencedCode]` at the method level. That fired IL2026 unconditionally for any consumer with `IsAotCompatible=true`, **even when the consumer had wired the `JasperFx.SourceGeneration` analyzer** that emits the trim-clean `DiscoveredCommands` manifest the runtime fallback already prefers. Net effect per #312's repro: trim-clean consumers were locked onto the obsolete per-store form indefinitely.

**Closes #312.** Per the issue's recommended Option 1, the annotation is pushed down to the inner fallback path that only runs when the manifest is absent.

## What changed
- **`CritterStackDefaults`** — `[RequiresUnreferencedCode]` removed. Remarks document the manifest-first contract.
- **`AddJasperFx`** — `[RequiresUnreferencedCode]` removed. `UnconditionalSuppressMessage` added for the two reachable RUC call sites (`DetermineCallingAssembly` and `ReadHostEnvironment`'s `establishApplicationAssembly` fallback), both stack-walk fallbacks gated on `RememberedApplicationAssembly == null` / `ApplicationAssembly == null`. AOT consumers are expected to call `JasperFxOptions.SetApplicationProject(...)` before `AddJasperFx` per the AOT publishing guide, which short-circuits both fallbacks at runtime.
- **`CommandLineHostingExtensions.ApplyFactoryDefaults`** — annotation removed. Now **manifest-first**: short-circuits via `factory.TryRegisterFromGeneratedManifest()` before the legacy upfront `RegisterCommands(typeof(RunCommand).Assembly)` + `RegisterCommands(applicationAssembly)` scans. The manifest already covers built-in + application + extension commands as one trim-clean list, so the upfront scans are now strictly the no-manifest fallback path. `UnconditionalSuppressMessage` covers the still-trim-unsafe fallback calls with justification text documenting that the fallback is only reached when the analyzer isn't wired.
- **Inner `CommandFactory.RegisterCommands(Assembly)`** keeps its `[RequiresUnreferencedCode]` — anything that bypasses the manifest-first short-circuit still surfaces the warning at its call site.

## Test plan
- [x] `dotnet build src/JasperFx/JasperFx.csproj` — clean (no IL2026 inside `JasperFxServiceCollectionExtensions.cs`).
- [x] `dotnet build src/JasperFx.AotSmoke/JasperFx.AotSmoke.csproj` — clean. The smoke project's csproj sets `IsAotCompatible=true` + `TrimMode=full` and promotes IL2026 to error, so it's the regression gate.
- [x] **`Program.cs` regression** — added a `services.CritterStackDefaults(...)` block to the AotSmoke `Program.cs`. Verified red against the pre-fix tip (`error IL2026` at the call site) and green on this branch.
- [x] `dotnet test jasperfx.sln` — 2,114 tests pass across CodegenTests, CommandLineTests, CoreTests, EventTests, EventStoreTests, SG tests on both net9.0 and net10.0.

## Out of scope
`RunJasperFxCommands` and the other `CommandLineHostingExtensions` public dispatch entry points still carry `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]`. Per the issue body those are lower priority (codegen-write is dev-only, not on the AOT-published runtime path) and warrant a separate PR. Confirmed scope with the issue author before starting.

## Version bumps (every packable project)
| Package | From | To |
|---|---|---|
| JasperFx | 2.0.0-alpha.17 | 2.0.0-alpha.18 |
| JasperFx.Events | 2.0.0-alpha.16 | 2.0.0-alpha.17 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.9 | 2.0.0-alpha.10 |
| JasperFx.SourceGenerator | 2.0.0-alpha.6 | 2.0.0-alpha.7 |
| JasperFx.SourceGeneration | 2.0.0-alpha.6 | 2.0.0-alpha.7 |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.5 | 5.0.0-alpha.6 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)