### PR TITLE
F# codegen: scoped-DI frame emit + 2.2.6 (#397)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              JasperFx.Events, JasperFx.Events.SourceGenerator) set
              <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
              value to release the whole set. -->
-        <JasperFxVersion>2.2.5</JasperFxVersion>
+        <JasperFxVersion>2.2.6</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/CodegenTests.FSharp/FSharpCodegenSample.cs
+++ b/src/CodegenTests.FSharp/FSharpCodegenSample.cs
@@ -1,8 +1,11 @@
 using System.Runtime.CompilerServices;
 using FSharpCodegenTarget;
+using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace CodegenTests.FSharp;
 
@@ -58,8 +61,28 @@ public static class FSharpCodegenSample
         AddSyncTaskHandlerType(assembly);
         AddCalculatorType(assembly);
         AddCastType(assembly);
+        AddScopedConsumerType(assembly);
 
         return assembly;
+    }
+
+    /// <summary>
+    ///     A handler that resolves a service-located <see cref="IScopedThing" /> and awaits it.
+    ///     Exercises the scoped-DI frames: <c>use serviceScope = …CreateAsyncScope(…)</c> +
+    ///     <c>let scopedThing = …GetRequiredService&lt;IScopedThing&gt;(serviceScope.ServiceProvider)</c>
+    ///     (jasperfx#397). Rendered with a ServiceCollectionServerVariableSource whose IScopedThing is
+    ///     an opaque scoped lambda factory (forcing service location).
+    /// </summary>
+    private static void AddScopedConsumerType(GeneratedAssembly assembly)
+    {
+        var type = assembly.AddType("GeneratedScopedConsumer", typeof(IScopedConsumerHandler));
+        var method = type.MethodFor(nameof(IScopedConsumerHandler.Handle));
+
+        // No Target — IScopedThing is resolved by the service-variable source (scoped lambda factory),
+        // which inserts ScopedContainerCreation + GetServiceFromScopedContainerFrame. Two awaits make
+        // the body a task { } (AsyncTask), exercising the `use … CreateAsyncScope()` path.
+        method.Frames.Add(new MethodCall(typeof(IScopedThing), nameof(IScopedThing.DoAsync)));
+        method.Frames.Add(new MethodCall(typeof(IScopedThing), nameof(IScopedThing.DoAsync)));
     }
 
     /// <summary>
@@ -304,7 +327,15 @@ public static class FSharpCodegenSample
     /// </summary>
     public static string GenerateCode()
     {
-        return BuildSampleAssembly().GenerateFSharpCode();
+        // A service-variable source backed by a scoped lambda-factory registration so the
+        // GeneratedScopedConsumer resolves IScopedThing via service location (the scoped-DI frames).
+        // The other sample types use constructor injection and are unaffected by the source.
+        var services = new ServiceCollection();
+        services.AddScoped<IScopedThing>(_ => new ScopedThing());
+        var container = new ServiceContainer(services, services.BuildServiceProvider());
+        var source = new ServiceCollectionServerVariableSource(container);
+
+        return BuildSampleAssembly().GenerateFSharpCode(source);
     }
 
     /// <summary>

--- a/src/CodegenTests.FSharpFixture/CodegenTests.FSharpFixture.fsproj
+++ b/src/CodegenTests.FSharpFixture/CodegenTests.FSharpFixture.fsproj
@@ -25,4 +25,10 @@
         <ProjectReference Include="..\FSharpCodegenTarget\FSharpCodegenTarget.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <!-- The scoped-DI sample's generated code references IServiceScopeFactory / GetRequiredService /
+             CreateAsyncScope (jasperfx#397). -->
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/CodegenTests.FSharpFixture/Generated.fs
+++ b/src/CodegenTests.FSharpFixture/Generated.fs
@@ -3,6 +3,7 @@
 namespace FSharpCodegenTarget.Generated
 
 open FSharpCodegenTarget
+open Microsoft.Extensions.DependencyInjection
 open System
 open System.Threading.Tasks
 
@@ -111,4 +112,16 @@ type GeneratedThingHandler(thingDescriber: FSharpCodegenTarget.ThingDescriber) =
         member this.Handle() : string =
             let thing = FSharpCodegenTarget.Thing()
             _thingDescriber.Describe((thing :> FSharpCodegenTarget.IThing))
+
+type GeneratedScopedConsumer(serviceScopeFactory: Microsoft.Extensions.DependencyInjection.IServiceScopeFactory) =
+    let _serviceScopeFactory = serviceScopeFactory
+
+    interface FSharpCodegenTarget.IScopedConsumerHandler with
+        member this.Handle() : System.Threading.Tasks.Task =
+            task {
+                use serviceScope = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.CreateAsyncScope(_serviceScopeFactory)
+                let scopedThing = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<FSharpCodegenTarget.IScopedThing>(serviceScope.ServiceProvider)
+                do! scopedThing.DoAsync()
+                do! scopedThing.DoAsync()
+            }
 

--- a/src/FSharpCodegenTarget/Contracts.cs
+++ b/src/FSharpCodegenTarget/Contracts.cs
@@ -77,6 +77,32 @@ public interface ISyncTaskHandler
 }
 
 /// <summary>
