### PR TITLE
Lift shared exceptions: DcbConcurrency + ProgressionOutOfOrder (closes #328)

### DIFF
--- a/src/EventTests/SharedExceptionTests.cs
+++ b/src/EventTests/SharedExceptionTests.cs
@@ -1,0 +1,48 @@
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Tags;
+using Shouldly;
+
+namespace EventTests;
+
+public class SharedExceptionTests
+{
+    [Fact]
+    public void dcb_concurrency_exception_carries_query_and_sequence_and_is_a_concurrency_exception()
+    {
+        var query = new EventTagQuery().Or<Guid>(Guid.NewGuid());
+        var ex = new DcbConcurrencyException(query, 42);
+
+        ex.ShouldBeAssignableTo<ConcurrencyException>();
+        ex.Query.ShouldBeSameAs(query);
+        ex.LastSeenSequence.ShouldBe(42);
+        ex.Message.ShouldContain("sequence 42");
+    }
+
+    [Fact]
+    public void progression_out_of_order_preserves_the_shardname_ctor()
+    {
+        var ex = new ProgressionProgressOutOfOrderException(new ShardName("Trip", "All", 1));
+
+        ex.Message.ShouldContain("out of order");
+        // The richer props default when constructed via the ShardName ctor.
+        ex.ProjectionName.ShouldBeNull();
+        ex.ExpectedFloor.ShouldBe(0);
+        ex.AttemptedCeiling.ShouldBe(0);
+    }
+
+    [Fact]
+    public void progression_out_of_order_folds_in_the_three_arg_ctor()
+    {
+        var ex = new ProgressionProgressOutOfOrderException("Trip", expectedFloor: 100, ceiling: 150);
+
+        ex.ProjectionName.ShouldBe("Trip");
+        ex.ExpectedFloor.ShouldBe(100);
+        ex.AttemptedCeiling.ShouldBe(150);
+        ex.Message.ShouldContain("Trip");
+        ex.Message.ShouldContain("100");
+        ex.Message.ShouldContain("150");
+    }
+}

--- a/src/JasperFx.Events/Daemon/ProgressionProgressOutOfOrderException.cs
+++ b/src/JasperFx.Events/Daemon/ProgressionProgressOutOfOrderException.cs
@@ -2,10 +2,49 @@ using JasperFx.Events.Projections;
 
 namespace JasperFx.Events.Daemon;
 
+/// <summary>
+/// Thrown when a projection-progression update fails an ordering / optimistic-concurrency
+/// check — typically because another process advanced the progression between this node's
+/// read and write.
+/// </summary>
+/// <remarks>
+/// The original shared 1-arg <see cref="ShardName"/> ctor (used by Marten) is preserved.
+/// Polecat shipped its own richer 3-arg variant
+/// (<c>projectionName, expectedFloor, ceiling</c> + <see cref="ExpectedFloor"/> /
+/// <see cref="AttemptedCeiling"/> props); that ctor and those props are folded in here so the
+/// two stores share one type. Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
 public class ProgressionProgressOutOfOrderException: Exception
 {
     public ProgressionProgressOutOfOrderException(ShardName progressionOrShardName): base(
         $"Progression '{progressionOrShardName}' is out of order. This may happen when multiple processes try to process the projection")
     {
     }
+
+    public ProgressionProgressOutOfOrderException(string projectionName, long expectedFloor, long ceiling): base(
+        $"Progression for '{projectionName}' is out of order. Expected floor {expectedFloor} but it had already moved. Attempted ceiling: {ceiling}.")
+    {
+        ProjectionName = projectionName;
+        ExpectedFloor = expectedFloor;
+        AttemptedCeiling = ceiling;
+    }
+
+    /// <summary>
+    /// The projection whose progression was out of order. Null when constructed via the
+    /// <see cref="ShardName"/> ctor.
+    /// </summary>
+    public string? ProjectionName { get; }
+
+    /// <summary>
+    /// The progression floor this update expected to advance from. Zero when constructed via
+    /// the <see cref="ShardName"/> ctor.
+    /// </summary>
+    public long ExpectedFloor { get; }
+
+    /// <summary>
+    /// The ceiling this update attempted to write. Zero when constructed via the
+    /// <see cref="ShardName"/> ctor.
+    /// </summary>
+    public long AttemptedCeiling { get; }
 }

--- a/src/JasperFx.Events/DcbConcurrencyException.cs
+++ b/src/JasperFx.Events/DcbConcurrencyException.cs
@@ -1,0 +1,31 @@
+using JasperFx.Events.Tags;
+
+namespace JasperFx.Events;
+
+/// <summary>
+/// Thrown when a Dynamic Consistency Boundary (DCB) check fails — new events matching the
+/// tag query were appended after the boundary was established.
+/// </summary>
+/// <remarks>
+/// Lifted from the conceptually-shared exception that lived in both Marten
+/// (<c>Marten.Events.Dcb.DcbConcurrencyException : MartenException</c>) and Polecat
+/// (<c>Polecat.Events.Dcb.DcbConcurrencyException : JasperFx.ConcurrencyException</c>).
+/// Both carried the identical message, the same <c>(EventTagQuery, long)</c> ctor, and the
+/// same <see cref="Query"/> / <see cref="LastSeenSequence"/> properties, and both already
+/// depend on the shared <see cref="EventTagQuery"/>. Canonical home is JasperFx.Events,
+/// based on <see cref="ConcurrencyException"/> (Polecat's shape). Part of the Critter Stack
+/// 2026 dedupe pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public class DcbConcurrencyException : ConcurrencyException
+{
+    public DcbConcurrencyException(EventTagQuery query, long lastSeenSequence)
+        : base(
+            $"DCB consistency violation: new events matching the tag query were appended after sequence {lastSeenSequence}")
+    {
+        Query = query;
+        LastSeenSequence = lastSeenSequence;
+    }
+
+    public EventTagQuery Query { get; }
+    public long LastSeenSequence { get; }
+}


### PR DESCRIPTION
## Summary
Items 1 and 2 of #328 — the clean exception lifts. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #328**, with item 3 carved out to #338 per the issue's own escape hatch.

1. **`JasperFx.Events.DcbConcurrencyException`** (new) — lifted from the conceptually-shared exception in both stores (Marten extended `MartenException`, Polecat extended `JasperFx.ConcurrencyException`). Identical message, `(EventTagQuery, long)` ctor, `Query`/`LastSeenSequence` props; both already on the shared `EventTagQuery`. Canonical home JasperFx.Events, based on `ConcurrencyException` (Polecat's shape).
2. **`ProgressionProgressOutOfOrderException`** — folded Polecat's richer 3-arg ctor (`projectionName, expectedFloor, ceiling`) + `ExpectedFloor`/`AttemptedCeiling` props into the existing shared 1-arg type. The original `ShardName` ctor (Marten) is kept; the new props default when it's used.

## Item 3 split out → #338
`DocumentAlreadyExistsException` reconciliation is genuinely noisy — base type, property names (`DocType` vs `DocumentType`), and message format all differ with downstream source-break implications. The issue explicitly authorizes splitting it ("items 1 and 2 are clean"). Tracked in **#338** with the decisions laid out.

## Test plan
- [x] `EventTests/SharedExceptionTests` — `DcbConcurrencyException` is-a `ConcurrencyException` + carries query/sequence; `ProgressionProgressOutOfOrderException` preserves the `ShardName` ctor (props default) and folds in the 3-arg ctor. 3/3 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Both stores consume the lifted types + verify their `InsertExceptionTransform` / `catch(2627)` mapping in follow-up PRs (downstream tracking issues filed). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)