### PR TITLE
Fail fast when a mixed-lifetime IEnumerable<T> singleton mirror is missing (#381)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              JasperFx.Events, JasperFx.Events.SourceGenerator) set
              <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
              value to release the whole set. -->
-        <JasperFxVersion>2.1.3</JasperFxVersion>
+        <JasperFxVersion>2.1.4</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/CodegenTests/Services/inline_enumerable_with_mixed_lifetimes.cs
+++ b/src/CodegenTests/Services/inline_enumerable_with_mixed_lifetimes.cs
@@ -42,6 +42,14 @@ public class inline_enumerable_with_mixed_lifetimes
 
     private (object built, string code) build(IServiceProvider provider, ServiceContainer graph, Type collectionType)
     {
+        var (builtType, code) = compile(graph, collectionType);
+        var harness = resolve(provider, builtType);
+        var built = builtType.GetMethod("Build")!.Invoke(harness, null)!;
+        return (built, code);
+    }
+
+    private (Type builtType, string code) compile(ServiceContainer graph, Type collectionType)
+    {
         var assembly = new GeneratedAssembly(new GenerationRules());
         var constructedType = typeof(ServiceHarness<>).MakeGenericType(collectionType);
         var type = assembly.AddType("ServiceAssertion", constructedType);
@@ -61,9 +69,29 @@ public class inline_enumerable_with_mixed_lifetimes
         var builtAssembly = compiler.Generate(code);
         var builtType = builtAssembly.ExportedTypes.Single();
 
-        var harness = resolve(provider, builtType);
-        var built = builtType.GetMethod("Build")!.Invoke(harness, null)!;
-        return (built, code);
+        return (builtType, code);
+    }
+
+    // The silent-null path: a keyed mirror that was never registered resolves to null under the
+    // optional GetKeyedService semantics that JasperFx's QuickBuild uses (ServiceContainer.QuickBuild
+    // -> GetKeyedService<T>). Mirrors that behaviour so the generated guard is exercised.
+    private static object resolveWithOptionalKeyed(IServiceProvider provider, Type builtType)
+    {
+        var ctor = builtType.GetConstructors().Single();
+        var args = ctor.GetParameters().Select(p =>
+        {
+            var keyed = p.GetCustomAttribute<FromKeyedServicesAttribute>();
+            if (keyed != null)
+            {
+                return ((IKeyedServiceProvider)provider).GetKeyedService(p.ParameterType, keyed.Key)!;
+            }
+
+            return p.ParameterType == typeof(IServiceProvider)
+                ? provider
+                : provider.GetService(p.ParameterType)!;
+        }).ToArray();
+
+        return Activator.CreateInstance(builtType, args)!;
     }
 
     // Mirrors how MS DI constructs the generated type: honor [FromKeyedServices] on constructor
@@ -202,6 +230,63 @@ public class inline_enumerable_with_mixed_lifetimes
         var (built, code) = build(provider, graph, typeof(IEnumerable<ITestService>));
 
         code.ShouldContain("new CodegenTests.Services.ITestService[]");
+        typesOf(built).ShouldBe(provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray());
+    }
+
+    // Builds a mixed-lifetime family WITHOUT calling AddJasperFxEnumerableSingletonSupport(), so the
+    // keyed mirror is never registered (the jasperfx#381 footgun).
+    private (Type builtType, string code, IServiceProvider provider) compileWithoutSingletonSupport()
+    {
+        var services = new ServiceCollection();
+        registerMixed(services);
+
+        // Deliberately NOT calling services.AddJasperFxEnumerableSingletonSupport().
+        var provider = services.BuildServiceProvider();
+        var graph = new ServiceContainer(services, provider);
+
+        var (builtType, code) = compile(graph, typeof(IEnumerable<ITestService>));
+        return (builtType, code, provider);
+    }
+
+    [Fact]
+    public void missing_mirror_emits_a_failfast_guard_in_the_generated_code()
+    {
+        var (_, code, _) = compileWithoutSingletonSupport();
+
+        // The guard null-checks the mirrored singleton element and throws an actionable message.
+        code.ShouldContain("jasperfx-enumerable-singleton-0");
+        code.ShouldContain("AddJasperFxEnumerableSingletonSupport()");
+        code.ShouldContain("throw new System.InvalidOperationException");
+    }
+
+    [Fact]
+    public void missing_mirror_throws_actionable_error_instead_of_injecting_null()
+    {
+        var (builtType, _, provider) = compileWithoutSingletonSupport();
+
+        // The mirror was never registered, so the optional keyed resolution hands back null — exactly
+        // the silent-null footgun. The generated guard must turn that into a clear error.
+        var harness = resolveWithOptionalKeyed(provider, builtType);
+
+        var ex = Should.Throw<TargetInvocationException>(
+            () => builtType.GetMethod("Build")!.Invoke(harness, null));
+
+        var inner = ex.InnerException.ShouldBeOfType<InvalidOperationException>();
+        inner.Message.ShouldContain("jasperfx-enumerable-singleton-0");
+        inner.Message.ShouldContain("AddJasperFxEnumerableSingletonSupport()");
+        inner.Message.ShouldContain("CodegenTests.Services.ITestService");
+    }
+
+    [Fact]
+    public void registered_mirror_does_not_trip_the_guard()
+    {
+        // Sanity: with support registered, the guard is present but the element is non-null so Build
+        // returns the populated enumerable normally.
+        var (provider, graph) = setup(registerMixed);
+
+        var (built, code) = build(provider, graph, typeof(IEnumerable<ITestService>));
+
+        code.ShouldContain("AddJasperFxEnumerableSingletonSupport()");
         typesOf(built).ShouldBe(provider.GetServices<ITestService>().Select(x => x.GetType()).ToArray());
     }
 }

