### PR TITLE
docs: stop dead-link-checking .cs source-file links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,10 @@ export default withMermaid(
   defineConfig({
     title: 'JasperFx',
     description: 'The foundational .NET library behind the Critter Stack',
+    // Relative links to .cs source files (with optional #Lxxx anchors) are source
+    // references, not doc pages — VitePress can't resolve them and fails the build.
+    // Don't dead-link-check source-file links; doc-to-doc links are still validated.
+    ignoreDeadLinks: [/\.cs(#.*)?$/],
     head: [
       ['link', { rel: 'icon', href: '/jasperfx-logo.png' }]
     ],


### PR DESCRIPTION
The `docs.yml` deploy fails on 16 dead links in `codegen/projection-apply-dispatch.md` — relative links to `.cs` source files (with `#Lxxx` anchors) that VitePress can't resolve as doc pages. Pre-existing; unrelated to the 2.0.0 version bump. Scopes `ignoreDeadLinks` to `.cs` links; doc-to-doc links stay validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)