### PR TITLE
F# codegen: F#-aware CastVariable usage + 2.2.5 (#395)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              JasperFx.Events, JasperFx.Events.SourceGenerator) set
              <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
              value to release the whole set. -->
-        <JasperFxVersion>2.2.4</JasperFxVersion>
+        <JasperFxVersion>2.2.5</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/CodegenTests.FSharp/FSharpCodegenSample.cs
+++ b/src/CodegenTests.FSharp/FSharpCodegenSample.cs
@@ -57,8 +57,33 @@ public static class FSharpCodegenSample
         AddOrderHandlerType(assembly);
         AddSyncTaskHandlerType(assembly);
         AddCalculatorType(assembly);
+        AddCastType(assembly);
 
         return assembly;
+    }
+
+    /// <summary>
+    ///     Constructs a concrete <see cref="Thing" /> and passes it to a service expecting the
+    ///     <see cref="IThing" /> interface via a <see cref="CastVariable" />. Exercises the F# cast
+    ///     operator: the argument renders as <c>(thing :> IThing)</c> rather than a C-style cast
+    ///     (jasperfx#395).
+    /// </summary>
+    private static void AddCastType(GeneratedAssembly assembly)
+    {
+        var type = assembly.AddType("GeneratedThingHandler", typeof(IThingHandler));
+        var method = type.MethodFor(nameof(IThingHandler.Handle));
+
+        var ctor = new ConstructorFrame(typeof(Thing), typeof(Thing).GetConstructors().Single());
+        method.Frames.Add(ctor);
+
+        var service = new InjectedField(typeof(ThingDescriber), "thingDescriber");
+        var call = new MethodCall(typeof(ThingDescriber), nameof(ThingDescriber.Describe))
+        {
+            Target = service,
+            ReturnAction = ReturnAction.Return
+        };
+        call.Arguments[0] = new CastVariable(ctor.Variable, typeof(IThing));
+        method.Frames.Add(call);
     }
 
     /// <summary>

--- a/src/CodegenTests.FSharpFixture/Generated.fs
+++ b/src/CodegenTests.FSharpFixture/Generated.fs
@@ -104,3 +104,11 @@ type GeneratedCalculator() =
         let result_of_Bump = this.Bump(seed)
         result_of_Bump
 
+type GeneratedThingHandler(thingDescriber: FSharpCodegenTarget.ThingDescriber) =
+    let _thingDescriber = thingDescriber
+
+    interface FSharpCodegenTarget.IThingHandler with
+        member this.Handle() : string =
+            let thing = FSharpCodegenTarget.Thing()
+            _thingDescriber.Describe((thing :> FSharpCodegenTarget.IThing))
+

--- a/src/FSharpCodegenTarget/Contracts.cs
+++ b/src/FSharpCodegenTarget/Contracts.cs
@@ -92,6 +92,28 @@ public abstract class CalculatorBase
     public abstract int Compute(int seed);
 }
 
+/// <summary>
+///     A concrete type, its interface, and a service taking the interface. The generated handler
+///     constructs the concrete type and passes it to the service through a <c>CastVariable</c> (upcast
+///     to the interface) — exercises the F# cast operator (<c>:&gt;</c>) for CastVariable (jasperfx#395).
+/// </summary>
+public interface IThing;
+
+public class Thing : IThing;
+
+public class ThingDescriber
+{
+    public string Describe(IThing thing)
+    {
+        return thing.GetType().Name;
+    }
+}
+
+public interface IThingHandler
+{
+    string Handle();
+}
+
 public class ControlFlowService
 {
     public string Fallback()

--- a/src/JasperFx/CodeGeneration/Frames/ConstructorFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/ConstructorFrame.cs
@@ -259,7 +259,7 @@ public class ConstructorFrame : SyncFrame
         }
 
         // F# omits the `new` keyword for ordinary construction.
-        return $"{BuiltType.FSharpName()}({Parameters.Select(x => x.Usage).Join(", ")})";
+        return $"{BuiltType.FSharpName()}({Parameters.Select(x => x.FSharpUsage).Join(", ")})";
     }
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)

--- a/src/JasperFx/CodeGeneration/Frames/IfElseNullGuardFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/IfElseNullGuardFrame.cs
@@ -45,7 +45,7 @@ public class IfElseNullGuardFrame : Frame
         // F# if/then/else is an expression: when it is the trailing position both branches yield
         // the method's return value; otherwise both branches must be unit. `else` dedents back to
         // align with `if` (no braces).
-        writer.Write($"BLOCK:if isNull {_subject.Usage} then");
+        writer.Write($"BLOCK:if isNull {_subject.FSharpUsage} then");
         foreach (var frame in _nullPath) frame.GenerateFSharpCode(method, writer);
         writer.FinishBlock();
 
@@ -113,7 +113,7 @@ public class IfElseNullGuardFrame : Frame
 
         protected override void generateFSharpCode(GeneratedMethod method, ISourceWriter writer, Frame inner)
         {
-            writer.Write($"BLOCK:if not (isNull {_variable.Usage}) then");
+            writer.Write($"BLOCK:if not (isNull {_variable.FSharpUsage}) then");
             inner.GenerateFSharpCode(method, writer);
             writer.FinishBlock();
         }

