### PR TITLE
Source-generate self-aggregating records from their own declaration (marten#4557)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -895,4 +895,39 @@ public class UpdatedEvent { }
         evolver.ShouldContain("case global::Test.CreatedEvent");
         evolver.ShouldContain("case global::Test.UpdatedEvent");
     }
+
+    // marten#4557: a self-aggregating immutable `record` with static Create/Apply must get
+    // an evolver emitted from its OWN declaration — with NO Snapshot<T> call site anywhere in
+    // the compilation, and WITHOUT being declared `partial`. This is what lets a record
+    // aggregate defined in a domain library work when the `Snapshot<T>` registration lives in
+    // a different (composition-root) assembly: the `[GeneratedEvolver]` lands in the record's
+    // own assembly, which is where the runtime scans. Pre-#4557 the record was skipped here
+    // (only Evolve/EvolveAsync triggered records), so it had to be reached via the call site.
+    [Fact]
+    public void self_aggregating_record_emits_evolver_from_its_own_declaration_without_partial()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public record MyType(Guid Id, string Name, int Count, string LastEvent)
+{
+    public static MyType Create(MyTypeCreated e) => new(e.Id, e.Name, 0, nameof(MyTypeCreated));
+    public static MyType Apply(MyTypeIncremented e, MyType current)
+        => current with { Count = current.Count + e.Amount, LastEvent = nameof(MyTypeIncremented) };
+}
+
+public record MyTypeCreated(Guid Id, string Name);
+public record MyTypeIncremented(int Amount);
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        var allGenerated = string.Join("\n", generatedSources);
+        allGenerated.ShouldContain("MyTypeEvolver");
+        allGenerated.ShouldContain("IGeneratedSyncEvolver");
+        allGenerated.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.MyType)");
+        diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error).ShouldBeFalse();
+    }
 }

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -47,19 +47,28 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
 
     private static bool IsCandidateClass(SyntaxNode node)
     {
-        if (node is ClassDeclarationSyntax classDecl)
+        // Classes and records are treated identically. A self-aggregating type owns its
+        // Apply/Create/ShouldDelete (or Evolve/EvolveAsync) methods; a projection subclass
+        // declares Apply/Create/ShouldDelete/Project/Transform (ApplyAsync covers an
+        // EventProjection override that still needs published-type registration).
+        //
+        // Records are NOT special-cased: a self-aggregating `record` with Apply/Create must
+        // get an evolver emitted from its OWN declaration (Pipeline 1) so it works regardless
+        // of where — or whether — a `Snapshot<T>` / `AggregateStream<T>` call site is visible,
+        // and crucially without ever requiring the record to be `partial`. Otherwise a record
+        // aggregate defined in one assembly but registered in another (the common
+        // domain-library + composition-root split) never gets a `[GeneratedEvolver]` emitted
+        // into its own assembly — which is exactly where the runtime scans. See marten#4557.
+        //
+        // (Pre-#4557 records were filtered to Evolve/EvolveAsync only, on the assumption that
+        // Apply/Create on a record were dispatched by a runtime reflection path. That path was
+        // removed in the 9.0 projections rework, so a self-aggregating record must be
+        // source-generated exactly like a class.)
+        if (node is ClassDeclarationSyntax or RecordDeclarationSyntax)
         {
-            // Classes: check for Apply, Create, ShouldDelete, Project, Transform, Evolve, EvolveAsync,
-            // or ApplyAsync (for EventProjection with explicit override that needs type registration)
-            return classDecl.Members.OfType<MethodDeclarationSyntax>()
+            var typeDecl = (TypeDeclarationSyntax)node;
+            return typeDecl.Members.OfType<MethodDeclarationSyntax>()
                 .Any(m => m.Identifier.ValueText is "Apply" or "Create" or "ShouldDelete" or "Project" or "Transform" or "Evolve" or "EvolveAsync" or "ApplyAsync");
-        }
-
-        if (node is RecordDeclarationSyntax recordDecl)
-        {
-            // Records: only check for Evolve/EvolveAsync (Apply/Create on records is handled at runtime)
-            return recordDecl.Members.OfType<MethodDeclarationSyntax>()
-                .Any(m => m.Identifier.ValueText is "Evolve" or "EvolveAsync");
         }
 
         return false;

--- a/src/JasperFx.Events/Aggregation/AggregateApplication.cs
+++ b/src/JasperFx.Events/Aggregation/AggregateApplication.cs
@@ -119,10 +119,14 @@ internal class AggregateApplication<TAggregate, TQuerySession> : IAggregator<TAg
     {
         var owner = _projectionType ?? typeof(TAggregate);
         return $"No source-generated dispatcher found for {owner.FullNameInCode()}. " +
-               "When using conventional Apply/Create/ShouldDelete methods, the projection class must be declared " +
-               "`partial` in an assembly that references the JasperFx.Events.SourceGenerator analyzer, " +
-               "or alternatively override Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly. " +
-               "See docs/codegen/aot.md for the AOT publishing guide.";
+               "Conventional Apply/Create/ShouldDelete methods are dispatched by the compile-time " +
+               "JasperFx.Events.SourceGenerator; there is no runtime fallback. Ensure that analyzer runs in the " +
+               $"assembly that defines {typeof(TAggregate).FullNameInCode()} (for Marten consumers the generator " +
+               "ships inside the Marten NuGet package, so verify the project reference does not exclude the " +
+               "'analyzers' asset). A self-aggregating type registered via Snapshot<T> / SingleStreamProjection<T> / " +
+               "AggregateStream<T> does NOT need to be `partial`; a projection subclass that uses convention methods " +
+               "DOES need to be declared `partial`. Alternatively, override " +
+               "Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.";
     }
 
     // IAggregator<>: the runtime aggregator contract. Reachable only when the registration-time

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Runtime.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Runtime.cs
@@ -149,10 +149,13 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
         // the registration flow).
         throw new InvalidOperationException(
             $"No source-generated dispatcher found for {GetType().FullNameInCode()}. " +
-            "When using conventional Apply/Create/ShouldDelete methods, the projection class must be declared " +
-            "`partial` in an assembly that references the JasperFx.Events.SourceGenerator analyzer, " +
-            "or alternatively override Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly. " +
-            "See docs/codegen/aot.md for the AOT publishing guide.");
+            "Conventional Apply/Create/ShouldDelete methods are dispatched by the compile-time " +
+            "JasperFx.Events.SourceGenerator; there is no runtime fallback. Ensure that analyzer runs in the " +
+            $"assembly that defines {typeof(TDoc).FullNameInCode()} (for Marten consumers the generator ships inside " +
+            "the Marten NuGet package, so verify the project reference does not exclude the 'analyzers' asset). " +
+            "A self-aggregating type registered via Snapshot<T> / SingleStreamProjection<T> / AggregateStream<T> does " +
+            "NOT need to be `partial`; a projection subclass that uses convention methods DOES need to be declared " +
+            "`partial`. Alternatively, override Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

Downstream report [JasperFx/marten#4557](https://github.com/JasperFx/marten/issues/4557): a user upgrading 8 → 9 has a self-aggregating immutable `record` with static `Create`/`Apply`, registered via `Projections.Snapshot<MyType>(Inline)`. It throws at `DocumentStore.For(...)`:

```
InvalidProjectionException: No source-generated dispatcher found for
SingleStreamProjection<MyType, System.Guid>...
```

## Root cause

The generator's candidate predicate treats **records** differently from **classes**:

- A **class** with conventional `Apply`/`Create` is discovered by Pipeline 1 from its **own declaration** and gets a free-standing evolver + `[assembly: GeneratedEvolver(...)]`.
- A **record** was filtered in `IsCandidateClass` to `Evolve`/`EvolveAsync` only (a fossil of the removed runtime-reflection path), so a self-aggregating record only ever got an evolver when the generator could see a `Snapshot<T>` / `AggregateStream<T>` **call site** (Pipeline 3).

That asymmetry is the root of the **cross-assembly gap**: a record aggregate defined in a domain library but registered in a separate composition-root assembly never has a `[GeneratedEvolver]` emitted into its **own** assembly — which is exactly where the runtime scans (`tryUseAssemblyRegisteredEvolver` keys on `typeof(TDoc).Assembly`). It also creates the impression that such a record must be `partial`, which it must not.

## Fix

- **`AggregateEvolverGenerator.IsCandidateClass`**: treat records identically to classes. A self-aggregating record with `Apply`/`Create` now gets its evolver emitted from its **own declaration** — no `Snapshot<T>` call site required, and **never** requiring `partial`. `ExecuteCombined`'s existing dedup keeps same-assembly registrations single-emit (Pipeline 1 claims the type; Pipeline 3 skips it), exactly as classes already behave.
- **Message accuracy**: corrected `AggregateApplication.MissingDispatcherMessage` and the `EvolveAsync` backstop — dropped the blanket "must be `partial`" claim (only projection *subclasses* need it), pointed at the assembly that *defines* the aggregate as the analyzer/lookup site, noted the generator ships inside the Marten package, and removed the dead `docs/codegen/aot.md` link.

Guiding principle: **self-aggregating types (class or record) must never have to be `partial`** — only projection subclasses do.

## Validation

- `JasperFx.Events.SourceGenerator.Tests`: **19/19 green**, including a new `self_aggregating_record_emits_evolver_from_its_own_declaration_without_partial` (non-`partial` record, no `Snapshot<T>` call site → asserts the evolver + `[GeneratedEvolver]` attribute are emitted, no errors).
- `EventTests` compiles clean (0 errors) under the new generator.

## Downstream

[JasperFx/marten#4557](https://github.com/JasperFx/marten/issues/4557). Marten separately bundles this analyzer in its own NuGet package so package consumers get the generator automatically; once a generator release carries this change, Marten's bundled analyzer picks up the record/cross-assembly fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)