### PR TITLE
Add ILongVersioned (long Version) alongside IRevisioned (int Version) (closes #348)

### DIFF
--- a/src/CoreTests/LongVersionedTests.cs
+++ b/src/CoreTests/LongVersionedTests.cs
@@ -1,0 +1,64 @@
+using JasperFx;
+using Shouldly;
+
+namespace CoreTests;
+
+public class LongVersionedTests
+{
+    [Fact]
+    public void irevisioned_is_still_int()
+    {
+        // #348 explicitly keeps IRevisioned.Version as int (Marten V8 signature). Guard it.
+        typeof(IRevisioned).GetProperty(nameof(IRevisioned.Version))!.PropertyType.ShouldBe(typeof(int));
+    }
+
+    [Fact]
+    public void ilongversioned_is_long()
+    {
+        typeof(ILongVersioned).GetProperty(nameof(ILongVersioned.Version))!.PropertyType.ShouldBe(typeof(long));
+    }
+
+    [Fact]
+    public void concurrency_exception_message_references_irevisioned_for_int_docs()
+    {
+        var message = ConcurrencyException.ToMessage(typeof(RevisionedDoc), "id-1");
+
+        message.ShouldContain("Optimistic concurrency check failed");
+        message.ShouldContain(nameof(IRevisioned));
+        message.ShouldNotContain(nameof(ILongVersioned));
+    }
+
+    [Fact]
+    public void concurrency_exception_message_references_ilongversioned_for_long_docs()
+    {
+        var message = ConcurrencyException.ToMessage(typeof(LongVersionedDoc), "id-2");
+
+        message.ShouldContain("Optimistic concurrency check failed");
+        message.ShouldContain(nameof(ILongVersioned));
+    }
+
+    [Fact]
+    public void concurrency_exception_message_plain_for_unversioned_docs()
+    {
+        var message = ConcurrencyException.ToMessage(typeof(PlainDoc), "id-3");
+
+        message.ShouldContain("Optimistic concurrency check failed");
+        message.ShouldNotContain(nameof(IRevisioned));
+        message.ShouldNotContain(nameof(ILongVersioned));
+    }
+
+    private sealed class RevisionedDoc : IRevisioned
+    {
+        public int Version { get; set; }
+    }
+
+    private sealed class LongVersionedDoc : ILongVersioned
+    {
+        public long Version { get; set; }
+    }
+
+    private sealed class PlainDoc
+    {
+        public string Name { get; set; } = "";
+    }
+}

--- a/src/JasperFx/ConcurrencyException.cs
+++ b/src/JasperFx/ConcurrencyException.cs
@@ -13,6 +13,11 @@ public class ConcurrencyException: Exception
             message +=
                 $". For documents of type {typeof(IRevisioned).FullNameInCode()}, JasperFx uses the current value of {nameof(IRevisioned)}.{nameof(IRevisioned.Version)} as the revision when a document storage operation is requested. You may need to explicitly call IDocumentSession.UpdateRevision() instead, or set the expected version correctly on the document itself";
         }
+        else if (docType.CanBeCastTo<ILongVersioned>())
+        {
+            message +=
+                $". For documents of type {typeof(ILongVersioned).FullNameInCode()}, JasperFx uses the current value of {nameof(ILongVersioned)}.{nameof(ILongVersioned.Version)} as the revision when a document storage operation is requested. You may need to explicitly call IDocumentSession.UpdateRevision() instead, or set the expected version correctly on the document itself";
+        }
 
         return message;
     }

--- a/src/JasperFx/ILongVersioned.cs
+++ b/src/JasperFx/ILongVersioned.cs
@@ -1,0 +1,25 @@
+#nullable enable
+namespace JasperFx;
+
+/// <summary>
+///     Optionally implement this interface on your document types to opt into optimistic
+///     concurrency with the version tracked on the <see cref="Version"/> property using a
+///     64-bit numeric revision. Prefer this over <see cref="IRevisioned"/> for documents
+///     projected from a multi-stream projection, where <see cref="Version"/> is the global
+///     event sequence number and can exceed <see cref="int"/>.
+/// </summary>
+/// <remarks>
+/// Sibling of <see cref="IRevisioned"/> (<c>int Version</c>, the Marten V8 signature, kept
+/// as-is). Users pick whichever fits: <see cref="IRevisioned"/> for ordinary per-document
+/// revision counters, <see cref="ILongVersioned"/> when the version is an event sequence
+/// number. See <see href="https://github.com/JasperFx/jasperfx/issues/348">#348</see>;
+/// part of the Critter Stack 2026 dedupe pillar
+/// (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>).
+/// </remarks>
+public interface ILongVersioned
+{
+    /// <summary>
+    /// The known version for this document.
+    /// </summary>
+    long Version { get; set; }
+}


### PR DESCRIPTION
## Summary
Splits the numeric optimistic-concurrency markers into two interfaces so users pick the one that fits. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #348.**

- `JasperFx.IRevisioned` — `int Version` (Marten V8 signature). **Kept exactly as-is.**
- `JasperFx.ILongVersioned` (new) — `long Version`. For documents projected from a `MultiStreamProjection` where `Version` is the global event sequence number and routinely exceeds `Int32`.

`ConcurrencyException.ToMessage` now recognizes `ILongVersioned` in addition to `IRevisioned` (same guidance, referencing `ILongVersioned.Version`), via an `else if` so a doc implementing `IRevisioned` still gets the `IRevisioned` message.

## Supersedes #341
This is the clean resolution of the int-vs-long tension surfaced in #330 and carved into #341: rather than unify or break the existing `int` interface, add a sibling. **#341 will be closed as superseded.**

## Test plan
- [x] `CoreTests/LongVersionedTests` (5): `IRevisioned.Version` stays `int` (guarded); `ILongVersioned.Version` is `long`; `ConcurrencyException` message references `IRevisioned` for int docs, `ILongVersioned` for long docs, neither for unversioned. 5/5 on net9.0 and net10.0.

## Scope / downstream
JasperFx-side only. Marten/Polecat add `ILongVersioned` support in follow-up PRs (downstream tracking issues filed). No version bump here; a coordinated **rc.2** bump + publish follows separately, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)