### PR TITLE
Bump all JasperFx packages to rc.3 (#338 + #352)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.0.0-rc.2</Version>
+        <Version>2.0.0-rc.3</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.0.0-rc.2</Version>
+        <Version>2.0.0-rc.3</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the

--- a/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
+++ b/src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Description>Runtime Roslyn Compilation and Code Generation Chicanery</Description>
         <PackageId>JasperFx.RuntimeCompiler</PackageId>
-        <Version>5.0.0-rc.2</Version>
+        <Version>5.0.0-rc.3</Version>
     </PropertyGroup>
     <ItemGroup>
 

--- a/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
+++ b/src/JasperFx.SourceGeneration/JasperFx.SourceGeneration.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx command discovery — eliminates runtime assembly scanning for CLI commands</Description>
         <PackageId>JasperFx.SourceGeneration</PackageId>
-        <Version>2.0.0-rc.2</Version>
+        <Version>2.0.0-rc.3</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
+++ b/src/JasperFx.SourceGenerator/JasperFx.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for JasperFx OptionsDescription — generates IDescribeMyself.ToDescription() without Reflection</Description>
         <PackageId>JasperFx.SourceGenerator</PackageId>
-        <Version>2.0.0-rc.2</Version>
+        <Version>2.0.0-rc.3</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>

--- a/src/JasperFx/JasperFx.csproj
+++ b/src/JasperFx/JasperFx.csproj
@@ -3,7 +3,7 @@
         <Description>Foundational helpers and command line support used by JasperFx and the Critter Stack projects</Description>
         <AssemblyName>JasperFx</AssemblyName>
         <PackageId>JasperFx</PackageId>
-        <Version>2.0.0-rc.2</Version>
+        <Version>2.0.0-rc.3</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective public surface that isn't already annotated with
              [RequiresDynamicCode] / [RequiresUnreferencedCode] / [DynamicallyAccessedMembers]


### PR DESCRIPTION
Bumps all published JasperFx packages from `rc.2` to `rc.3` to release the two changes merged since:

- **#353** (closes #338) — `JasperFx.DocumentAlreadyExistsException` lifted + reconciled into core
- **#354** (closes #352) — `ProjectionCoordinatorBase` tolerates a null distributor

Versions:
- JasperFx / JasperFx.Events / JasperFx.Events.SourceGenerator / JasperFx.SourceGenerator / JasperFx.SourceGeneration: `2.0.0-rc.2` → `2.0.0-rc.3`
- JasperFx.RuntimeCompiler: `5.0.0-rc.2` → `5.0.0-rc.3`

Same six-csproj footprint as the rc.2 bump (#351). NuGet publish to follow via the manual publish action once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)