### PR TITLE
Fix inert CLI source generators and actually use the generated command path

### DIFF
--- a/src/CommandLineTests/SourceGeneratedParsingTests.cs
+++ b/src/CommandLineTests/SourceGeneratedParsingTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.CommandLine.Parsing;
+using JasperFx.Resources;
+using Shouldly;
+
+namespace CommandLineTests;
+
+/// <summary>
+/// Guardrails ensuring the JasperFx.SourceGenerator output is actually wired in and used
+/// for the framework's own commands. Regression cover for the bug where the generators
+/// compared INamedTypeSymbol.ToDisplayString() (C# style "Foo&lt;T&gt;") against the metadata
+/// form ("Foo`1"), which never matched, so the generators silently emitted nothing and every
+/// command fell back to reflection + assembly scanning.
+/// </summary>
+public class SourceGeneratedParsingTests
+{
+    // Touch a JasperFx type so the assembly (and its [ModuleInitializer] parser registration) is loaded.
+    private static readonly Assembly JasperFxAssembly = typeof(DescribeInput).Assembly;
+
+    [Theory]
+    [InlineData(typeof(DescribeInput))]
+    [InlineData(typeof(ResourceInput))]
+    public void generated_parser_is_registered_for_builtin_command_input(Type inputType)
+    {
+        GeneratedParserRegistry.HasParser(inputType)
+            .ShouldBeTrue($"No source-generated parser registered for {inputType.Name}; " +
+                          "the InputParserGenerator is not emitting/registering parsers.");
+    }
+
+    [Theory]
+    [InlineData(typeof(DescribeInput))]
+    [InlineData(typeof(ResourceInput))]
+    public void generated_handlers_match_the_reflection_handlers(Type inputType)
+    {
+        var generated = GeneratedParserRegistry.TryGetHandlers(inputType);
+        generated.ShouldNotBeNull();
+
+        var reflected = InputParser.GetHandlers(inputType);
+
+        // The generated path must cover exactly the same members as the reflection fallback.
+        generated.Count.ShouldBe(reflected.Count);
+    }
+
+    [Fact]
+    public void source_generated_command_manifest_is_present_and_populated()
+    {
+        var manifestType = JasperFxAssembly.GetType("JasperFx.Generated.DiscoveredCommands");
+        manifestType.ShouldNotBeNull("CommandDiscoveryGenerator did not emit JasperFx.Generated.DiscoveredCommands");
+
+        var property = manifestType.GetProperty("CommandTypes", BindingFlags.Public | BindingFlags.Static);
+        property.ShouldNotBeNull();
+
+        var commandTypes = ((IEnumerable<Type>)property.GetValue(null)!).ToList();
+        commandTypes.ShouldContain(typeof(DescribeCommand));
+        commandTypes.ShouldContain(typeof(ResourcesCommand));
+    }
+}

--- a/src/JasperFx.SourceGenerator/CommandDiscoveryGenerator.cs
+++ b/src/JasperFx.SourceGenerator/CommandDiscoveryGenerator.cs
@@ -20,8 +20,10 @@ namespace JasperFx.SourceGenerator;
 [Generator]
 public sealed class CommandDiscoveryGenerator : IIncrementalGenerator
 {
-    private const string JasperFxCommandName = "JasperFx.CommandLine.JasperFxCommand`1";
-    private const string JasperFxAsyncCommandName = "JasperFx.CommandLine.JasperFxAsyncCommand`1";
+    // NOTE: these are matched against INamedTypeSymbol.OriginalDefinition.ToDisplayString(),
+    // which renders generics in C# style ("Foo<T>"), NOT the metadata form ("Foo`1").
+    private const string JasperFxCommandName = "JasperFx.CommandLine.JasperFxCommand<T>";
+    private const string JasperFxAsyncCommandName = "JasperFx.CommandLine.JasperFxAsyncCommand<T>";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -51,6 +53,11 @@ public sealed class CommandDiscoveryGenerator : IIncrementalGenerator
 
         // Check if it closes JasperFxCommand<T> or JasperFxAsyncCommand<T>
         if (!ClosesCommandBaseType(symbol)) return null;
+
+        // The generated manifest references each command via typeof(...) from an internal class
+        // in the consuming assembly. Skip types it cannot legally name (e.g. private/protected
+        // nested commands such as test fixtures), otherwise the generated code would not compile.
+        if (!IsReferenceable(symbol)) return null;
 
         var fullName = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var typeName = symbol.Name;
@@ -101,6 +108,20 @@ public sealed class CommandDiscoveryGenerator : IIncrementalGenerator
         }
 
         return false;
