### PR TITLE
Fix source generator evolver and hint-name failures

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -665,6 +665,65 @@ public class Registration
         allGenerated.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.Counter)");
     }
 
+    [Fact]
+    public void nullable_aggregate_parameter_attribute_does_not_crash_hint_name_generation()
+    {
+        var source = @"
+#nullable enable
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+
+namespace Test;
+
+public class ReadAggregateAttribute(string memberName) : Attribute, IRefersToAggregate;
+
+public record EigenPrestatie
+{
+    public required string Id { get; init; }
+    public required string Prestatiecode { get; init; }
+
+    public static EigenPrestatie Create(EigenPrestatieAangemaakt e) => new()
+    {
+        Id = e.PrestatieId,
+        Prestatiecode = e.Prestatiecode
+    };
+}
+
+public class EigenPrestatieAangemaakt
+{
+    public string PrestatieId { get; set; } = """";
+    public string Prestatiecode { get; set; } = """";
+}
+
+public class EigenTariefAanmaken
+{
+    public string PrestatieId { get; set; } = """";
+}
+
+public static class EigenTariefAanmakenEndpoint
+{
+    public static void Validate(
+        EigenTariefAanmaken request,
+        [ReadAggregate(nameof(EigenTariefAanmaken.PrestatieId))]
+        EigenPrestatie? prestatie)
+    {
+    }
+}
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        diagnostics
+            .Where(d => d.Id == "CS8785")
+            .Select(d => d.GetMessage())
+            .ShouldBeEmpty();
+
+        generatedSources.Length.ShouldBeGreaterThan(0);
+        var allGenerated = string.Join("\n", generatedSources);
+        allGenerated.ShouldContain("IGeneratedSyncEvolver<global::Test.EigenPrestatie, string>");
+        allGenerated.ShouldContain("EigenPrestatieEvolver");
+    }
+
     // Negative case for #293: a same-named Snapshot<T>() helper in a user namespace must NOT
     // trip Pipeline 3, otherwise unrelated user code with a generic Snapshot<T> method would
     // start producing spurious evolvers for arbitrary type arguments.

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -111,6 +111,109 @@ public partial class AllSync : SingleStreamProjection<MyAggregate, Guid>
     }
 
     [Fact]
+    public void partial_projection_for_required_member_aggregate_suppresses_snapshot_fallback()
+    {
+        var source = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace Marten.Events.Projections
+{
+    public class ProjectionOptions
+    {
+        public void Snapshot<T>() { }
+    }
+}
+
+namespace Test
+{
+
+public record DiagnostiekActiviteit(string Id)
+{
+    public required string Aanlevercode { get; set; }
+    public required int Prestatiecodelijst { get; set; }
+
+    public DiagnostiekActiviteit(DiagnosticProvidedCareImported e) : this(e.ProvidedCareId)
+    {
+        Aanlevercode = e.Prestatiecode;
+        Prestatiecodelijst = e.Prestatiecodelijst;
+    }
+}
+
+public class DiagnosticProvidedCareReceived
+{
+    public string ProvidedCareId { get; set; } = """";
+    public string Prestatiecode { get; set; } = """";
+    public int Prestatiecodelijst { get; set; }
+}
+
+public class DiagnosticProvidedCareImported
+{
+    public string ProvidedCareId { get; set; } = """";
+    public string Prestatiecode { get; set; } = """";
+    public int Prestatiecodelijst { get; set; }
+}
+
+public class StubOperations : IStorageOperations
+{
+    public bool EnableSideEffectsOnInlineProjections => false;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<IProjectionStorage<TDoc, TId>> FetchProjectionStorageAsync<TDoc, TId>(
+        string tenantId,
+        CancellationToken cancellationToken) => throw new NotSupportedException();
+
+    public ValueTask<IMessageSink> GetOrStartMessageSink() => throw new NotSupportedException();
+}
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, StubOperations, StubOperations>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() { }
+}
+
+public partial class DiagnostiekActiviteitProjection : SingleStreamProjection<DiagnostiekActiviteit, string>
+{
+    public static DiagnostiekActiviteit Create(DiagnosticProvidedCareReceived e) => new(e.ProvidedCareId)
+    {
+        Aanlevercode = e.Prestatiecode,
+        Prestatiecodelijst = e.Prestatiecodelijst
+    };
+
+    public void Apply(DiagnosticProvidedCareImported e, DiagnostiekActiviteit a) { }
+}
+
+public class Registration
+{
+    public void Register(Marten.Events.Projections.ProjectionOptions opts)
+    {
+        opts.Snapshot<DiagnostiekActiviteit>();
+    }
+}
+}
+";
+        var diagnostics = CompileWithGenerator(source);
+
+        diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.GetMessage())
+            .ShouldBeEmpty();
+
+        var (_, generatedSources) = RunGenerator(source);
+        var allGenerated = string.Join("\n", generatedSources);
+
+        allGenerated.ShouldContain("partial class DiagnostiekActiviteitProjection");
+        allGenerated.ShouldNotContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.DiagnostiekActiviteit)");
+        allGenerated.ShouldNotContain("DiagnostiekActiviteit_StringEvolver");
+    }
+
+    [Fact]
     public void generates_evolver_for_self_aggregating_type()
     {
         var source = @"

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -1339,9 +1339,9 @@ internal static class AggregateAnalyzer
     {
         // Always-true: the emitter knows how to instantiate every reference
         // type via `BuildAggregateConstructorExpression`, which picks between
-        // `new T()`, `new T { ... = default! }` (required members), or
-        // `RuntimeHelpers.GetUninitializedObject(typeof(T))` (no public
-        // parameterless ctor). Keeping the property name + signature
+        // `new T()`, `new T { ... = default! }` (required members with a
+        // public parameterless ctor), or `RuntimeHelpers.GetUninitializedObject(typeof(T))`
+        // (no public parameterless ctor). Keeping the property name + signature
         // unchanged so downstream gates that read it still compile; the value
         // now reflects "can the emitter produce an instance?" rather than
         // strictly "is there a public parameterless ctor?". See #297.

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -273,14 +273,13 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         ImmutableArray<CandidateInfo?> refs,
         ImmutableArray<CandidateInfo?> snapshots)
     {
-        var seen = new System.Collections.Generic.HashSet<string>();
+        var seen = new HashSet<string>();
 
         // Pipeline 1 candidates have priority
         foreach (var info in direct)
         {
             if (info == null) continue;
-            var key = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            seen.Add(key);
+            MarkSeen(seen, info);
             Execute(spc, info);
         }
 
@@ -288,7 +287,7 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         foreach (var info in refs)
         {
             if (info == null) continue;
-            var key = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            var key = SymbolKey(info.ClassSymbol);
             if (seen.Add(key))
             {
                 Execute(spc, info);
@@ -322,6 +321,21 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
                 Execute(spc, info);
             }
         }
+    }
+
+    private static void MarkSeen(HashSet<string> seen, CandidateInfo info)
+    {
+        seen.Add(SymbolKey(info.ClassSymbol));
+
+        if (info.Mode == CandidateMode.PartialProjection && info.AggregateType != null && info.Methods.Count > 0)
+        {
+            seen.Add(SymbolKey(info.AggregateType));
+        }
+    }
+
+    private static string SymbolKey(INamedTypeSymbol symbol)
+    {
+        return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
     }
 
     private static void Execute(SourceProductionContext context, CandidateInfo info)

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -168,6 +168,7 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         // and aborted the whole SG run for that compilation. See #297.
         if (aggregateSymbol is not INamedTypeSymbol aggregateType)
             return null;
+        aggregateType = NormalizeAggregateType(aggregateType);
 
         // Resolve the invoked method and require it to be defined on a JasperFx.Events
         // or Marten projections-collection-style API. The conservative check: the
@@ -244,20 +245,7 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
                     // Get the parameter type (the aggregate type)
                     var paramSymbol = ctx.SemanticModel.GetDeclaredSymbol(param, ct) as IParameterSymbol;
                     if (paramSymbol?.Type is not INamedTypeSymbol aggregateType) continue;
-
-                    // Unwrap nullable
-                    if (aggregateType.IsGenericType &&
-                        aggregateType.ConstructedFrom.ToDisplayString() == "System.Nullable<T>")
-                    {
-                        aggregateType = (INamedTypeSymbol)aggregateType.TypeArguments[0];
-                    }
-
-                    // Unwrap IEventStream<T>
-                    if (aggregateType.IsGenericType &&
-                        aggregateType.ConstructedFrom.ToDisplayString().Contains("IEventStream"))
-                    {
-                        aggregateType = (INamedTypeSymbol)aggregateType.TypeArguments[0];
-                    }
+                    aggregateType = NormalizeAggregateType(aggregateType);
 
                     return AggregateAnalyzer.AnalyzeRefersToAggregate(aggregateType, ct);
                 }
@@ -265,6 +253,29 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         }
 
         return null;
+    }
+
+    private static INamedTypeSymbol NormalizeAggregateType(INamedTypeSymbol aggregateType)
+    {
+        if (aggregateType.IsGenericType &&
+            aggregateType.ConstructedFrom.ToDisplayString() == "System.Nullable<T>")
+        {
+            aggregateType = (INamedTypeSymbol)aggregateType.TypeArguments[0];
+        }
+
+        if (aggregateType.IsGenericType &&
+            aggregateType.ConstructedFrom.ToDisplayString().Contains("IEventStream"))
+        {
+            aggregateType = (INamedTypeSymbol)aggregateType.TypeArguments[0];
+        }
+
+        if (aggregateType.IsGenericType &&
+            aggregateType.ConstructedFrom.ToDisplayString() == "System.Nullable<T>")
+        {
+            aggregateType = (INamedTypeSymbol)aggregateType.TypeArguments[0];
+        }
+
+        return (INamedTypeSymbol)aggregateType.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
     }
 
     private static void ExecuteCombined(
@@ -392,8 +403,20 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
 
     private static string SafeHintName(INamedTypeSymbol symbol, string suffix)
     {
-        var fullName = symbol.ToDisplayString().Replace('<', '_').Replace('>', '_').Replace(',', '_').Replace(' ', '_').Replace('.', '_');
+        var fullName = SanitizeHintNamePart(symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
         return $"{fullName}{suffix}.g.cs";
+    }
+
+    private static string SanitizeHintNamePart(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+
+        foreach (var ch in value)
+        {
+            builder.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>
@@ -406,11 +429,9 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
     /// </summary>
     private static string SafeSelfAggregatingHintName(CandidateInfo info, string suffix)
     {
-        var typeName = info.ClassSymbol.ToDisplayString();
-        var idName = info.IdentityType?.ToDisplayString() ?? string.Empty;
-        var combined = (typeName + "_" + idName)
-            .Replace('<', '_').Replace('>', '_').Replace(',', '_').Replace(' ', '_').Replace('.', '_');
-        return $"{combined}{suffix}.g.cs";
+        var typeName = info.ClassSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var idName = info.IdentityType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty;
+        return $"{SanitizeHintNamePart(typeName + "_" + idName)}{suffix}.g.cs";
     }
 
     private static void EmitPartialProjection(SourceProductionContext context, CandidateInfo info)

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -594,11 +594,11 @@ internal static class EvolverCodeEmitter
         // Emit the Evolve or EvolveAsync method
         if (isAsync)
         {
-            EmitAsyncEvolveMethod(sb, evolve, aggregateFullName, idFullName);
+            EmitAsyncEvolveMethod(sb, evolve, info.AggregateType!, aggregateFullName, idFullName);
         }
         else
         {
-            EmitSyncEvolveMethod(sb, evolve, aggregateFullName, idFullName);
+            EmitSyncEvolveMethod(sb, evolve, info.AggregateType!, aggregateFullName, idFullName);
         }
 
         sb.AppendLine("}");
@@ -621,16 +621,17 @@ internal static class EvolverCodeEmitter
         }
     }
 
-    private static void EmitSyncEvolveMethod(StringBuilder sb, EvolveMethodInfo evolve,
+    private static void EmitSyncEvolveMethod(StringBuilder sb, EvolveMethodInfo evolve, INamedTypeSymbol aggregateType,
         string docType, string idType)
     {
+        var ctorExpression = BuildAggregateConstructorExpression(aggregateType);
         sb.AppendLine($"    public {docType}? Evolve({docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e)");
         sb.AppendLine("    {");
 
         if (evolve.IsMutable)
         {
             // void Evolve(object) or void Evolve(IEvent)
-            sb.AppendLine($"        snapshot ??= new {docType}();");
+            sb.AppendLine($"        snapshot ??= {ctorExpression};");
             if (evolve.TakesIEvent)
             {
                 sb.AppendLine("        snapshot.Evolve(e);");
@@ -646,20 +647,21 @@ internal static class EvolverCodeEmitter
             // TDoc Evolve(object) or TDoc Evolve(IEvent)
             if (evolve.TakesIEvent)
             {
-                sb.AppendLine($"        return (snapshot ?? new {docType}()).Evolve(e);");
+                sb.AppendLine($"        return (snapshot ?? {ctorExpression}).Evolve(e);");
             }
             else
             {
-                sb.AppendLine($"        return (snapshot ?? new {docType}()).Evolve(e.Data);");
+                sb.AppendLine($"        return (snapshot ?? {ctorExpression}).Evolve(e.Data);");
             }
         }
 
         sb.AppendLine("    }");
     }
 
-    private static void EmitAsyncEvolveMethod(StringBuilder sb, EvolveMethodInfo evolve,
+    private static void EmitAsyncEvolveMethod(StringBuilder sb, EvolveMethodInfo evolve, INamedTypeSymbol aggregateType,
         string docType, string idType)
     {
+        var ctorExpression = BuildAggregateConstructorExpression(aggregateType);
         sb.AppendLine($"    public async global::System.Threading.Tasks.ValueTask<{docType}?> EvolveAsync(");
         sb.AppendLine($"        {docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e,");
         sb.AppendLine("        object session, global::System.Threading.CancellationToken ct)");
@@ -691,13 +693,13 @@ internal static class EvolverCodeEmitter
 
         if (evolve.IsMutable)
         {
-            sb.AppendLine($"        snapshot ??= new {docType}();");
+            sb.AppendLine($"        snapshot ??= {ctorExpression};");
             sb.AppendLine($"        await snapshot.{methodName}({argsStr});");
             sb.AppendLine("        return snapshot;");
         }
         else
         {
-            sb.AppendLine($"        return await (snapshot ?? new {docType}()).{methodName}({argsStr});");
+            sb.AppendLine($"        return await (snapshot ?? {ctorExpression}).{methodName}({argsStr});");
         }
 
         sb.AppendLine("    }");
@@ -714,9 +716,9 @@ internal static class EvolverCodeEmitter
     /// fresh instance in the Apply-only / null-snapshot branch. Three cases:
     ///
     /// 1. Public parameterless ctor, no required members → `new T()`.
-    /// 2. Required members → `new T { Required = default!, ... }`. The C#
-    ///    compiler accepts the construction even though required members are
-    ///    about to be overwritten by Apply.
+    /// 2. Public parameterless ctor with required members →
+    ///    `new T { Required = default!, ... }`. The C# compiler accepts the
+    ///    construction even though required members are about to be overwritten by Apply.
     /// 3. No public parameterless ctor (e.g. `private T()` signalling
     ///    "construct me reflectively" or no parameterless ctor at all) →
     ///    `(T)RuntimeHelpers.GetUninitializedObject(typeof(T))`. Allocates
@@ -745,11 +747,11 @@ internal static class EvolverCodeEmitter
             }
         }
 
-        var ctors = type.InstanceConstructors;
-        var hasPublicParameterless = ctors.Length == 0
-            || ctors.Any(c => c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
+        var hasPublicParameterless = type.TypeKind == TypeKind.Struct ||
+            type.InstanceConstructors.Any(c =>
+                c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
 
-        if (requiredMembers.Count > 0)
+        if (hasPublicParameterless && requiredMembers.Count > 0)
         {
             var inits = string.Join(", ", requiredMembers.Select(n => $"{n} = default!"));
             return $"new {fqn} {{ {inits} }}";


### PR DESCRIPTION
## What changed

- Treat a generated partial projection as covering its aggregate type so the snapshot-registration pipeline does not emit a second standalone evolver for the same aggregate.
- Reuse the aggregate constructor helper for generated Evolve/EvolveAsync fallback paths.
- Avoid emitting required-member object initializers for aggregate types without a public parameterless constructor.
- Normalize aggregate types discovered from snapshot/ref-aggregate call sites so nullable reference annotations do not leak into generated evolvers.
- Sanitize source-generator hint names before calling `AddSource()` so Roslyn-invalid characters such as `?` cannot crash generation.
- Add regression tests for required-member primary-constructor aggregates with conventional projection Create/Apply methods and nullable `[ReadAggregate]` aggregate parameters discovered via `IRefersToAggregate` attributes.

## Why

Two source-generator paths could break Marten 9 upgrade scenarios:

- A partial projection could generate the correct dispatcher while a later source-generator pipeline also emitted a fallback evolver for the same aggregate. That fallback did not know about the projection Create method and could generate construction code that fails for aggregates using required members and primary constructors.
- Aggregate types discovered from nullable parameters such as `[ReadAggregate] EigenPrestatie? prestatie` could feed `?` into generated hint names, causing Roslyn to reject `AddSource()` and abort the whole generator pass.

Addresses JasperFx/marten#4542 and JasperFx/marten#4543.

## Validation

- `dotnet test .\src\JasperFx.Events.SourceGenerator.Tests\JasperFx.Events.SourceGenerator.Tests.csproj --no-restore`