### PR TITLE
Let ProjectionCoordinatorBase tolerate a null distributor (closes #352)

### DIFF
--- a/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
+++ b/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
@@ -97,6 +97,41 @@ public class ProjectionCoordinatorBaseTests
         daemon.StopAllCount.ShouldBeGreaterThanOrEqualTo(1);
     }
 
+    // #352: a coordinator can be legitimately constructed but never started when the async
+    // daemon is Disabled — the store's BuildDistributor returns null because there is nothing
+    // to coordinate. The ctor must not reject that; the lifecycle methods must no-op cleanly.
+    [Fact]
+    public void can_be_constructed_with_a_null_distributor()
+    {
+        var coordinator = new TestCoordinator(
+            distributor: null,
+            new FakeDaemon(),
+            leadershipPollingTime: TimeSpan.FromSeconds(30),
+            agentPauseTime: TimeSpan.FromSeconds(30),
+            healthCheckPollingTime: TimeSpan.FromSeconds(30));
+
+        coordinator.Distributor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task start_and_stop_no_op_when_the_distributor_is_null()
+    {
+        var daemon = new FakeDaemon();
+        var coordinator = new TestCoordinator(
+            distributor: null,
+            daemon,
+            leadershipPollingTime: TimeSpan.FromSeconds(30),
+            agentPauseTime: TimeSpan.FromSeconds(30),
+            healthCheckPollingTime: TimeSpan.FromSeconds(30));
+
+        // No runner spins up, and neither lifecycle call throws on the absent distributor.
+        await Should.NotThrowAsync(() => coordinator.StartAsync(CancellationToken.None));
+        await Should.NotThrowAsync(() => coordinator.StopAsync(CancellationToken.None));
+
+        // The loop never ran, so no agents were touched.
+        daemon.Started.ShouldBeEmpty();
+    }
+
     private static async Task WaitFor(Func<bool> condition, int timeoutMs = 3000)
     {
         var elapsed = 0;
@@ -111,7 +146,7 @@ public class ProjectionCoordinatorBaseTests
     {
         private readonly FakeDaemon _daemon;
 
-        public TestCoordinator(IProjectionDistributor distributor, FakeDaemon daemon,
+        public TestCoordinator(IProjectionDistributor? distributor, FakeDaemon daemon,
             TimeSpan leadershipPollingTime, TimeSpan agentPauseTime, TimeSpan healthCheckPollingTime)
             : base(distributor, NullLogger.Instance, ResiliencePipeline.Empty, TimeProvider.System,
                 leadershipPollingTime, agentPauseTime, healthCheckPollingTime)

--- a/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
+++ b/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
@@ -50,12 +50,21 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
 
     /// <summary>
     /// The distributor that decides which (database × shards) sets this node should
-    /// try to run, and negotiates the per-set leadership locks.
+    /// try to run, and negotiates the per-set leadership locks. Null when the coordinator
+    /// is constructed in a "nothing to coordinate" state — see the <see cref="ProjectionCoordinatorBase"/>
+    /// ctor remarks.
     /// </summary>
-    public IProjectionDistributor Distributor { get; }
+    public IProjectionDistributor? Distributor { get; }
 
+    /// <param name="distributor">
+    /// May be null. A coordinator can be legitimately constructed but never started when the
+    /// async daemon is <c>Disabled</c>: there is no distribution work, so a store's
+    /// <c>BuildDistributor</c> naturally returns null in that mode. In that case
+    /// <see cref="StartAsync"/> no-ops and the loop never runs. See
+    /// <see href="https://github.com/JasperFx/jasperfx/issues/352">#352</see>.
+    /// </param>
     protected ProjectionCoordinatorBase(
-        IProjectionDistributor distributor,
+        IProjectionDistributor? distributor,
         ILogger logger,
         ResiliencePipeline resilience,
         TimeProvider timeProvider,
@@ -63,7 +72,7 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
         TimeSpan agentPauseTime,
         TimeSpan healthCheckPollingTime)
     {
-        Distributor = distributor ?? throw new ArgumentNullException(nameof(distributor));
+        Distributor = distributor;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _resilience = resilience ?? throw new ArgumentNullException(nameof(resilience));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
@@ -98,6 +107,13 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // No distributor means there is nothing to coordinate (e.g. a Disabled async daemon).
+        // The coordinator was constructed but should never spin up its leadership loop. See #352.
+        if (Distributor == null)
+        {
+            return Task.CompletedTask;
+        }
+
         _cancellation?.SafeDispose();
 
         _cancellation = new CancellationTokenSource();
@@ -146,13 +162,17 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
             daemon.SafeDispose();
         }
 
-        try
+        var distributor = Distributor;
+        if (distributor != null)
         {
-            await Distributor.ReleaseAllLocks().ConfigureAwait(false);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Error trying to release subscription agent locks");
+            try
+            {
+                await distributor.ReleaseAllLocks().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error trying to release subscription agent locks");
+            }
         }
     }
 
@@ -182,32 +202,37 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
 
     private async Task executeAsync(CancellationToken stoppingToken)
     {
-        await Distributor.RandomWait(stoppingToken).ConfigureAwait(false);
+        // StartAsync only reaches here with a non-null distributor; capture it locally so the
+        // null-state flows cleanly through the loop and the nested start path.
+        var distributor = Distributor;
+        if (distributor == null) return;
+
+        await distributor.RandomWait(stoppingToken).ConfigureAwait(false);
 
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
-                var sets = await Distributor.BuildDistributionAsync().ConfigureAwait(false);
+                var sets = await distributor.BuildDistributionAsync().ConfigureAwait(false);
 
                 foreach (var set in sets)
                 {
                     if (stoppingToken.IsCancellationRequested) return;
 
                     // Is it already running here?
-                    if (Distributor.HasLock(set))
+                    if (distributor.HasLock(set))
                     {
                         var daemon = ResolveDaemon(set);
-                        await startAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                        await startAgentsIfNecessaryAsync(distributor, set, daemon, stoppingToken).ConfigureAwait(false);
                         continue;
                     }
 
                     try
                     {
-                        if (await Distributor.TryAttainLockAsync(set, stoppingToken).ConfigureAwait(false))
+                        if (await distributor.TryAttainLockAsync(set, stoppingToken).ConfigureAwait(false))
                         {
                             var daemon = ResolveDaemon(set);
-                            await startAgentsIfNecessaryAsync(set, daemon, stoppingToken).ConfigureAwait(false);
+                            await startAgentsIfNecessaryAsync(distributor, set, daemon, stoppingToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -264,20 +289,20 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
         }
     }
 
-    private async Task startAgentsIfNecessaryAsync(IProjectionSet set, IProjectionDaemon daemon,
-        CancellationToken stoppingToken)
+    private async Task startAgentsIfNecessaryAsync(IProjectionDistributor distributor, IProjectionSet set,
+        IProjectionDaemon daemon, CancellationToken stoppingToken)
     {
         foreach (var name in set.Names)
         {
             var agent = daemon.CurrentAgents().FirstOrDefault(x => x.Name.Equals(name));
             if (agent == null)
             {
-                await tryStartAgent(stoppingToken, daemon, name, set).ConfigureAwait(false);
+                await tryStartAgent(distributor, stoppingToken, daemon, name, set).ConfigureAwait(false);
             }
             else if (agent is { Status: AgentStatus.Paused, PausedTime: not null } &&
                      _timeProvider.GetUtcNow().Subtract(agent.PausedTime.Value) > _healthCheckPollingTime)
             {
-                await tryStartAgent(stoppingToken, daemon, name, set).ConfigureAwait(false);
+                await tryStartAgent(distributor, stoppingToken, daemon, name, set).ConfigureAwait(false);
             }
         }
     }
@@ -294,8 +319,8 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
         }
     }
 
-    private async Task tryStartAgent(CancellationToken stoppingToken, IProjectionDaemon daemon, ShardName name,
-        IProjectionSet set)
+    private async Task tryStartAgent(IProjectionDistributor distributor, CancellationToken stoppingToken,
+        IProjectionDaemon daemon, ShardName name, IProjectionSet set)
     {
         try
         {
@@ -312,7 +337,7 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
                 daemon.EjectPausedShard(name.Identity);
             }
 
-            await Distributor.ReleaseLockAsync(set).ConfigureAwait(false);
+            await distributor.ReleaseLockAsync(set).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
## Summary
The #326 dedupe lifted the coordinator leadership/agent loop into `JasperFx.Events.Daemon.ProjectionCoordinatorBase`, whose ctor hard-rejected a null distributor:

```csharp
Distributor = distributor ?? throw new ArgumentNullException(nameof(distributor));
```

But a coordinator can be legitimately **constructed but never started** when the async daemon is `Disabled` — there's no distribution work, so a store's `BuildDistributor` naturally returns null in that mode. Pre-dedupe (Marten) this was a plain null assignment that constructed fine; the loop simply never ran because the coordinator wasn't started.

This regressed **Marten 9.0.0-rc.1** (resolving the coordinator in Disabled mode threw `ArgumentNullException`), surfaced by Wolverine's ancillary-store integration which news up `ProjectionCoordinator<T>` directly for stores whose distribution Wolverine manages itself. Marten worked around it with a no-op distributor (JasperFx/marten#4535). **Closes #352** and restores the documented pre-dedupe behavior centrally, so that workaround can be retired.

## Fix
- `Distributor` property + ctor param are now **nullable**; the ctor no longer throws.
- `StartAsync` **no-ops** when `Distributor` is null (nothing to coordinate).
- `StopAsync` guards `ReleaseAllLocks` for null.
- `executeAsync` captures the distributor into a non-null local (it's only reached post-`StartAsync` guard) and threads it through `startAgentsIfNecessaryAsync` / `tryStartAgent`, so the nullable annotation flows cleanly with **no new warnings**.

## Test plan
- [x] `EventTests/ProjectionCoordinatorBaseTests` (+2 → 6): constructing with a null distributor doesn't throw; `Start`/`Stop` no-op cleanly without spinning up the loop. The 4 existing loop tests (non-null distributor) still pass. **6/6 on net9.0 and net10.0.**

## Scope / downstream
JasperFx-side only. Follow-ups filed so each store realigns once it picks up the rc containing this:
- **Marten** — retire the `NulloProjectionDistributor` workaround (#4535) now that the base tolerates null. The 3 `coordinator.Distributor.ShouldBeOfType<…>()` test reads may need a `!` against the now-nullable property (warning only).
- **Polecat** — not affected today (its `ProjectionCoordinator` hasn't migrated to `ProjectionCoordinatorBase`); the migration can now rely on null = "nothing to coordinate" rather than a lazy distributor.

Refs: regressor #326 · Marten workaround JasperFx/marten#4535 · pillar #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)