### PR TITLE
Lift OpenTelemetryOptions base + TrackLevel into JasperFx (closes #332)

### DIFF
--- a/src/CoreTests/OpenTelemetryOptionsTests.cs
+++ b/src/CoreTests/OpenTelemetryOptionsTests.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.Metrics;
+using JasperFx.OpenTelemetry;
+using Shouldly;
+
+namespace CoreTests;
+
+public class OpenTelemetryOptionsTests
+{
+    [Fact]
+    public void track_level_ordinals()
+    {
+        ((int)TrackLevel.None).ShouldBe(0);
+        ((int)TrackLevel.Normal).ShouldBe(1);
+        ((int)TrackLevel.Verbose).ShouldBe(2);
+    }
+
+    [Fact]
+    public void base_defaults_track_connections_to_none_and_names_the_meter()
+    {
+        var options = new OpenTelemetryOptions("Polecat");
+
+        options.TrackConnections.ShouldBe(TrackLevel.None);
+        options.Meter.Name.ShouldBe("Polecat");
+    }
+
+    // Models Marten's posture: a store-specific subclass that names the meter and adds the
+    // changeset-metrics surface while inheriting TrackConnections + Meter from the base.
+    [Fact]
+    public void store_specific_subclass_inherits_base_and_adds_metrics()
+    {
+        var options = new FakeStoreOtelOptions();
+
+        options.ShouldBeAssignableTo<OpenTelemetryOptions>();
+        options.Meter.Name.ShouldBe("FakeStore");
+        options.TrackConnections = TrackLevel.Verbose;
+        options.TrackConnections.ShouldBe(TrackLevel.Verbose);
+
+        var counter = options.AddCounter("things", "count");
+        counter.ShouldNotBeNull();
+    }
+
+    private sealed class FakeStoreOtelOptions() : OpenTelemetryOptions("FakeStore")
+    {
+        // Stand-in for Marten's ExportCounterOnChangeSets, which uses the inherited Meter.
+        public Counter<long> AddCounter(string name, string units) => Meter.CreateCounter<long>(name, units);
+    }
+}

--- a/src/JasperFx/OpenTelemetry/OpenTelemetryOptions.cs
+++ b/src/JasperFx/OpenTelemetry/OpenTelemetryOptions.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Descriptors;
+
+namespace JasperFx.OpenTelemetry;
+
+/// <summary>
+/// Common OpenTelemetry configuration shared by Critter Stack tools: the connection/session
+/// tracking level and the per-tool <see cref="System.Diagnostics.Metrics.Meter"/> used for
+/// custom metrics.
+/// </summary>
+/// <remarks>
+/// Lifted as the common base from Marten's and Polecat's near-identical
+/// <c>OpenTelemetryOptions</c>. The only structural difference was the meter name
+/// ("Marten" vs "Polecat"), supplied here via the ctor. Marten's changeset-metrics surface
+/// (<c>ExportCounterOnChangeSets</c> / <c>TrackEventCounters</c>, which depend on Marten's
+/// <c>IChangeSet</c>) stays in a Marten-side derived class. Part of the Critter Stack 2026
+/// dedupe pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+///
+/// The pass-N audit deliberately left the <c>MartenTracing</c> / <c>PolecatTracing</c>
+/// ActivitySource holders per-library (they're tiny, the source name is baked in, and OTel
+/// filtering wants per-library sources) — only this options type + <see cref="TrackLevel"/>
+/// are lifted.
+/// </remarks>
+public class OpenTelemetryOptions
+{
+    /// <param name="meterName">
+    /// The <see cref="System.Diagnostics.Metrics.Meter"/> name for this tool's custom metrics
+    /// (e.g. "Marten", "Polecat").
+    /// </param>
+    public OpenTelemetryOptions(string meterName)
+    {
+        Meter = new Meter(meterName);
+    }
+
+    /// <summary>
+    /// Used to track OpenTelemetry events for opening a connection or exceptions on a
+    /// connection (e.g. when a command or data reader is executed). Defaults to
+    /// <see cref="TrackLevel.None"/>.
+    /// </summary>
+    public TrackLevel TrackConnections { get; set; } = TrackLevel.None;
+
+    /// <summary>
+    /// The meter used to create custom counters/instruments for this tool.
+    /// </summary>
+    [IgnoreDescription]
+    public Meter Meter { get; }
+}

--- a/src/JasperFx/OpenTelemetry/TrackLevel.cs
+++ b/src/JasperFx/OpenTelemetry/TrackLevel.cs
@@ -1,0 +1,28 @@
+namespace JasperFx.OpenTelemetry;
+
+/// <summary>
+/// Controls the level of OpenTelemetry tracking emitted by a Critter Stack tool.
+/// </summary>
+/// <remarks>
+/// Lifted from the near-identical <c>TrackLevel</c> enums in Marten (<c>Marten.Services</c>)
+/// and Polecat (<c>Polecat.Internal.OpenTelemetry</c>). Part of the Critter Stack 2026 dedupe
+/// pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>). Each store
+/// type-forwards its old public name to this type.
+/// </remarks>
+public enum TrackLevel
+{
+    /// <summary>
+    /// No OpenTelemetry tracking.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Normal level of OpenTelemetry tracking (connection / session lifecycle).
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// Very verbose tracking, only suitable for debugging or performance tuning.
+    /// </summary>
+    Verbose
+}


### PR DESCRIPTION
## Summary
OpenTelemetry options were near-identical between the stores. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #332.**

- `JasperFx.OpenTelemetry.TrackLevel` (`None`/`Normal`/`Verbose`).
- `JasperFx.OpenTelemetry.OpenTelemetryOptions` — the common base: `TrackConnections` (default `None`) + a per-tool `Meter` named via the ctor (the only structural difference was the meter name, "Marten" vs "Polecat"). `[IgnoreDescription]` on `Meter` carried over from Marten.

Marten's changeset-metrics surface (`ExportCounterOnChangeSets`/`TrackEventCounters`/`MartenCommitMetrics`, which depend on `IChangeSet`) stays in a Marten-side derived class. Per the issue's pass-N note, the `MartenTracing`/`PolecatTracing` ActivitySource holders are deliberately **not** folded in.

## Test plan
- [x] `CoreTests/OpenTelemetryOptionsTests` — `TrackLevel` ordinals; base defaults + meter naming; a store-specific subclass inherits the base and adds a counter via the inherited `Meter` (models Marten's posture). 3/3 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Marten's `OpenTelemetryOptions` derives from the base (keeps its name + extras); Polecat consumes the base; `TrackLevel` type-forwarded. Follow-up PRs (downstream tracking issues filed). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)