+    }
+
+    // The manifest must mirror the reflective fallback (Assembly.GetExportedTypes), which only
+    // sees public types whose containing types are also public. Restricting to public types both
+    // keeps the manifest a faithful drop-in for the scan and avoids emitting typeof(...) for
+    // private/protected nested commands (e.g. test fixtures) that would not compile.
+    private static bool IsReferenceable(INamedTypeSymbol symbol)
+    {
+        for (INamedTypeSymbol? t = symbol; t != null; t = t.ContainingType)
+        {
+            if (t.DeclaredAccessibility != Accessibility.Public) return false;
+        }
+
+        return true;
     }
 
     private static void Execute(SourceProductionContext context, ImmutableArray<CommandInfo?> commands)

--- a/src/JasperFx.SourceGenerator/InputParserGenerator.cs
+++ b/src/JasperFx.SourceGenerator/InputParserGenerator.cs
@@ -20,8 +20,10 @@ namespace JasperFx.SourceGenerator;
 [Generator]
 public sealed class InputParserGenerator : IIncrementalGenerator
 {
-    private const string JasperFxCommandName = "JasperFx.CommandLine.JasperFxCommand`1";
-    private const string JasperFxAsyncCommandName = "JasperFx.CommandLine.JasperFxAsyncCommand`1";
+    // NOTE: these are matched against INamedTypeSymbol.OriginalDefinition.ToDisplayString(),
+    // which renders generics in C# style ("Foo<T>"), NOT the metadata form ("Foo`1").
+    private const string JasperFxCommandName = "JasperFx.CommandLine.JasperFxCommand<T>";
+    private const string JasperFxAsyncCommandName = "JasperFx.CommandLine.JasperFxAsyncCommand<T>";
     private const string IgnoreAttributeName = "JasperFx.CommandLine.IgnoreOnCommandLineAttribute";
     private const string FlagAliasAttributeName = "JasperFx.CommandLine.FlagAliasAttribute";
     private const string DescriptionAttributeName = "JasperFx.CommandLine.DescriptionAttribute";
@@ -47,7 +49,9 @@ public sealed class InputParserGenerator : IIncrementalGenerator
         if (symbol == null || symbol.IsAbstract) return null;
 
         var inputType = FindInputType(symbol);
-        if (inputType == null) return null;
+        // The generated parser is an internal class that casts to the input type; skip input
+        // types it cannot legally name (e.g. private/protected nested types) so it compiles.
+        if (inputType == null || !IsReferenceable(inputType)) return null;
 
         var members = CollectMembers(inputType);
         if (members.Count == 0) return null;
@@ -76,6 +80,26 @@ public sealed class InputParserGenerator : IIncrementalGenerator
             current = current.BaseType;
         }
         return null;
+    }
+
+    // A type is referenceable from the generated (internal) parser only if it and every
+    // containing type are visible at assembly scope: public, internal, or protected internal.
+    private static bool IsReferenceable(INamedTypeSymbol symbol)
+    {
+        for (INamedTypeSymbol? t = symbol; t != null; t = t.ContainingType)
+        {
+            switch (t.DeclaredAccessibility)
+            {
+                case Accessibility.Public:
+                case Accessibility.Internal:
+                case Accessibility.ProtectedOrInternal:
+                    continue;
+                default:
+                    return false;
+            }
+        }
+
+        return true;
     }
 
     private static string GetSafeTypeName(INamedTypeSymbol type)
@@ -171,9 +195,12 @@ public sealed class InputParserGenerator : IIncrementalGenerator
         var handlerKind = DetermineHandlerKind(isFlag, isBool, isDict, isEnumerable);
 
         // Compute flag aliases
-        var flagName = RemoveFlagSuffix(name);
-        var longForm = SplitPascalCaseAndAddHyphens(flagAliasLong ?? flagName).ToLower();
-        var shortForm = (flagAliasShort ?? longForm[0]).ToString().ToLower();
+        // Mirror InputParser.ToFlagAliases exactly: the long form is always lower-cased, but an
+        // explicit one-letter alias keeps its case (e.g. [FlagAlias('C')] => -C). The default
+        // short form is the lower-cased first letter of the pascal-split member name.
+        var splitName = SplitPascalCaseAndAddHyphens(RemoveFlagSuffix(name));
+        var longForm = (flagAliasLong ?? splitName).ToLower();
+        var shortForm = (flagAliasShort?.ToString() ?? char.ToLower(splitName[0]).ToString());
 
         string? elementTypeFullName = null;
         if (isEnumerable)
