### PR TITLE
Honor per-file ServiceProviderSource override in the CLI codegen paths (2.3.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              JasperFx.Events, JasperFx.Events.SourceGenerator) set
              <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
              value to release the whole set. -->
-        <JasperFxVersion>2.2.7</JasperFxVersion>
+        <JasperFxVersion>2.2.8</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
              JasperFx.Events, JasperFx.Events.SourceGenerator) set
              <Version>$(JasperFxVersion)</Version> so they always release together. Bump this one
              value to release the whole set. -->
-        <JasperFxVersion>2.2.8</JasperFxVersion>
+        <JasperFxVersion>2.3.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/CodegenTests/DynamicCodeBuilderTests.cs
+++ b/src/CodegenTests/DynamicCodeBuilderTests.cs
@@ -83,6 +83,31 @@ public class DynamicCodeBuilderTests
         recorder.AssertionCalls.ShouldBe(0);
     }
 
+    // #2991: across files sharing one IServiceVariableSource (the CLI codegen path), a per-file
+    // ServiceProviderSource override (TryReplaceServiceProvider -> true, e.g. HTTP's
+    // httpContext.RequestServices) must be applied for that file and RESET before the next file so it
+    // cannot leak into a file that should keep the default isolated-and-scoped provider.
+    [Fact]
+    public void per_file_service_provider_override_is_isolated_to_its_own_file()
+    {
+        var httpStyle = new RecordingFile("HttpStyle") { ReplacesProvider = true };
+        var plain = new RecordingFile("Plain");
+        var source = new FakeServiceVariableSource(reportName: null);
+
+        var builder = new DynamicCodeBuilder(
+            new ServiceCollection().BuildServiceProvider(),
+            new ICodeFileCollection[] { new RecordingCollection(httpStyle, plain) })
+        {
+            ServiceVariableSource = source
+        };
+
+        builder.GenerateAllCode();
+
+        // Reset runs once per file; ReplaceServiceProvider runs only for the file that opts in — and the
+        // reset between files prevents the override from leaking into the plain file.
+        source.Calls.ShouldBe(new[] { "reset", "replace:httpContext.RequestServices", "reset" });
+    }
+
     private static DynamicCodeBuilder BuildWithCollection(RecordingFile file, IServiceVariableSource source)
     {
         return new DynamicCodeBuilder(
@@ -100,6 +125,18 @@ public class DynamicCodeBuilderTests
         public string FileName { get; }
         public int AssertionCalls { get; private set; }
         public ServiceLocationReport[]? LastReports { get; private set; }
+
+        // When true, mimics an HTTP endpoint configured with ServiceProviderSource.FromHttpContextRequestServices.
+        public bool ReplacesProvider { get; init; }
+
+        public bool TryReplaceServiceProvider(out JasperFx.CodeGeneration.Model.Variable serviceProvider)
+        {
+            serviceProvider = default!;
+            if (!ReplacesProvider) return false;
+
+            serviceProvider = new JasperFx.CodeGeneration.Model.Variable(typeof(IServiceProvider), "httpContext.RequestServices");
+            return true;
+        }
 
         public void AssembleTypes(GeneratedAssembly assembly)
         {
@@ -121,11 +158,11 @@ public class DynamicCodeBuilderTests
 
     private sealed class RecordingCollection : ICodeFileCollectionWithServices
     {
-        private readonly ICodeFile _file;
-        public RecordingCollection(ICodeFile file) { _file = file; }
+        private readonly ICodeFile[] _files;
+        public RecordingCollection(params ICodeFile[] files) { _files = files; }
         public string ChildNamespace => "RecordedNamespace";
         public GenerationRules Rules { get; } = new("RecordedNamespace");
-        public IReadOnlyList<ICodeFile> BuildFiles() => new[] { _file };
+        public IReadOnlyList<ICodeFile> BuildFiles() => _files;
     }
 
     private sealed class ServicelessCollection : ICodeFileCollection
@@ -150,6 +187,14 @@ public class DynamicCodeBuilderTests
         public void ReplaceVariables(IMethodVariables method) { }
         public void StartNewType() { }
         public void StartNewMethod() { }
+
+        // #2991: record the per-file override lifecycle so the test can assert isolation.
+        public List<string> Calls { get; } = new();
+
+        public void ReplaceServiceProvider(JasperFx.CodeGeneration.Model.Variable serviceProvider)
+            => Calls.Add($"replace:{serviceProvider.Usage}");
+
+        public void ResetServiceProvider() => Calls.Add("reset");
 
         public ServiceLocationReport[] ServiceLocations()
         {

--- a/src/JasperFx/CodeGeneration/DynamicCodeBuilder.cs
+++ b/src/JasperFx/CodeGeneration/DynamicCodeBuilder.cs
@@ -122,6 +122,11 @@ public class DynamicCodeBuilder
                     var generatedAssembly = collection.StartAssembly(collection.Rules);
                     file.AssembleTypes(generatedAssembly);
 
+                    // #2991: apply any per-file service-provider override (e.g. HTTP's
+                    // httpContext.RequestServices), matching the runtime DynamicTypeLoader path.
+                    // `services` is shared across every file here, so reset the prior override first.
+                    applyServiceProviderOverride(file, services);
+
                     var code = generatedAssembly.GenerateCode(services);
 
                     // #227: enforce ServiceLocationPolicy per-file, matching the
@@ -176,6 +181,10 @@ public class DynamicCodeBuilder
                 throw new CodeGenerationException(file, e);
             }
 
+            // #2991: see WriteGeneratedCode — honor a per-file service-provider override on the
+            // shared source.
+            applyServiceProviderOverride(file, services);
+
             var code = generatedAssembly.GenerateCode(services);
             assertServiceLocationsAllowed(file, services);
 
@@ -208,6 +217,9 @@ public class DynamicCodeBuilder
                 var generatedAssembly = collection.StartAssembly(collection.Rules);
                 file.AssembleTypes(generatedAssembly);
 
+                // #2991: see WriteGeneratedCode.
+                applyServiceProviderOverride(file, services);
+
                 try
                 {
                     withAssembly(generatedAssembly, services);
@@ -219,6 +231,21 @@ public class DynamicCodeBuilder
 
                 assertServiceLocationsAllowed(file, services);
             }
+        }
+    }
+
+    // GH-2991: honor a per-file ServiceProviderSource override (e.g. HTTP's httpContext.RequestServices)
+    // in the CLI codegen paths, matching DynamicTypeLoader.Initialize/CompileAndAttach. Because the CLI
+    // reuses a single shared IServiceVariableSource across every file, reset any prior override first so
+    // it cannot leak into a following file that should keep the default isolated-and-scoped provider.
+    private static void applyServiceProviderOverride(ICodeFile file, IServiceVariableSource? services)
+    {
+        if (services == null) return;
+
+        services.ResetServiceProvider();
+        if (file.TryReplaceServiceProvider(out var serviceProvider))
+        {
+            services.ReplaceServiceProvider(serviceProvider);
         }
     }
 

--- a/src/JasperFx/CodeGeneration/Model/IServiceVariableSource.cs
+++ b/src/JasperFx/CodeGeneration/Model/IServiceVariableSource.cs
@@ -36,6 +36,13 @@ public interface IServiceVariableSource : IVariableSource
         // Nothing, but implement for realsies!
     }
 
