### PR TITLE
Lift document-metadata markers ISoftDeleted/IVersioned/ITracked into JasperFx (closes #330)

### DIFF
--- a/src/CoreTests/MetadataMarkerTests.cs
+++ b/src/CoreTests/MetadataMarkerTests.cs
@@ -1,0 +1,41 @@
+using JasperFx.Metadata;
+using Shouldly;
+
+namespace CoreTests;
+
+// Compile-pins the lifted marker-interface member shapes: if a member is renamed or its
+// type changes, this sample implementation stops compiling. Also a smoke check that the
+// interfaces are assignable as expected.
+public class MetadataMarkerTests
+{
+    [Fact]
+    public void sample_document_implements_all_three_markers()
+    {
+        var doc = new SampleDoc
+        {
+            Deleted = true,
+            DeletedAt = DateTimeOffset.UtcNow,
+            Version = Guid.NewGuid(),
+            CorrelationId = "corr",
+            CausationId = "cause",
+            LastModifiedBy = "tester"
+        };
+
+        doc.ShouldBeAssignableTo<ISoftDeleted>();
+        doc.ShouldBeAssignableTo<IVersioned>();
+        doc.ShouldBeAssignableTo<ITracked>();
+        doc.Deleted.ShouldBeTrue();
+        doc.Version.ShouldNotBe(Guid.Empty);
+        doc.LastModifiedBy.ShouldBe("tester");
+    }
+
+    private sealed class SampleDoc : ISoftDeleted, IVersioned, ITracked
+    {
+        public bool Deleted { get; set; }
+        public DateTimeOffset? DeletedAt { get; set; }
+        public Guid Version { get; set; }
+        public string CorrelationId { get; set; } = "";
+        public string CausationId { get; set; } = "";
+        public string LastModifiedBy { get; set; } = "";
+    }
+}

--- a/src/JasperFx/Metadata/ISoftDeleted.cs
+++ b/src/JasperFx/Metadata/ISoftDeleted.cs
@@ -1,0 +1,24 @@
+namespace JasperFx.Metadata;
+
+/// <summary>
+///     Optionally implement this interface on your document types to opt into "soft delete"
+///     mechanics, with the deletion information tracked directly on the documents.
+/// </summary>
+/// <remarks>
+/// Lifted from the byte-equivalent <c>ISoftDeleted</c> interfaces in Marten
+/// (<c>Marten.Metadata</c>) and Polecat (<c>Polecat.Metadata</c>). Part of the Critter Stack
+/// 2026 dedupe pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// Each store type-forwards its old public name to this type.
+/// </remarks>
+public interface ISoftDeleted
+{
+    /// <summary>
+    ///     Has the store marked this document as soft deleted?
+    /// </summary>
+    bool Deleted { get; set; }
+
+    /// <summary>
+    ///     When was this document marked as deleted?
+    /// </summary>
+    DateTimeOffset? DeletedAt { get; set; }
+}

--- a/src/JasperFx/Metadata/ITracked.cs
+++ b/src/JasperFx/Metadata/ITracked.cs
@@ -1,0 +1,32 @@
+namespace JasperFx.Metadata;
+
+/// <summary>
+///     Optionally implement this interface to add correlation/causation tracking to your
+///     document type, with the tracking information copied from the session onto the document
+///     on save.
+/// </summary>
+/// <remarks>
+/// Lifted from the <c>ITracked</c> interfaces in Marten (<c>Marten.Metadata</c>) and Polecat
+/// (<c>Polecat.Metadata</c>). Marten's non-nullable <c>string</c> shape is canonical here;
+/// Polecat declared the members nullable — it keeps its own annotations on the concrete
+/// document classes when consuming this. Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>). Each store
+/// type-forwards its old public name to this type.
+/// </remarks>
+public interface ITracked
+{
+    /// <summary>
+    ///     Correlation id for the last system activity to edit this document.
+    /// </summary>
+    string CorrelationId { get; set; }
+
+    /// <summary>
+    ///     Causation id for the last system activity to edit this document.
+    /// </summary>
+    string CausationId { get; set; }
+
+    /// <summary>
+    ///     The user who last modified this document.
+    /// </summary>
+    string LastModifiedBy { get; set; }
+}

--- a/src/JasperFx/Metadata/IVersioned.cs
+++ b/src/JasperFx/Metadata/IVersioned.cs
@@ -1,0 +1,19 @@
+namespace JasperFx.Metadata;
+
+/// <summary>
+///     Optionally implement this interface on your document types to opt into optimistic
+///     concurrency with a <see cref="Guid"/> version tracked on the document.
+/// </summary>
+/// <remarks>
+/// Lifted from the identical <c>IVersioned</c> interfaces in Marten (<c>Marten.Metadata</c>)
+/// and Polecat (<c>Polecat.Metadata</c>), both <c>Guid Version</c>. Part of the Critter Stack
+/// 2026 dedupe pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// Each store type-forwards its old public name to this type.
+/// </remarks>
+public interface IVersioned
+{
+    /// <summary>
+    ///     The store's version for this document.
+    /// </summary>
+    Guid Version { get; set; }
+}


### PR DESCRIPTION
## Summary
Three of #330's four document-metadata marker interfaces — the clean ones — lifted to `JasperFx.Metadata`. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #330**, with `IRevisioned` carved to #341.

- `JasperFx.Metadata.ISoftDeleted` (`bool Deleted` / `DateTimeOffset? DeletedAt`) — byte-equivalent in both stores.
- `JasperFx.Metadata.IVersioned` (`Guid Version`) — identical.
- `JasperFx.Metadata.ITracked` (`string CorrelationId/CausationId/LastModifiedBy`) — Marten's non-nullable shape is canonical; Polecat declared them nullable and keeps its concrete-class annotations.

## IRevisioned deferred → #341
A `JasperFx.IRevisioned` already exists in core (root namespace, `int Version`, used by `ConcurrencyException`) while Marten's is `long Version`. Unifying that touches a load-bearing core type, so per the confirmed call it's carved out to #341 to be decided deliberately rather than baked in here.

## Test plan
- [x] `CoreTests/MetadataMarkerTests` compile-pins all three member shapes via a sample document implementing all three. 1/1 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Both stores type-forward their old public names in follow-up PRs (downstream tracking issues filed). No source-compat break. No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)