### PR TITLE
Lift + reconcile DocumentAlreadyExistsException into JasperFx core (closes #338)

### DIFF
--- a/src/CoreTests/DocumentAlreadyExistsExceptionTests.cs
+++ b/src/CoreTests/DocumentAlreadyExistsExceptionTests.cs
@@ -1,0 +1,59 @@
+using JasperFx;
+using Shouldly;
+
+namespace CoreTests;
+
+public class DocumentAlreadyExistsExceptionTests
+{
+    [Fact]
+    public void no_inner_ctor_carries_document_type_and_id()
+    {
+        var ex = new DocumentAlreadyExistsException(typeof(Target), "abc");
+
+        ex.DocumentType.ShouldBe(typeof(Target));
+        ex.Id.ShouldBe("abc");
+        ex.InnerException.ShouldBeNull();
+    }
+
+    [Fact]
+    public void inner_exception_ctor_carries_inner_plus_document_type_and_id()
+    {
+        var inner = new Exception("boom");
+        var ex = new DocumentAlreadyExistsException(inner, typeof(Target), 42);
+
+        ex.InnerException.ShouldBeSameAs(inner);
+        ex.DocumentType.ShouldBe(typeof(Target));
+        ex.Id.ShouldBe(42);
+    }
+
+    [Fact]
+    public void inner_exception_ctor_tolerates_a_null_inner()
+    {
+        // Marten's closed-shape insert path constructs with a null inner.
+        var ex = new DocumentAlreadyExistsException(null, typeof(Target), 42);
+
+        ex.InnerException.ShouldBeNull();
+        ex.DocumentType.ShouldBe(typeof(Target));
+    }
+
+    [Fact]
+    public void message_uses_martens_fullname_format()
+    {
+        var ex = new DocumentAlreadyExistsException(typeof(Target), "abc");
+
+        ex.Message.ShouldBe($"Document already exists {typeof(Target).FullName}: abc");
+    }
+
+    [Fact]
+    public void doctype_alias_mirrors_document_type_for_marten_source_compat()
+    {
+        var ex = new DocumentAlreadyExistsException(typeof(Target), "abc");
+
+        ex.DocType.ShouldBe(ex.DocumentType);
+    }
+
+    public class Target
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/JasperFx/DocumentAlreadyExistsException.cs
+++ b/src/JasperFx/DocumentAlreadyExistsException.cs
@@ -1,0 +1,63 @@
+namespace JasperFx;
+
+/// <summary>
+/// Thrown when an Insert is attempted for a document whose id already exists in storage.
+/// </summary>
+/// <remarks>
+/// Lifted and reconciled from the conceptually-shared exception that lived in both Marten
+/// (<c>Marten.Exceptions.DocumentAlreadyExistsException : MartenException</c>, carrying an inner
+/// exception, a <c>DocType</c> (Type) and <c>Id</c>, plus a legacy serialization ctor) and Polecat
+/// (<c>Polecat.Exceptions.DocumentAlreadyExistsException : Exception</c>, with <c>DocumentType</c>
+/// (Type) and <c>Id</c>, no inner exception). Canonical home is JasperFx core next to
+/// <see cref="ConcurrencyException"/>, on a plain <see cref="Exception"/> base. Part of the Critter
+/// Stack 2026 dedupe pillar (<see href="https://github.com/JasperFx/jasperfx/issues/214">#214</see>),
+/// carved out of <see href="https://github.com/JasperFx/jasperfx/issues/328">#328</see> as
+/// <see href="https://github.com/JasperFx/jasperfx/issues/338">#338</see>.
+///
+/// Reconciliation decisions (the three differing axes):
+/// <list type="bullet">
+/// <item><description>
+/// <b>Property name:</b> canonical <see cref="DocumentType"/> (Polecat's name; descriptive and avoids
+/// colliding with <see cref="ConcurrencyException"/>'s <c>DocType</c>, which is a <c>string</c> FullName,
+/// not a Type). A get-only <see cref="DocType"/> alias is kept for Marten source-compat.
+/// </description></item>
+/// <item><description>
+/// <b>Message format:</b> Marten's <c>"Document already exists {FullName}: {id}"</c> — uses FullName so
+/// types sharing a simple name across namespaces stay unambiguous.
+/// </description></item>
+/// <item><description>
+/// <b>Ctors:</b> both the inner-exception form (Marten, inner is nullable since Marten passes
+/// <c>null</c> from its closed-shape insert path) and the no-inner form (Polecat). The legacy
+/// <c>(SerializationInfo, StreamingContext)</c> ctor is dropped — binary exception serialization is
+/// obsolete on .NET 8+ (SYSLIB0051) and JasperFx targets net9/net10.
+/// </description></item>
+/// </list>
+/// </remarks>
+public class DocumentAlreadyExistsException : Exception
+{
+    public DocumentAlreadyExistsException(Type documentType, object id)
+        : base(ToMessage(documentType, id))
+    {
+        DocumentType = documentType;
+        Id = id;
+    }
+
+    public DocumentAlreadyExistsException(Exception? inner, Type documentType, object id)
+        : base(ToMessage(documentType, id), inner)
+    {
+        DocumentType = documentType;
+        Id = id;
+    }
+
+    public static string ToMessage(Type documentType, object id)
+        => $"Document already exists {documentType.FullName}: {id}";
+
+    public Type DocumentType { get; }
+    public object Id { get; }
+
+    /// <summary>
+    /// Alias for <see cref="DocumentType"/>, retained for source compatibility with Marten's
+    /// original <c>DocType</c> property.
+    /// </summary>
+    public Type DocType => DocumentType;
+}


### PR DESCRIPTION
## Summary
Item 3 of #328 — the deferred, *noisy* exception lift — carved out to #338 per #328's own escape hatch (*"if the reconciliation proves noisy, split this third one out — items 1 and 2 are clean"*). Items 1 and 2 landed in #339. Part of the Critter Stack 2026 dedupe pillar (#214). **Closes #338.**

The two stores' `DocumentAlreadyExistsException` differed on every axis the issue flagged — base type, ctors, property name, and message format — each with downstream source-break implications. This reconciles them and lifts a single `JasperFx.DocumentAlreadyExistsException` to core next to `ConcurrencyException`, on a plain `Exception` base (no `MartenException` in core).

## Decisions recorded (the three differing axes)
| Axis | Decision | Why |
|---|---|---|
| **Property name** | canonical **`DocumentType`** (Type), with a get-only **`DocType` alias** for Marten source-compat | `DocumentType` (Polecat's name) is more descriptive and avoids colliding with the sibling `ConcurrencyException.DocType`, which is a `string` FullName — not a `Type`. No call site currently reads the exception's property, so the alias covers Marten cleanly. |
| **Message format** | Marten's **`"Document already exists {FullName}: {id}"`** | FullName keeps types that share a simple name across namespaces unambiguous; Marten is the larger existing audience. |
| **Ctors** | both `(Type, object)` (Polecat) and `(Exception? inner, Type, object)` (Marten); **serialization ctor dropped** | Inner is nullable because Marten's closed-shape insert path passes `null`. Binary exception serialization is obsolete on .NET 8+ (SYSLIB0051) and JasperFx targets net9/net10; the sibling `ConcurrencyException` has none either. |

## Test plan
- [x] `CoreTests/DocumentAlreadyExistsExceptionTests` (5): both ctors carry `DocumentType`/`Id`; the inner ctor preserves — and tolerates a `null` — inner; the message uses the FullName format; the `DocType` alias mirrors `DocumentType`. **5/5 on net9.0 and net10.0.**

## Scope / downstream
JasperFx-side only, matching the #339 model. In follow-up PRs both stores consume the lifted type, type-forward their old names (Marten also relies on the `DocType` prop alias), and verify their `InsertExceptionTransform` (Marten) / inline `catch (2627)` (Polecat) mapping to the shared type. No version bump here — a coordinated bump follows the wave.

Refs: parent #328 · pillar #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)