### PR TITLE
Pack and publish JasperFx.SourceGenerator (companion to the other SG packages)

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -140,7 +140,8 @@ partial class Build : NukeBuild
                 Solution.JasperFx_RuntimeCompiler,
                 Solution.JasperFx_Events,
                 Solution.src.JasperFx_Events_SourceGenerator,
-                Solution.src.JasperFx_SourceGeneration
+                Solution.src.JasperFx_SourceGeneration,
+                Solution.src.JasperFx_SourceGenerator
             };
 
             foreach (var project in projects)

--- a/jasperfx.sln
+++ b/jasperfx.sln
@@ -75,6 +75,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLineBenchmarks", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JasperFx.AotSmoke", "src\JasperFx.AotSmoke\JasperFx.AotSmoke.csproj", "{8FB8216F-216F-480F-9519-A5893F7F3151}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JasperFx.SourceGenerator", "src\JasperFx.SourceGenerator\JasperFx.SourceGenerator.csproj", "{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -403,6 +405,18 @@ Global
 		{8FB8216F-216F-480F-9519-A5893F7F3151}.Release|x64.Build.0 = Release|Any CPU
 		{8FB8216F-216F-480F-9519-A5893F7F3151}.Release|x86.ActiveCfg = Release|Any CPU
 		{8FB8216F-216F-480F-9519-A5893F7F3151}.Release|x86.Build.0 = Release|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Debug|x64.Build.0 = Debug|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Debug|x86.Build.0 = Debug|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Release|x64.ActiveCfg = Release|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Release|x64.Build.0 = Release|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Release|x86.ActiveCfg = Release|Any CPU
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -423,5 +437,6 @@ Global
 		{37E2EECE-FF24-4D39-96B6-BED9BCE8D1D4} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{8D7BF9A9-0345-4FBA-9972-1F8413006DC2} = {A1BBEFB2-1FDB-4A32-8D00-DD5AA8E1E43A}
 		{8FB8216F-216F-480F-9519-A5893F7F3151} = {A1BBEFB2-1FDB-4A32-8D00-DD5AA8E1E43A}
+		{E48F04F5-A8A3-4C47-9965-53C9D5DDC806} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
`JasperFx.SourceGenerator` (the `IDescribeMyself.ToDescription()` analyzer) was in `src/` and carried `<PackageId>` / `<Version>` in its csproj, but was missing from `jasperfx.sln` entirely — which meant `Build.cs`'s `NugetPack` target couldn't enumerate it (the existing list uses `Solution.src.JasperFx_SourceGenerator` via the typed accessor, generated only for projects in the sln). Net effect: every alpha publish since the package was introduced shipped its five siblings but silently skipped this one. NuGet returns 404 for it today.

This is the first publish of the package — version stays at the existing `2.0.0-alpha.9` on main (no bump needed since NuGet has nothing to compare against).

## What changed
- `dotnet sln jasperfx.sln add src/JasperFx.SourceGenerator/...` registers the project under a fresh GUID + standard configuration sections, matching how `JasperFx.SourceGeneration` is registered.
- One line added to the `projects[]` array in `Build.cs`'s `NugetPack` target so the typed `Solution.src.JasperFx_SourceGenerator` accessor is hit alongside the other SG packages.

## Test plan
- [x] `dotnet build build/Build.csproj` — clean (the typed accessor resolves now that the project is in the sln).
- [x] `dotnet pack src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj -c Release` locally — produces `JasperFx.SourceGenerator.2.0.0-alpha.9.nupkg` shipping `analyzers/dotnet/cs/JasperFx.SourceGenerator.dll`, the same on-wire shape as the existing `JasperFx.SourceGeneration` and `JasperFx.Events.SourceGenerator` packages.
- [x] `dotnet build jasperfx.sln` — solution-wide build clean.

## After merge
Trigger `on-manual-do-nuget-publish.yml` to ship the first `JasperFx.SourceGenerator 2.0.0-alpha.9` to NuGet alongside the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)