### PR TITLE
Accept "ev" as a conventional event parameter name (#4562)

### DIFF
--- a/src/EventTests/event_parameter_naming_convention.cs
+++ b/src/EventTests/event_parameter_naming_convention.cs
@@ -1,0 +1,28 @@
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace EventTests;
+
+public class event_parameter_naming_convention
+{
+    public record FooEvent(System.Guid Id);
+
+    public class Helper { }
+
+    // Two concrete candidate parameters, so the event cannot be inferred by type
+    // alone. The conventional event parameter name decides which one is the event.
+    public void by_event_name(Helper helper, FooEvent @event) { }
+    public void by_e_name(Helper helper, FooEvent e) { }
+    public void by_ev_name(Helper helper, FooEvent ev) { }
+
+    [Theory]
+    [InlineData(nameof(by_event_name))]
+    [InlineData(nameof(by_e_name))]
+    [InlineData(nameof(by_ev_name))]
+    public void conventional_event_parameter_names_disambiguate(string methodName)
+    {
+        var method = GetType().GetMethod(methodName)!;
+        method.GetEventType(null).ShouldBe(typeof(FooEvent));
+    }
+}

--- a/src/JasperFx.Events/Projections/CodeGenerationExtensions.cs
+++ b/src/JasperFx.Events/Projections/CodeGenerationExtensions.cs
@@ -46,7 +46,10 @@ public static class CodeGenerationExtensions
             }
         }
 
-        var parameterInfo = method.GetParameters().FirstOrDefault(x => x.Name == "@event" || x.Name == "event" || x.Name == "e");
+        // When the event argument can't be inferred by type alone (e.g. more than one
+        // candidate parameter), fall back to the conventional event parameter names.
+        var parameterInfo = method.GetParameters()
+            .FirstOrDefault(x => x.Name is "@event" or "event" or "e" or "ev");
         if (parameterInfo == null)
         {
             var candidates = method


### PR DESCRIPTION
Follow-up to the event-source-generator naming work for JasperFx/marten#4562.

## What

`CodeGenerationExtensions.GetEventType` is the single shared rule that all projection types (`SingleStreamProjection`, `MultiStreamProjection`, and `EventProjection`) use to decide which parameter of a conventional method is the event. When the event can't be inferred by type alone (more than one candidate parameter), it falls back to the conventional event parameter **name**.

This adds **`"ev"`** to the accepted names, alongside the existing `@event`, `event`, and `e` — `ev` is a common shorthand and there's no reason to reject it.

```csharp
// all four now resolve the event parameter when type inference is ambiguous:
public void Apply(SomeEvent @event, MyAggregate agg) { }
public void Apply(SomeEvent ev, MyAggregate agg) { }
public void Apply(SomeEvent e, MyAggregate agg) { }
```

## Notes

- For the overwhelmingly common case (a single concrete event parameter, with session/operations as interfaces), the event is still inferred **by type** — no special parameter name is required. The name convention only matters as a disambiguator.
- Added a focused unit test covering `@event`, `e`, and `ev` disambiguation.
- The naming convention itself is being documented clearly in companion docs PRs for Marten (including the 9.0 migration guide) and Polecat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)