### PR TITLE
#409: consistent dynamic-tenancy management surface (2.6.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,13 @@
              Also fixes a Command.Start optimized-rebuild double-load that could duplicate the
              progression INSERT (pk_mt_event_progression 23505). Released from the pt209.1–pt209.6
              local-feed prerelease line consumed downstream by Marten/Polecat/Wolverine.CritterWatch. -->
-        <JasperFxVersion>2.5.0</JasperFxVersion>
+        <!-- 2.6.0: consistent dynamic-tenancy management surface (#409, CritterWatch#209). Adds an
+             auto-assign AddTenantAsync(tenantId, CancellationToken) overload on IDynamicTenantSource<T>
+             (default throws; sharded/partitioned sources override) and a uniform IServiceProvider/IHost
+             admin entrypoint (DynamicTenancyAdminExtensions) that dispatches add/disable/enable/remove
+             to every registered dynamic tenant source — graceful no-op when none — so CritterWatch never
+             sniffs the concrete tenancy type. -->
+        <JasperFxVersion>2.6.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/CoreTests/MultiTenancy/dynamic_tenancy_admin_surface.cs
+++ b/src/CoreTests/MultiTenancy/dynamic_tenancy_admin_surface.cs
@@ -1,0 +1,183 @@
+using JasperFx.Descriptors;
+using JasperFx.MultiTenancy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+
+namespace CoreTests.MultiTenancy;
+
+// jasperfx#409: uniform dynamic-tenancy admin surface (CritterWatch#209).
+public class dynamic_tenancy_admin_surface
+{
+    [Fact]
+    public async Task auto_assign_overload_throws_by_default()
+    {
+        IDynamicTenantSource<string> source = new ValueOnlyTenantSource();
+        await Should.ThrowAsync<NotSupportedException>(() => source.AddTenantAsync("acme"));
+    }
+
+    [Fact]
+    public async Task auto_assign_overload_is_used_when_a_source_supports_it()
+    {
+        var source = new AutoAssignTenantSource();
+        await ((IDynamicTenantSource<string>)source).AddTenantAsync("acme");
+        source.AutoAssigned.ShouldBe(["acme"]);
+    }
+
+    [Fact]
+    public async Task add_tenant_with_value_dispatches_to_registered_sources()
+    {
+        var source = new ValueOnlyTenantSource();
+        var services = provider(source);
+
+        await services.AddTenantAsync("acme", "Host=db1");
+
+        source.Added.ShouldBe([("acme", "Host=db1")]);
+    }
+
+    [Fact]
+    public async Task auto_assign_add_dispatches_to_registered_sources()
+    {
+        var source = new AutoAssignTenantSource();
+        var services = provider(source);
+
+        await services.AddTenantAsync("acme");
+
+        source.AutoAssigned.ShouldBe(["acme"]);
+    }
+
+    [Fact]
+    public async Task disable_enable_remove_dispatch_to_registered_sources()
+    {
+        var source = new ValueOnlyTenantSource();
+        var services = provider(source);
+
+        await services.DisableTenantAsync("acme");
+        source.Disabled.ShouldBe(["acme"]);
+        (await services.AllDisabledTenantsAsync()).ShouldBe(["acme"]);
+
+        await services.EnableTenantAsync("acme");
+        source.Disabled.ShouldBeEmpty();
+
+        await services.RemoveTenantAsync("acme");
+        source.Removed.ShouldBe(["acme"]);
+    }
+
+    [Fact]
+    public async Task dispatches_to_every_registered_dynamic_source()
+    {
+        var a = new ValueOnlyTenantSource();
+        var b = new ValueOnlyTenantSource();
+        var services = provider(a, b);
+
+        services.DynamicTenantSources().Count.ShouldBe(2);
+
+        await services.AddTenantAsync("acme", "Host=db1");
+
+        a.Added.ShouldBe([("acme", "Host=db1")]);
+        b.Added.ShouldBe([("acme", "Host=db1")]);
+    }
+
+    [Fact]
+    public async Task is_a_graceful_no_op_when_no_dynamic_source_is_registered()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        services.DynamicTenantSources().ShouldBeEmpty();
+
+        // None of these should throw with no source registered
+        await services.AddTenantAsync("acme", "Host=db1");
+        await services.AddTenantAsync("acme");
+        await services.DisableTenantAsync("acme");
+        await services.EnableTenantAsync("acme");
+        await services.RemoveTenantAsync("acme");
+        (await services.AllDisabledTenantsAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ihost_overloads_delegate_to_the_service_provider()
+    {
+        var source = new ValueOnlyTenantSource();
+        IHost host = new FakeHost(provider(source));
+
+        await host.AddTenantAsync("acme", "Host=db1");
+        host.DynamicTenantSources().Count.ShouldBe(1);
+
+        source.Added.ShouldBe([("acme", "Host=db1")]);
+    }
+
+    private static IServiceProvider provider(params IDynamicTenantSource<string>[] sources)
+    {
+        var services = new ServiceCollection();
+        foreach (var source in sources)
+        {
+            services.AddSingleton(source);
+        }
+
+        return services.BuildServiceProvider();
+    }
+}
+
+internal class ValueOnlyTenantSource : IDynamicTenantSource<string>
+{
+    public List<(string TenantId, string Value)> Added { get; } = new();
+    public List<string> Disabled { get; } = new();
+    public List<string> Enabled { get; } = new();
+    public List<string> Removed { get; } = new();
+
+    public DatabaseCardinality Cardinality => DatabaseCardinality.DynamicMultiple;
+    public ValueTask<string> FindAsync(string tenantId) => new(tenantId);
+    public Task RefreshAsync() => Task.CompletedTask;
+    public IReadOnlyList<string> AllActive() => Added.Select(x => x.Value).ToList();
+
+    public IReadOnlyList<Assignment<string>> AllActiveByTenant()
+        => Added.Select(x => new Assignment<string>(x.TenantId, x.Value)).ToList();
+
+    public Task AddTenantAsync(string tenantId, string connectionValue)
+    {
+        Added.Add((tenantId, connectionValue));
+        return Task.CompletedTask;
+    }
+
+    public Task DisableTenantAsync(string tenantId)
+    {
+        Disabled.Add(tenantId);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveTenantAsync(string tenantId)
+    {
+        Removed.Add(tenantId);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<string>> AllDisabledAsync() => Task.FromResult<IReadOnlyList<string>>(Disabled);
+
+    public Task EnableTenantAsync(string tenantId)
+    {
+        Enabled.Add(tenantId);
+        Disabled.Remove(tenantId);
+        return Task.CompletedTask;
+    }
+}
+
+// Supports the auto-assign provisioning shape (sharded/partitioned style). Re-declares the interface so
+// its AddTenantAsync(string, CancellationToken) takes over the default interface member's mapping.
+internal class AutoAssignTenantSource : ValueOnlyTenantSource, IDynamicTenantSource<string>
+{
+    public List<string> AutoAssigned { get; } = new();
+
+    public Task AddTenantAsync(string tenantId, CancellationToken token = default)
+    {
+        AutoAssigned.Add(tenantId);
+        return Task.CompletedTask;
+    }
+}
+
+internal class FakeHost(IServiceProvider services) : IHost
+{
+    public IServiceProvider Services { get; } = services;
+    public void Dispose() { }
+    public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task StopAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+}

--- a/src/JasperFx/MultiTenancy/DynamicTenancyAdminExtensions.cs
+++ b/src/JasperFx/MultiTenancy/DynamicTenancyAdminExtensions.cs
@@ -1,0 +1,112 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace JasperFx.MultiTenancy;
+
+/// <summary>
+/// One uniform entrypoint for managing dynamic multi-tenancy on a running Critter Stack service,
+/// regardless of which tenancy model backs it (Marten master-table, sharded-database pooling, Wolverine's
+/// master tenant source, or a future Polecat model). Dispatches each admin operation to every registered
+/// <see cref="IDynamicTenantSource{T}" /> of <c>string</c> connection values, so a tool such as
+/// CritterWatch consumes only these extensions and never sniffs the concrete tenancy type. Following the
+/// store-agnostic pattern, every method is a graceful no-op when no dynamic tenant source is registered.
+/// See jasperfx#409 (CritterWatch#209).
+/// </summary>
+public static class DynamicTenancyAdminExtensions
+{
+    /// <summary>
+    /// All registered dynamic (string-keyed) tenant sources. Empty when the service has no dynamic
+    /// tenancy model registered.
+    /// </summary>
+    public static IReadOnlyList<IDynamicTenantSource<string>> DynamicTenantSources(this IServiceProvider services)
+        => services.GetServices<IDynamicTenantSource<string>>().ToList();
+
+    /// <summary>
+    /// Add a tenant with a caller-supplied connection value (master-table style). Dispatched to every
+    /// registered dynamic tenant source.
+    /// </summary>
+    public static Task AddTenantAsync(this IServiceProvider services, string tenantId, string connectionValue)
+        => forEachSource(services, source => source.AddTenantAsync(tenantId, connectionValue));
+
+    /// <summary>
+    /// Add a tenant whose connection/partition is auto-assigned by the source (sharded/partitioned style;
+    /// no caller-supplied value). Dispatched to every registered dynamic tenant source — a source that
+    /// requires a connection value will surface <see cref="NotSupportedException" /> from its default
+    /// <see cref="IDynamicTenantSource{T}.AddTenantAsync(string,CancellationToken)" />.
+    /// </summary>
+    public static Task AddTenantAsync(this IServiceProvider services, string tenantId,
+        CancellationToken token = default)
+        => forEachSource(services, source => source.AddTenantAsync(tenantId, token));
+
+    /// <summary>
+    /// Disable (soft delete) a tenant across every registered dynamic tenant source.
+    /// </summary>
+    public static Task DisableTenantAsync(this IServiceProvider services, string tenantId)
+        => forEachSource(services, source => source.DisableTenantAsync(tenantId));
+
+    /// <summary>
+    /// Re-enable a previously disabled tenant across every registered dynamic tenant source.
+    /// </summary>
+    public static Task EnableTenantAsync(this IServiceProvider services, string tenantId)
+        => forEachSource(services, source => source.EnableTenantAsync(tenantId));
+
+    /// <summary>
+    /// Remove a tenant from the registry across every registered dynamic tenant source. Does not delete
+    /// the tenant's data.
+    /// </summary>
+    public static Task RemoveTenantAsync(this IServiceProvider services, string tenantId)
+        => forEachSource(services, source => source.RemoveTenantAsync(tenantId));
+
+    /// <summary>
+    /// The distinct set of currently disabled tenants across every registered dynamic tenant source.
+    /// </summary>
+    public static async Task<IReadOnlyList<string>> AllDisabledTenantsAsync(this IServiceProvider services)
+    {
+        var disabled = new List<string>();
+        foreach (var source in services.DynamicTenantSources())
+        {
+            disabled.AddRange(await source.AllDisabledAsync().ConfigureAwait(false));
+        }
+
+        return disabled.Distinct().ToList();
+    }
+
+    private static async Task forEachSource(IServiceProvider services,
+        Func<IDynamicTenantSource<string>, Task> action)
+    {
+        foreach (var source in services.DynamicTenantSources())
+        {
+            await action(source).ConfigureAwait(false);
+        }
+    }
+
+    // ---- IHost conveniences (the natural admin entrypoint for a monitored service) ----
+
+    /// <summary><inheritdoc cref="DynamicTenantSources(IServiceProvider)" /></summary>
+    public static IReadOnlyList<IDynamicTenantSource<string>> DynamicTenantSources(this IHost host)
+        => host.Services.DynamicTenantSources();
+
+    /// <summary><inheritdoc cref="AddTenantAsync(IServiceProvider,string,string)" /></summary>
+    public static Task AddTenantAsync(this IHost host, string tenantId, string connectionValue)
+        => host.Services.AddTenantAsync(tenantId, connectionValue);
+
+    /// <summary><inheritdoc cref="AddTenantAsync(IServiceProvider,string,CancellationToken)" /></summary>
+    public static Task AddTenantAsync(this IHost host, string tenantId, CancellationToken token = default)
+        => host.Services.AddTenantAsync(tenantId, token);
+
+    /// <summary><inheritdoc cref="DisableTenantAsync(IServiceProvider,string)" /></summary>
+    public static Task DisableTenantAsync(this IHost host, string tenantId)
+        => host.Services.DisableTenantAsync(tenantId);
+
+    /// <summary><inheritdoc cref="EnableTenantAsync(IServiceProvider,string)" /></summary>
+    public static Task EnableTenantAsync(this IHost host, string tenantId)
+        => host.Services.EnableTenantAsync(tenantId);
+
+    /// <summary><inheritdoc cref="RemoveTenantAsync(IServiceProvider,string)" /></summary>
+    public static Task RemoveTenantAsync(this IHost host, string tenantId)
+        => host.Services.RemoveTenantAsync(tenantId);
+
+    /// <summary><inheritdoc cref="AllDisabledTenantsAsync(IServiceProvider)" /></summary>
+    public static Task<IReadOnlyList<string>> AllDisabledTenantsAsync(this IHost host)
+        => host.Services.AllDisabledTenantsAsync();
+}

--- a/src/JasperFx/MultiTenancy/IDynamicTenantSource.cs
+++ b/src/JasperFx/MultiTenancy/IDynamicTenantSource.cs
@@ -12,6 +12,19 @@ public interface IDynamicTenantSource<T> : ITenantedSource<T>
     Task AddTenantAsync(string tenantId, T connectionValue);
 
     /// <summary>
+    /// Provision a new tenant whose connection/partition is auto-assigned by the source's configured
+    /// strategy — e.g. sharded-database pooling or per-tenant event partitions — rather than a
+    /// caller-supplied connection value. The default implementation throws
+    /// <see cref="NotSupportedException" />; sources that auto-assign (e.g. Marten's sharded tenancy)
+    /// override it. This is the uniform "add a tenant" entrypoint for provisioning models that own the
+    /// physical assignment, so a tool such as CritterWatch never has to sniff the concrete tenancy type.
+    /// See jasperfx#409.
+    /// </summary>
+    Task AddTenantAsync(string tenantId, CancellationToken token = default)
+        => throw new NotSupportedException(
+            $"This tenant source ({GetType().FullName}) requires a caller-supplied connection value; call AddTenantAsync(tenantId, connectionValue) instead, or use a source that supports auto-assignment.");
+
+    /// <summary>
     /// Disable a tenant (soft delete). The tenant data is preserved but
     /// the tenant is no longer active. Agents are stopped, caches evicted.
     /// </summary>


### PR DESCRIPTION
Closes the JasperFx-side of #409 — standardize runtime tenant management on the existing `JasperFx.MultiTenancy.IDynamicTenantSource<T>` so a monitoring tool (CritterWatch) can add/disable/enable/remove tenants on any Critter Stack service **without sniffing the concrete tenancy type**. Part of CritterWatch #209. Additive and non-breaking.

Branches off the **2.5.0** release commit (`5f94c0c`); this is a single commit and a **minor bump to 2.6.0**.

## Changes
- **`IDynamicTenantSource<T>`** — new auto-assign overload `AddTenantAsync(string tenantId, CancellationToken = default)`, default-implemented to throw `NotSupportedException`. Resolves the issue's open question: it covers the sharded/partitioned provisioning shape that has **no caller-supplied connection value**; auto-assigning sources (Marten `ShardedTenancy`, marten#4598) override it. The value-supplied `AddTenantAsync(tenantId, connectionValue)` is unchanged.
- **`DynamicTenancyAdminExtensions`** — a uniform `IServiceProvider`/`IHost` admin entrypoint that resolves every registered `IDynamicTenantSource<string>` and dispatches add (value + auto-assign) / disable / enable / remove / all-disabled to each — a **graceful no-op when none is registered** (store-agnostic pattern). CritterWatch consumes only this.

Out of scope here (other repos): proposal item 1 (`ShardedTenancy` implementing the interface, marten#4598) and item 3 (Wolverine `MartenMessageDatabaseSource`).

## Verification
- **CoreTests: 447/447 on net9.0 and net10.0** (8 new tests: default-throws, auto-assign override, value + auto-assign dispatch, disable/enable/remove, multi-source fan-out, graceful no-op when unregistered, `IHost` overloads).
- Full solution builds clean.

## Publish
Version bumped to **2.6.0** in `Directory.Build.props`. After merge, publish via the **"JasperFx NuGet Manual Publish"** workflow (`workflow_dispatch` → `./build.sh NugetPush`, `NUGET_API_KEY` secret). Package set: JasperFx, JasperFx.Events, JasperFx.Events.SourceGenerator, JasperFx.SourceGenerator, JasperFx.Aspire (RuntimeCompiler versions independently, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)