### PR TITLE
Lock all packages except JasperFx.RuntimeCompiler to a single version (2.1.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <!-- Shared version for the core JasperFx package and its merged source generator
-             (JasperFx.SourceGenerator). Both leaf csprojs set <Version>$(JasperFxVersion)</Version>
-             so they always bump together (jasperfx#365). Other packages in this repo
-             (JasperFx.Events, JasperFx.RuntimeCompiler, JasperFx.Events.SourceGenerator)
-             version independently and keep their own <Version> in their csproj. -->
-        <JasperFxVersion>2.1.0</JasperFxVersion>
+        <!-- Single shared version for EVERY packable project in this repo EXCEPT
+             JasperFx.RuntimeCompiler, which versions independently and keeps its own <Version>
+             in its csproj. All other leaf csprojs (JasperFx, JasperFx.SourceGenerator,
+             JasperFx.Events, JasperFx.Events.SourceGenerator) set
+             <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
+             value to release the whole set. -->
+        <JasperFxVersion>2.1.2</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
+++ b/src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj
@@ -12,7 +12,7 @@
         <IsRoslynComponent>true</IsRoslynComponent>
         <Description>Source generator for Fast Aggregate Projections for Marten and future JasperFx Event Stores</Description>
         <PackageId>JasperFx.Events.SourceGenerator</PackageId>
-        <Version>2.1.1</Version>
+        <Version>$(JasperFxVersion)</Version>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <!-- Deliberately NOT a DevelopmentDependency. This analyzer must flow transitively
              from packages that reference it (notably Marten) to *their* consumers: Marten 9

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>2.1.1</Version>
+        <Version>$(JasperFxVersion)</Version>
         <!-- AOT pillar (jasperfx#213). Enables IL2026/IL2075/IL3050 analyzers so any
              reflective surface that isn't already annotated surfaces during our own
              build. JasperFx.csproj carries the same flag — together they're the


### PR DESCRIPTION
Per request: every produced NuGet at a version higher than what's on NuGet.org so the whole set can **publish together**, and going forward lock all versions **except `JasperFx.RuntimeCompiler`** to the shared `$(JasperFxVersion)` in `Directory.Build.props`.

## Why 2.1.2
Checked NuGet.org — `JasperFx.Events` and `JasperFx.Events.SourceGenerator` **2.1.1 are already published**, so 2.1.1 couldn't republish. 2.1.2 clears every package's latest published version:

| Package | Latest on NuGet.org | This PR | Publishable together |
|---|---|---|---|
| JasperFx | 2.0.1 | 2.1.2 | ✅ |
| JasperFx.SourceGenerator | 2.0.1 | 2.1.2 | ✅ |
| JasperFx.Events | 2.1.1 | 2.1.2 | ✅ |
| JasperFx.Events.SourceGenerator | 2.1.1 | 2.1.2 | ✅ |
| JasperFx.RuntimeCompiler | 5.0.0 | 5.0.0 (excluded) | n/a |

## Changes
- `Directory.Build.props`: `$(JasperFxVersion)` → **2.1.2** (single shared version) + comment documenting the policy.
- `JasperFx.Events` and `JasperFx.Events.SourceGenerator`: `<Version>2.1.1</Version>` → `<Version>$(JasperFxVersion)</Version>`.
- `JasperFx` and `JasperFx.SourceGenerator` already tracked `$(JasperFxVersion)`.
- `JasperFx.RuntimeCompiler` stays independent at **5.0.0**.

Going forward, releasing the whole set is a one-line bump of `$(JasperFxVersion)`. Verified evaluated `Version` per project; `dotnet pack` produces clean 2.1.2 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)