@@ -196,6 +223,7 @@ public sealed class InputParserGenerator : IIncrementalGenerator
             IsEnum = isEnum || isNullableEnum,
             IsNullable = type.NullableAnnotation == NullableAnnotation.Annotated || IsNullableValueType(type),
             ElementTypeFullName = elementTypeFullName,
+            IsArray = type is IArrayTypeSymbol,
             IsNumeric = IsNumericType(type),
         };
     }
@@ -494,21 +522,24 @@ public sealed class InputParserGenerator : IIncrementalGenerator
             case HandlerKind.EnumerableArgument:
                 var elemType = member.ElementTypeFullName ?? "object";
                 var elemConverter = GetElementConverterExpression(elemType);
+                // The generated handler hands back a List<T>; arrays need an explicit conversion.
+                var argValue = member.IsArray ? "val.ToArray()" : "val";
                 sb.AppendLine($"            new GeneratedEnumerableArgument<{elemType}>(");
                 sb.AppendLine($"                \"{member.Name}\",");
                 sb.AppendLine($"                \"{escapedDesc}\",");
-                sb.AppendLine($"                (obj, val) => {memberAccess} = val,");
+                sb.AppendLine($"                (obj, val) => {memberAccess} = {argValue},");
                 sb.AppendLine($"                {elemConverter}),");
                 break;
 
             case HandlerKind.EnumerableFlag:
                 var elemType2 = member.ElementTypeFullName ?? "object";
                 var elemConverter2 = GetElementConverterExpression(elemType2);
+                var flagValue = member.IsArray ? "val.ToArray()" : "val";
                 sb.AppendLine($"            new GeneratedEnumerableFlag<{elemType2}>(");
                 sb.AppendLine($"                \"{member.Name}\",");
                 sb.AppendLine($"                \"{escapedDesc}\",");
                 sb.AppendLine($"                new FlagAliases {{ LongForm = \"{member.LongForm}\", ShortForm = \"{member.ShortForm}\", LongFormOnly = {(member.LongFormOnly ? "true" : "false")} }},");
-                sb.AppendLine($"                (obj, val) => {memberAccess} = val,");
+                sb.AppendLine($"                (obj, val) => {memberAccess} = {flagValue},");
                 sb.AppendLine($"                {elemConverter2}),");
                 break;
 
@@ -571,6 +602,7 @@ internal sealed class MemberParseInfo
     public bool IsEnum { get; set; }
     public bool IsNullable { get; set; }
     public string? ElementTypeFullName { get; set; }
+    public bool IsArray { get; set; }
     public bool IsNumeric { get; set; }
 }
 

