### PR TITLE
Lift SoloProjectionDistributor concrete into JasperFx.Events (closes #315)

### DIFF
--- a/src/EventTests/Daemon/SoloProjectionDistributorTests.cs
+++ b/src/EventTests/Daemon/SoloProjectionDistributorTests.cs
@@ -1,0 +1,121 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class SoloProjectionDistributorTests
+{
+    [Fact]
+    public async Task build_distribution_returns_one_set_per_database_with_all_shards()
+    {
+        var dbA = new FakeProjectionDatabase("a", new Uri("fake://a"));
+        var dbB = new FakeProjectionDatabase("b", new Uri("fake://b"));
+        var shards = new[]
+        {
+            new ShardName("Trip", "All", 1),
+            new ShardName("Day", "All", 1)
+        };
+
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { dbA, dbB }),
+            allShards: () => shards,
+            setFactory: (db, names, lockId) => new FakeProjectionSet(db, names, lockId),
+            baseLockId: 4711);
+
+        var sets = await distributor.BuildDistributionAsync();
+
+        sets.Count.ShouldBe(2);
+        sets[0].Database.Identifier.ShouldBe("a");
+        sets[1].Database.Identifier.ShouldBe("b");
+        sets[0].Names.ShouldBe(shards);
+        sets[1].Names.ShouldBe(shards);
+        sets[0].LockId.ShouldBe(4711);
+    }
+
+    [Fact]
+    public async Task build_distribution_reruns_all_shards_closure_each_call()
+    {
+        var db = new FakeProjectionDatabase("only", new Uri("fake://only"));
+        var shards = new List<ShardName> { new("Trip", "All", 1) };
+
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => shards,
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 1);
+
+        (await distributor.BuildDistributionAsync())[0].Names.Count.ShouldBe(1);
+
+        // Adding a shard after construction is picked up — the closure is re-evaluated.
+        shards.Add(new ShardName("Day", "All", 1));
+        (await distributor.BuildDistributionAsync())[0].Names.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task no_locks_in_solo_mode()
+    {
+        var set = new FakeProjectionSet(new FakeProjectionDatabase("a", new Uri("fake://a")), [], 0);
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(Array.Empty<IProjectionDatabase>()),
+            allShards: () => [],
+            setFactory: (_, _, _) => set,
+            baseLockId: 0);
+
+        distributor.HasLock(set).ShouldBeTrue();
+        (await distributor.TryAttainLockAsync(set, CancellationToken.None)).ShouldBeTrue();
+        await Should.NotThrowAsync(distributor.RandomWait(CancellationToken.None));
+        await Should.NotThrowAsync(distributor.ReleaseLockAsync(set));
+        await Should.NotThrowAsync(distributor.ReleaseAllLocks());
+        await Should.NotThrowAsync(async () => await distributor.DisposeAsync());
+    }
+
+    [Fact]
+    public void constructor_rejects_null_required_closures()
+    {
+        Should.Throw<ArgumentNullException>(() => new SoloProjectionDistributor(
+            databaseSource: null!,
+            allShards: () => [],
+            setFactory: (_, _, _) => null!,
+            baseLockId: 0));
+
+        Should.Throw<ArgumentNullException>(() => new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(Array.Empty<IProjectionDatabase>()),
+            allShards: null!,
+            setFactory: (_, _, _) => null!,
+            baseLockId: 0));
+
+        Should.Throw<ArgumentNullException>(() => new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(Array.Empty<IProjectionDatabase>()),
+            allShards: () => [],
+            setFactory: null!,
+            baseLockId: 0));
+    }
+
+    private sealed class FakeProjectionDatabase : IProjectionDatabase
+    {
+        public FakeProjectionDatabase(string identifier, Uri uri)
+        {
+            Identifier = identifier;
+            DatabaseUri = uri;
+        }
+
+        public string Identifier { get; }
+        public Uri DatabaseUri { get; }
+    }
+
+    private sealed class FakeProjectionSet : IProjectionSet
+    {
+        public FakeProjectionSet(IProjectionDatabase database, IReadOnlyList<ShardName> names, int lockId)
+        {
+            Database = database;
+            Names = names;
+            LockId = lockId;
+        }
+
+        public int LockId { get; }
+        public IProjectionDatabase Database { get; }
+        public IReadOnlyList<ShardName> Names { get; }
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.10</Version>
+        <Version>2.0.0-alpha.11</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/Daemon/SoloProjectionDistributor.cs
+++ b/src/JasperFx.Events/Daemon/SoloProjectionDistributor.cs
@@ -1,0 +1,93 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Single-node distributor — every set is owned by this node, no locks. Use when
+/// the application is known not to scale out (single-process deployments, local
+/// dev / test setups, sidecars where lock coordination is delegated upstream).
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>SoloProjectionDistributor</c> and Polecat's near-
+/// identical clone (the only difference between the two was the database-source
+/// accessor path). Each store wires this concrete with closures over its own
+/// database accessor and a factory that produces the store-specific
+/// <see cref="IProjectionSet"/> implementation. Tracked under
+/// <see href="https://github.com/JasperFx/jasperfx/issues/315">#315</see>; part
+/// of the Critter Stack 2026 dedupe pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+///
+/// All lock-coordination methods are no-ops: there is no real distributed lock
+/// since only one node ever runs. Callers should not depend on lock acquisition
+/// failing in this mode — by construction, <see cref="HasLock"/> and
+/// <see cref="TryAttainLockAsync"/> always succeed.
+/// </remarks>
+public sealed class SoloProjectionDistributor : IProjectionDistributor
+{
+    private readonly Func<ValueTask<IReadOnlyList<IProjectionDatabase>>> _databaseSource;
+    private readonly Func<IEnumerable<ShardName>> _allShards;
+    private readonly Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> _setFactory;
+    private readonly int _baseLockId;
+
+    /// <summary>
+    /// Construct a Solo distributor with store-supplied closures.
+    /// </summary>
+    /// <param name="databaseSource">
+    /// Async accessor returning every database the daemon should run shards against.
+    /// Typically wraps the store's tenancy / database collection.
+    /// </param>
+    /// <param name="allShards">
+    /// Snapshot accessor for every shard the daemon currently knows about. Re-evaluated
+    /// on each <see cref="BuildDistributionAsync"/> call so shard additions registered
+    /// after construction are picked up.
+    /// </param>
+    /// <param name="setFactory">
+    /// Factory that produces the store-specific <see cref="IProjectionSet"/> for one
+    /// (database, shards, lockId) triple. Lets each store keep its richer
+    /// <c>ProjectionSet</c> concrete (with <c>BuildDaemon()</c> / store back-reference
+    /// hooks) while sharing this distributor skeleton.
+    /// </param>
+    /// <param name="baseLockId">
+    /// Base lock identifier from the store's projection options. Solo mode never
+    /// actually takes a lock, but the value is still threaded through to the
+    /// produced <see cref="IProjectionSet"/>s so they expose the same
+    /// <see cref="IProjectionSet.LockId"/> a multi-node distributor would.
+    /// </param>
+    public SoloProjectionDistributor(
+        Func<ValueTask<IReadOnlyList<IProjectionDatabase>>> databaseSource,
+        Func<IEnumerable<ShardName>> allShards,
+        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
+        int baseLockId)
+    {
+        _databaseSource = databaseSource ?? throw new ArgumentNullException(nameof(databaseSource));
+        _allShards = allShards ?? throw new ArgumentNullException(nameof(allShards));
+        _setFactory = setFactory ?? throw new ArgumentNullException(nameof(setFactory));
+        _baseLockId = baseLockId;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync()
+    {
+        var databases = await _databaseSource().ConfigureAwait(false);
+        var shards = _allShards().ToList();
+        return databases.Select(db => _setFactory(db, shards, _baseLockId)).ToList();
+    }
+
+    /// <inheritdoc />
+    public Task RandomWait(CancellationToken token) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public bool HasLock(IProjectionSet set) => true;
+
+    /// <inheritdoc />
+    public Task<bool> TryAttainLockAsync(IProjectionSet set, CancellationToken token)
+        => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public Task ReleaseLockAsync(IProjectionSet set) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task ReleaseAllLocks() => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.17</Version>
+        <Version>2.0.0-alpha.18</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-alpha.6</Version>
+        <Version>5.0.0-alpha.7</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-alpha.7</Version>
+        <Version>2.0.0-alpha.8</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.7</Version>
+        <Version>2.0.0-alpha.8</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.18</Version>
+        <Version>2.0.0-alpha.19</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
## Summary
Marten and Polecat each carry near-identical `SoloProjectionDistributor` implementations — ~95% identical, the only difference being the database-source accessor path. Lifting this concrete (the simplest of the three distributors per #271's analysis — no lock-id semantics to coordinate) lets both stores delete their copies and construct the shared one with store-specific closures. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #315.**

## What changed
New class `JasperFx.Events.Daemon.SoloProjectionDistributor`, shaped per the issue's proposed design:

```csharp
public sealed class SoloProjectionDistributor : IProjectionDistributor
{
    public SoloProjectionDistributor(
        Func<ValueTask<IReadOnlyList<IProjectionDatabase>>> databaseSource,
        Func<IEnumerable<ShardName>> allShards,
        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
        int baseLockId)
}
```

- The `setFactory` closure lets each store keep its richer `ProjectionSet` concrete (Marten's carries a `DocumentStore` + `BuildDaemon()` method; Polecat's may grow similar hooks) while sharing this distributor's skeleton.
- `allShards` is re-evaluated on every `BuildDistributionAsync` call so shards added after construction are picked up — matching Marten's `projectionOptions.AllShards()` re-read on each build.
- `HasLock` / `TryAttainLockAsync` are unconditionally true; the release / wait / dispose methods complete synchronously. Solo means single node, no real locks.

## Test plan
- [x] `src/EventTests/Daemon/SoloProjectionDistributorTests.cs` — 4 cases covering distribution shape, all-shards re-evaluation, no-locks semantics, and constructor null-guard. All pass on net9.0 and net10.0.
- [x] `dotnet test jasperfx.sln` — full suite green.

## Downstream cleanup
Marten / Polecat each delete their `SoloProjectionDistributor` in follow-up PRs in those repos. The lifted concrete here is the shared target they construct against. Tracked under their per-store dedupe-pillar issues; this PR is the upstream prerequisite.

## Out of scope
- `SingleTenantProjectionDistributor` lift — separate issue (different lock-id concerns).
- `MultiTenantedProjectionDistributor` lift — separate issue (lock-factory plumbing).

## Version bumps (every packable project)
| Package | From | To |
|---|---|---|
| JasperFx | 2.0.0-alpha.18 | 2.0.0-alpha.19 |
| JasperFx.Events | 2.0.0-alpha.17 | 2.0.0-alpha.18 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.10 | 2.0.0-alpha.11 |
| JasperFx.SourceGenerator | 2.0.0-alpha.7 | 2.0.0-alpha.8 |
| JasperFx.SourceGeneration | 2.0.0-alpha.7 | 2.0.0-alpha.8 |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.6 | 5.0.0-alpha.7 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)