### PR TITLE
Lift SkippedEventsCountObserver + ResilientEventLoader into JasperFx.Events (closes #329)

### DIFF
--- a/src/EventTests/Daemon/DaemonRuntimeConcretesTests.cs
+++ b/src/EventTests/Daemon/DaemonRuntimeConcretesTests.cs
@@ -1,0 +1,115 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using NSubstitute;
+using Polly;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class SkippedEventsCountObserverTests
+{
+    [Fact]
+    public void populates_skipped_count_on_high_water_mark_skip()
+    {
+        var state = new ShardState(ShardState.HighWaterMark, 100)
+        {
+            Action = ShardAction.Skipped,
+            PreviousGoodMark = 90
+        };
+
+        new SkippedEventsCountObserver().OnNext(state);
+
+        state.SkippedEventsCount.ShouldBe(10);
+    }
+
+    [Fact]
+    public void ignores_non_skip_actions()
+    {
+        var state = new ShardState(ShardState.HighWaterMark, 100)
+        {
+            Action = ShardAction.Updated,
+            PreviousGoodMark = 90
+        };
+
+        new SkippedEventsCountObserver().OnNext(state);
+
+        state.SkippedEventsCount.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ignores_skips_for_non_high_water_mark_shards()
+    {
+        // Marten's superset guard: only the HighWaterMark shard's skips set the count.
+        var state = new ShardState("Trip:All", 100)
+        {
+            Action = ShardAction.Skipped,
+            PreviousGoodMark = 90
+        };
+
+        new SkippedEventsCountObserver().OnNext(state);
+
+        state.SkippedEventsCount.ShouldBeNull();
+    }
+
+    [Fact]
+    public void does_not_overwrite_an_existing_count()
+    {
+        var state = new ShardState(ShardState.HighWaterMark, 100)
+        {
+            Action = ShardAction.Skipped,
+            PreviousGoodMark = 90,
+            SkippedEventsCount = 7
+        };
+
+        new SkippedEventsCountObserver().OnNext(state);
+
+        state.SkippedEventsCount.ShouldBe(7);
+    }
+}
+
+public class ResilientEventLoaderTests
+{
+    private static readonly ShardName TheShard = new("Trip", "All", 1);
+
+    private static EventRequest BuildRequest(ISubscriptionMetrics metrics)
+        => new() { Name = TheShard, Metrics = metrics };
+
+    [Fact]
+    public async Task delegates_to_the_inner_loader_through_the_pipeline()
+    {
+        var page = new EventPage(0);
+        var inner = new StubLoader(_ => Task.FromResult(page));
+        var loader = new ResilientEventLoader(ResiliencePipeline.Empty, inner,
+            Substitute.For<IEventDatabase>());
+
+        var result = await loader.LoadAsync(BuildRequest(Substitute.For<ISubscriptionMetrics>()),
+            CancellationToken.None);
+
+        result.ShouldBeSameAs(page);
+        inner.Calls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task tracks_loading_metrics()
+    {
+        var metrics = Substitute.For<ISubscriptionMetrics>();
+        var loader = new ResilientEventLoader(ResiliencePipeline.Empty,
+            new StubLoader(_ => Task.FromResult(new EventPage(0))), Substitute.For<IEventDatabase>());
+
+        await loader.LoadAsync(BuildRequest(metrics), CancellationToken.None);
+
+        metrics.Received(1).TrackLoading(Arg.Any<EventRequest>());
+    }
+
+    private sealed class StubLoader(Func<EventRequest, Task<EventPage>> handler) : IEventLoader
+    {
+        public int Calls { get; private set; }
+
+        public Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+        {
+            Calls++;
+            return handler(request);
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/EventLoaderException.cs
+++ b/src/JasperFx.Events/Daemon/EventLoaderException.cs
@@ -1,0 +1,22 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Thrown when an event store fails to load events for a projection shard.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>EventLoaderException</c> (which extended <c>MartenException</c> and
+/// was typed to <c>IMartenDatabase</c>) and re-typed to the shared
+/// <see cref="IEventDatabase"/> so the lifted <see cref="ResilientEventLoader"/> can throw it.
+/// Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public class EventLoaderException : Exception
+{
+    public EventLoaderException(ShardName name, IEventDatabase database, Exception innerException) : base(
+        $"Failure while trying to load events for projection shard '{name}@{database.Identifier}'",
+        innerException)
+    {
+    }
+}

--- a/src/JasperFx.Events/Daemon/ResilientEventLoader.cs
+++ b/src/JasperFx.Events/Daemon/ResilientEventLoader.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics;
+using JasperFx.Events.Projections;
+using Polly;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// An <see cref="IEventLoader"/> decorator that runs the inner loader through a
+/// <see cref="ResiliencePipeline"/> and tracks loading metrics via
+/// <c>EventRequest.Metrics.TrackLoading()</c>. Failures are wrapped in an
+/// <see cref="EventLoaderException"/> carrying the shard name + database identifier.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>ResilientEventLoader</c>. The only store-specific tail was the
+/// <see cref="EventLoaderException"/> wrap typed to <c>IMartenDatabase</c>; the database is now
+/// supplied as an <see cref="IEventDatabase"/> ctor arg so the decorator wraps any
+/// <see cref="IEventLoader"/> without an interface change. Adopting this shared decorator also
+/// gives Polecat loading-metrics parity for free (it previously inlined the Polly call with no
+/// <c>TrackLoading</c>). Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public class ResilientEventLoader : IEventLoader
+{
+    private readonly ResiliencePipeline _pipeline;
+    private readonly IEventLoader _inner;
+    private readonly IEventDatabase _database;
+
+    private record EventLoadExecution(EventRequest Request, IEventLoader Loader)
+    {
+        public async ValueTask<EventPage> ExecuteAsync(CancellationToken token)
+        {
+            using Activity? activity = Request.Metrics.TrackLoading(Request);
+
+            try
+            {
+                var results = await Loader.LoadAsync(Request, token).ConfigureAwait(false);
+                return results;
+            }
+            catch (Exception e)
+            {
+                activity?.AddException(e);
+                throw;
+            }
+            finally
+            {
+                activity?.Stop();
+            }
+        }
+    }
+
+    public ResilientEventLoader(ResiliencePipeline pipeline, IEventLoader inner, IEventDatabase database)
+    {
+        _pipeline = pipeline;
+        _inner = inner;
+        _database = database;
+    }
+
+    public Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+    {
+        try
+        {
+            var execution = new EventLoadExecution(request, _inner);
+            return _pipeline.ExecuteAsync(static (x, t) => x.ExecuteAsync(t), execution, token).AsTask();
+        }
+        catch (Exception e)
+        {
+            throw new EventLoaderException(request.Name, _database, e);
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/SkippedEventsCountObserver.cs
+++ b/src/JasperFx.Events/Daemon/SkippedEventsCountObserver.cs
@@ -1,0 +1,39 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Populates <see cref="ShardState.SkippedEventsCount"/> on the HighWaterMark state when the
+/// HighWaterAgent publishes a <see cref="ShardAction.Skipped"/> event. The shared
+/// <see cref="ShardStateTracker.MarkSkippingAsync"/> helper supplies
+/// <see cref="ShardState.Sequence"/> and <see cref="ShardState.PreviousGoodMark"/> but does
+/// not compute the count, so it is filled here using the most-recent semantic
+/// (gap size = <c>Sequence - PreviousGoodMark</c>).
+/// </summary>
+/// <remarks>
+/// Lifted from the functionally-identical observers in both stores (Marten's
+/// <c>SkippedEventsCountObserver</c> and Polecat's <c>SkippedEventsCountAugmenter</c>).
+/// Marten's <c>ShardName != ShardState.HighWaterMark</c> guard is a strict superset — kept
+/// here. It is harmless for Polecat, which only subscribes this observer for the HighWaterMark
+/// tracker. Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public sealed class SkippedEventsCountObserver : IObserver<ShardState>
+{
+    public void OnCompleted() { }
+
+    public void OnError(Exception error) { }
+
+    public void OnNext(ShardState value)
+    {
+        if (value.Action != ShardAction.Skipped) return;
+        if (value.ShardName != ShardState.HighWaterMark) return;
+        if (value.SkippedEventsCount.HasValue) return;
+
+        var skipped = value.Sequence - value.PreviousGoodMark;
+        if (skipped > 0)
+        {
+            value.SkippedEventsCount = skipped;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Two daemon-runtime concretes near-identical between Marten and Polecat. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #329.**

1. **`JasperFx.Events.Daemon.SkippedEventsCountObserver`** — lifted from Marten's `SkippedEventsCountObserver` and Polecat's `SkippedEventsCountAugmenter` (functionally identical `IObserver<ShardState>`). Kept Marten's `ShardName != ShardState.HighWaterMark` guard (strict superset, harmless for Polecat).
2. **`JasperFx.Events.Daemon.ResilientEventLoader`** (+ `EventLoaderException`) — lifted from Marten's decorator. `EventLoaderException` re-typed to the shared `IEventDatabase`; the decorator takes the database as an `IEventDatabase` ctor arg so it wraps any `IEventLoader` without an interface change. Polecat gains loading-metrics parity (`EventRequest.Metrics.TrackLoading()`) for free and can drop its inline Polly wrap.

## Test plan
- [x] `EventTests/Daemon/DaemonRuntimeConcretesTests` — observer: HWM-skip count, ignores non-skip, ignores non-HWM shards (the superset guard), no overwrite; loader: delegates through pipeline + tracks metrics. 6/6 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Marten deletes its copies; Polecat wraps its loader + deletes its augmenter/inline-Polly — follow-up PRs (downstream tracking issues filed). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)