--- a/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
@@ -113,6 +113,21 @@ public class CreateArrayFrame : SyncFrame
     
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
+        // Fail fast (jasperfx#381) if a mixed-lifetime singleton element was injected as null because
+        // its keyed mirror is missing. Without this guard the enumerable silently contains a null that
+        // surfaces far away as an NRE; the actionable message points straight at the missing
+        // AddJasperFxEnumerableSingletonSupport() call.
+        foreach (var element in _elements)
+        {
+            if (element is InjectedSingleton { Descriptor: { IsKeyedService: true } descriptor }
+                && EnumerableSingletons.IsMirrorKey(descriptor.ServiceKey))
+            {
+                var message = EnumerableSingletons.MissingMirrorMessage(_elementType, descriptor.ServiceKey);
+                writer.WriteLine(
+                    $"if ({element.Usage} == null) throw new {typeof(InvalidOperationException).FullNameInCode()}({CodeFormatter.Write(message)});");
+            }
+        }
+
         writer.WriteLine($"{_serviceType.FullNameInCode()} {Variable.Usage} = new {_elementType.FullNameInCode()}[]{{{_elements.Select(x => x.Usage).Join(", ")}}};");
         Next?.GenerateCode(method, writer);
     }

--- a/src/JasperFx/CodeGeneration/Services/EnumerableSingletons.cs
+++ b/src/JasperFx/CodeGeneration/Services/EnumerableSingletons.cs
@@ -1,3 +1,4 @@
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace JasperFx.CodeGeneration.Services;
@@ -11,9 +12,33 @@ namespace JasperFx.CodeGeneration.Services;
 /// </summary>
 internal static class EnumerableSingletons
 {
+    /// <summary>
+    /// Prefix shared by every keyed mirror registration. The full key is this prefix followed by the
+    /// element's non-keyed ordinal within its service family.
+    /// </summary>
+    public const string KeyPrefix = "jasperfx-enumerable-singleton-";
+
     // Stable key per non-keyed registration ordinal within a service family. Keyed services are
     // scoped by (ServiceType, key), so uniqueness of the ordinal within the family is sufficient.
-    public static string KeyFor(int nonKeyedOrdinal) => "jasperfx-enumerable-singleton-" + nonKeyedOrdinal;
+    public static string KeyFor(int nonKeyedOrdinal) => KeyPrefix + nonKeyedOrdinal;
+
+    /// <summary>
+    /// True when <paramref name="key"/> is one of the keyed mirror keys minted by <see cref="KeyFor"/>.
+    /// Used by the generated enumerable code to decide which singleton elements need a missing-mirror
+    /// null guard.
+    /// </summary>
+    public static bool IsMirrorKey(object? key) =>
+        key is string s && s.StartsWith(KeyPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Actionable message thrown by the generated enumerable guard when a keyed mirror is missing —
+    /// i.e. the singleton element resolved to <see langword="null"/> because
+    /// <see cref="JasperFx.EnumerableSingletonRegistrationExtensions.AddJasperFxEnumerableSingletonSupport"/>
+    /// was never called (or ran before the mixed-lifetime family was registered).
+    /// </summary>
+    public static string MissingMirrorMessage(Type elementType, object? key) =>
+        $"Keyed mirror '{key}' for the singleton element of IEnumerable<{elementType.FullNameInCode()}> was not found. " +
+        "Call AddJasperFxEnumerableSingletonSupport() once during DI setup, before BuildServiceProvider().";
 
     /// <summary>
     /// A keyed singleton descriptor that forwards to the <paramref name="nonKeyedOrdinal"/>-th


### PR DESCRIPTION
## Summary

Fixes #381 — the mixed-lifetime `IEnumerable<T>` codegen routes each **singleton** element through a keyed "mirror" registration created by `AddJasperFxEnumerableSingletonSupport()`. If a consumer never calls that method (or registers a mixed-lifetime family *after* it runs), the mirror doesn't exist and the singleton element was injected as **`null` with no error** — the enumerable silently contained a null that surfaced far away as an NRE inside a handler (the footgun behind #380).

This implements **option 2** from the issue: a small guard in the generated enumerable code.

## What changed

- **`CreateArrayFrame.GenerateCode`** now emits a null guard before the `new T[]{…}` array literal for any singleton element sourced from a keyed mirror. When the mirror is absent, the generated code throws an actionable `InvalidOperationException` instead of yielding a null element:

  > Keyed mirror `jasperfx-enumerable-singleton-0` for the singleton element of `IEnumerable<T>` was not found. Call `AddJasperFxEnumerableSingletonSupport()` once during DI setup, before `BuildServiceProvider()`.

- **`EnumerableSingletons`** gains a `KeyPrefix` constant, an `IsMirrorKey()` detector, and a `MissingMirrorMessage()` builder.

The guard is robust regardless of how the constructor parameter was populated (MS DI's keyed resolution, or JasperFx's `QuickBuild` optional `GetKeyedService` path that produced the silent null).

## Tests

Added to `inline_enumerable_with_mixed_lifetimes`:
- `missing_mirror_emits_a_failfast_guard_in_the_generated_code` — asserts the guard text
- `missing_mirror_throws_actionable_error_instead_of_injecting_null` — exercises the silent-null path (optional keyed resolution returns null) and asserts the actionable throw
- `registered_mirror_does_not_trip_the_guard` — no-regression case with support registered

Full CodegenTests (359) and CoreTests (439) pass on net9.0 and net10.0.

## Version

Bumps `JasperFxVersion` 2.1.3 → 2.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)