### PR TITLE
Lift TenancyStyle + DeleteStyle enums into JasperFx (closes #327)

### DIFF
--- a/src/CoreTests/LiftedEnumValueTests.cs
+++ b/src/CoreTests/LiftedEnumValueTests.cs
@@ -1,0 +1,25 @@
+using JasperFx;
+using JasperFx.MultiTenancy;
+using Shouldly;
+
+namespace CoreTests;
+
+// The underlying int values of these lifted enums are part of the compatibility
+// contract: downstream stores (Marten/Polecat) and any persisted configuration may
+// depend on the ordinals. Reordering would silently shift them, so pin them here.
+public class LiftedEnumValueTests
+{
+    [Fact]
+    public void tenancy_style_ordinals()
+    {
+        ((int)TenancyStyle.Single).ShouldBe(0);
+        ((int)TenancyStyle.Conjoined).ShouldBe(1);
+    }
+
+    [Fact]
+    public void delete_style_ordinals()
+    {
+        ((int)DeleteStyle.Remove).ShouldBe(0);
+        ((int)DeleteStyle.SoftDelete).ShouldBe(1);
+    }
+}

--- a/src/JasperFx/DeleteStyle.cs
+++ b/src/JasperFx/DeleteStyle.cs
@@ -1,0 +1,24 @@
+namespace JasperFx;
+
+/// <summary>
+/// Controls how documents are deleted. Lifted from the byte-identical enum that lived
+/// in Marten's <c>Marten.Schema.DeleteStyle</c> and Polecat's
+/// <c>Polecat.Metadata.DeleteStyle</c>.
+/// </summary>
+/// <remarks>
+/// Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>). Each store
+/// type-forwards its old public name to this type so downstream consumers keep compiling.
+/// </remarks>
+public enum DeleteStyle
+{
+    /// <summary>
+    ///     Hard delete: physically removes the row from the database.
+    /// </summary>
+    Remove,
+
+    /// <summary>
+    ///     Soft delete: marks the row as deleted without removing it.
+    /// </summary>
+    SoftDelete
+}

--- a/src/JasperFx/MultiTenancy/TenancyStyle.cs
+++ b/src/JasperFx/MultiTenancy/TenancyStyle.cs
@@ -1,0 +1,26 @@
+namespace JasperFx.MultiTenancy;
+
+/// <summary>
+/// Describes how a document store partitions data across tenants. Lifted from the
+/// byte-identical enum that lived in Marten's <c>Marten.Storage.TenancyStyle</c> and
+/// inline in Polecat's <c>StoreOptions</c>. Canonical home is JasperFx.MultiTenancy,
+/// beside <see cref="TenantIdStyle"/> and <see cref="IHasTenantId"/>.
+/// </summary>
+/// <remarks>
+/// Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>). Each store
+/// type-forwards its old public name to this type so downstream apps importing
+/// <c>Marten.Storage.TenancyStyle</c> keep compiling.
+/// </remarks>
+public enum TenancyStyle
+{
+    /// <summary>
+    ///     No multi-tenancy, the default mode
+    /// </summary>
+    Single,
+
+    /// <summary>
+    ///     Multi-tenanted within the same database/schema through a tenant id
+    /// </summary>
+    Conjoined
+}


### PR DESCRIPTION
## Summary
Two enums byte-identical between Marten and Polecat, lifted to JasperFx core. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #327.**

- `JasperFx.MultiTenancy.TenancyStyle` (`Single`/`Conjoined`) — beside `TenantIdStyle`/`IHasTenantId`. Was `Marten.Storage.TenancyStyle` + inline in Polecat `StoreOptions`.
- `JasperFx.DeleteStyle` (`Remove`/`SoftDelete`) — at the JasperFx root namespace next to `AutoCreate`/`AgentStatus`. Was `Marten.Schema.DeleteStyle` + `Polecat.Metadata.DeleteStyle`.

## Test plan
- [x] `CoreTests/LiftedEnumValueTests` pins the ordinal values (part of the compat contract — downstream may persist them as ints). 2/2 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Each store type-forwards its old public name in follow-up PRs (downstream tracking issues filed). No source-compat break. No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)