--- a/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
+++ b/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
@@ -423,7 +423,7 @@ public class MethodCall : Frame
             methodName += $"<{Method.GetGenericArguments().Select(x => x.FSharpName()).Join(", ")}>";
         }
 
-        var callingCode = $"{methodName}({Arguments.Select(x => x.Usage).Join(", ")})";
+        var callingCode = $"{methodName}({Arguments.Select(x => x.FSharpUsage).Join(", ")})";
 
         return $"{fsharpDetermineTarget()}{callingCode}";
     }
@@ -440,7 +440,7 @@ public class MethodCall : Frame
 
         var target = Method.IsStatic
             ? HandlerType.FSharpName()
-            : Target!.Usage;
+            : Target!.FSharpUsage;
 
         return target + ".";
     }

--- a/src/JasperFx/CodeGeneration/Frames/ReturnFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/ReturnFrame.cs
@@ -34,7 +34,7 @@ public class ReturnFrame : SyncFrame
         // F# is expression-oriented: a synchronous method body ends with a bare
         // trailing expression (no `return`), while inside a `task { }` computation
         // expression you DO use `return`. `unit` is written as `()`.
-        var expression = ReturnedVariable == null ? "()" : ReturnedVariable.Usage;
+        var expression = ReturnedVariable == null ? "()" : ReturnedVariable.FSharpUsage;
         var insideTaskBlock = method.AsyncMode == AsyncMode.AsyncTask;
 
         writer.Write(insideTaskBlock ? $"return {expression}" : expression);

--- a/src/JasperFx/CodeGeneration/Model/CastVariable.cs
+++ b/src/JasperFx/CodeGeneration/Model/CastVariable.cs
@@ -13,4 +13,17 @@ public class CastVariable : Variable
 
     // strictly for easier testing
     public Variable Inner { get; }
+
+    /// <summary>
+    ///     F# has no C-style cast. Render an upcast (<c>:&gt;</c>) when the cast target is a base of the
+    ///     inner variable's type, otherwise a dynamic downcast (<c>:?&gt;</c>). See jasperfx#395.
+    /// </summary>
+    public override string FSharpUsage
+    {
+        get
+        {
+            var op = VariableType.IsAssignableFrom(Inner.VariableType) ? ":>" : ":?>";
+            return $"({Inner.FSharpUsage} {op} {VariableType.FSharpName()})";
+        }
+    }
 }

--- a/src/JasperFx/CodeGeneration/Model/Variable.cs
+++ b/src/JasperFx/CodeGeneration/Model/Variable.cs
@@ -176,6 +176,14 @@ public class Variable
     /// </summary>
     public virtual string FSharpAssignmentUsage => Mutable ? $"let mutable {Usage}" : $"let {Usage}";
 
+    /// <summary>
+    ///     EXPERIMENTAL (F# code generation). How the variable is referenced (read) in F#. Defaults to
+    ///     <see cref="Usage" />; overridden by variables whose C# <see cref="Usage" /> is not valid F#
+    ///     (e.g. <see cref="CastVariable" />, whose C-style cast becomes an F# <c>:&gt;</c>/<c>:?&gt;</c>).
+    ///     F# emit paths should consume this rather than <see cref="Usage" /> for argument/value reads.
+    /// </summary>
+    public virtual string FSharpUsage => Usage;
+
     public virtual string ArgumentDeclaration => Usage;
 
     /// <summary>


### PR DESCRIPTION
Closes #395. Ships as **2.2.5**.

## Problem
`CastVariable.Usage` bakes a C# `((Type)x)` cast, which `Variable.Usage`-consuming F# emit paths render verbatim — invalid F#. Hits the injected `ILogger<TMessage>` passed as `ILogger` to validation/continuation frames (Wolverine worked around it locally).

## Fix
- Add a virtual **`Variable.FSharpUsage`** (defaults to `Usage`).
- **`CastVariable`** overrides it with the F# cast operator: `(inner :> Type)` for an upcast, `(inner :?> Type)` for a downcast (chosen by `IsAssignableFrom`).
- F# emit read-sites now consume `FSharpUsage` instead of `Usage`: `MethodCall` arguments + target, `ConstructorFrame` parameters, `ReturnFrame`, and `IfElseNullGuardFrame`'s subject.

## Test
New `GeneratedThingHandler` fixture constructs a concrete `Thing` and passes it to a service via a `CastVariable` upcast to `IThing`; the compile gate proves the emitted F# is `(thing :> IThing)` and compiles:

```fsharp
type GeneratedThingHandler(thingDescriber: FSharpCodegenTarget.ThingDescriber) =
    interface FSharpCodegenTarget.IThingHandler with
        member this.Handle() : string =
            let thing = FSharpCodegenTarget.Thing()
            _thingDescriber.Describe((thing :> FSharpCodegenTarget.IThing))
```

## Verification
- `CodegenTests` F# generation tests: 30/30 pass.
- `CodegenTests.FSharp` compile gate: regenerated `Generated.fs` (incl. the cast case) compiles.

Bumps `JasperFxVersion` 2.2.4 → 2.2.5 (RuntimeCompiler versions independently and is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)