### PR TITLE
#407 Phase 0: additive per-tenant surface for JasperFx.Events

### DIFF
--- a/src/EventTests/ShardNameTests.cs
+++ b/src/EventTests/ShardNameTests.cs
@@ -56,13 +56,95 @@ public class ShardNameTests
         var name = new ShardName("Foo", "Other", 2);
         var database = new Uri("postgresql://server1/db1/schema1");
         var clone = name.CloneForDatabase(database);
-        
+
         clone.ShouldNotBeSameAs(name);
         clone.Database.ShouldBe(database);
         clone.Name.ShouldBe("Foo");
         clone.ShardKey.ShouldBe("Other");
         clone.Version.ShouldBe((uint)2);
     }
-    
-    
+
+    [Fact]
+    public void null_tenant_keeps_identity_and_url_unchanged()
+    {
+        // The whole grammar change is additive: a null tenant must look exactly like today.
+        var name = ShardName.Compose("Foo", "All");
+        name.TenantId.ShouldBeNull();
+        name.Identity.ShouldBe("Foo:All");
+        name.RelativeUrl.ShouldBe("foo/all");
+
+        var versioned = ShardName.Compose("Foo", "All", version: 2);
+        versioned.TenantId.ShouldBeNull();
+        versioned.Identity.ShouldBe("Foo:V2:All");
+        versioned.RelativeUrl.ShouldBe("foo/all/v2");
+    }
+
+    [Fact]
+    public void compose_with_tenant_appends_distinct_trailing_slot()
+    {
+        var name = ShardName.Compose("Foo", "All", "tenant1");
+        name.TenantId.ShouldBe("tenant1");
+        name.ShardKey.ShouldBe("All"); // tenant is NOT folded into the shard key
+        name.Identity.ShouldBe("Foo:All:tenant1");
+        name.RelativeUrl.ShouldBe("foo/all/tenant1");
+
+        var versioned = ShardName.Compose("Foo", "All", "tenant1", 2);
+        versioned.Identity.ShouldBe("Foo:V2:All:tenant1");
+        versioned.RelativeUrl.ShouldBe("foo/all/v2/tenant1");
+    }
+
+    [Fact]
+    public void compose_treats_empty_tenant_as_store_global()
+    {
+        ShardName.Compose("Foo", "All", "").TenantId.ShouldBeNull();
+        ShardName.Compose("Foo", "All", "").Identity.ShouldBe("Foo:All");
+    }
+
+    [Theory]
+    [InlineData("Foo", "All", null, 1u)]      // 2-segment
+    [InlineData("Foo", "Other", null, 1u)]    // 2-segment, custom key
+    [InlineData("Foo", "All", "tenant1", 1u)] // 3-segment tenant form
+    [InlineData("Foo", "All", null, 2u)]      // 3-segment version form
+    [InlineData("Foo", "All", "tenant1", 3u)] // 4-segment version + tenant
+    [InlineData("Foo", "Other", "acme", 2u)]
+    public void try_parse_round_trips_compose(string name, string key, string? tenant, uint version)
+    {
+        var composed = ShardName.Compose(name, key, tenant, version);
+
+        ShardName.TryParse(composed.Identity, out var parsed).ShouldBeTrue();
+        parsed.ShouldNotBeNull();
+        parsed!.Name.ShouldBe(name);
+        parsed.ShardKey.ShouldBe(key);
+        parsed.TenantId.ShouldBe(tenant);
+        parsed.Version.ShouldBe(version);
+        parsed.Identity.ShouldBe(composed.Identity);
+        parsed.ShouldBe(composed); // equality is identity-based
+    }
+
+    [Fact]
+    public void try_parse_round_trips_high_water_mark()
+    {
+        ShardName.TryParse(ShardState.HighWaterMark, out var parsed).ShouldBeTrue();
+        parsed!.Identity.ShouldBe(ShardState.HighWaterMark);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void try_parse_rejects_empty(string? text)
+    {
+        ShardName.TryParse(text, out var parsed).ShouldBeFalse();
+        parsed.ShouldBeNull();
+    }
+
+    [Fact]
+    public void for_tenant_rebinds_to_tenant_partition()
+    {
+        var global = ShardName.Compose("Foo", "All");
+        var scoped = global.ForTenant("tenant1");
+
+        scoped.TenantId.ShouldBe("tenant1");
+        scoped.Identity.ShouldBe("Foo:All:tenant1");
+        scoped.ForTenant(null).TenantId.ShouldBeNull();
+    }
 }

