### PR TITLE
Lift IPatchExpression<T> + RemoveAction into JasperFx.Events (closes #331)

### DIFF
--- a/src/EventTests/PatchExpressionContractTests.cs
+++ b/src/EventTests/PatchExpressionContractTests.cs
@@ -1,0 +1,86 @@
+using System.Linq.Expressions;
+using JasperFx.Events;
+using Shouldly;
+
+namespace EventTests;
+
+// Compile-pins the entire lifted IPatchExpression<T> surface (Marten's superset) by
+// implementing it, and verifies the fluent methods chain. If a method signature changes,
+// RecordingPatchExpression stops compiling.
+public class PatchExpressionContractTests
+{
+    [Fact]
+    public void remove_action_ordinals_match_both_stores()
+    {
+        ((int)RemoveAction.RemoveFirst).ShouldBe(0);
+        ((int)RemoveAction.RemoveAll).ShouldBe(1);
+    }
+
+    [Fact]
+    public void fluent_surface_chains()
+    {
+        IPatchExpression<Target> patch = new RecordingPatchExpression<Target>();
+
+        var result = patch
+            .Set("Name", "x")
+            .Set(t => t.Count, 5)
+            .Increment(t => t.Count)
+            .Increment(t => t.Count, 3)
+            .Append(t => t.Tags, "a")
+            .AppendIfNotExists(t => t.Tags, "b")
+            .AppendIfNotExists(t => t.Tags, "c", e => e == "c")
+            .Insert(t => t.Tags, "d")
+            .InsertIfNotExists(t => t.Tags, "e", e => e == "e", 0)
+            .Remove(t => t.Tags, "a")
+            .Remove(t => t.Tags, e => e.StartsWith("a"), RemoveAction.RemoveAll)
+            .Rename("old", t => (object)t.Name)
+            .Delete("redundant")
+            .Delete(t => t.Count);
+
+        result.ShouldBeSameAs(patch);
+        ((RecordingPatchExpression<Target>)patch).Calls.ShouldBeGreaterThan(10);
+    }
+
+    private sealed class Target
+    {
+        public string Name { get; set; } = "";
+        public int Count { get; set; }
+        public List<string> Tags { get; set; } = [];
+    }
+
+    private sealed class RecordingPatchExpression<T> : IPatchExpression<T>
+    {
+        public int Calls { get; private set; }
+
+        private IPatchExpression<T> Track()
+        {
+            Calls++;
+            return this;
+        }
+
+        public IPatchExpression<T> Set<TValue>(string name, TValue value) => Track();
+        public IPatchExpression<T> Set<TParent, TValue>(string name, Expression<Func<T, TParent>> expression, TValue value) => Track();
+        public IPatchExpression<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value) => Track();
+        public IPatchExpression<T> Duplicate<TElement>(Expression<Func<T, TElement>> expression, params Expression<Func<T, TElement>>[] destinations) => Track();
+        public IPatchExpression<T> Increment(Expression<Func<T, int>> expression, int increment = 1) => Track();
+        public IPatchExpression<T> Increment(Expression<Func<T, long>> expression, long increment = 1) => Track();
+        public IPatchExpression<T> Increment(Expression<Func<T, double>> expression, double increment = 1) => Track();
+        public IPatchExpression<T> Increment(Expression<Func<T, float>> expression, float increment = 1) => Track();
+        public IPatchExpression<T> Increment(Expression<Func<T, decimal>> expression, decimal increment = 1) => Track();
+        public IPatchExpression<T> Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element) => Track();
+        public IPatchExpression<T> Append<TElement>(Expression<Func<T, IDictionary<string, TElement>>> expression, string key, TElement element) => Track();
+        public IPatchExpression<T> AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element) => Track();
+        public IPatchExpression<T> AppendIfNotExists<TElement>(Expression<Func<T, IDictionary<string, TElement>>> expression, string key, TElement element) => Track();
+        public IPatchExpression<T> AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, Expression<Func<TElement, bool>> predicate) => Track();
+        public IPatchExpression<T> Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int? index = null) => Track();
+        public IPatchExpression<T> InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, int? index = null) => Track();
+        public IPatchExpression<T> InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, Expression<Func<TElement, bool>> predicate, int? index = null) => Track();
+        public IPatchExpression<T> Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element, RemoveAction action = RemoveAction.RemoveFirst) => Track();
+        public IPatchExpression<T> Remove<TElement>(Expression<Func<T, IDictionary<string, TElement>>> expression, string key) => Track();
+        public IPatchExpression<T> Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, Expression<Func<TElement, bool>> predicate, RemoveAction action = RemoveAction.RemoveFirst) => Track();
+        public IPatchExpression<T> Rename(string oldName, Expression<Func<T, object>> expression) => Track();
+        public IPatchExpression<T> Delete(string name) => Track();
+        public IPatchExpression<T> Delete<TParent>(string name, Expression<Func<T, TParent>> expression) => Track();
+        public IPatchExpression<T> Delete<TElement>(Expression<Func<T, TElement>> expression) => Track();
+    }
+}