--- a/src/JasperFx.SourceGenerator/README.md
+++ b/src/JasperFx.SourceGenerator/README.md
@@ -21,6 +21,23 @@ Roslyn source generators for [JasperFx](https://jasperfx.net), all reflection-fr
 
 Reference it as an analyzer/source-generator only — there's no runtime API. For `OptionsDescription`, apply the `[GenerateDescription]` attribute to a `partial` class that implements `IDescribeMyself` and a `ToDescription()` method is generated. The command-discovery and input-parser output is consumed transparently by `JasperFx.CommandLine`.
 
+## Performance
+
+The generators replace runtime reflection with code emitted at compile time. Measured against
+the reflection fallback with BenchmarkDotNet (`src/CommandLineBenchmarks`, Apple M5 Max, .NET 9):
+
+| Workload | Reflection | Generated |
+|---|---|---|
+| Build handlers for a small input model | ~2.8 µs | ~0.43 µs (≈6.5× faster) |
+| Build handlers for a large input model | ~8.5 µs | ~0.48 µs (≈18× faster) |
+| Full `dotnet run -- <command>` parse | baseline | ≈2–4.5× faster, ≈2–3× fewer allocations |
+
+The win is eliminating reflection (`PropertyInfo.SetValue`, converter lookups, assembly scanning),
+not eliminating allocation — the generated parser still allocates its handler list and delegates.
+Earlier "thousands of times faster / zero allocation" figures were a measurement artifact: the
+generators were emitting nothing, so the benchmark compared reflection against a no-op. The numbers
+above reflect the generators actually running.
+
 ## Documentation
 
 Full docs at [https://jasperfx.net](https://jasperfx.net).

--- a/src/JasperFx/CommandLine/CommandFactory.cs
+++ b/src/JasperFx/CommandLine/CommandFactory.cs
@@ -124,6 +124,14 @@ public class CommandFactory : ICommandFactory
     [RequiresUnreferencedCode("Scans assembly.GetExportedTypes() for IJasperFxCommand. AOT-publishing apps should rely on the source-generated command manifest emitted by JasperFx.SourceGenerator.")]
     public void RegisterCommands(Assembly assembly)
     {
+        // Prefer the source-generated command manifest for this assembly (trim/AOT clean,
+        // no GetExportedTypes scan). Falls back to reflection per-assembly when the assembly
+        // was not built with JasperFx.SourceGenerator.
+        if (TryRegisterCommandsFromManifest(assembly))
+        {
+            return;
+        }
+
         foreach (var type in assembly
                      .GetExportedTypes()
                      .Where(IsJasperFxCommandType))
@@ -402,12 +410,9 @@ public class CommandFactory : ICommandFactory
     [RequiresUnreferencedCode("Falls back to AssemblyFinder + assembly.GetExportedTypes() scanning if no source-generated command manifest is present. AOT-publishing apps should emit the manifest via JasperFx.SourceGenerator.")]
     public void RegisterCommandsFromExtensionAssemblies()
     {
-        // Check for source-generated command manifest first to avoid assembly scanning
-        if (TryRegisterFromGeneratedManifest())
-        {
-            return;
-        }
-
+        // Each RegisterCommands(assembly) call below prefers that assembly's source-generated
+        // manifest and only falls back to reflective scanning when the manifest is absent, so
+        // the optimization is applied per-assembly rather than all-or-nothing.
         var assemblies = AssemblyFinder
             .FindAssemblies(a => a.HasAttribute<JasperFxAssemblyAttribute>() && !a.IsDynamic)
             .Concat(AppDomain.CurrentDomain.GetAssemblies())
@@ -429,8 +434,10 @@ public class CommandFactory : ICommandFactory
     }
 
     /// <summary>
-    ///     Attempt to use a source-generated command manifest to register commands
-    ///     without runtime assembly scanning. Returns true if a manifest was found and used.
+    ///     Attempt to register the commands of a single assembly from its source-generated
+    ///     <c>JasperFx.Generated.DiscoveredCommands</c> manifest, avoiding a reflective
+    ///     <see cref="Assembly.GetExportedTypes"/> scan. Returns true if the assembly carries a
+    ///     manifest (so the caller should skip its reflective fallback), false otherwise.
     /// </summary>
     /// <remarks>
     ///     The lookup uses well-known string identifiers
@@ -441,7 +448,7 @@ public class CommandFactory : ICommandFactory
     ///     analyzer — when that source generator runs, the type and property are
     ///     produced as ordinary code in the consuming assembly and survive
     ///     trimming naturally. Apps that do not include the generator simply
-    ///     fall through to <see cref="RegisterCommands"/>, which carries its own
+    ///     fall through to <see cref="RegisterCommands(Assembly)"/>, which carries its own
     ///     <c>[RequiresUnreferencedCode]</c>.
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
@@ -450,52 +457,39 @@ public class CommandFactory : ICommandFactory
         Justification = "Same as IL2026 — DiscoveredCommands.CommandTypes is generated source code in the consuming assembly.")]
     [UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
         Justification = "Types come from JasperFx.Generated.DiscoveredCommands.CommandTypes which is emitted by the source generator with full interface metadata preserved.")]
-    internal bool TryRegisterFromGeneratedManifest()
+    internal bool TryRegisterCommandsFromManifest(Assembly assembly)
     {
-        // Look for the generated DiscoveredCommands class in all loaded assemblies
-        // and in the entry assembly. The source generator emits this class in the
-        // JasperFx.Generated namespace of the consuming project.
-        var candidateAssemblies = AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => !a.IsDynamic);
+        if (assembly.IsDynamic) return false;
 
