### PR TITLE
Lift ProjectionCoordinatorBase execute loop into JasperFx.Events (closes #326)

### DIFF
--- a/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
+++ b/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
@@ -1,0 +1,257 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using Polly;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class ProjectionCoordinatorBaseTests
+{
+    private static readonly ShardName TheShard = new("Trip", "All", 1);
+
+    private static TestCoordinator BuildCoordinator(FakeDistributor distributor, FakeDaemon daemon)
+    {
+        return new TestCoordinator(
+            distributor,
+            daemon,
+            leadershipPollingTime: TimeSpan.FromSeconds(30),
+            agentPauseTime: TimeSpan.FromSeconds(30),
+            healthCheckPollingTime: TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public async Task starts_agents_for_a_set_we_already_hold_the_lock_for()
+    {
+        var set = new FakeProjectionSet("db1", [TheShard], 100);
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([set]) { LockHeld = true };
+
+        var coordinator = BuildCoordinator(distributor, daemon);
+        await coordinator.StartAsync(CancellationToken.None);
+
+        await WaitFor(() => daemon.Started.Contains(TheShard.Identity));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Started.ShouldContain(TheShard.Identity);
+    }
+
+    // The behavioral fix from #326: Polecat called StartAgentAsync raw — no
+    // resilience, no lock-release-on-failure. The shared loop adopts Marten's
+    // resilient tryStartAgent, so a failed agent start now releases the set's lock
+    // (and ejects a paused shard) so another node can pick the set up.
+    [Fact]
+    public async Task releases_lock_when_agent_start_fails()
+    {
+        var set = new FakeProjectionSet("db1", [TheShard], 100);
+        var daemon = new FakeDaemon { ThrowOnStart = true, StatusAfterFailure = AgentStatus.Paused };
+        var distributor = new FakeDistributor([set]) { LockHeld = true };
+
+        var coordinator = BuildCoordinator(distributor, daemon);
+        await coordinator.StartAsync(CancellationToken.None);
+
+        await WaitFor(() => distributor.ReleasedLocks.Contains(set));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        distributor.ReleasedLocks.ShouldContain(set);
+        daemon.Ejected.ShouldContain(TheShard.Identity);
+    }
+
+    [Fact]
+    public async Task stops_agents_for_a_set_whose_lock_we_could_not_attain()
+    {
+        var set = new FakeProjectionSet("db1", [TheShard], 100);
+        // We don't hold the lock and can't attain it — a set we used to run must be stopped.
+        var daemon = new FakeDaemon { Status = AgentStatus.Running };
+        var distributor = new FakeDistributor([set]) { LockHeld = false, CanAttain = false };
+
+        var coordinator = BuildCoordinator(distributor, daemon);
+        await coordinator.StartAsync(CancellationToken.None);
+
+        await WaitFor(() => daemon.Stopped.Contains(TheShard.Identity));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Stopped.ShouldContain(TheShard.Identity);
+    }
+
+    [Fact]
+    public async Task stop_releases_all_locks_and_disposes_daemons()
+    {
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([]);
+
+        var coordinator = BuildCoordinator(distributor, daemon);
+        await coordinator.StartAsync(CancellationToken.None);
+        // Touch the cache so there is a daemon to dispose / stop.
+        coordinator.ForceResolve();
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        distributor.ReleaseAllLocksCount.ShouldBeGreaterThanOrEqualTo(1);
+        daemon.DisposeCount.ShouldBeGreaterThanOrEqualTo(1);
+        daemon.StopAllCount.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    private static async Task WaitFor(Func<bool> condition, int timeoutMs = 3000)
+    {
+        var elapsed = 0;
+        while (!condition() && elapsed < timeoutMs)
+        {
+            await Task.Delay(25);
+            elapsed += 25;
+        }
+    }
+
+    private sealed class TestCoordinator : ProjectionCoordinatorBase
+    {
+        private readonly FakeDaemon _daemon;
+
+        public TestCoordinator(IProjectionDistributor distributor, FakeDaemon daemon,
+            TimeSpan leadershipPollingTime, TimeSpan agentPauseTime, TimeSpan healthCheckPollingTime)
+            : base(distributor, NullLogger.Instance, ResiliencePipeline.Empty, TimeProvider.System,
+                leadershipPollingTime, agentPauseTime, healthCheckPollingTime)
+        {
+            _daemon = daemon;
+        }
+
+        private bool _resolved;
+
+        public void ForceResolve() => _resolved = true;
+
+        protected override IProjectionDaemon ResolveDaemon(IProjectionSet set)
+        {
+            _resolved = true;
+            return _daemon;
+        }
+
+        protected override IReadOnlyList<IProjectionDaemon> ResolvedDaemons()
+            => _resolved ? [_daemon] : [];
+
+        public override IProjectionDaemon DaemonForMainDatabase() => _daemon;
+
+        public override ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier)
+            => new(_daemon);
+
+        public override ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync()
+            => new(new IProjectionDaemon[] { _daemon });
+    }
+
+    private sealed class FakeProjectionSet(string id, IReadOnlyList<ShardName> names, int lockId) : IProjectionSet
+    {
+        public int LockId { get; } = lockId;
+        public IProjectionDatabase Database { get; } = new FakeDatabase(id);
+        public IReadOnlyList<ShardName> Names { get; } = names;
+    }
+
+    private sealed class FakeDatabase(string id) : IProjectionDatabase
+    {
+        public string Identifier { get; } = id;
+        public Uri DatabaseUri { get; } = new($"fake://{id}");
+    }
+
+    private sealed class FakeDistributor(IReadOnlyList<IProjectionSet> sets) : IProjectionDistributor
+    {
+        public bool LockHeld { get; init; }
+        public bool CanAttain { get; init; } = true;
+        public List<IProjectionSet> ReleasedLocks { get; } = [];
+        public int ReleaseAllLocksCount { get; private set; }
+
+        public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync() => new(sets);
+        public Task RandomWait(CancellationToken token) => Task.CompletedTask;
+        public bool HasLock(IProjectionSet set) => LockHeld;
+        public Task<bool> TryAttainLockAsync(IProjectionSet set, CancellationToken token) => Task.FromResult(CanAttain);
+
+        public Task ReleaseLockAsync(IProjectionSet set)
+        {
+            ReleasedLocks.Add(set);
+            return Task.CompletedTask;
+        }
+
+        public Task ReleaseAllLocks()
+        {
+            ReleaseAllLocksCount++;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    // IProjectionDaemon is large; the coordinator loop only touches the members
+    // implemented here. The rest throw so an accidental new dependency surfaces loudly.
+    private sealed class FakeDaemon : IProjectionDaemon
+    {
+        public bool ThrowOnStart { get; init; }
+        public AgentStatus Status { get; init; } = AgentStatus.Stopped;
+        public AgentStatus StatusAfterFailure { get; init; } = AgentStatus.Stopped;
+
+        public List<string> Started { get; } = [];
+        public List<string> Stopped { get; } = [];
+        public List<string> Ejected { get; } = [];
+        public int DisposeCount { get; private set; }
+        public int StopAllCount { get; private set; }
+
+        private bool _failed;
+
+        public Task StartAgentAsync(string shardName, CancellationToken token)
+        {
+            if (ThrowOnStart)
+            {
+                _failed = true;
+                throw new InvalidOperationException("boom");
+            }
+
+            Started.Add(shardName);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAgentAsync(string shardName, Exception? ex = null)
+        {
+            Stopped.Add(shardName);
+            return Task.CompletedTask;
+        }
+
+        public AgentStatus StatusFor(string shardName)
+        {
+            if (_failed) return StatusAfterFailure;
+            return Status;
+        }
+
+        public IReadOnlyList<ISubscriptionAgent> CurrentAgents() => [];
+        public bool HasAnyPaused() => false;
+
+        public void EjectPausedShard(string shardName) => Ejected.Add(shardName);
+
+        public Task StopAllAsync()
+        {
+            StopAllCount++;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() => DisposeCount++;
+
+        // ---- Unused by the coordinator loop ----
+        public Task PrepareForRebuildsAsync() => throw new NotSupportedException();
+        public ShardStateTracker Tracker => throw new NotSupportedException();
+        public bool IsRunning => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(string projectionName, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync<TView>(CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(Type projectionType, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(Type projectionType, TimeSpan shardTimeout, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(string projectionName, TimeSpan shardTimeout, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync<TView>(TimeSpan shardTimeout, CancellationToken token) => throw new NotSupportedException();
+        public Task<ISubscriptionAgent> StartAgentAsync(ShardName name, CancellationToken token) => throw new NotSupportedException();
+        public Task StopAgentAsync(ShardName shardName, Exception? ex = null) => throw new NotSupportedException();
+        public Task StartAllAsync() => throw new NotSupportedException();
+        public Task CatchUpAsync(CancellationToken cancellation) => throw new NotSupportedException();
+        public Task CatchUpAsync(TimeSpan timeout, CancellationToken cancellation) => throw new NotSupportedException();
+        public Task WaitForNonStaleData(TimeSpan timeout) => throw new NotSupportedException();
+        public long HighWaterMark() => throw new NotSupportedException();
+        public Task WaitForShardToBeRunning(string shardName, TimeSpan timeout) => throw new NotSupportedException();
+        public Task RewindSubscriptionAsync(string subscriptionName, CancellationToken token, long? sequenceFloor = 0, DateTimeOffset? timestamp = null) => throw new NotSupportedException();
+    }
+}

--- a/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
+++ b/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
@@ -1,0 +1,320 @@
+using JasperFx.Core;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging;
+using Polly;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Shared leadership-election + agent-lifecycle loop for the projection coordinator.
+/// Lifted from the slot-for-slot duplicate that lived in Marten's
+/// <c>ProjectionCoordinator.executeAsync</c> and Polecat's
+/// <c>ProjectionCoordinator.ExecuteAsync</c> (Polecat's own xmldoc said it
+/// "mirrors Marten's executeAsync loop slot-for-slot").
+/// </summary>
+/// <remarks>
+/// Everything the loop touches is already on a lifted contract
+/// (<see cref="IProjectionDistributor"/>, <see cref="IProjectionDaemon"/>,
+/// <see cref="IProjectionSet"/>, <see cref="ISubscriptionAgent"/>), so the only
+/// store-specific seams are: how a database resolves to an
+/// <see cref="IProjectionDaemon"/> (kept in the subclass behind
+/// <see cref="ResolveDaemon"/> so each store keeps its own daemon cache and
+/// concurrency model), and the three <see cref="IProjectionCoordinator"/> daemon
+/// accessors which need each store's tenancy/database resolution.
+///
+/// This lift also normalizes two real divergences (see #326):
+/// <list type="bullet">
+///   <item>Agent-start resilience — Marten wrapped <c>StartAgentAsync</c> in a
+///   <see cref="ResiliencePipeline"/> with eject-paused-shard + release-lock on
+///   failure; Polecat called it raw. The shared loop adopts Marten's resilient
+///   variant, so Polecat gains lock-release-on-failure.</item>
+///   <item>Pause/Resume/Stop bookkeeping — normalized on Marten's single
+///   cancellation-source + awaited runner model rather than Polecat's separate
+///   paused/cts/task tracking.</item>
+/// </list>
+///
+/// Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
+{
+    private readonly ILogger _logger;
+    private readonly ResiliencePipeline _resilience;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _leadershipPollingTime;
+    private readonly TimeSpan _agentPauseTime;
+    private readonly TimeSpan _healthCheckPollingTime;
+
+    private CancellationTokenSource? _cancellation;
+    private Task? _runner;
+
+    /// <summary>
+    /// The distributor that decides which (database × shards) sets this node should
+    /// try to run, and negotiates the per-set leadership locks.
+    /// </summary>
+    public IProjectionDistributor Distributor { get; }
+
+    protected ProjectionCoordinatorBase(
+        IProjectionDistributor distributor,
+        ILogger logger,
+        ResiliencePipeline resilience,
+        TimeProvider timeProvider,
+        TimeSpan leadershipPollingTime,
+        TimeSpan agentPauseTime,
+        TimeSpan healthCheckPollingTime)
+    {
+        Distributor = distributor ?? throw new ArgumentNullException(nameof(distributor));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _resilience = resilience ?? throw new ArgumentNullException(nameof(resilience));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _leadershipPollingTime = leadershipPollingTime;
+        _agentPauseTime = agentPauseTime;
+        _healthCheckPollingTime = healthCheckPollingTime;
+    }
+
+    /// <summary>
+    /// Resolve (and cache, in the subclass) the <see cref="IProjectionDaemon"/> that
+    /// runs the shards for the given set's database. Kept in the subclass so each store
+    /// keeps its own cache + concurrency model (Marten: ImHashMap + double-checked lock;
+    /// Polecat: a plain dictionary under single-threaded execution).
+    /// </summary>
+    protected abstract IProjectionDaemon ResolveDaemon(IProjectionSet set);
+
+    /// <summary>
+    /// A snapshot of the daemons currently resolved/cached by the subclass. Used by the
+    /// loop's pause-time heuristic and by Pause/Stop to fan out across every running daemon.
+    /// </summary>
+    protected abstract IReadOnlyList<IProjectionDaemon> ResolvedDaemons();
+
+    /// <inheritdoc />
+    public abstract IProjectionDaemon DaemonForMainDatabase();
+
+    /// <inheritdoc />
+    public abstract ValueTask<IProjectionDaemon> DaemonForDatabase(string databaseIdentifier);
+
+    /// <inheritdoc />
+    public abstract ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync();
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cancellation?.SafeDispose();
+
+        _cancellation = new CancellationTokenSource();
+        _runner = Task.Run(() => executeAsync(_cancellation.Token), _cancellation.Token);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task PauseAsync()
+    {
+        _logger.LogInformation("Pausing ProjectionCoordinator");
+        if (_cancellation != null)
+        {
+            await _cancellation.CancelAsync().ConfigureAwait(false);
+        }
+
+        await drainRunner().ConfigureAwait(false);
+
+        foreach (var daemon in ResolvedDaemons())
+        {
+            try
+            {
+                await daemon.StopAllAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, "Error while trying to stop daemon agents");
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Task ResumeAsync()
+    {
+        return StartAsync(default);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await PauseAsync().ConfigureAwait(false);
+
+        foreach (var daemon in ResolvedDaemons())
+        {
+            daemon.SafeDispose();
+        }
+
+        try
+        {
+            await Distributor.ReleaseAllLocks().ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error trying to release subscription agent locks");
+        }
+    }
+
+    private async Task drainRunner()
+    {
+        if (_runner == null) return;
+
+        try
+        {
+#pragma warning disable VSTHRD003
+            await _runner.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+        }
+        catch (TaskCanceledException)
+        {
+            // Nothing, just from shutting down
+        }
+        catch (OperationCanceledException)
+        {
+            // Nothing, just from shutting down
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while trying to stop the ProjectionCoordinator");
+        }
+    }
+
+    private async Task executeAsync(CancellationToken stoppingToken)
+    {
+        await Distributor.RandomWait(stoppingToken).ConfigureAwait(false);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var sets = await Distributor.BuildDistributionAsync().ConfigureAwait(false);
+
+                foreach (var set in sets)
+                {
+                    if (stoppingToken.IsCancellationRequested) return;
+
+                    // Is it already running here?
+                    if (Distributor.HasLock(set))
+                    {
+                        var daemon = ResolveDaemon(set);
+                        await startAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (await Distributor.TryAttainLockAsync(set, stoppingToken).ConfigureAwait(false))
+                        {
+                            var daemon = ResolveDaemon(set);
+                            await startAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            // We don't hold the lock, so we might've lost it due to a database
+                            // outage. Make sure any agents are no longer running on this node.
+                            var daemon = ResolveDaemon(set);
+                            await stopAgentsIfNecessaryAsync(set, daemon).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e,
+                            "Error trying to attain a lock for set {Name} and lock id {LockId}. Will retry later",
+                            set.Names.Select(x => x.Identity).Join(", "), set.LockId);
+                        await Task.Delay(_leadershipPollingTime, stoppingToken).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                if (stoppingToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                // Only really expect any errors if there are dynamic tenants in place
+                _logger.LogError(e, "Error trying to resolve projection distributions");
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                if (ResolvedDaemons().Any(x => x.HasAnyPaused()))
+                {
+                    await Task.Delay(_agentPauseTime, stoppingToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await Task.Delay(_leadershipPollingTime, stoppingToken).ConfigureAwait(false);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // just get out of here, this signals a graceful shutdown attempt
+            }
+            catch (OperationCanceledException)
+            {
+                // Nothing, just from shutting down
+            }
+        }
+    }
+
+    private async Task startAgentsIfNecessaryAsync(IProjectionSet set, IProjectionDaemon daemon,
+        CancellationToken stoppingToken)
+    {
+        foreach (var name in set.Names)
+        {
+            var agent = daemon.CurrentAgents().FirstOrDefault(x => x.Name.Equals(name));
+            if (agent == null)
+            {
+                await tryStartAgent(stoppingToken, daemon, name, set).ConfigureAwait(false);
+            }
+            else if (agent is { Status: AgentStatus.Paused, PausedTime: not null } &&
+                     _timeProvider.GetUtcNow().Subtract(agent.PausedTime.Value) > _healthCheckPollingTime)
+            {
+                await tryStartAgent(stoppingToken, daemon, name, set).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task stopAgentsIfNecessaryAsync(IProjectionSet set, IProjectionDaemon daemon)
+    {
+        foreach (var shardName in set.Names)
+        {
+            var status = daemon.StatusFor(shardName.Identity);
+            if (status == AgentStatus.Running)
+            {
+                await daemon.StopAgentAsync(shardName.Identity).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task tryStartAgent(CancellationToken stoppingToken, IProjectionDaemon daemon, ShardName name,
+        IProjectionSet set)
+    {
+        try
+        {
+            await _resilience.ExecuteAsync(
+                static (x, t) => new ValueTask(x.Daemon.StartAgentAsync(x.Name.Identity, t)),
+                new DaemonShardName(daemon, name), stoppingToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error trying to start subscription {Name} on database {Database}", name.Identity,
+                set.Database.Identifier);
+            if (daemon.StatusFor(name.Identity) == AgentStatus.Paused)
+            {
+                daemon.EjectPausedShard(name.Identity);
+            }
+
+            await Distributor.ReleaseLockAsync(set).ConfigureAwait(false);
+        }
+    }
+
+    private record DaemonShardName(IProjectionDaemon Daemon, ShardName Name);
+}


### PR DESCRIPTION
## Summary
Marten's `ProjectionCoordinator.executeAsync` and Polecat's `ExecuteAsync` were mirror-maintained slot-for-slot (~250 lines across two repos, plus the `startAgentsIfNecessary` / `stopAgentsIfNecessary` / `tryStartAgent` trio). Everything the loop touches is already on a lifted contract, so the loop lifts cleanly. Part of the Critter Stack 2026 dedupe pillar (#214); unblocked by the distributor lifts #315/#316/#317. **Closes #326.**

## What's new
`JasperFx.Events.Daemon.ProjectionCoordinatorBase` (abstract):
- Execute loop + three agent helpers + Start/Pause/Resume/Stop lifecycle.
- Ctor: `IProjectionDistributor`, `ILogger`, `ResiliencePipeline`, `TimeProvider`, and the three settings as `TimeSpan` (each store converts its own options at the seam).
- `abstract ResolveDaemon(IProjectionSet)` keeps the daemon cache + concurrency model in the subclass; `abstract ResolvedDaemons()` snapshot for the pause-time heuristic + Pause/Stop fan-out.
- The three `IProjectionCoordinator` daemon accessors stay abstract (store-specific tenancy/db resolution).

## Divergences normalized (the lift also fixes a real gap)
- **Agent-start resilience** — shared `tryStartAgent` adopts Marten's resilient variant (`ResiliencePipeline.ExecuteAsync` + eject-paused-shard + `ReleaseLockAsync` on failure). Polecat called `StartAgentAsync` raw — it gains lock-release-on-failure.
- **Lifecycle** — single `_cancellation` CTS + awaited `_runner` (Marten's model) rather than Polecat's separate `_paused`/`_runCts`/`_runTask`.

## Test plan
- [x] `EventTests/Daemon/ProjectionCoordinatorBaseTests` — fake distributor + daemon drive the loop via a test subclass: lock-held start path, **lock-release + eject on agent-start failure** (the behavioral fix), stop-on-lost-lock, and StopAsync release-all-locks + dispose. 4/4 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Marten's and Polecat's `ProjectionCoordinator` reduce to a subclass supplying the distributor + daemon resolver — follow-up PRs in those repos (tracking issues filed). No version bump in this PR; a single rc.1 bump lands at the end of the dedupe wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)