### PR TITLE
Lift generic store-config contracts IInitialData<TStore> + IConfigureStore<TOptions> (closes #334)

### DIFF
--- a/src/CoreTests/StoreConfigContractTests.cs
+++ b/src/CoreTests/StoreConfigContractTests.cs
@@ -1,0 +1,84 @@
+using JasperFx;
+using Shouldly;
+
+namespace CoreTests;
+
+public class StoreConfigContractTests
+{
+    [Fact]
+    public async Task initial_data_collection_runs_class_and_lambda_populators()
+    {
+        var store = new FakeStore();
+        var collection = new InitialDataCollection<FakeStore>
+        {
+            new SeedItem(),
+        };
+        collection.Add((s, _) =>
+        {
+            s.Seeded.Add("lambda");
+            return Task.CompletedTask;
+        });
+
+        foreach (var data in collection)
+        {
+            await data.Populate(store, CancellationToken.None);
+        }
+
+        store.Seeded.ShouldBe(["class", "lambda"]);
+    }
+
+    [Fact]
+    public void configure_store_hook_mutates_options()
+    {
+        var options = new FakeOptions();
+        IConfigureStore<FakeOptions> hook = new SetNameHook("configured");
+
+        hook.Configure(services: null!, options);
+
+        options.Name.ShouldBe("configured");
+    }
+
+    [Fact]
+    public async Task async_configure_store_hook_mutates_options()
+    {
+        var options = new FakeOptions();
+        IAsyncConfigureStore<FakeOptions> hook = new AsyncSetNameHook("async-configured");
+
+        await hook.Configure(options, CancellationToken.None);
+
+        options.Name.ShouldBe("async-configured");
+    }
+
+    private sealed class FakeStore
+    {
+        public List<string> Seeded { get; } = [];
+    }
+
+    private sealed class FakeOptions
+    {
+        public string? Name { get; set; }
+    }
+
+    private sealed class SeedItem : IInitialData<FakeStore>
+    {
+        public Task Populate(FakeStore store, CancellationToken cancellation)
+        {
+            store.Seeded.Add("class");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SetNameHook(string name) : IConfigureStore<FakeOptions>
+    {
+        public void Configure(IServiceProvider services, FakeOptions options) => options.Name = name;
+    }
+
+    private sealed class AsyncSetNameHook(string name) : IAsyncConfigureStore<FakeOptions>
+    {
+        public ValueTask Configure(FakeOptions options, CancellationToken cancellationToken)
+        {
+            options.Name = name;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/JasperFx/IConfigureStore.cs
+++ b/src/JasperFx/IConfigureStore.cs
@@ -1,0 +1,35 @@
+namespace JasperFx;
+
+/// <summary>
+/// A DI-registered hook that mutates a store's options during <c>AddX()</c> bootstrapping,
+/// with access to the service provider. Lifted from the structurally-identical
+/// <c>IConfigureMarten</c> / <c>IConfigurePolecat</c> (both
+/// <c>void Configure(IServiceProvider, StoreOptions)</c>), generic over the options type.
+/// </summary>
+/// <typeparam name="TOptions">The store's options type (e.g. Marten/Polecat <c>StoreOptions</c>).</typeparam>
+/// <remarks>
+/// Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>). Each store
+/// type-forwards its old interface name to this type.
+/// </remarks>
+public interface IConfigureStore<in TOptions>
+{
+    /// <summary>
+    /// Configure the store options. Called during the <c>AddX()</c> factory.
+    /// </summary>
+    void Configure(IServiceProvider services, TOptions options);
+}
+
+/// <summary>
+/// The asynchronous sibling of <see cref="IConfigureStore{TOptions}"/>, for configuration that
+/// must await work (e.g. fetching secrets) during bootstrapping. Lifted from Marten's
+/// <c>IAsyncConfigureMarten</c>.
+/// </summary>
+/// <typeparam name="TOptions">The store's options type.</typeparam>
+public interface IAsyncConfigureStore<in TOptions>
+{
+    /// <summary>
+    /// Configure the store options asynchronously.
+    /// </summary>
+    ValueTask Configure(TOptions options, CancellationToken cancellationToken);
+}

--- a/src/JasperFx/IInitialData.cs
+++ b/src/JasperFx/IInitialData.cs
@@ -1,0 +1,54 @@
+namespace JasperFx;
+
+/// <summary>
+/// A set of initial data used to pre-populate a document store at startup. Implementers are
+/// responsible for not duplicating data across restarts.
+/// </summary>
+/// <typeparam name="TStore">
+/// The store type to populate (e.g. Marten's <c>IDocumentStore</c>, Polecat's <c>IDocumentStore</c>).
+/// </typeparam>
+/// <remarks>
+/// Lifted from the structurally-identical <c>IInitialData</c> in Marten (<c>Marten.Schema</c>)
+/// and Polecat — both <c>Task Populate(IDocumentStore, CancellationToken)</c>, blocked from
+/// sharing only by the store-typed parameter, resolved here with the generic
+/// <typeparamref name="TStore"/>. Part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public interface IInitialData<in TStore>
+{
+    /// <summary>
+    /// Apply the data loading against the given store.
+    /// </summary>
+    Task Populate(TStore store, CancellationToken cancellation);
+}
+
+/// <summary>
+/// A collection of <see cref="IInitialData{TStore}"/> instances executed on startup. Carries
+/// Polecat's lambda-overload convenience (which Marten lacked) so a simple populator can be
+/// registered without a class.
+/// </summary>
+public class InitialDataCollection<TStore> : List<IInitialData<TStore>>
+{
+    /// <summary>
+    /// Add a simple lambda-based initial-data populator.
+    /// </summary>
+    public void Add(Func<TStore, CancellationToken, Task> populate)
+    {
+        Add(new LambdaInitialData(populate));
+    }
+
+    private sealed class LambdaInitialData : IInitialData<TStore>
+    {
+        private readonly Func<TStore, CancellationToken, Task> _populate;
+
+        public LambdaInitialData(Func<TStore, CancellationToken, Task> populate)
+        {
+            _populate = populate;
+        }
+
+        public Task Populate(TStore store, CancellationToken cancellation)
+        {
+            return _populate(store, cancellation);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Configuration-contract shapes that are structural twins between Marten and Polecat, blocked from sharing only by a store-typed parameter — resolved with generics. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #334.**

- `JasperFx.IInitialData<TStore>` — Marten's `IInitialData` and Polecat's were identical (`Task Populate(IDocumentStore, CancellationToken)`) modulo the store type. Carries Polecat's `InitialDataCollection<TStore>` convenience (a `List<IInitialData<TStore>>` with the lambda `Add` overload Marten lacked).
- `JasperFx.IConfigureStore<TOptions>` (+ `IAsyncConfigureStore<TOptions>`) — Marten's `IConfigureMarten`/`IAsyncConfigureMarten` and Polecat's `IConfigurePolecat` shared the same shape, generic over the options type.

## Item 3 (resilience API shape) intentionally skipped
The issue flags `ConfigureResilience`/`ExtendResilience` a "borderline wash" while Polecat's defaults are an empty stub, to be done "only if the generic-contracts work is already opening this surface." Items 1–2 touch different files than the resilience builder, so per that guidance it's left out.

## Test plan
- [x] `CoreTests/StoreConfigContractTests` — `InitialDataCollection` runs a class + a lambda populator in order; `IConfigureStore` + `IAsyncConfigureStore` hooks mutate a fake options object. 3/3 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Both stores consume the generic contracts + type-forward their old interface names in follow-up PRs (downstream tracking issues filed). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)