### PR TITLE
Lift shared document ID-resolution + IdentityAttribute into JasperFx core (closes #335)

### DIFF
--- a/src/CoreTests/DocumentIdentityTests.cs
+++ b/src/CoreTests/DocumentIdentityTests.cs
@@ -1,0 +1,92 @@
+using JasperFx;
+using Shouldly;
+
+namespace CoreTests;
+
+public class DocumentIdentityTests
+{
+    [Fact]
+    public void valid_id_types_are_the_canonical_four()
+    {
+        DocumentIdentity.ValidIdTypes.ShouldBe([typeof(int), typeof(Guid), typeof(long), typeof(string)]);
+    }
+
+    [Fact]
+    public void resolves_conventional_id_property()
+    {
+        DocumentIdentity.FindIdMember(typeof(ConventionalId))!.Name.ShouldBe("Id");
+    }
+
+    [Fact]
+    public void resolves_id_case_insensitively()
+    {
+        DocumentIdentity.FindIdMember(typeof(LowercaseId))!.Name.ShouldBe("id");
+    }
+
+    [Fact]
+    public void identity_attribute_takes_priority_over_conventional_id()
+    {
+        DocumentIdentity.FindIdMember(typeof(AttributedNonId))!.Name.ShouldBe("Code");
+    }
+
+    [Fact]
+    public void supports_fields_not_just_properties()
+    {
+        // Polecat was property-only; the lifted helper returns MemberInfo and finds fields too.
+        DocumentIdentity.FindIdMember(typeof(FieldId))!.Name.ShouldBe("Id");
+    }
+
+    [Fact]
+    public void ignores_id_of_a_non_valid_type()
+    {
+        // A DateTime "Id" is not one of the canonical valid id types.
+        DocumentIdentity.FindIdMember(typeof(WrongTypeId)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void returns_null_when_no_identity_member()
+    {
+        DocumentIdentity.FindIdMember(typeof(NoId)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void predicate_overload_lets_a_store_widen_the_valid_types()
+    {
+        // The default predicate rejects a DateTime Id; a store-supplied predicate can accept it.
+        // This is the seam stores use for strong-typed-id support without provider side effects here.
+        DocumentIdentity.FindIdMember(typeof(WrongTypeId), t => t == typeof(DateTime))!.Name.ShouldBe("Id");
+    }
+
+    private sealed class ConventionalId
+    {
+        public Guid Id { get; set; }
+    }
+
+    private sealed class LowercaseId
+    {
+        public string id { get; set; } = "";
+    }
+
+    private sealed class AttributedNonId
+    {
+        [Identity] public string Code { get; set; } = "";
+        public Guid Id { get; set; }
+    }
+
+    private sealed class FieldId
+    {
+#pragma warning disable CS0649
+        public long Id;
+#pragma warning restore CS0649
+    }
+
+    private sealed class WrongTypeId
+    {
+        public DateTime Id { get; set; }
+    }
+
+    private sealed class NoId
+    {
+        public string Name { get; set; } = "";
+    }
+}

--- a/src/JasperFx/DocumentIdentity.cs
+++ b/src/JasperFx/DocumentIdentity.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using JasperFx.Core.Reflection;
+
+namespace JasperFx;
+
+/// <summary>
+/// Side-effect-free document ID-resolution convention shared by the Critter Stack stores.
+/// Resolves the identity member of a document type via the same attribute-then-convention
+/// intent both stores used: <see cref="IdentityAttribute"/> first, then a case-insensitive
+/// "Id" member.
+/// </summary>
+/// <remarks>
+/// Lifted from Marten's <c>DocumentMapping.FindIdMember</c> and Polecat's
+/// <c>DocumentMapping.FindIdProperty</c>. The shared helper returns <see cref="MemberInfo"/>
+/// (Marten supports fields; Polecat was property-only — fields are a strict superset and
+/// harmless) and is deliberately free of provider side effects: it does <b>not</b> register
+/// Postgres provider mappings or run strong-typed-id detection. Each store keeps that
+/// provider-coupled value-type registration on its own side and can supply its richer
+/// candidate-type predicate via the <see cref="FindIdMember(Type, Func{Type, bool})"/>
+/// overload to preserve its exact resolution behavior. Part of the Critter Stack 2026 dedupe
+/// pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>) — see
+/// <see href="https://github.com/JasperFx/jasperfx/issues/335">#335</see>.
+/// </remarks>
+public static class DocumentIdentity
+{
+    /// <summary>
+    /// The canonical scalar identity types both stores accept: <see cref="int"/>,
+    /// <see cref="Guid"/>, <see cref="long"/>, <see cref="string"/>. Stores that also accept
+    /// strong-typed ids layer that on top via their own predicate — this set is the
+    /// provider-agnostic core.
+    /// </summary>
+    public static readonly Type[] ValidIdTypes = [typeof(int), typeof(Guid), typeof(long), typeof(string)];
+
+    /// <summary>
+    /// Resolve the identity member of <paramref name="documentType"/> using the canonical
+    /// <see cref="ValidIdTypes"/> as the candidate-type filter. Side-effect-free.
+    /// </summary>
+    /// <returns>The identity member, or <c>null</c> if none is found.</returns>
+    public static MemberInfo? FindIdMember(Type documentType)
+        => FindIdMember(documentType, t => ValidIdTypes.Contains(t));
+
+    /// <summary>
+    /// Resolve the identity member of <paramref name="documentType"/>, using the supplied
+    /// <paramref name="isValidIdType"/> predicate to decide which member types are eligible.
+    /// Stores pass their own predicate (which may recognize strong-typed ids) to preserve
+    /// their exact resolution behavior while keeping this traversal side-effect-free.
+    /// </summary>
+    /// <remarks>
+    /// Resolution order (Marten's superset): <see cref="IdentityAttribute"/> on a property,
+    /// then on a field, then a case-insensitive "id" property, then an "id" field.
+    /// </remarks>
+    /// <returns>The identity member, or <c>null</c> if none is found.</returns>
+    public static MemberInfo? FindIdMember(Type documentType, Func<Type, bool> isValidIdType)
+    {
+        ArgumentNullException.ThrowIfNull(documentType);
+        ArgumentNullException.ThrowIfNull(isValidIdType);
+
+        var candidateProperties = GetProperties(documentType)
+            .Where(p => isValidIdType(p.PropertyType))
+            .ToArray();
+
+        var candidateFields = documentType.GetFields()
+            .Where(f => isValidIdType(f.FieldType))
+            .ToArray();
+
+        return candidateProperties.FirstOrDefault(x => x.HasAttribute<IdentityAttribute>())
+               ?? candidateFields.FirstOrDefault(x => x.HasAttribute<IdentityAttribute>())
+               ?? (MemberInfo?)candidateProperties.FirstOrDefault(x => x.Name.Equals("id", StringComparison.OrdinalIgnoreCase))
+               ?? candidateFields.FirstOrDefault(x => x.Name.Equals("id", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static PropertyInfo[] GetProperties(Type type)
+    {
+        return type.GetTypeInfo().IsInterface
+            ? new[] { type }
+                .Concat(type.GetInterfaces())
+                .SelectMany(i => i.GetProperties())
+                .ToArray()
+            : type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .OrderByDescending(x => x.DeclaringType == type)
+                .ToArray();
+    }
+}

--- a/src/JasperFx/IdentityAttribute.cs
+++ b/src/JasperFx/IdentityAttribute.cs
@@ -1,0 +1,17 @@
+namespace JasperFx;
+
+/// <summary>
+///     Designates the identity property or field on a document type that does not follow the
+///     <c>id</c>/<c>Id</c> naming convention. Takes priority over the conventional "Id" lookup.
+/// </summary>
+/// <remarks>
+/// Lifted from the marker <c>IdentityAttribute</c> in Marten (<c>Marten.Schema</c>, which
+/// extended <c>MartenAttribute</c> with an empty body — the <c>Modify</c> coupling is illusory)
+/// and Polecat (<c>Polecat.Attributes</c>, extended <c>Attribute</c>). Lifted as a plain marker
+/// so both stores type-forward their old public names. Part of the Critter Stack 2026 dedupe
+/// pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+public class IdentityAttribute : Attribute
+{
+}


### PR DESCRIPTION
## Summary
The document ID-resolution convention was the same intent in both stores but needed design care to avoid dragging provider side effects across the boundary. Implemented per the issue's proposed sketch, with the three flagged design questions resolved the conservative way. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #335.**

- `JasperFx.IdentityAttribute` — the shared `[Identity]` marker. Both stores' attribute was an empty marker (`Field|Property`); lifted as a plain `Attribute` so both type-forward their old names. (Marten's `MartenAttribute.Modify` coupling is illusory on an empty body.)
- `JasperFx.DocumentIdentity.FindIdMember(Type) → MemberInfo?` + canonical `ValidIdTypes` ({int, Guid, long, string}). **Side-effect-free**: no Postgres provider-mapping registration, no strong-typed-id detection. Resolution order is Marten's superset (`[Identity]` property → `[Identity]` field → "id" property → "id" field). Returns `MemberInfo` (Marten supports fields; Polecat was property-only — fields are a strict superset).

## Design questions resolved
1. **Returns `MemberInfo`** (supports fields), not `PropertyInfo`.
2. **Side-effect-free** — provider-mapping/value-type registration stays per-store. A `FindIdMember(Type, Func<Type,bool> isValidIdType)` overload is the seam each store uses to inject its richer candidate-type predicate (strong-typed ids) **without** the shared traversal touching provider mappings — preserving each store's exact resolution behavior.
3. **Shared `[Identity]` lives in JasperFx core**; both stores type-forward.

## Test plan
- [x] `CoreTests/DocumentIdentityTests` (8): canonical `ValidIdTypes`; conventional `Id`; case-insensitive `id`; `[Identity]` priority over conventional `Id`; field support; rejects an `Id` of a non-valid type; null when absent; **predicate overload widens accepted types** (the strong-typed-id seam). 8/8 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Both stores route ID resolution through the shared helper (passing their own type predicate) + type-forward `IdentityAttribute`, keeping provider-mapping registration in-store. Follow-up PRs (downstream tracking issues filed). No version bump; single rc.1 bump at the end of the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)