### PR TITLE
Lift IDocumentSchemaResolver into JasperFx.Events (closes #333)

### DIFF
--- a/src/EventTests/DocumentSchemaResolverContractTests.cs
+++ b/src/EventTests/DocumentSchemaResolverContractTests.cs
@@ -1,0 +1,43 @@
+using JasperFx.Events;
+using Shouldly;
+
+namespace EventTests;
+
+// Compile-pins the lifted IDocumentSchemaResolver surface by implementing it, and smoke-checks
+// the qualified/bare behavior a real resolver provides.
+public class DocumentSchemaResolverContractTests
+{
+    [Fact]
+    public void implementable_with_qualified_and_bare_names()
+    {
+        IDocumentSchemaResolver resolver = new FakeResolver("public");
+
+        resolver.DatabaseSchemaName.ShouldBe("public");
+        resolver.EventsSchemaName.ShouldBe("public");
+
+        resolver.For<DocumentSchemaResolverContractTests>().ShouldBe("public.documentschemaresolvercontracttests");
+        resolver.For<DocumentSchemaResolverContractTests>(qualified: false).ShouldBe("documentschemaresolvercontracttests");
+        resolver.For(typeof(DocumentSchemaResolverContractTests), qualified: false).ShouldBe("documentschemaresolvercontracttests");
+
+        resolver.ForEvents().ShouldBe("public.mt_events");
+        resolver.ForStreams().ShouldBe("public.mt_streams");
+        resolver.ForEventProgression(qualified: false).ShouldBe("mt_event_progression");
+    }
+
+    private sealed class FakeResolver(string schema) : IDocumentSchemaResolver
+    {
+        public string DatabaseSchemaName { get; } = schema;
+        public string EventsSchemaName { get; } = schema;
+
+        public string For<TDocument>(bool qualified = true) => For(typeof(TDocument), qualified);
+
+        public string For(Type documentType, bool qualified = true)
+            => Qualify(documentType.Name.ToLowerInvariant(), qualified);
+
+        public string ForEvents(bool qualified = true) => Qualify("mt_events", qualified);
+        public string ForStreams(bool qualified = true) => Qualify("mt_streams", qualified);
+        public string ForEventProgression(bool qualified = true) => Qualify("mt_event_progression", qualified);
+
+        private string Qualify(string table, bool qualified) => qualified ? $"{DatabaseSchemaName}.{table}" : table;
+    }
+}

--- a/src/JasperFx.Events/IDocumentSchemaResolver.cs
+++ b/src/JasperFx.Events/IDocumentSchemaResolver.cs
@@ -1,0 +1,79 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Resolves the database table name backing a document, projection, or event-store table —
+/// qualified (schema + table) or bare. A single "where does this document live" surface for
+/// diagnostics, schema inspection, and projection-coordinator activity tags.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>Marten.IDocumentSchemaResolver</c> as the canonical, dialect-agnostic
+/// contract. The implementation stays per-store. Polecat has no equivalent yet but will need
+/// one; lifting the contract preemptively establishes a shared cross-store diagnostics surface
+/// and saves a second-rewrite cost. Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public interface IDocumentSchemaResolver
+{
+    /// <summary>
+    ///     The schema name used to store the documents.
+    /// </summary>
+    string DatabaseSchemaName { get; }
+
+    /// <summary>
+    ///     The database schema name for event related tables. By default this
+    ///     is the same schema as the document storage.
+    /// </summary>
+    string EventsSchemaName { get; }
+
+    /// <summary>
+    ///     Find the database name of the table backing <typeparamref name="TDocument"/>. Supports documents and projections.
+    /// </summary>
+    /// <typeparam name="TDocument">The document or projection to look up.</typeparam>
+    /// <param name="qualified">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of <typeparamref name="TDocument"/> in the database.</returns>
+    string For<TDocument>(bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the table backing <paramref name="documentType"/>. Supports documents and projections.
+    /// </summary>
+    /// <param name="documentType">The document type.</param>
+    /// <param name="qualified">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of <paramref name="documentType"/> in the database.</returns>
+    string For(Type documentType, bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the events table.
+    /// </summary>
+    /// <param name="qualified">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of the events table in the database.</returns>
+    string ForEvents(bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the event streams table.
+    /// </summary>
+    /// <param name="qualified">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of the event streams table in the database.</returns>
+    string ForStreams(bool qualified = true);
+
+    /// <summary>
+    ///     Find the database name of the event progression table.
+    /// </summary>
+    /// <param name="qualified">
+    ///     When true (default) the qualified name is returned (schema and table name).
+    ///     Otherwise only the table name is returned.
+    /// </param>
+    /// <returns>The name of the event progression table in the database.</returns>
+    string ForEventProgression(bool qualified = true);
+}


### PR DESCRIPTION
## Summary
`IDocumentSchemaResolver` is dialect-agnostic ("what table backs this document, qualified or not") and matters for diagnostics, schema inspection, and projection-coordinator activity tags. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #333.**

- `JasperFx.Events.IDocumentSchemaResolver` — lifted from Marten's contract verbatim (`DatabaseSchemaName`, `EventsSchemaName`, `For<T>`/`For(Type)`, `ForEvents`/`ForStreams`/`ForEventProgression`, each with a `qualified` flag). Implementation stays per-store.

Marten-only today; lifting the contract preemptively saves the second-rewrite cost when Polecat adds one and establishes a single cross-store "where does this document live" surface.

## Test plan
- [x] `EventTests/DocumentSchemaResolverContractTests` — a `FakeResolver` implements the full contract (compile-pinning every member) and exercises qualified/bare behavior. 1/1 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Marten's resolver implements the lifted contract + type-forwards the old name; Polecat implements it new. Follow-up PRs (downstream tracking issues filed). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)