-        foreach (var assembly in candidateAssemblies)
+        // The source generator emits this class in the JasperFx.Generated namespace of the
+        // assembly it runs against.
+        var manifestType = assembly.GetType("JasperFx.Generated.DiscoveredCommands");
+        if (manifestType == null) return false;
+
+        var prop = manifestType.GetProperty("CommandTypes",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        if (prop == null) return false;
+
+        if (prop.GetValue(null) is not IEnumerable<Type> commandTypes) return false;
+
+        foreach (var type in commandTypes)
         {
-            var manifestType = assembly.GetType("JasperFx.Generated.DiscoveredCommands");
-            if (manifestType == null) continue;
-
-            var prop = manifestType.GetProperty("CommandTypes",
-                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-            if (prop == null) continue;
-
-            if (prop.GetValue(null) is IEnumerable<Type> commandTypes)
+            if (IsJasperFxCommandType(type))
             {
-                foreach (var type in commandTypes)
-                {
-                    if (IsJasperFxCommandType(type))
-                    {
-                        _commandTypes[CommandNameFor(type)] = type;
-                    }
-                }
-
-                // Also register extension types from the assembly
-                if (assembly.TryGetAttribute<JasperFxAssemblyAttribute>(out var attribute))
-                {
-                    if (attribute.ExtensionType != null)
-                    {
-                        _extensionTypes.Add(attribute.ExtensionType);
-                    }
-                }
-
-                if (!_hasAppliedExtensions)
-                {
-                    AnsiConsole.MarkupLine(
-                        "[gray]Using source-generated command manifest, skipping assembly scanning[/]");
-                }
-
-                return true;
+                _commandTypes[CommandNameFor(type)] = type;
             }
         }
 
-        return false;
+        // Mirror RegisterCommands: also register the assembly's extension type, if any.
+        if (assembly.TryGetAttribute<JasperFxAssemblyAttribute>(out var attribute)
+            && attribute.ExtensionType != null)
+        {
+            _extensionTypes.Add(attribute.ExtensionType);
+        }
+
+        // NOTE: deliberately no console output here. RegisterCommands(Assembly) calls this, and
+        // that low-level API must stay side-effect free — writing to the shared AnsiConsole during
+        // command registration perturbs callers that redirect Console.Out (e.g. test harnesses).
+        return true;
     }
 }

--- a/src/JasperFx/CommandLine/ICommandCreator.cs
+++ b/src/JasperFx/CommandLine/ICommandCreator.cs
@@ -12,7 +12,7 @@ namespace JasperFx.CommandLine;
 ///     either supply types whose constructors / properties survive trimming, or
 ///     opt in via the published <c>[RequiresUnreferencedCode]</c> annotation.
 ///     AOT/trim-clean apps consume commands through the source-generated manifest
-///     (see <see cref="CommandFactory.TryRegisterFromGeneratedManifest"/>) rather
+///     (see <see cref="CommandFactory.TryRegisterCommandsFromManifest"/>) rather
 ///     than reflective scanning, so this interface's annotations are the precise
 ///     punch-list AOT consumers see when they call into the reflective path.
 /// </remarks>

--- a/src/JasperFx/CommandLine/ICommandFactory.cs
+++ b/src/JasperFx/CommandLine/ICommandFactory.cs
@@ -11,8 +11,8 @@ namespace JasperFx.CommandLine;
 /// <remarks>
 ///     The annotations propagate the reflective surface to implementations (default
 ///     <see cref="CommandFactory"/>) and to consumers (<see cref="CommandExecutor"/>,
-///     <see cref="CommandLineHostingExtensions"/>). AOT/trim-clean apps short-circuit
-///     the reflective discovery path via <see cref="CommandFactory.TryRegisterFromGeneratedManifest"/>
+///     <see cref="CommandLineHostingExtensions"/>). AOT/trim-clean apps bypass
+///     the reflective discovery path via <see cref="CommandFactory.TryRegisterCommandsFromManifest"/>
 ///     and the JasperFx.SourceGenerator-emitted <c>DiscoveredCommands</c> manifest.
 /// </remarks>
 public interface ICommandFactory

--- a/src/JasperFx/CommandLineHostingExtensions.cs
+++ b/src/JasperFx/CommandLineHostingExtensions.cs
@@ -119,23 +119,18 @@ public static class CommandLineHostingExtensions
     /// and commands contributed by extension assemblies.
     /// </summary>
     /// <remarks>