--- a/src/EventTests/TenantIdSurfaceSerializationTests.cs
+++ b/src/EventTests/TenantIdSurfaceSerializationTests.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests;
+
+// jasperfx#407 Phase 0: the new nullable TenantId slot on ShardState / HighWaterStatistics must be
+// purely additive -- default to null and never break existing serialized payloads that predate it.
+public class TenantIdSurfaceSerializationTests
+{
+    [Fact]
+    public void shard_state_defaults_tenant_to_null()
+    {
+        new ShardState("Foo:All", 5).TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void shard_state_copies_tenant_from_shard_name()
+    {
+        var state = new ShardState(ShardName.Compose("Foo", "All", "tenant1"), 5);
+        state.TenantId.ShouldBe("tenant1");
+    }
+
+    [Fact]
+    public void shard_state_serializes_null_tenant_without_throwing()
+    {
+        // ShardState is published in-memory rather than JSON round-tripped, but writing it must
+        // still emit the additive slot as null so any consumer that does serialize it sees null.
+        var json = JsonSerializer.Serialize(new ShardState("Foo:All", 5));
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("TenantId").ValueKind.ShouldBe(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public void shard_state_serializes_set_tenant()
+    {
+        var json = JsonSerializer.Serialize(new ShardState("Foo:All", 5) { TenantId = "tenant1" });
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("TenantId").GetString().ShouldBe("tenant1");
+    }
+
+    [Fact]
+    public void high_water_statistics_defaults_tenant_to_null()
+    {
+        new HighWaterStatistics().TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void high_water_statistics_round_trips_tenant()
+    {
+        var stats = new HighWaterStatistics { CurrentMark = 10, TenantId = "tenant1" };
+        var restored = JsonSerializer.Deserialize<HighWaterStatistics>(JsonSerializer.Serialize(stats));
+        restored!.TenantId.ShouldBe("tenant1");
+        restored.CurrentMark.ShouldBe(10);
+    }
+
+    [Fact]
+    public void existing_high_water_payload_without_tenant_still_deserializes()
+    {
+        const string legacy = """{"LastMark":3,"CurrentMark":7,"HighestSequence":7}""";
+        var restored = JsonSerializer.Deserialize<HighWaterStatistics>(legacy);
+        restored!.TenantId.ShouldBeNull();
+        restored.CurrentMark.ShouldBe(7);
+    }
+}

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterStatistics.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterStatistics.cs
@@ -16,6 +16,13 @@ public class HighWaterStatistics
     public bool IncludesSkipping { get; set; }
     public DateTimeOffset Timestamp { get; set; } = default;
 
+    /// <summary>
+    /// Tenant partition this high water reading belongs to. Null means store-global, which is
+    /// the only behavior that existed before per-tenant partitioning. A vectorized high-water
+    /// agent emits one reading per assigned tenant; existing single-reading consumers leave this null.
+    /// </summary>
+    public string? TenantId { get; set; }
+
     public HighWaterStatus InterpretStatus(HighWaterStatistics previous)
     {
         // Postgres sequences start w/ 1 by default. So the initial state is "HighestSequence = 1".

--- a/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
@@ -35,6 +35,18 @@ public interface IProjectionDaemon: IDisposable
     /// <returns></returns>
     Task RebuildProjectionAsync(string projectionName, CancellationToken token);
 
+    /// <summary>
+    ///     Rebuilds a single projection by projection name for a single tenant partition inline.
+    ///     A null <paramref name="tenantId" /> is store-global and delegates to the tenant-less overload
+    ///     (today's behavior). Daemons that implement per-tenant partitioning override this; the default
+    ///     throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    Task RebuildProjectionAsync(string projectionName, string? tenantId, CancellationToken token)
+        => tenantId == null
+            ? RebuildProjectionAsync(projectionName, token)
+            : throw new NotSupportedException(
+                "Per-tenant RebuildProjectionAsync is not implemented on this IProjectionDaemon. Use an event store that implements per-tenant partitioning.");
+
 
     /// <summary>
     ///     Rebuilds a single projection by projection type inline.
@@ -71,6 +83,18 @@ public interface IProjectionDaemon: IDisposable
     /// <param name="token"></param>
     /// <returns></returns>
     Task RebuildProjectionAsync(string projectionName, TimeSpan shardTimeout, CancellationToken token);
+
+    /// <summary>
+    ///     Rebuilds a single projection by projection name for a single tenant partition inline.
+    ///     A null <paramref name="tenantId" /> is store-global and delegates to the tenant-less overload
+    ///     (today's behavior). Daemons that implement per-tenant partitioning override this; the default
+    ///     throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    Task RebuildProjectionAsync(string projectionName, string? tenantId, TimeSpan shardTimeout, CancellationToken token)
+        => tenantId == null
+            ? RebuildProjectionAsync(projectionName, shardTimeout, token)
+            : throw new NotSupportedException(
+                "Per-tenant RebuildProjectionAsync is not implemented on this IProjectionDaemon. Use an event store that implements per-tenant partitioning.");
 
 
     /// <summary>
@@ -202,4 +226,22 @@ public interface IProjectionDaemon: IDisposable
     /// <returns></returns>
     Task RewindSubscriptionAsync(string subscriptionName, CancellationToken token, long? sequenceFloor = 0,
         DateTimeOffset? timestamp = null);
+
+    /// <summary>
+    /// Rewinds a subscription (or projection) for a single tenant partition to a certain point and
+    /// allows it to restart at that point. A null <paramref name="tenantId" /> is store-global and
+    /// delegates to the tenant-less overload (today's behavior). Daemons that implement per-tenant
+    /// partitioning override this; the default throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    /// <param name="subscriptionName">Name of the subscription</param>
+    /// <param name="tenantId">Tenant partition to scope the rewind to. Null means store-global.</param>
+    /// <param name="token"></param>
+    /// <param name="sequenceFloor">The point at which to rewind the subscription. The default is zero</param>
+    /// <param name="timestamp">Optional parameter to rewind the subscription to rerun any events that were posted on or after this time. If the system cannot determine the sequence, it will do nothing</param>
+    Task RewindSubscriptionAsync(string subscriptionName, string? tenantId, CancellationToken token,
+        long? sequenceFloor = 0, DateTimeOffset? timestamp = null)
+        => tenantId == null
+            ? RewindSubscriptionAsync(subscriptionName, token, sequenceFloor, timestamp)
+            : throw new NotSupportedException(
+                "Per-tenant RewindSubscriptionAsync is not implemented on this IProjectionDaemon. Use an event store that implements per-tenant partitioning.");
 }

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -52,7 +52,19 @@ public interface IEventDatabase
     /// <param name="token"></param>
     /// <returns></returns>
     Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token);
-    
+
+    /// <summary>
+    /// Find the position of the event store sequence just below the supplied timestamp for a single
+    /// tenant partition. A null <paramref name="tenantId" /> is store-global and delegates to the
+    /// tenant-less overload (today's behavior). Event stores that implement per-tenant partitioning
+    /// override this; the default throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, string? tenantId, CancellationToken token)
+        => tenantId == null
+            ? FindEventStoreFloorAtTimeAsync(timestamp, token)
+            : throw new NotSupportedException(
+                "Per-tenant FindEventStoreFloorAtTimeAsync is not implemented on this IEventDatabase. Use an event store that implements per-tenant partitioning.");
+
     string StorageIdentifier { get; }
     Task<long> FetchHighestEventSequenceNumber(CancellationToken token);
     
@@ -67,6 +79,20 @@ public interface IEventDatabase
     /// <returns></returns>
     Task<IReadOnlyList<ShardState>> AllProjectionProgress(
         CancellationToken token = default);
+
+    /// <summary>
+    ///     Check the current progress of all asynchronous projections for a single tenant partition.
+    ///     A null <paramref name="tenantId" /> is store-global and delegates to the tenant-less overload
+    ///     (today's behavior). Event stores that implement per-tenant partitioning override this; the
+    ///     default throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    /// <param name="tenantId">Tenant partition to scope progress to. Null means store-global.</param>
+    /// <param name="token"></param>
+    Task<IReadOnlyList<ShardState>> AllProjectionProgress(string? tenantId, CancellationToken token = default)
+        => tenantId == null
+            ? AllProjectionProgress(token)
+            : throw new NotSupportedException(
+                "Per-tenant AllProjectionProgress is not implemented on this IEventDatabase. Use an event store that implements per-tenant partitioning.");
 
     /// <summary>
     ///     Count the stored dead letter events for a single projection/subscription shard. With
@@ -84,7 +110,7 @@ public interface IEventDatabase
     /// <summary>
     ///     Fetch the stored dead letter event counts for this database, one row per shard
     ///     (<see cref="DeadLetterShardCount.ProjectionName" /> + <see cref="DeadLetterShardCount.ShardKey" />).
-    ///     Mirrors the "give me every row" shape of <see cref="AllProjectionProgress" />.
+    ///     Mirrors the "give me every row" shape of <see cref="AllProjectionProgress(CancellationToken)" />.
     ///     The default implementation returns an empty list as a stand-in; event stores that
     ///     persist dead letters should override this. See jasperfx#356.
     /// </summary>

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -175,6 +175,20 @@ public interface IEventStore
             "GetProjectionStatusesAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for the projections page.");
 
     /// <summary>
+    /// Return a snapshot of every projection's status scoped to a single tenant partition.
+    /// A null <paramref name="tenantId"/> is store-global and delegates to the tenant-less
+    /// overload (today's behavior). Event stores that implement per-tenant partitioning
+    /// override this; the default throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    /// <param name="tenantId">Tenant partition to scope statuses to. Null means store-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<ProjectionStatus>> GetProjectionStatusesAsync(string? tenantId, CancellationToken ct)
+        => tenantId == null
+            ? GetProjectionStatusesAsync(ct)
+            : throw new NotSupportedException(
+                "Per-tenant GetProjectionStatusesAsync is not implemented on this IEventStore. Use an event store that implements per-tenant partitioning.");
+
+    /// <summary>
     /// Replay a projection over a fixed in-memory event list, returning
     /// the per-step before/after state. Stateless — nothing is persisted
     /// and no server-side session is created. Powers the explorer's
@@ -260,6 +274,19 @@ public interface IEventStore<TOperations, TQuerySession> : IEventStore where TOp
     /// <returns></returns>
     Task DeleteProjectionProgressAsync(IEventDatabase database, string subscriptionName,
         CancellationToken token);
+
+    /// <summary>
+    /// Delete *only* any persisted projection progress data for a single tenant partition.
+    /// A null <paramref name="tenantId"/> is store-global and delegates to the tenant-less
+    /// overload (today's behavior). Event stores that implement per-tenant partitioning
+    /// override this; the default throws for a non-null tenant. See jasperfx#407.
+    /// </summary>
+    Task DeleteProjectionProgressAsync(IEventDatabase database, string subscriptionName, string? tenantId,
+        CancellationToken token)
+        => tenantId == null
+            ? DeleteProjectionProgressAsync(database, subscriptionName, token)
+            : throw new NotSupportedException(
+                "Per-tenant DeleteProjectionProgressAsync is not implemented on this IEventStore. Use an event store that implements per-tenant partitioning.");
 
     ValueTask<IProjectionBatch<TOperations, TQuerySession>> StartProjectionBatchAsync(EventRange range,
         IEventDatabase database, ShardExecutionMode mode, AsyncOptions projectionOptions, CancellationToken token);

--- a/src/JasperFx.Events/Projections/ShardName.cs
+++ b/src/JasperFx.Events/Projections/ShardName.cs
@@ -9,25 +9,32 @@ public class ShardName
 {
     public const string All = "All";
 
-    
+
     [JsonConstructor]
-    public ShardName(string name, string shardKey, uint version)
+    public ShardName(string name, string shardKey, uint version, string? tenantId)
     {
         Name = name;
         ShardKey = shardKey;
         Version = version;
+        TenantId = string.IsNullOrEmpty(tenantId) ? null : tenantId;
+
+        // The tenant is a distinct, trailing slot in the grammar -- it is NEVER folded
+        // into the ShardKey. A null/empty tenant means "store-global" and keeps the
+        // Identity/RelativeUrl byte-for-byte identical to the pre-tenancy behavior.
+        var identitySuffix = TenantId == null ? string.Empty : $":{TenantId}";
+        var urlSuffix = TenantId == null ? string.Empty : $"/{TenantId}";
 
         if (version > 1)
         {
-            Identity = $"{name}:V{version}:{shardKey}";
-            RelativeUrl = $"{name}/{shardKey}/v{version}".ToLowerInvariant();
+            Identity = $"{name}:V{version}:{shardKey}{identitySuffix}";
+            RelativeUrl = $"{name}/{shardKey}/v{version}{urlSuffix}".ToLowerInvariant();
         }
         else
         {
-            Identity = $"{name}:{shardKey}";
-            RelativeUrl = $"{name}/{shardKey}".ToLowerInvariant();
+            Identity = $"{name}:{shardKey}{identitySuffix}";
+            RelativeUrl = $"{name}/{shardKey}{urlSuffix}".ToLowerInvariant();
         }
-        
+
         if (name == ShardState.HighWaterMark)
         {
             Identity = ShardState.HighWaterMark;
@@ -35,15 +42,102 @@ public class ShardName
 
     }
 
-    public ShardName(string name): this(name, All, 1)
+    public ShardName(string name, string shardKey, uint version): this(name, shardKey, version, null)
     {
     }
-    
+
+    public ShardName(string name): this(name, All, 1, null)
+    {
+    }
+
+    /// <summary>
+    ///     Compose a <see cref="ShardName" /> from its parts. The optional <paramref name="tenantId" />
+    ///     occupies a distinct, trailing slot in the shard grammar and is never folded into the
+    ///     <paramref name="shardKey" />. A null/empty tenant is store-global (today's default behavior).
+    /// </summary>
+    /// <param name="name">Projection or composite-group identity</param>
+    /// <param name="shardKey">Identity of the shard within the projection. Defaults to "All".</param>
+    /// <param name="tenantId">Optional tenant partition suffix. Null/empty means store-global.</param>
+    /// <param name="version">Projection version. Defaults to 1.</param>
+    public static ShardName Compose(string name, string? shardKey = All, string? tenantId = null, uint version = 1)
+    {
+        return new ShardName(name, string.IsNullOrEmpty(shardKey) ? All : shardKey, version, tenantId);
+    }
+
+    /// <summary>
+    ///     Parse a shard <see cref="Identity" /> string back into a <see cref="ShardName" />.
+    ///     Understands every form produced by <see cref="Compose" />/<see cref="Identity" />:
+    ///     <c>Name:ShardKey</c>, <c>Name:ShardKey:Tenant</c>, <c>Name:V{n}:ShardKey</c>, and
+    ///     <c>Name:V{n}:ShardKey:Tenant</c>. A leading <c>V{digits}</c> segment is interpreted as a
+    ///     version marker; otherwise the trailing segment of a 3-part identity is the tenant.
+    /// </summary>
+    public static bool TryParse(string? text, out ShardName? shardName)
+    {
+        shardName = null;
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        if (text == ShardState.HighWaterMark)
+        {
+            shardName = new ShardName(ShardState.HighWaterMark);
+            return true;
+        }
+
+        var parts = text.Split(':');
+        switch (parts.Length)
+        {
+            case 2:
+                // Name:ShardKey
+                shardName = new ShardName(parts[0], parts[1], 1, null);
+                return true;
+
+            case 3 when TryParseVersion(parts[1], out var versionedKeyVersion):
+                // Name:V{n}:ShardKey
+                shardName = new ShardName(parts[0], parts[2], versionedKeyVersion, null);
+                return true;
+
+            case 3:
+                // Name:ShardKey:Tenant
+                shardName = new ShardName(parts[0], parts[1], 1, parts[2]);
+                return true;
+
+            case 4 when TryParseVersion(parts[1], out var versionedTenantVersion):
+                // Name:V{n}:ShardKey:Tenant
+                shardName = new ShardName(parts[0], parts[2], versionedTenantVersion, parts[3]);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryParseVersion(string segment, out uint version)
+    {
+        version = 1;
+        if (segment.Length < 2 || segment[0] != 'V')
+        {
+            return false;
+        }
+
+        return uint.TryParse(segment.AsSpan(1), out version);
+    }
+
     public string RelativeUrl { get; }
 
     public ShardName CloneForDatabase(Uri database)
     {
-        return new ShardName(Name, ShardKey, Version) { Database = database };
+        return new ShardName(Name, ShardKey, Version, TenantId) { Database = database };
+    }
+
+    /// <summary>
+    ///     Return an equivalent <see cref="ShardName" /> bound to the supplied tenant. A null/empty
+    ///     tenant yields the store-global shard.
+    /// </summary>
+    public ShardName ForTenant(string? tenantId)
+    {
+        return new ShardName(Name, ShardKey, Version, tenantId) { Database = Database };
     }
 
     public Uri Database { get; set; } = new Uri("database://default");
@@ -58,6 +152,13 @@ public class ShardName
     ///     one shard for a projection, this will be "All"
     /// </summary>
     public string ShardKey { get; }
+
+    /// <summary>
+    ///     Optional tenant partition this shard is scoped to. Null means store-global -- the only
+    ///     behavior that existed before per-tenant partitioning. This is a distinct slot in the shard
+    ///     grammar and is never folded into <see cref="ShardKey" />.
+    /// </summary>
+    public string? TenantId { get; }
 
     /// <summary>
     ///     {ProjectionName}:{Key}. Single identity string that should be unique within this application

--- a/src/JasperFx.Events/Projections/ShardState.cs
+++ b/src/JasperFx.Events/Projections/ShardState.cs
@@ -26,7 +26,15 @@ public class ShardState
 
     public ShardState(ShardName shardName, long sequence): this(shardName.Identity, sequence)
     {
+        TenantId = shardName.TenantId;
     }
+
+    /// <summary>
+    /// Tenant partition this shard state belongs to. Null means store-global, which is the
+    /// only behavior that existed before per-tenant partitioning. Serializes as null for
+    /// existing consumers that never set it.
+    /// </summary>
+    public string? TenantId { get; set; }
 
     public long RebuildThreshold { get; set; }
 


### PR DESCRIPTION
Closes the **Phase 0 — Surface (additive)** portion of #407 (the standalone first PR / "first round of JasperFx work"). Part of the per-tenant partitioning master plan [CritterWatch#209](https://github.com/JasperFx/CritterWatch/issues/209).

This is **purely additive with zero behavior change** — a `null` tenant everywhere is store-global, i.e. today's exact behavior. It unblocks Marten's signature-level work on [marten#4596](https://github.com/JasperFx/marten/issues/4596). Phases A (composite replay executor) and 2 (daemon abstractions) are intentionally **not** in this PR — per the issue they co-evolve with marten#4596 afterward.

## Changes

**`ShardName` grammar**
- New nullable `TenantId` — a **distinct trailing slot**, never folded into `ShardKey`.
- `Compose(name, shardKey, tenantId, version)` factory + `TryParse(...)` handling all forms: `Name:ShardKey`, `Name:ShardKey:Tenant`, `Name:V{n}:ShardKey`, `Name:V{n}:ShardKey:Tenant`.
- `ForTenant(...)` helper. Null/empty tenant keeps `Identity`/`RelativeUrl` byte-for-byte identical to today.

**State types**
- Nullable `TenantId` on `ShardState` (copied from `ShardName`) and `HighWaterStatistics`. Defaults null; serializes null without breaking existing consumers.

**Admin-API tenant overloads** (default interface implementations: delegate when tenant is null, throw `NotSupportedException` otherwise — so existing implementers compile untouched and override later)
- `IEventDatabase`: `AllProjectionProgress`, `FindEventStoreFloorAtTimeAsync`
- `IEventStore` / `IEventStore<,>`: `GetProjectionStatusesAsync`, `DeleteProjectionProgressAsync`
- `IProjectionDaemon`: `RebuildProjectionAsync` (×2), `RewindSubscriptionAsync`
- APIs already taking a `ShardName` (`ProjectionProgressFor`, `StartAgentAsync`, `StopAgentAsync`) thread tenant through it — no new methods, per the issue's principle.

## Tests
- `ShardNameTests`: `Compose`/`TryParse` round-trip for 2-/3-/4-segment forms, null-tenant unchanged, empty→global, HighWaterMark, `ForTenant`.
- New `TenantIdSurfaceSerializationTests`: `ShardState`/`HighWaterStatistics` serialize `TenantId` as null and round-trip a set value.

**Verification:** full `EventTests` suite green — **323/323 on net9.0 and net10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)