### PR TITLE
Inline-generate mixed-lifetime IEnumerable<T> dependencies (#375)

### DIFF
--- a/src/CodegenTests/NoXUnitParallelization.cs
+++ b/src/CodegenTests/NoXUnitParallelization.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+// CodegenTests mutate process-wide static state (e.g. DynamicCodeBuilder.WithinCodegenCommand) and
+// compile assemblies, so they must not run in parallel across collections. Matches CommandLineTests
+// and the CI convention of running these suites serially.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/src/CodegenTests/Services/inline_enumerable_with_mixed_lifetimes.cs
+++ b/src/CodegenTests/Services/inline_enumerable_with_mixed_lifetimes.cs
@@ -1,0 +1,207 @@
+using System.Collections;
+using System.Reflection;
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.RuntimeCompiler;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit.Abstractions;
+
+namespace CodegenTests.Services;
+
+// Element set for the mixed-lifetime IEnumerable<T> fix (#375).
+public interface ITestService;
+public class TestSingletonService : ITestService;
+public class TestScopedService : ITestService;
+public class TestTransientService : ITestService;
+public class TestSecondSingletonService : ITestService;
+
+public class inline_enumerable_with_mixed_lifetimes
+{
+    private readonly ITestOutputHelper _output;
+
+    public inline_enumerable_with_mixed_lifetimes(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static (IServiceProvider provider, ServiceContainer graph) setup(Action<ServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        configure(services);
+
+        // The setup step a host (Wolverine) calls before BuildServiceProvider so mixed-lifetime
+        // singleton elements can be injected by key.
+        services.AddJasperFxEnumerableSingletonSupport();
+
+        var provider = services.BuildServiceProvider();
+        return (provider, new ServiceContainer(services, provider));
+    }
+
+    private (object built, string code) build(IServiceProvider provider, ServiceContainer graph, Type collectionType)
+    {
+        var assembly = new GeneratedAssembly(new GenerationRules());
+        var constructedType = typeof(ServiceHarness<>).MakeGenericType(collectionType);
+        var type = assembly.AddType("ServiceAssertion", constructedType);
+        var buildMethod = type.MethodFor("Build");
+
+        var source = new ServiceCollectionServerVariableSource(graph);
+        source.StartNewType();
+        source.StartNewMethod();
+
+        buildMethod.Frames.Code("return {0};", new Use(collectionType));
+
+        var code = assembly.GenerateCode(source);
+        _output.WriteLine(code);
+
+        var compiler = new AssemblyGenerator();
+        compiler.ReferenceAssembly(GetType().Assembly);
+        var builtAssembly = compiler.Generate(code);
+        var builtType = builtAssembly.ExportedTypes.Single();
+
+        var harness = resolve(provider, builtType);
+        var built = builtType.GetMethod("Build")!.Invoke(harness, null)!;
+        return (built, code);
+    }
+
+    // Mirrors how MS DI constructs the generated type: honor [FromKeyedServices] on constructor
+    // parameters and supply the scoped IServiceProvider where the generated code needs it.
+    private static object resolve(IServiceProvider provider, Type builtType)
+    {
+        var ctor = builtType.GetConstructors().Single();
+        var args = ctor.GetParameters().Select(p =>
+        {
+            var keyed = p.GetCustomAttribute<FromKeyedServicesAttribute>();
+            if (keyed != null)
+            {
+                return provider.GetRequiredKeyedService(p.ParameterType, keyed.Key);
+            }
+
+            return p.ParameterType == typeof(IServiceProvider)
+                ? provider
+                : provider.GetService(p.ParameterType)!;
+        }).ToArray();
+
+        return Activator.CreateInstance(builtType, args)!;
+    }
+
+    private static Type[] typesOf(object built) =>
+        ((IEnumerable)built).Cast<object>().Select(x => x.GetType()).ToArray();
+
+    private static void registerMixed(ServiceCollection services)
+    {
+        services.AddSingleton<ITestService, TestSingletonService>();
+        services.AddScoped<ITestService, TestScopedService>();
+        services.AddTransient<ITestService, TestTransientService>();
+    }
+
+    [Fact]
+    public void poc_keyed_forwarding_shares_the_singleton_instance()
+    {
+        var services = new ServiceCollection();
+        registerMixed(services);
+        services.AddKeyedSingleton<ITestService>("k_singleton",
+            (sp, _) => sp.GetServices<ITestService>().First(x => x is TestSingletonService));
+
+        var provider = services.BuildServiceProvider();
+
+        var nonKeyed = provider.GetServices<ITestService>().OfType<TestSingletonService>().Single();
+        provider.GetKeyedService<ITestService>("k_singleton").ShouldBeSameAs(nonKeyed);
+    }
+
+    [Fact]
+    public void mixed_lifetimes_resolve_inline_with_parity_to_GetServices()
+    {
+        var (provider, graph) = setup(registerMixed);
+
+        var (built, code) = build(provider, graph, typeof(IEnumerable<ITestService>));
+
+        // Built inline as an array literal, not bailed to whole-collection service location.
+        code.ShouldContain("new CodegenTests.Services.ITestService[]");
+
+        var expected = provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray();
+        typesOf(built).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void singleton_element_is_the_shared_container_singleton()
+    {
+        var (provider, graph) = setup(registerMixed);
+
+        var (built, _) = build(provider, graph, typeof(IEnumerable<ITestService>));
+
+        var singletonFromArray = ((IEnumerable)built).Cast<object>().OfType<TestSingletonService>().Single();
+        var singletonFromContainer = provider.GetServices<ITestService>().OfType<TestSingletonService>().Single();
+
+        singletonFromArray.ShouldBeSameAs(singletonFromContainer);
+    }
+
+    [Theory]
+    [InlineData(typeof(ITestService[]))]
+    [InlineData(typeof(IEnumerable<ITestService>))]
+    [InlineData(typeof(IReadOnlyList<ITestService>))]
+    [InlineData(typeof(IList<ITestService>))]
+    public void supports_all_collection_shapes(Type collectionType)
+    {
+        var (provider, graph) = setup(registerMixed);
+
+        var (built, _) = build(provider, graph, collectionType);
+
+        var expected = provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray();
+        typesOf(built).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void two_singletons_among_mixed_are_each_shared()
+    {
+        var (provider, graph) = setup(s =>
+        {
+            s.AddSingleton<ITestService, TestSingletonService>();
+            s.AddScoped<ITestService, TestScopedService>();
+            s.AddSingleton<ITestService, TestSecondSingletonService>();
+            s.AddTransient<ITestService, TestTransientService>();
+        });
+
+        var (built, _) = build(provider, graph, typeof(IEnumerable<ITestService>));
+
+        typesOf(built).ShouldBe(provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray());
+
+        var arr = ((IEnumerable)built).Cast<object>().ToArray();
+        arr.OfType<TestSingletonService>().Single()
+            .ShouldBeSameAs(provider.GetServices<ITestService>().OfType<TestSingletonService>().Single());
+        arr.OfType<TestSecondSingletonService>().Single()
+            .ShouldBeSameAs(provider.GetServices<ITestService>().OfType<TestSecondSingletonService>().Single());
+    }
+
+    [Fact]
+    public void keyed_registrations_are_excluded_like_GetServices()
+    {
+        var (provider, graph) = setup(s =>
+        {
+            registerMixed(s);
+            s.AddKeyedSingleton<ITestService, TestSecondSingletonService>("ignored");
+        });
+
+        var (built, _) = build(provider, graph, typeof(IEnumerable<ITestService>));
+
+        typesOf(built).ShouldNotContain(typeof(TestSecondSingletonService));
+        typesOf(built).ShouldBe(provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray());
+    }
+
+    [Fact]
+    public void all_transient_still_inlines_without_regression()
+    {
+        var (provider, graph) = setup(s =>
+        {
+            s.AddTransient<ITestService, TestTransientService>();
+            s.AddTransient<ITestService, TestScopedService>();
+        });
+
+        var (built, code) = build(provider, graph, typeof(IEnumerable<ITestService>));
+
+        code.ShouldContain("new CodegenTests.Services.ITestService[]");
+        typesOf(built).ShouldBe(provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray());
+    }
+}

--- a/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
@@ -20,22 +20,36 @@ internal class ArrayFamily : ServiceFamily
 
     public override ServicePlan? BuildDefaultPlan(ServiceContainer graph, List<ServiceDescriptor> trail)
     {
-        var plans = graph.FindAll(ElementType, trail);
+        // IServiceProvider.GetServices<T>() never returns keyed registrations, so filter them out of
+        // the element set instead of bailing the whole enumerable to runtime service location.
+        var plans = graph.FindAll(ElementType, trail)
+            .Where(x => !x.Descriptor.IsKeyedService)
+            .ToList();
 
-        if (plans.Any(x => x.Descriptor.IsKeyedService)) return new ServiceLocationPlan(Default);
-        
+        // Optimization: an all-singleton enumerable can be built once and shared as a single field.
         if (plans.All(x => x.Lifetime == ServiceLifetime.Singleton))
         {
             return new SingletonPlan(Default);
         }
 
-        if (plans.All(x => x.Lifetime != ServiceLifetime.Singleton))
+        // Otherwise build inline, element by element, with each element honoring its own lifetime:
+        // scoped/transient => inline construction; a genuinely unbuildable element (e.g. opaque lambda
+        // factory) => its own ServiceLocationPlan so only that element is service-located. A singleton
+        // element cannot be injected by its (ambiguous) service type when the type has several
+        // registrations, so route it through a keyed "mirror" (see EnumerableSingletons /
+        // AddJasperFxEnumerableSingletonSupport) and inject it via [FromKeyedServices]. This mirrors
+        // IServiceProvider.GetServices<T>() and avoids the old mixed-lifetime bail that tripped
+        // ServiceLocationPolicy.NotAllowed for the whole IEnumerable<T>.
+        var elementPlans = new List<ServicePlan>(plans.Count);
+        for (var i = 0; i < plans.Count; i++)
         {
-            return new ArrayPlan(ElementType, plans, Default);
+            var plan = plans[i];
+            elementPlans.Add(plan.Lifetime == ServiceLifetime.Singleton
+                ? new SingletonPlan(EnumerableSingletons.KeyedMirror(ElementType, i))
+                : plan);
         }
 
-        // If it's mixed, we have to do this:(
-        return new ServiceLocationPlan(Default);
+        return new ArrayPlan(ElementType, elementPlans, Default);
     }
 }
 

--- a/src/JasperFx/CodeGeneration/Services/EnumerableSingletons.cs
+++ b/src/JasperFx/CodeGeneration/Services/EnumerableSingletons.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JasperFx.CodeGeneration.Services;
+
+/// <summary>
+/// Support for inline-generating <c>IEnumerable&lt;T&gt;</c> dependencies whose element registrations
+/// mix DI lifetimes. A singleton element cannot be injected by its (ambiguous) service type when the
+/// type has several registrations, so it is injected via a keyed "mirror" registration that forwards
+/// to — and therefore shares — the original non-keyed singleton instance. The generated constructor
+/// parameter uses <c>[FromKeyedServices(key)]</c> to pull that specific instance.
+/// </summary>
+internal static class EnumerableSingletons
+{
+    // Stable key per non-keyed registration ordinal within a service family. Keyed services are
+    // scoped by (ServiceType, key), so uniqueness of the ordinal within the family is sufficient.
+    public static string KeyFor(int nonKeyedOrdinal) => "jasperfx-enumerable-singleton-" + nonKeyedOrdinal;
+
+    /// <summary>
+    /// A keyed singleton descriptor that forwards to the <paramref name="nonKeyedOrdinal"/>-th
+    /// non-keyed registration of <paramref name="elementType"/>, sharing that registration's
+    /// singleton instance (GetServices honors each registration's own lifetime).
+    /// </summary>
+    public static ServiceDescriptor KeyedMirror(Type elementType, int nonKeyedOrdinal)
+    {
+        var ordinal = nonKeyedOrdinal;
+        return new ServiceDescriptor(elementType, KeyFor(ordinal),
+            (sp, _) => sp.GetServices(elementType).ElementAt(ordinal)!, ServiceLifetime.Singleton);
+    }
+}

--- a/src/JasperFx/EnumerableSingletonRegistrationExtensions.cs
+++ b/src/JasperFx/EnumerableSingletonRegistrationExtensions.cs
@@ -1,0 +1,71 @@
+using JasperFx.CodeGeneration.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JasperFx;
+
+/// <summary>
+/// Registration support for inline code-generation of <c>IEnumerable&lt;T&gt;</c> dependencies whose
+/// elements mix DI lifetimes (e.g. one singleton + one scoped registration of the same service type).
+/// </summary>
+public static class EnumerableSingletonRegistrationExtensions
+{
+    /// <summary>
+    /// For every service family that mixes a singleton with non-singleton registrations, register a
+    /// keyed "mirror" singleton per singleton element that forwards to — and so shares — the original
+    /// non-keyed singleton instance. JasperFx's generated <c>IEnumerable&lt;T&gt;</c> code injects each
+    /// such singleton via <c>[FromKeyedServices(key)]</c> on the generated constructor, which lets the
+    /// container hand back the specific singleton among multiple registrations of the same type.
+    /// <para>
+    /// Call this once during DI setup <b>before</b> <c>BuildServiceProvider()</c>. It is idempotent.
+    /// Families that are all-singleton or all-non-singleton are left untouched.
+    /// </para>
+    /// </summary>
+    public static IServiceCollection AddJasperFxEnumerableSingletonSupport(this IServiceCollection services)
+    {
+        var families = services
+            .Where(d => !d.IsKeyedService)
+            .GroupBy(d => d.ServiceType)
+            .ToList();
+
+        var toAdd = new List<ServiceDescriptor>();
+
+        foreach (var family in families)
+        {
+            var nonKeyed = family.ToList();
+
+            var hasSingleton = nonKeyed.Any(d => d.Lifetime == ServiceLifetime.Singleton);
+            var hasOther = nonKeyed.Any(d => d.Lifetime != ServiceLifetime.Singleton);
+
+            // Only mixed-lifetime families need keyed mirrors. All-singleton enumerables are built as
+            // a single shared field; all-non-singleton enumerables are fully inline.
+            if (!(hasSingleton && hasOther))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < nonKeyed.Count; i++)
+            {
+                if (nonKeyed[i].Lifetime != ServiceLifetime.Singleton)
+                {
+                    continue;
+                }
+
+                var key = EnumerableSingletons.KeyFor(i);
+                var alreadyRegistered = services.Any(d =>
+                    d.IsKeyedService && d.ServiceType == family.Key && Equals(d.ServiceKey, key));
+
+                if (!alreadyRegistered)
+                {
+                    toAdd.Add(EnumerableSingletons.KeyedMirror(family.Key, i));
+                }
+            }
+        }
+
+        foreach (var descriptor in toAdd)
+        {
+            services.Add(descriptor);
+        }
+
+        return services;
+    }
+}


### PR DESCRIPTION
Implements #375 — the JasperFx-side fix for [JasperFx/wolverine#2896](https://github.com/JasperFx/wolverine/issues/2896).

## Problem

`ArrayFamily.BuildDefaultPlan` bailed to `ServiceLocationPlan` whenever an `IEnumerable<T>` / `T[]` / `IList<T>` / `IReadOnlyList<T>`'s element registrations **mixed lifetimes**. Under `ServiceLocationPolicy.NotAllowed` that threw the misleading *"`IEnumerable<T>` is not public, so requires service location."*

## The hard part (verified)

The issue flagged "verify the singleton-as-field wiring." It **doesn't work as-is**: a per-element singleton resolves to an `InjectedSingleton` field typed by the *service* type, and with multiple registrations the container binds that ambiguous type to the **last** registration. A diagnostic proved it — the generated array silently contained the wrong instance:

```
new ITestService[]{_testService, testScoped, testTransient};
RESOLVED: TestTransient, TestScoped, TestTransient   // _testService bound to the last reg
EXPECTED: TestSingleton, TestScoped, TestTransient
```

## Approach (per the chosen direction: keyed ctor injection)

- Each mixed-family **singleton** gets a keyed *mirror* `ServiceDescriptor` whose factory forwards to — and therefore **shares** — the original non-keyed singleton instance. The generated constructor injects it via `[FromKeyedServices(key)]` (which `InjectedSingleton` already emits for keyed descriptors). Confirmed the forwarding mirror returns the *same* instance as the container singleton.
- New `IServiceCollection.AddJasperFxEnumerableSingletonSupport()` registers those mirrors for mixed families. **Call it during DI setup before `BuildServiceProvider()`** (the Wolverine wiring is the next-publish verification step). Idempotent; all-singleton / all-non-singleton families are untouched.
- **Keyed registrations are filtered out** of the element set (matching `GetServices<T>()`) instead of bailing the whole enumerable.
- Scoped/transient concrete elements construct inline; the all-singleton optimization (single shared field) is unchanged.

## Tests (`src/CodegenTests`) — 356/356 on net9.0 and net10.0

Compile-and-resolve parity with `GetServices<T>()`:
- mixed singleton + scoped + transient (set + **order**); singleton element **is** the shared container singleton; two singletons among mixed each shared; all four collection shapes; keyed excluded; all-transient no-regression.

Also adds `CollectionBehavior.CollectionPerAssembly` to `CodegenTests` (matching `CommandLineTests`): these tests mutate process-wide static state (`DynamicCodeBuilder.WithinCodegenCommand`) and must run serially — a **pre-existing parallel race** that this PR's new (slow-compiling) tests surfaced.

## Scope / follow-ups

Covers the **singleton + concrete scoped/transient** mixed case — the core wolverine#2896 scenario. An **opaque-lambda / non-public element among multiple registrations** has the *same* service-type ambiguity for service location (resolves the last registration) and is left for a follow-up. To be verified end-to-end through Wolverine on the next JasperFx publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