+///     A scoped dependency + its consumer. Registering <see cref="IScopedThing" /> as an opaque
+///     <c>AddScoped&lt;T&gt;(_ =&gt; …)</c> lambda factory forces JasperFx to resolve it via service
+///     location, so the generated <see cref="IScopedConsumerHandler" /> implementation emits the
+///     scoped-DI frames (ScopedContainerCreation + GetServiceFromScopedContainerFrame). The async
+///     <c>DoAsync</c> makes the handler a <c>task { }</c> body, exercising the
+///     <c>use … CreateAsyncScope()</c> path. See jasperfx#397.
+/// </summary>
+public interface IScopedThing
+{
+    Task DoAsync();
+}
+
+public class ScopedThing : IScopedThing
+{
+    public Task DoAsync()
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public interface IScopedConsumerHandler
+{
+    Task Handle();
+}
+
+/// <summary>
 ///     A base class with a public instance method (<see cref="Bump" />) and an abstract method to
 ///     override (<see cref="Compute" />). The generated subclass overrides <c>Compute</c> and calls the
 ///     inherited instance <c>Bump</c> via a local (this-qualified) MethodCall — exercises the named-self

--- a/src/JasperFx/CodeGeneration/Services/GetServiceFromScopedContainerFrame.cs
+++ b/src/JasperFx/CodeGeneration/Services/GetServiceFromScopedContainerFrame.cs
@@ -77,4 +77,22 @@ public class GetServiceFromScopedContainerFrame : SyncFrame
 
         Next?.GenerateCode(method, writer);
     }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // NOTE: the optional Header is a C#-style code fragment (/* */ comments) and is intentionally
+        // not emitted on the F# path — those comment delimiters are invalid F#.
+        if (_serviceKey != null)
+        {
+            writer.Write(
+                $"{Variable.FSharpAssignmentUsage} = {typeof(ServiceProviderKeyedServiceExtensions).FSharpName()}.{nameof(ServiceProviderKeyedServiceExtensions.GetRequiredKeyedService)}<{Variable.VariableType.FSharpName()}>({_scoped.FSharpUsage}, {CodeFormatter.Write(_serviceKey)})");
+        }
+        else
+        {
+            writer.Write(
+                $"{Variable.FSharpAssignmentUsage} = {typeof(ServiceProviderServiceExtensions).FSharpName()}.{nameof(ServiceProviderServiceExtensions.GetRequiredService)}<{Variable.VariableType.FSharpName()}>({_scoped.FSharpUsage})");
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
 }

--- a/src/JasperFx/CodeGeneration/Services/ScopedContainerCreation.cs
+++ b/src/JasperFx/CodeGeneration/Services/ScopedContainerCreation.cs
@@ -1,5 +1,6 @@
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace JasperFx.CodeGeneration.Services;
@@ -103,5 +104,34 @@ internal class ScopedContainerCreation : SyncFrame, IScopedContainerCreation
         }
 
         Next?.GenerateCode(method, writer);
+    }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        // F# `use` disposes the scope at the end of the enclosing scope, like `using var`. In a
+        // `task { }` body it binds an AsyncServiceScope (IAsyncDisposable) and the task CE's `use`
+        // awaits DisposeAsync. CreateAsyncScope is an extension method, so emit it as a static call to
+        // avoid relying on an `open`; CreateScope is a direct interface method. See jasperfx#397.
+        if (method.AsyncMode == AsyncMode.AsyncTask)
+        {
+            writer.Write(
+                $"use {Scope.Usage} = {typeof(ServiceProviderServiceExtensions).FSharpName()}.{nameof(ServiceProviderServiceExtensions.CreateAsyncScope)}({Factory.FSharpUsage})");
+        }
+        else
+        {
+            writer.Write($"use {Scope.Usage} = {Factory.FSharpUsage}.{nameof(IServiceScopeFactory.CreateScope)}()");
+        }
+
+        if (_postprocessors.Count > 0)
+        {
+            for (var i = 1; i < _postprocessors.Count; i++)
+            {
+                _postprocessors[i - 1].Next = _postprocessors[i];
+            }
+
+            _postprocessors[0].GenerateFSharpCode(method, writer);
+        }
+
+        Next?.GenerateFSharpCode(method, writer);
     }
 }


### PR DESCRIPTION
Closes #397. Ships as **2.2.6**.

## Problem
A generated method that resolves a **scoped** service via service location uses `ScopedContainerCreation` + `GetServiceFromScopedContainerFrame` (`JasperFx.CodeGeneration.Services`), neither of which emitted F#. So any handler injecting a scoped dependency — EF Core `DbContext`, Marten `IDocumentSession`, most real handlers — threw `NotSupportedException` on the F# render.

## Fix
- **`ScopedContainerCreation`** → `use serviceScope = ServiceProviderServiceExtensions.CreateAsyncScope(serviceScopeFactory)` inside a `task { }` body (the CE's `use` awaits `DisposeAsync` on the `AsyncServiceScope`), or `use serviceScope = serviceScopeFactory.CreateScope()` for a synchronous body; then postprocessors, then `Next`. (F# `use` disposes at end of scope, like `using var`.)
- **`GetServiceFromScopedContainerFrame`** → `let x = ServiceProviderServiceExtensions.GetRequiredService<T>(scoped)` / `…GetRequiredKeyedService<T>(scoped, key)`. The optional `Header` (a C#-style `/* */` comment fragment) is **not** emitted on the F# path — those delimiters are invalid F#.

## Test
New `GeneratedScopedConsumer` fixture resolves an `AddScoped<IScopedThing>(_ => …)` lambda-factory dependency (forcing service location) and awaits it twice, so the compile gate proves the scoped-DI F# compiles:

```fsharp
member this.Handle() : System.Threading.Tasks.Task =
    task {
        use serviceScope = ServiceProviderServiceExtensions.CreateAsyncScope(_serviceScopeFactory)
        let scopedThing = ServiceProviderServiceExtensions.GetRequiredService<IScopedThing>(serviceScope.ServiceProvider)
        do! scopedThing.DoAsync()
        do! scopedThing.DoAsync()
    }
```

## Verification
- `CodegenTests` F# generation tests 30/30; `CodegenTests.FSharp` compile gate green.

Bumps `JasperFxVersion` 2.2.5 → 2.2.6 (RuntimeCompiler untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)