--- a/src/JasperFx.Events/Patching/IPatchExpression.cs
+++ b/src/JasperFx.Events/Patching/IPatchExpression.cs
@@ -1,0 +1,152 @@
+using System.Linq.Expressions;
+
+namespace JasperFx.Events;
+
+/// <summary>
+/// Fluent surface for modifying JSON properties of a persisted document in-place, without
+/// loading/deserializing the full document. The interface is dialect-agnostic; concrete
+/// implementations translate to the store's JSON-mutation idiom (Postgres <c>jsonb_set</c>,
+/// SQL Server <c>JSON_MODIFY</c>, etc.).
+/// </summary>
+/// <remarks>
+/// Lifted from the near-verbatim duplicate that lived in Marten (<c>Marten.Patching</c>) and
+/// Polecat (<c>Polecat.Patching</c>). Marten's interface is the canonical superset adopted
+/// here — it carries predicate-based <see cref="AppendIfNotExists{TElement}(Expression{Func{T, IEnumerable{TElement}}}, TElement, Expression{Func{TElement, bool}})"/>,
+/// <c>InsertIfNotExists(..., predicate, ...)</c>, and <c>Remove(..., predicate, ...)</c>
+/// overloads that Polecat lacked, plus the <c>Rename(string, Expression&lt;Func&lt;T, object&gt;&gt;)</c>
+/// shape (Polecat had a generic <c>Rename&lt;TElement&gt;</c>). Polecat grows the missing
+/// overloads when it adopts this. Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public interface IPatchExpression<T>
+{
+    /// <summary>
+    /// Set a single field or property value within the persisted JSON data
+    /// </summary>
+    IPatchExpression<T> Set<TValue>(string name, TValue value);
+
+    /// <summary>
+    /// Set a single field or property value within the persisted JSON data, relative to a parent path
+    /// </summary>
+    IPatchExpression<T> Set<TParent, TValue>(string name, Expression<Func<T, TParent>> expression, TValue value);
+
+    /// <summary>
+    /// Set a single field or property value within the persisted JSON data
+    /// </summary>
+    IPatchExpression<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value);
+
+    /// <summary>
+    /// Copy a single field or property value within the persisted JSON data to one or more destinations
+    /// </summary>
+    IPatchExpression<T> Duplicate<TElement>(Expression<Func<T, TElement>> expression,
+        params Expression<Func<T, TElement>>[] destinations);
+
+    /// <summary>
+    /// Increment a single field or property by adding the increment value to the persisted value
+    /// </summary>
+    IPatchExpression<T> Increment(Expression<Func<T, int>> expression, int increment = 1);
+
+    /// <summary>
+    /// Increment a single field or property by adding the increment value to the persisted value
+    /// </summary>
+    IPatchExpression<T> Increment(Expression<Func<T, long>> expression, long increment = 1);
+
+    /// <summary>
+    /// Increment a single field or property by adding the increment value to the persisted value
+    /// </summary>
+    IPatchExpression<T> Increment(Expression<Func<T, double>> expression, double increment = 1);
+
+    /// <summary>
+    /// Increment a single field or property by adding the increment value to the persisted value
+    /// </summary>
+    IPatchExpression<T> Increment(Expression<Func<T, float>> expression, float increment = 1);
+
+    /// <summary>
+    /// Increment a single field or property by adding the increment value to the persisted value
+    /// </summary>
+    IPatchExpression<T> Increment(Expression<Func<T, decimal>> expression, decimal increment = 1);
+
+    /// <summary>
+    /// Append an element to the end of a child collection on the persisted document
+    /// </summary>
+    IPatchExpression<T> Append<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element);
+
+    /// <summary>
+    /// Append an element with the specified key to a child dictionary on the persisted document
+    /// </summary>
+    IPatchExpression<T> Append<TElement>(Expression<Func<T, IDictionary<string, TElement>>> expression, string key,
+        TElement element);
+
+    /// <summary>
+    /// Append an element to the end of a child collection on the persisted document if the element does not already exist
+    /// </summary>
+    IPatchExpression<T> AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression,
+        TElement element);
+
+    /// <summary>
+    /// Append an element with the specified key to a child dictionary on the persisted document if the key does not already exist
+    /// </summary>
+    IPatchExpression<T> AppendIfNotExists<TElement>(Expression<Func<T, IDictionary<string, TElement>>> expression,
+        string key, TElement element);
+
+    /// <summary>
+    /// Append an element to the end of a child collection on the persisted document if the element does not already exist by predicate
+    /// </summary>
+    IPatchExpression<T> AppendIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression,
+        TElement element, Expression<Func<TElement, bool>> predicate);
+
+    /// <summary>
+    /// Insert an element at the designated index to a child collection on the persisted document
+    /// </summary>
+    IPatchExpression<T> Insert<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
+        int? index = null);
+
+    /// <summary>
+    /// Insert an element at the designated index to a child collection on the persisted document if the value does not already exist at that index
+    /// </summary>
+    IPatchExpression<T> InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression,
+        TElement element, int? index = null);
+
+    /// <summary>
+    /// Insert an element at the designated index to a child collection on the persisted document if the value does not already exist by predicate
+    /// </summary>
+    IPatchExpression<T> InsertIfNotExists<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression,
+        TElement element, Expression<Func<TElement, bool>> predicate, int? index = null);
+
+    /// <summary>
+    /// Remove element from a child collection on the persisted document
+    /// </summary>
+    IPatchExpression<T> Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression, TElement element,
+        RemoveAction action = RemoveAction.RemoveFirst);
+
+    /// <summary>
+    /// Remove an element with the specified key from a child dictionary on the persisted document
+    /// </summary>
+    IPatchExpression<T> Remove<TElement>(Expression<Func<T, IDictionary<string, TElement>>> expression, string key);
+
+    /// <summary>
+    /// Remove element from a child collection by predicate on the persisted document
+    /// </summary>
+    IPatchExpression<T> Remove<TElement>(Expression<Func<T, IEnumerable<TElement>>> expression,
+        Expression<Func<TElement, bool>> predicate, RemoveAction action = RemoveAction.RemoveFirst);
+
+    /// <summary>
+    /// Rename a property or field in the persisted JSON document
+    /// </summary>
+    IPatchExpression<T> Rename(string oldName, Expression<Func<T, object>> expression);
+
+    /// <summary>
+    /// Delete a removed property or field in the persisted JSON data
+    /// </summary>
+    IPatchExpression<T> Delete(string name);
+
+    /// <summary>
+    /// Delete a removed property or field in the persisted JSON data, relative to a parent path
+    /// </summary>
+    IPatchExpression<T> Delete<TParent>(string name, Expression<Func<T, TParent>> expression);
+
+    /// <summary>
+    /// Delete an existing property or field in the persisted JSON data
+    /// </summary>
+    IPatchExpression<T> Delete<TElement>(Expression<Func<T, TElement>> expression);
+}