+    // GH-2991: undo a prior per-file ReplaceServiceProvider so a shared source instance (the CLI
+    // codegen path reuses one across all files) can isolate the override per ICodeFile.
+    void ResetServiceProvider()
+    {
+        // Nothing by default.
+    }
+
     ServiceLocationReport[] ServiceLocations() => [];
 
 

--- a/src/JasperFx/CodeGeneration/Services/ServiceCollectionServerVariableSource.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceCollectionServerVariableSource.cs
@@ -102,6 +102,19 @@ because at least one dependency is directly using IServiceProvider or has an opa
         _scoped = serviceProvider;
     }
 
+    // GH-2991: the runtime (DynamicTypeLoader) resolves a fresh transient IServiceVariableSource per
+    // ICodeFile, so a ReplaceServiceProvider() call there is naturally isolated to one file. The CLI
+    // codegen paths (DynamicCodeBuilder write/preview/test) reuse a SINGLE shared instance across every
+    // file, and ReplaceServiceProvider latches _replacedServiceProvider = true permanently (StartNewMethod
+    // only re-creates the default scope when it is false). Reset between files so a per-file
+    // ServiceProviderSource override (e.g. HTTP's httpContext.RequestServices) does not leak into the
+    // following files.
+    public void ResetServiceProvider()
+    {
+        _replacedServiceProvider = false;
+        _scoped = new ScopedContainerCreation().Scoped;
+    }
+
     public ServiceLocationReport[] ServiceLocations()
     {
         return _serviceLocations.ToArray();


### PR DESCRIPTION
Fixes the root cause of [wolverine#2991](https://github.com/JasperFx/wolverine/issues/2991) / [wolverine#2992](https://github.com/JasperFx/wolverine/pull/2992): *"HTTP endpoints resolve services wrong in codegen, but works in tests."*

## Root cause
The **runtime** type loader applies a per-`ICodeFile` service-provider override:
```
DynamicTypeLoader.Initialize / CompileAndAttach:
  if (serviceVariables != null && file.TryReplaceServiceProvider(out var sp))
      serviceVariables.ReplaceServiceProvider(sp);
```
So a Wolverine HTTP endpoint configured with `ServiceProviderSource.FromHttpContextRequestServices` resolves its service-located dependencies from `httpContext.RequestServices`.

The **CLI** codegen paths in `DynamicCodeBuilder` (`WriteGeneratedCode` / `generateCode` / `TryBuildAndCompileAll`) call `generatedAssembly.GenerateCode(services)` **without that step**. So `dotnet run -- codegen write` produced *different and wrong* code than the runtime: an opaque scoped lambda-factory dependency fell back to a created `serviceScope`, while a sibling `DbContext` used `httpContext.RequestServices` → two different scoped instances for one logical request.

## Fix
Apply the override per file in all three CLI loops via a shared `applyServiceProviderOverride(file, services)`.

### The non-obvious part (regression guard)
The runtime path registers `IServiceVariableSource` as **transient** (fresh per file), so its `ReplaceServiceProvider` is naturally isolated. The CLI reuses **one shared instance** across every file, and `ServiceCollectionServerVariableSource` latches `_replacedServiceProvider = true` **permanently** (`StartNewMethod` only re-creates the default scope while it is *false*). So naively applying the override in the loop would **leak `httpContext.RequestServices` into every subsequent file** — non-HTTP message handlers, `IsolatedAndScoped` endpoints, etc.

The helper therefore calls a **new `IServiceVariableSource.ResetServiceProvider()`** (default no-op; implemented on `ServiceCollectionServerVariableSource`) before each file, so each file's override is isolated.

## Tests
- New `DynamicCodeBuilderTests.per_file_service_provider_override_is_isolated_to_its_own_file`: an HTTP-style file (opts into the override) followed by a plain file, asserting the call sequence `reset, replace, reset` — i.e. the plain file does **not** inherit the override.
- All 399 `CodegenTests` pass on net9.0 + net10.0.

## Verified downstream
Built `WolverineWebApi` (the #2992 repro) against this (local 2.2.8) and ran `codegen write`: the repro endpoint now resolves the opaque scoped service **and** the `DbContext` both from `httpContext.RequestServices`, and **no** non-HTTP `MessageHandler` file references `httpContext.RequestServices` (reset isolates correctly).

Bumps `JasperFxVersion` to **2.2.8**.

> Note: this changes `codegen write`/preview/test output for any consumer using a `ServiceProviderSource` override, so the downstream Wolverine PR (pin bump + de-skipping the #2992 repro) should run the full Wolverine suite to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)