### PR TITLE
Bump JasperFxVersion to 2.2.0 for release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              JasperFx.Events, JasperFx.Events.SourceGenerator) set
              <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
              value to release the whole set. -->
-        <JasperFxVersion>2.1.4</JasperFxVersion>
+        <JasperFxVersion>2.2.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>


### PR DESCRIPTION
Minor-version bump of the shared `$(JasperFxVersion)` (`2.1.4` → `2.2.0`), covering the four packable Critter Stack projects:

- JasperFx
- JasperFx.SourceGenerator
- JasperFx.Events
- JasperFx.Events.SourceGenerator

`JasperFx.RuntimeCompiler` is intentionally left at its independent `5.0.0` (per the user request to bump everything *but* RuntimeCompiler; `NugetPush` runs with `--skip-duplicate`, so the unchanged package is skipped on publish).

## Releases the work merged since 2.1.4
- #385 — scoped-container postprocessor frames + `IUsesServiceProviderFrame`
- #387 — store-agnostic `IEventStore.AllDatabases()`
- #383 — F# pre-generated code generation, milestone 1

Once merged, the **JasperFx NuGet Manual Publish** workflow will be dispatched against `main` to push 2.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)