### PR TITLE
Bump all JasperFx packages to rc.1 (Critter Stack 2026 release candidate)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.13</Version>
+        <Version>2.0.0-rc.1</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-alpha.21</Version>
+        <Version>2.0.0-rc.1</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-alpha.8</Version>
+        <Version>5.0.0-rc.1</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-alpha.9</Version>
+        <Version>2.0.0-rc.1</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-alpha.9</Version>
+        <Version>2.0.0-rc.1</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-alpha.20</Version>
+        <Version>2.0.0-rc.1</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
## Summary
Graduates the whole JasperFx family from alpha to **rc.1** as a coordinated release candidate, following the dedupe-pillar lift wave (#326–#335) landing on main. The single version bump was held to the end of the wave so the ten feature PRs stayed version-collision-free.

| Package | From | To |
|---|---|---|
| JasperFx | 2.0.0-alpha.20 | 2.0.0-rc.1 |
| JasperFx.Events | 2.0.0-alpha.21 | 2.0.0-rc.1 |
| JasperFx.Events.SourceGenerator | 2.0.0-alpha.13 | 2.0.0-rc.1 |
| JasperFx.SourceGenerator | 2.0.0-alpha.9 | 2.0.0-rc.1 |
| JasperFx.SourceGeneration | 2.0.0-alpha.9 | 2.0.0-rc.1 |
| JasperFx.RuntimeCompiler | 5.0.0-alpha.8 | 5.0.0-rc.1 |

`rc.1` > `alpha.N` in SemVer prerelease ordering, so every package moves forward.

## Test plan
- [x] `dotnet build jasperfx.sln -c Release` — clean.

## After merge
Trigger `on-manual-do-nuget-publish.yml` to publish the rc.1 family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)