### PR TITLE
Fix DatabaseId dotted server roundtrip

### DIFF
--- a/src/CoreTests/Descriptors/DatabaseIdTests.cs
+++ b/src/CoreTests/Descriptors/DatabaseIdTests.cs
@@ -32,7 +32,8 @@ public class DatabaseIdTests
     [Theory]
     [InlineData("one")]
     [InlineData("one,two")]
-    [InlineData("one.two.three")]
+    [InlineData("one.")]
+    [InlineData(".one")]
     public void try_parse_sad_path(string text)
     {
         DatabaseId.TryParse(text, out var id).ShouldBeFalse();
@@ -59,5 +60,44 @@ public class DatabaseIdTests
         DatabaseId.TryParse("~some~host.tom", out var id).ShouldBeTrue();
         id.Server.ShouldBe("/some/host");
         id.Name.ShouldBe("tom");
+    }
+
+    [Fact]
+    public void round_trips_dotted_server_name()
+    {
+        var id = new DatabaseId(
+            "database-feature2.zorgdeclaraties-test.aws.topicus.healthcare",
+            "feature2_claims2");
+
+        var roundTripped = DatabaseId.Parse(id.ToString());
+
+        roundTripped.ShouldBe(id);
+    }
+
+    [Fact]
+    public void parse_legacy_dotted_server_name()
+    {
+        var id = DatabaseId.Parse(
+            "database-feature2.zorgdeclaraties-test.aws.topicus.healthcare.feature2_claims2");
+
+        id.Server.ShouldBe("database-feature2.zorgdeclaraties-test.aws.topicus.healthcare");
+        id.Name.ShouldBe("feature2_claims2");
+    }
+
+    [Fact]
+    public void escapes_dots_inside_segments()
+    {
+        var id = new DatabaseId("server.with.dots", "name.with.dots");
+
+        id.ToString().ShouldBe("server%2Ewith%2Edots.name%2Ewith%2Edots");
+        DatabaseId.Parse(id.ToString()).ShouldBe(id);
+    }
+
+    [Fact]
+    public void round_trips_percent_encoded_text()
+    {
+        var id = new DatabaseId("server%2Ename", "db%25name");
+
+        DatabaseId.Parse(id.ToString()).ShouldBe(id);
     }
 }

--- a/src/JasperFx/Descriptors/DatabaseId.cs
+++ b/src/JasperFx/Descriptors/DatabaseId.cs
@@ -1,5 +1,3 @@
-using JasperFx.Core;
-
 namespace JasperFx.Descriptors;
 
 public record DatabaseId(string Server, string Name)
@@ -8,25 +6,48 @@ public record DatabaseId(string Server, string Name)
 
     public static DatabaseId Parse(string text)
     {
-        var parts = text.Replace('~', '/').ToDelimitedArray('.');
-        return new DatabaseId(parts[0], parts[1]);
+        if (TryParse(text, out var id))
+        {
+            return id;
+        }
+
+        throw new FormatException($"Invalid database id '{text}'");
     }
 
     public static bool TryParse(string text, out DatabaseId id)
     {
-        var parts = text.Replace('~', '/').ToDelimitedArray('.');
-        if (parts.Length != 2)
+        var separator = text.LastIndexOf('.');
+        if (separator <= 0 || separator == text.Length - 1)
         {
-            id = default;
+            id = default!;
             return false;
         }
-        
-        id = new DatabaseId(parts[0], parts[1]);
+
+        var server = text[..separator];
+        var name = text[(separator + 1)..];
+
+        id = new DatabaseId(UnescapeSegment(server), UnescapeSegment(name));
         return true;
     }
 
     public override string ToString()
     {
-        return Identity.Replace('/', '~');
+        return $"{EscapeSegment(Server)}.{EscapeSegment(Name)}";
+    }
+
+    private static string EscapeSegment(string value)
+    {
+        return value
+            .Replace("%", "%25", StringComparison.Ordinal)
+            .Replace("/", "~", StringComparison.Ordinal)
+            .Replace(".", "%2E", StringComparison.Ordinal);
+    }
+
+    private static string UnescapeSegment(string value)
+    {
+        return value
+            .Replace("%2E", ".", StringComparison.OrdinalIgnoreCase)
+            .Replace("~", "/", StringComparison.Ordinal)
+            .Replace("%25", "%", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary

Fixes JasperFx/jasperfx#360.

`DatabaseId.Parse` previously split on every dot and only used the first two segments. That dropped most of a dotted server hostname when a `DatabaseId` was serialized with `ToString()` and parsed back.

This changes the identifier format handling so:

- `Parse`/`TryParse` split on the final dot, preserving legacy identifiers that already contain dotted server names.
- `ToString()` escapes dots inside each segment so new identifiers are unambiguous.
- Existing slash-to-tilde behavior is preserved, and percent sequences roundtrip correctly.

## Tests

- `dotnet test .\src\CoreTests\CoreTests.csproj --filter DatabaseIdTests --no-restore`