### PR TITLE
Recover SingleTenantProjectionDistributor onto main + JasperFx.Events alpha.20 (closes #322)

### DIFF
--- a/src/EventTests/Daemon/SingleTenantProjectionDistributorTests.cs
+++ b/src/EventTests/Daemon/SingleTenantProjectionDistributorTests.cs
@@ -1,0 +1,209 @@
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class SingleTenantProjectionDistributorTests
+{
+    // Regression guard for #317's acceptance bullet: "asserts the lifted distributor
+    // produces lock ids identical to Marten's current formula for a sample
+    // (schema, shardName, baseLockId) tuple." Marten's pre-lift formula was:
+    //
+    //   Math.Abs($"{schema}:{shardName.Identity}".GetDeterministicHashCode()) + baseLockId
+    //
+    // The lifted distributor routes through ProjectionLockIds.Compute. This test
+    // pins the formula equivalence — if either side ever drifts, both downstream
+    // stores' lock namespaces shift and existing deployments lose lock continuity.
+    [Theory]
+    [InlineData("public", "Trip", "All", 1u, 4711)]
+    [InlineData("events", "Day", "All", 1u, 0)]
+    [InlineData("schema_with_underscore", "Multi", "Tenant", 3u, 1_000_000)]
+    public void lock_id_formula_matches_martens_pre_lift_formula(
+        string schemaQualifier, string projection, string key, uint version, int baseLockId)
+    {
+        var shard = new ShardName(projection, key, version);
+        var expected = Math.Abs(
+            $"{schemaQualifier}:{shard.Identity}".GetDeterministicHashCode())
+            + baseLockId;
+
+        ProjectionLockIds.Compute(schemaQualifier, shard, baseLockId).ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task build_distribution_emits_one_set_per_shard()
+    {
+        var db = new FakeProjectionDatabase("only");
+        var shards = new[]
+        {
+            new ShardName("Trip", "All", 1),
+            new ShardName("Day", "All", 1),
+            new ShardName("Activity", "All", 1)
+        };
+
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => shards,
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 100);
+
+        var sets = await distributor.BuildDistributionAsync();
+
+        sets.Count.ShouldBe(3);
+        foreach (var set in sets)
+        {
+            set.Names.Count.ShouldBe(1);
+            set.Database.ShouldBe(db);
+        }
+
+        // Each set carries the Marten-canonical lock id for its single shard.
+        var byShard = sets.ToDictionary(s => s.Names[0].Identity);
+        foreach (var shard in shards)
+        {
+            byShard[shard.Identity].LockId.ShouldBe(
+                ProjectionLockIds.Compute("public", shard, 100));
+        }
+    }
+
+    [Fact]
+    public async Task try_attain_lock_caches_one_advisory_lock_per_database()
+    {
+        var db = new FakeProjectionDatabase("only");
+        var built = 0;
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { new ShardName("Trip", "All", 1), new ShardName("Day", "All", 1) },
+            lockFactory: _ =>
+            {
+                built++;
+                return new FakeAdvisoryLock();
+            },
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0);
+
+        foreach (var set in await distributor.BuildDistributionAsync())
+        {
+            await distributor.TryAttainLockAsync(set, CancellationToken.None);
+        }
+
+        // One advisory lock per database, regardless of how many shards.
+        built.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task release_all_locks_disposes_every_cached_lock_and_swallows_exceptions()
+    {
+        var db = new FakeProjectionDatabase("only");
+        var advisoryLock = new FakeAdvisoryLock { ThrowOnDispose = true };
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => advisoryLock,
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0);
+
+        var set = (await distributor.BuildDistributionAsync())[0];
+        await distributor.TryAttainLockAsync(set, CancellationToken.None);
+
+        await Should.NotThrowAsync(distributor.ReleaseAllLocks());
+        advisoryLock.Disposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task dispose_async_releases_all_locks()
+    {
+        var db = new FakeProjectionDatabase("only");
+        var disposed = false;
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock { OnDispose = () => disposed = true },
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0);
+
+        var set = (await distributor.BuildDistributionAsync())[0];
+        await distributor.TryAttainLockAsync(set, CancellationToken.None);
+
+        await distributor.DisposeAsync();
+        disposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void constructor_rejects_null_required_closures_and_schema()
+    {
+        Func<IProjectionDatabase> db = () => new FakeProjectionDatabase("x");
+        Func<IEnumerable<ShardName>> shards = Array.Empty<ShardName>;
+        Func<IProjectionDatabase, IAdvisoryLock> locks = _ => new FakeAdvisoryLock();
+        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> sets =
+            (database, names, lockId) => new FakeProjectionSet(database, names, lockId);
+
+        Should.Throw<ArgumentNullException>(() => new SingleTenantProjectionDistributor(null!, shards, locks, sets, "public", 0));
+        Should.Throw<ArgumentNullException>(() => new SingleTenantProjectionDistributor(db, null!, locks, sets, "public", 0));
+        Should.Throw<ArgumentNullException>(() => new SingleTenantProjectionDistributor(db, shards, null!, sets, "public", 0));
+        Should.Throw<ArgumentNullException>(() => new SingleTenantProjectionDistributor(db, shards, locks, null!, "public", 0));
+        Should.Throw<ArgumentNullException>(() => new SingleTenantProjectionDistributor(db, shards, locks, sets, null!, 0));
+    }
+
+    private sealed class FakeProjectionDatabase : IProjectionDatabase
+    {
+        public FakeProjectionDatabase(string identifier)
+        {
+            Identifier = identifier;
+            DatabaseUri = new Uri($"fake://{identifier}");
+        }
+
+        public string Identifier { get; }
+        public Uri DatabaseUri { get; }
+    }
+
+    private sealed class FakeProjectionSet : IProjectionSet
+    {
+        public FakeProjectionSet(IProjectionDatabase database, IReadOnlyList<ShardName> names, int lockId)
+        {
+            Database = database;
+            Names = names;
+            LockId = lockId;
+        }
+
+        public int LockId { get; }
+        public IProjectionDatabase Database { get; }
+        public IReadOnlyList<ShardName> Names { get; }
+    }
+
+    private sealed class FakeAdvisoryLock : IAdvisoryLock
+    {
+        public HashSet<int> HeldIds { get; } = new();
+        public bool Disposed { get; private set; }
+        public bool ThrowOnDispose { get; init; }
+        public Action? OnDispose { get; init; }
+
+        public bool HasLock(int lockId) => HeldIds.Contains(lockId);
+
+        public Task<bool> TryAttainLockAsync(int lockId, CancellationToken token)
+        {
+            HeldIds.Add(lockId);
+            return Task.FromResult(true);
+        }
+
+        public Task ReleaseLockAsync(int lockId)
+        {
+            HeldIds.Remove(lockId);
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            OnDispose?.Invoke();
+            if (ThrowOnDispose) throw new InvalidOperationException("simulated shutdown failure");
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/SingleTenantProjectionDistributor.cs
+++ b/src/JasperFx.Events/Daemon/SingleTenantProjectionDistributor.cs
@@ -1,0 +1,163 @@
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Multi-node, single-tenant distributor. One <see cref="IProjectionSet"/> per
+/// shard — per-shard lock granularity, so different shards can be picked up by
+/// different nodes in parallel. Trades the simpler "tenant on a single node"
+/// invariant for finer-grained scaling.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's and Polecat's near-identical <c>SingleTenantProjectionDistributor</c>
+/// concretes. Skeleton, lifecycle, and lock dispatch were already byte-identical;
+/// the only meaningful divergence was the deterministic lock-id formula, which is
+/// resolved by routing both stores through
+/// <see cref="ProjectionLockIds.Compute"/> (Marten's formula is canonical —
+/// Polecat aligns to it via <see href="https://github.com/JasperFx/polecat/issues/117">polecat#117</see>).
+/// See <see href="https://github.com/JasperFx/jasperfx/issues/317">#317</see>;
+/// part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+///
+/// Shares the per-database advisory-lock caching and shutdown-resilience pattern
+/// with <see cref="MultiTenantedProjectionDistributor"/>. The two distributors
+/// differ only in distribution granularity: SingleTenant emits one
+/// <see cref="IProjectionSet"/> per shard, MultiTenanted emits one per database.
+/// </remarks>
+public class SingleTenantProjectionDistributor : IProjectionDistributor
+{
+    private readonly Func<IProjectionDatabase> _databaseAccessor;
+    private readonly Func<IEnumerable<ShardName>> _allShards;
+    private readonly Func<IProjectionDatabase, IAdvisoryLock> _lockFactory;
+    private readonly Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> _setFactory;
+    private readonly string _schemaQualifier;
+    private readonly int _baseLockId;
+    private readonly Dictionary<string, IAdvisoryLock> _locks = new();
+
+    /// <summary>
+    /// Construct a single-tenant distributor with store-supplied closures.
+    /// </summary>
+    /// <param name="databaseAccessor">
+    /// Accessor returning the single database this daemon runs against. Single-tenant
+    /// deployments expose exactly one database; the closure shape (rather than a
+    /// captured value) lets the consumption site lazily resolve from the store's
+    /// tenancy after construction.
+    /// </param>
+    /// <param name="allShards">
+    /// Snapshot accessor for every shard the daemon currently knows about. Re-evaluated
+    /// on each <see cref="BuildDistributionAsync"/> call so shards added after
+    /// construction are picked up.
+    /// </param>
+    /// <param name="lockFactory">
+    /// Per-database lock factory. See
+    /// <see cref="MultiTenantedProjectionDistributor"/> for the same closure shape.
+    /// </param>
+    /// <param name="setFactory">
+    /// Factory that produces the store-specific <see cref="IProjectionSet"/> for one
+    /// (database, [single-shard], computed-lockId) triple.
+    /// </param>
+    /// <param name="schemaQualifier">
+    /// Schema-name prefix mixed into <see cref="ProjectionLockIds.Compute"/> so the
+    /// computed lock identifier is stable across nodes (every node mixes in the
+    /// same schema name + shard identity). Marten threads its
+    /// <c>EventGraph.DatabaseSchemaName</c> here.
+    /// </param>
+    /// <param name="baseLockId">
+    /// Base lock identifier from the store's projection options. Added to the
+    /// schema-+-shard hash so every produced shard set gets a stable but
+    /// deployment-isolated lock id.
+    /// </param>
+    public SingleTenantProjectionDistributor(
+        Func<IProjectionDatabase> databaseAccessor,
+        Func<IEnumerable<ShardName>> allShards,
+        Func<IProjectionDatabase, IAdvisoryLock> lockFactory,
+        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
+        string schemaQualifier,
+        int baseLockId)
+    {
+        _databaseAccessor = databaseAccessor ?? throw new ArgumentNullException(nameof(databaseAccessor));
+        _allShards = allShards ?? throw new ArgumentNullException(nameof(allShards));
+        _lockFactory = lockFactory ?? throw new ArgumentNullException(nameof(lockFactory));
+        _setFactory = setFactory ?? throw new ArgumentNullException(nameof(setFactory));
+        _schemaQualifier = schemaQualifier ?? throw new ArgumentNullException(nameof(schemaQualifier));
+        _baseLockId = baseLockId;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync()
+    {
+        var database = _databaseAccessor();
+
+        // One IProjectionSet per shard — per-shard lock granularity. Shuffle the
+        // result so multiple nodes coming up at the same time don't race for locks
+        // in identical order (same trick MultiTenanted uses, same trick both
+        // Marten and Polecat already shipped).
+        IReadOnlyList<IProjectionSet> sets = _allShards()
+            .Select(shard => _setFactory(
+                database,
+                [shard],
+                ProjectionLockIds.Compute(_schemaQualifier, shard, _baseLockId)))
+            .OrderBy(_ => Random.Shared.NextDouble())
+            .ToList();
+
+        return ValueTask.FromResult(sets);
+    }
+
+    /// <summary>
+    /// Apply a 0–500ms random delay before polling. Virtual so tests can stub
+    /// out the wait without touching <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.
+    /// </summary>
+    public virtual Task RandomWait(CancellationToken token)
+        => Task.Delay(Random.Shared.Next(0, 500).Milliseconds(), token);
+
+    /// <inheritdoc />
+    public bool HasLock(IProjectionSet set)
+        => _locks.TryGetValue(set.Database.Identifier, out var advisoryLock)
+           && advisoryLock.HasLock(set.LockId);
+
+    /// <inheritdoc />
+    public Task<bool> TryAttainLockAsync(IProjectionSet set, CancellationToken token)
+        => LockFor(set.Database).TryAttainLockAsync(set.LockId, token);
+
+    /// <inheritdoc />
+    public Task ReleaseLockAsync(IProjectionSet set)
+        => LockFor(set.Database).ReleaseLockAsync(set.LockId);
+
+    /// <inheritdoc />
+    public async Task ReleaseAllLocks()
+    {
+        foreach (var advisoryLock in _locks.Values)
+        {
+            try
+            {
+                await advisoryLock.DisposeAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Swallow shutdown failures — advisory locks can hang in test
+                // harnesses, best-effort release is the correct shutdown contract.
+                // Carried over from both Marten's and Polecat's source.
+            }
+        }
+
+        _locks.Clear();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await ReleaseAllLocks().ConfigureAwait(false);
+    }
+
+    private IAdvisoryLock LockFor(IProjectionDatabase database)
+    {
+        if (!_locks.TryGetValue(database.Identifier, out var advisoryLock))
+        {
+            advisoryLock = _lockFactory(database);
+            _locks[database.Identifier] = advisoryLock;
+        }
+
+        return advisoryLock;
+    }
+}

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.19</Version>
+        <Version>2.0.0-alpha.20</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the


### PR DESCRIPTION
## Summary
Fixes the broken delivery documented in #322: `JasperFx.Events 2.0.0-alpha.19` shipped the Solo + MultiTenanted distributors but **not** `SingleTenantProjectionDistributor`, because PR #320 merged into the stacked base branch (`feat/316-lift-multitenanted-distributor`) **after** PR #319 had already merged that branch to main — so the SingleTenant code landed in a now-orphaned branch and never reached `main`. **Closes #322** (and completes the delivery of the already-closed #317).

This is the cherry-pick-to-main + new-alpha fix the issue's "Suggested fix" calls for (items 1 and 2).

## What changed
- `src/JasperFx.Events/Daemon/SingleTenantProjectionDistributor.cs` — recovered verbatim from commit `547dd24` (the content reviewed in #320).
- `src/EventTests/Daemon/SingleTenantProjectionDistributorTests.cs` — 8 tests including the lock-id formula regression Theory pinning `ProjectionLockIds.Compute` to Marten's pre-lift formula.
- `JasperFx.Events` bumped 2.0.0-alpha.19 → **2.0.0-alpha.20** — the only package whose content changed.

`IAdvisoryLock` (the only cross-file dependency) is already on main via #319, so the recovered code compiles and tests as-is.

## Test plan
- [x] `dotnet build src/JasperFx.Events` — clean.
- [x] `dotnet test ... --filter SingleTenantProjectionDistributor` — 8/8 on net9.0 and net10.0.
- [x] CI green.

## Publish
After merge, dispatch `on-manual-do-nuget-publish.yml`. Only `JasperFx.Events 2.0.0-alpha.20` actually pushes — the other five packages keep their current versions and are no-op'd by `--skip-duplicate`.

## Downstream (out of scope for this repo)
Issue #322's item 3 — updating the [polecat#119](https://github.com/JasperFx/polecat/issues/119) foundation-matrix chip to reference Events alpha.20 — lives in the Polecat repo and is handled by Polecat's own Phase-2 adoption work, which this publish unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)