### PR TITLE
Make JasperFx.Events.SourceGenerator flow transitively (drop DevelopmentDependency)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -14,7 +14,15 @@
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
         <Version>2.1.1</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
-        <DevelopmentDependency>true</DevelopmentDependency>
+        <!-- Deliberately NOT a DevelopmentDependency. This analyzer must flow transitively
+             from packages that reference it (notably Marten) to *their* consumers: Marten 9
+             removed the runtime evolver fallback, so any project defining projection types
+             needs this generator, including ones that only reference Marten. A
+             developmentDependency is consumed as PrivateAssets=all and never flows, which is
+             what left plain-Marten consumers without the generator (marten#4557). The package
+             is analyzer-only (IncludeBuildOutput=false, no lib/), so flowing it adds no runtime
+             assembly. Because it is a single package identity, a consumer that also references
+             it directly collapses to one analyzer path (no duplicate generation / CS0111). -->
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Problem

Marten 9 removed the runtime evolver fallback, so **every project that defines projection types needs this source generator at compile time** — including projects that reference only the `Marten` package.

This package is marked `<DevelopmentDependency>true</DevelopmentDependency>`, which NuGet consumes as `PrivateAssets=all`, so the analyzer **never flows transitively** from a package that references it (notably Marten) to that package's consumers. A consumer referencing only `Marten` therefore never ran the generator and hit `No source-generated dispatcher found ...` at `DocumentStore.For()` (marten#4557).

The workaround in Marten 9.0.2 (marten#4558) was to **bundle a copy** of this analyzer DLL inside the Marten package (`analyzers/dotnet/cs`). That fixed plain-Marten consumers but introduced a new failure: any project that *also* references this package directly now receives the analyzer from **two distinct package paths** (Marten's bundled copy + this package). Roslyn can't dedup analyzers by content, so `AggregateEvolverGenerator` runs twice and emits each projection's generated constructor + `Evolve`/`DetermineActionAsync` twice — `CS0111` "already defines a member". This broke real downstream solutions whose projection-defining projects followed the documented guidance of referencing this package explicitly.

## Fix

Drop `DevelopmentDependency` so the package flows transitively as a normal **analyzer-only** dependency.

- It has no runtime surface (`IncludeBuildOutput=false`, no `lib/`), so flowing it adds nothing to consumers at runtime.
- Because it's a **single package identity**, a consumer that also references it directly collapses (direct + transitive) to **one** analyzer path — duplicate generation / `CS0111` becomes impossible.

## Companion change (separate Marten PR)

Marten should stop bundling the analyzer and instead reference this package with `PrivateAssets=none` so it flows. That Marten change should target the release that carries this version, and bump Marten's `JasperFx.Events.SourceGenerator` reference accordingly.

## Verification

Built two repro consumers against locally-built packages:
- **Marten only** → generator flows transitively, evolver generated, clean build (fixes marten#4557).
- **Marten + explicit reference to this package** → exactly one analyzer path reached `csc`, one evolver generated, zero `CS0111`, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)