--- a/src/JasperFx.Events/Patching/RemoveAction.cs
+++ b/src/JasperFx.Events/Patching/RemoveAction.cs
@@ -1,0 +1,23 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Controls the behavior when removing elements from a child collection during a patch.
+/// </summary>
+/// <remarks>
+/// Lifted from the near-identical <c>RemoveAction</c> enums in Marten (<c>Marten.Patching</c>)
+/// and Polecat (<c>Polecat.Patching</c>); both ordered <c>RemoveFirst=0</c>, <c>RemoveAll=1</c>.
+/// Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public enum RemoveAction
+{
+    /// <summary>
+    ///     Remove the first occurrence.
+    /// </summary>
+    RemoveFirst,
+
+    /// <summary>
+    ///     Remove all occurrences.
+    /// </summary>
+    RemoveAll
+}


### PR DESCRIPTION
## Summary
One of the larger near-verbatim duplications still alive — the patching fluent surface. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #331.**

- `JasperFx.Events.IPatchExpression<T>` — lifted as **Marten's canonical superset**. Method names match across both stores, but the overload sets differed: Marten carries predicate-based `AppendIfNotExists`/`InsertIfNotExists`/`Remove` overloads Polecat lacked, and uses `Rename(string, Expression<Func<T, object>>)` where Polecat had a generic `Rename<TElement>`. Lifting Marten's superset keeps Marten a no-op rebind and requires Polecat to grow the missing overloads on adoption (downstream).
- `JasperFx.Events.RemoveAction` — `RemoveFirst`/`RemoveAll`, identical in both.

Bodies (`PatchExpression<T>`, dialect-specific `jsonb_set` vs `JSON_MODIFY`) stay in-store. The expression-tree → dotted-path helper is explicitly out of scope per the issue.

## Test plan
- [x] `EventTests/PatchExpressionContractTests` — a `RecordingPatchExpression<T>` implements the **full** interface (compile-pinning every signature) + verifies fluent chaining; `RemoveAction` ordinals pinned. 2/2 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Both stores' `PatchExpression<T>` implement the lifted interface + type-forward old names in follow-up PRs (downstream tracking issues filed — Polecat's notes the overloads it must add). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)