### PR TITLE
Source-generate an evolver for identity-less DCB boundary aggregates (closes #324)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -225,6 +225,69 @@ public class SomeEvent { }
         generatedSources.ShouldBeEmpty();
     }
 
+    // Regression for #324: a pure DCB boundary aggregate has Apply methods but no
+    // single-stream identity (no Id, no [AggregateIdentity]). Without opt-in the SG
+    // emits nothing (see skips_type_without_id_property above). Marking the type
+    // [BoundaryAggregate] opts it into evolver generation, keyed on string TId to
+    // match the SingleStreamProjection<T, string> the DCB aggregator builds.
+    [Fact]
+    public void generates_string_keyed_evolver_for_boundary_aggregate_with_attribute()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+
+namespace Test;
+
+[BoundaryAggregate]
+public class SubscriptionState
+{
+    public int Count { get; set; }
+    public void Apply(Subscribed e) { Count++; }
+}
+
+public class Subscribed { }
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        generatedSources.Length.ShouldBeGreaterThan(0);
+        var generated = generatedSources[0];
+        // The evolver class carries the _String TId-disambiguation suffix
+        // (BuildUniqueEvolverName) since the boundary aggregate has no own Id.
+        generated.ShouldContain("SubscriptionState_StringEvolver");
+        // Identity-less boundary aggregate is keyed on string (decision B in #324).
+        generated.ShouldContain("global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<global::Test.SubscriptionState, string>");
+        generated.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.SubscriptionState)");
+        generated.ShouldContain("snapshot.Apply(data)");
+    }
+
+    // Negative half of #324: the marker is required. An identity-less aggregate
+    // WITHOUT [BoundaryAggregate] still emits nothing — a bare no-Id aggregate is far
+    // more likely a forgot-the-Id mistake than an intentional boundary aggregate, and
+    // we don't want to silently swallow that into a string-keyed evolver.
+    [Fact]
+    public void skips_identity_less_aggregate_without_boundary_attribute()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public class SubscriptionState
+{
+    public int Count { get; set; }
+    public void Apply(Subscribed e) { Count++; }
+}
+
+public class Subscribed { }
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        generatedSources.ShouldBeEmpty();
+    }
+
     [Fact]
     public void generates_determine_action_for_self_aggregating_with_should_delete()
     {

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -167,7 +167,7 @@ internal static class AggregateAnalyzer
         // Not a projection subclass - check if self-aggregating
         if (!IsProjectionBase(classSymbol))
         {
-            return AnalyzeSelfAggregating(classDecl, classSymbol, ct);
+            return AnalyzeSelfAggregating(classDecl, classSymbol, context.SemanticModel, ct);
         }
 
         return null;
@@ -221,6 +221,7 @@ internal static class AggregateAnalyzer
     private static CandidateInfo? AnalyzeSelfAggregating(
         TypeDeclarationSyntax classDecl,
         INamedTypeSymbol classSymbol,
+        SemanticModel semanticModel,
         CancellationToken ct)
     {
         // Check for Evolve/EvolveAsync methods first — these take priority
@@ -233,7 +234,18 @@ internal static class AggregateAnalyzer
 
         // Infer TId from Id property or AggregateIdentityAttribute
         var idType = InferIdentityType(classSymbol);
-        if (idType == null) return null; // Will emit diagnostic elsewhere
+        if (idType == null)
+        {
+            // Identity-less "boundary" aggregate (DCB): no Id and no [AggregateIdentity],
+            // so there's nothing to key a single stream on. We only emit an evolver when
+            // the type opts in with [BoundaryAggregate] — a bare no-Id aggregate is far
+            // more likely a mistake (forgot the Id) than an intentional boundary aggregate,
+            // and we don't want to silently swallow that. When opted in, default TId to
+            // string to match the SingleStreamProjection<T, string> the DCB aggregator
+            // builds; the id is vestigial for boundary dispatch. See #324.
+            if (!HasBoundaryAggregateAttribute(classSymbol)) return null;
+            idType = semanticModel.Compilation.GetSpecialType(SpecialType.System_String);
+        }
 
         return new CandidateInfo
         {
@@ -1250,6 +1262,16 @@ internal static class AggregateAnalyzer
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// True when the aggregate type opts into identity-less boundary-aggregate evolver
+    /// generation via [BoundaryAggregate] (JasperFx.Events.Aggregation). See #324.
+    /// </summary>
+    private static bool HasBoundaryAggregateAttribute(INamedTypeSymbol classSymbol)
+    {
+        return classSymbol.GetAttributes()
+            .Any(a => a.AttributeClass?.Name is "BoundaryAggregateAttribute" or "BoundaryAggregate");
     }
 
     public static INamedTypeSymbol? InferIdentityType(INamedTypeSymbol classSymbol)

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.12</Version>
+        <Version>2.0.0-alpha.13</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/Aggregation/BoundaryAggregateAttribute.cs
+++ b/src/JasperFx.Events/Aggregation/BoundaryAggregateAttribute.cs
@@ -1,0 +1,35 @@
+namespace JasperFx.Events.Aggregation;
+
+/// <summary>
+/// Marks an identity-less "boundary" aggregate — one with conventional
+/// <c>Apply</c> / <c>Create</c> methods but no single-stream identity (no <c>Id</c>
+/// property and no <see cref="AggregateIdentityAttribute"/>) — so the source
+/// generator emits an evolver for it.
+/// </summary>
+/// <remarks>
+/// Boundary aggregates span multiple streams by tag rather than being keyed to a
+/// single stream id. They are fetched via the Dynamic Consistency Boundary (DCB)
+/// surface — e.g. Marten's <c>FetchForWritingByTags&lt;T&gt;</c> /
+/// <c>AggregateByTagsAsync&lt;T&gt;</c>, registered through
+/// <c>RegisterTagType&lt;...&gt;().ForAggregate&lt;T&gt;()</c>.
+///
+/// Without a single-stream identity the generator cannot infer a <c>TId</c>, so by
+/// default it emits nothing and the runtime throws
+/// <c>InvalidProjectionException: No source-generated dispatcher found</c> when the
+/// aggregate is fetched. Applying this attribute to the (partial) aggregate type
+/// opts it into evolver generation: the generator emits an
+/// <c>IGeneratedSyncEvolver&lt;TDoc, string&gt;</c> built from the type's
+/// <c>Apply</c> / <c>Create</c> methods (the <c>string</c> TId is vestigial — it
+/// matches the <c>SingleStreamProjection&lt;T, string&gt;</c> the DCB aggregator
+/// builds and is never used by boundary-aggregate dispatch).
+///
+/// The attribute must sit on the aggregate type in <b>its own defining assembly</b>:
+/// that is the compilation the generator emits the
+/// <see cref="GeneratedEvolverAttribute"/> into, and it is the assembly the runtime
+/// scans (<c>typeof(TDoc).Assembly</c>) when resolving the evolver. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/324">#324</see>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class)]
+public class BoundaryAggregateAttribute : Attribute
+{
+}

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.20</Version>
+        <Version>2.0.0-alpha.21</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the


### PR DESCRIPTION
## Summary
A pure DCB boundary aggregate — `Apply`/`Create` methods but no single-stream identity (no `Id`, no `[AggregateIdentity]`), registered only via `RegisterTagType<...>().ForAggregate<T>()` — had no way to get a source-generated evolver. `AggregateAnalyzer.AnalyzeSelfAggregating` bailed when `InferIdentityType` returned null, so the SG emitted nothing and Marten's `FetchForWritingByTags<T>` threw `InvalidProjectionException: No source-generated dispatcher found for SingleStreamProjection<T, string>` (consumer report: marten#4510). **Closes #324.**

## Design decisions (both confirmed with the issue author)
- **B. Evolver contract** — reuse `IGeneratedSyncEvolver<TDoc, string>`. The `string` TId matches the `SingleStreamProjection<T, string>` that `AggregatorFor<T>` already builds, so the existing runtime scan resolves it with **no runtime change**. The TId is vestigial for boundary dispatch.
- **C. SG trigger** — opt-in `[BoundaryAggregate]` marker attribute on the aggregate type. A generator can only emit into the compilation it runs in, but the runtime scans `typeof(TDoc).Assembly` for the `[assembly: GeneratedEvolver]` registration — so the trigger must live in the aggregate's own assembly. A marker attribute does exactly that and sidesteps the cross-assembly hole that keying off `ForAggregate<T>()` call sites would open. Zero false positives: a bare no-Id aggregate stays unemitted (far more likely a forgot-the-Id mistake than an intentional boundary aggregate).

## Changes
- New `JasperFx.Events.Aggregation.BoundaryAggregateAttribute`.
- `AggregateAnalyzer.AnalyzeSelfAggregating`: when `InferIdentityType` returns null, emit only if `[BoundaryAggregate]` is present, defaulting TId to `System.String`.
- The emitter is unchanged — with TId defaulted to string it produces an ordinary `IGeneratedSyncEvolver<TDoc, string>` (named `{Type}_StringEvolver` via the existing TId-disambiguation path).

## Test plan
- [x] `generates_string_keyed_evolver_for_boundary_aggregate_with_attribute` — verified red without the analyzer change, green with it.
- [x] `skips_identity_less_aggregate_without_boundary_attribute` — the marker is required; no silent swallow.
- [x] 16/16 SG tests; 279/279 EventTests on net9.0 and net10.0.

## Version bumps — two packages because the feature spans both
The attribute (consumer-referenced) and the analyzer that acts on it live in different packages, so both must ship together or the feature is dead on arrival:
| Package | From | To |
|---|---|---|
| JasperFx.Events | 2.0.0-alpha.20 | 2.0.0-alpha.21 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.12 | 2.0.0-alpha.13 |

> Heads-up: the issue text asked to bump JasperFx.Events; I've also bumped JasperFx.Events.SourceGenerator since the analyzer change ships there. Without both, consumers get the attribute but no generator that recognizes it.

## Consumer wiring (separate, marten#4510)
`ForAggregate<T>()` registration consuming the emitted evolver + applying `[BoundaryAggregate]` to Marten's DCB boundary aggregate types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)