-    /// Tries the source-generated <c>DiscoveredCommands</c> manifest first and
-    /// short-circuits entirely when it's present — the manifest already covers
-    /// built-in + application + extension commands as a single trim-clean list.
-    /// Only the no-manifest fallback path is trim-unsafe; its
-    /// <see cref="CommandFactory.RegisterCommands(Assembly)"/> calls are suppressed
-    /// here with documented justification so AOT-compatible consumers don't see
-    /// IL2026 at the <c>CritterStackDefaults</c> / <c>AddJasperFx</c> call site.
+    /// Each <see cref="CommandFactory.RegisterCommands(Assembly)"/> call prefers that
+    /// assembly's source-generated <c>DiscoveredCommands</c> manifest and only falls back to a
+    /// reflective scan when the manifest is absent. The manifest is therefore a per-assembly
+    /// optimization that still covers built-in + application + extension commands; an app is
+    /// fully trim-clean when every contributing assembly was built with JasperFx.SourceGenerator.
+    /// The suppression below documents that the trim-unsafe fallback is only reached for
+    /// assemblies that omit the generator.
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-        Justification = "Fallback assembly scan is only reached when the source-generated DiscoveredCommands manifest is absent. Consumers targeting trim/AOT wire JasperFx.SourceGenerator, which emits the manifest as ordinary code in the consuming assembly so RegisterCommands(Assembly) is never reached at runtime. Apps that omit the analyzer are by definition opting into the runtime-codegen path and accept the scan.")]
+        Justification = "Fallback assembly scan is only reached for assemblies without a source-generated DiscoveredCommands manifest. Consumers targeting trim/AOT wire JasperFx.SourceGenerator, which emits the manifest as ordinary code in each consuming assembly so RegisterCommands(Assembly) never reaches GetExportedTypes at runtime. Apps that omit the analyzer are by definition opting into the runtime-codegen path and accept the scan.")]
     internal static void ApplyFactoryDefaults(this CommandFactory factory, Assembly? applicationAssembly)
     {
-        if (factory.TryRegisterFromGeneratedManifest())
-        {
-            return;
-        }
-
         factory.RegisterCommands(typeof(RunCommand).GetTypeInfo().Assembly);
 
         if (applicationAssembly != null)


### PR DESCRIPTION
## Problem

The CLI source generators (`CommandDiscoveryGenerator`, `InputParserGenerator`) have been **emitting nothing** — on this branch and on `main`. Both matched the command base type with:

```csharp
var originalDef = current.OriginalDefinition?.ToDisplayString();   // "JasperFx.CommandLine.JasperFxCommand<T>"
if (originalDef == "JasperFx.CommandLine.JasperFxCommand`1" ...)    // metadata form — never equal
```

`ISymbol.ToDisplayString()` renders generics in C# style (`<T>`), not the metadata `` `1 `` form, so every candidate was rejected. Result: no `DiscoveredCommands` manifest and no input parsers were generated, and all command discovery/parsing silently fell back to runtime reflection + assembly scanning. Verified in isolation with `CSharpGeneratorDriver` against Roslyn 4.14 — it's a logic bug, not a Roslyn-version issue.

## Fixes

**Generators**
- Match the command base type by its C# display form in both generators.
- Skip inaccessible (private/protected nested) command/input types so emitted `typeof(...)`/casts compile; restrict the command manifest to **public** types so it mirrors `Assembly.GetExportedTypes()`.
- Emit `.ToArray()` for array-typed collection flags (`List<T>` → `T[]`).
- Preserve explicit one-letter flag-alias casing (`[FlagAlias('C')]` → `-C`, not `-c`).

**Discovery (`CommandFactory` / `CommandLineHostingExtensions`)**
- Make the generated `DiscoveredCommands` manifest a **per-assembly** optimization inside `RegisterCommands(Assembly)` (manifest if present, else reflective scan), replacing the all-or-nothing short-circuit that registered only the first manifest found and dropped the built-in `describe`/`run`/`check` commands. `RegisterCommands` is kept side-effect free.

**Guardrails**
- New `SourceGeneratedParsingTests` assert that parsers are registered for the built-in input models and the manifest contains the built-in commands, so the generated path can't silently go inert again.

## Performance (correcting #178's commit message)

Real measured numbers (BenchmarkDotNet, `src/CommandLineBenchmarks`, Apple M5 Max, .NET 9):

| Workload | Reflection | Generated |
|---|---|---|
| Build handlers (small input model) | ~2.8 µs | ~0.43 µs (≈6.5× faster) |
| Build handlers (large input model) | ~8.5 µs | ~0.48 µs (≈18× faster) |
| Full `dotnet run -- <command>` parse | baseline | ≈2–4.5× faster, ≈2–3× fewer allocations |

The win is eliminating reflection, **not** eliminating allocation — the generated parser still allocates its handler list and delegates. The "~3,600–9,200× / zero allocation" figures in #178's commit message were a measurement artifact: the generators were inert, so the benchmark compared reflection against a no-op (`TryGetHandlers` returning `null`). The package README now documents the honest numbers.

## Testing

- `CommandLineTests`: **285/285** on `net9.0` and `net10.0`.
- Full solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
