### PR TITLE
Add store-agnostic AllDatabases() to IEventStore (#387)

### DIFF
--- a/src/EventTests/AllDatabasesDefaultTests.cs
+++ b/src/EventTests/AllDatabasesDefaultTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests;
+
+public class AllDatabasesDefaultTests
+{
+    // A bare IEventStore that does NOT override AllDatabases(), so the call below exercises the
+    // default interface implementation added for jasperfx#387 (the "return empty array" stand-in
+    // for stores that don't yet expose their databases store-agnostically). Everything else throws —
+    // those members are never invoked here.
+    private sealed class BareEventStore : IEventStore
+    {
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private readonly IEventStore theStore = new BareEventStore();
+
+    [Fact]
+    public async Task all_databases_default_returns_empty()
+    {
+        var databases = await theStore.AllDatabases();
+        databases.ShouldBeEmpty();
+    }
+}

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -36,7 +36,18 @@ public interface IEventStore
     
     DatabaseCardinality DatabaseCardinality { get; }
     bool HasMultipleTenants { get; }
-    
+
+    /// <summary>
+    ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
+    ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
+    ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read
+    ///     abstractions (<c>AllProjectionProgress</c>, <c>FetchDeadLetterCountsAsync</c>, <c>CountDeadLetterEventsAsync</c>)
+    ///     without referencing concrete store types. The default implementation returns an empty array as a
+    ///     stand-in; event stores should override this to return their real databases. See jasperfx#387.
+    /// </summary>
+    ValueTask<IReadOnlyList<IEventDatabase>> AllDatabases()
+        => ValueTask.FromResult<IReadOnlyList<IEventDatabase>>([]);
+
     /// <summary>
     /// Identifies the event store within an application
     /// </summary>


### PR DESCRIPTION
Closes #387.

## What

Adds a store-neutral database accessor to `JasperFx.Events.IEventStore`:

```csharp
ValueTask<IReadOnlyList<IEventDatabase>> AllDatabases();
```

Shipped as a **default interface member that returns an empty array** as a stand-in, so every existing `IEventStore` implementer keeps compiling and degrades gracefully until it overrides. Signature mirrors Marten's existing `IMartenStorage.AllDatabases()`.

## Why

Store-agnostic monitoring/tooling (e.g. CritterWatch) needs an `IEventDatabase` to call the read abstractions — `AllProjectionProgress(...)` plus `FetchDeadLetterCountsAsync(...)` / `CountDeadLetterEventsAsync(...)` from #356 — but there was no store-neutral way to obtain one:

- A Marten + Wolverine host registers `IEventStore` in DI (concrete `Marten.DocumentStore`) but does **not** register `IEventDatabase`, so `GetServices<IEventDatabase>()` is empty.
- The registered `IEventStore` could only yield its databases through Marten's own `IMartenStorage.AllDatabases()` — concrete-store types a store-agnostic consumer must not reference.
- `IEventStore` itself exposed only `DatabaseCardinality` — no path to `IEventDatabase`.

`AllDatabases()` closes the loop: consumers resolve the already-registered `IEventStore` and enumerate `IEventDatabase` store-agnostically.

## Follow-ups (real implementations)

The default returns empty; the concrete stores will override:

- **Marten** — JasperFx/marten#4570 (delegate to `IMartenStorage.AllDatabases()`)
- **Polecat** — JasperFx/polecat#156 (project `ITenancy.AllDatabases()`)

## Tests

`AllDatabasesDefaultTests` exercises the default member against a bare `IEventStore` and asserts an empty result, mirroring `DeadLetterCountDefaultsTests` from #356.

Companion to #356; unblocks CritterWatch#213 (ProjectionDeadLetters alert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)