### PR TITLE
#411: remove HttpChainDescriptor pipeline-introspection fields (2.6.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,12 @@
              admin entrypoint (DynamicTenancyAdminExtensions) that dispatches add/disable/enable/remove
              to every registered dynamic tenant source — graceful no-op when none — so CritterWatch never
              sniffs the concrete tenancy type. -->
-        <JasperFxVersion>2.6.0</JasperFxVersion>
+        <!-- 2.6.1: remove redundant HttpChainDescriptor pipeline-introspection fields (#411). Drops
+             HttpChainDescriptor.Middleware/Postprocessors/ServiceDependencies, the MiddlewareStepDescriptor
+             type, and graph-level HttpGraphUsage.MiddlewareTypes — the same operator-facing pipeline
+             information is available on demand via the chain's generated source code, so the descriptor
+             copies were redundant payload (~30-50 KB compressed per ~163-endpoint topology). -->
+        <JasperFxVersion>2.6.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx/Descriptors/HttpChainDescriptor.cs
+++ b/src/JasperFx/Descriptors/HttpChainDescriptor.cs
@@ -109,11 +109,10 @@ public class HttpChainDescriptor : OptionsDescription
     /// <summary>OpenAPI tags applied to this chain.</summary>
     public new List<string> Tags { get; set; } = new();
 
-    /// <summary>Middleware steps in apply order.</summary>
-    public List<MiddlewareStepDescriptor> Middleware { get; set; } = new();
-
-    /// <summary>Postprocessor steps in apply order.</summary>
-    public List<MiddlewareStepDescriptor> Postprocessors { get; set; } = new();
+    // jasperfx#411: the Middleware / Postprocessors / ServiceDependencies pipeline-introspection fields
+    // were removed. The same operator-facing information is available on demand via the chain's generated
+    // source code (RequestHandlerSourceCode in Wolverine.CritterWatch) — the generated C# IS the compiled
+    // pipeline — so the descriptor copies were redundant payload.
 
     /// <summary>
     /// Cascading message types this chain may publish — the
@@ -121,9 +120,6 @@ public class HttpChainDescriptor : OptionsDescription
     /// renders these as clickable chips into the messaging detail page.
     /// </summary>
     public List<TypeDescriptor> CascadingMessageTypes { get; set; } = new();
-
-    /// <summary>Service dependencies the chain resolves at runtime.</summary>
-    public List<TypeDescriptor> ServiceDependencies { get; set; } = new();
 
     /// <summary>Full OpenAPI shape of the operation, when discoverable.</summary>
     public OpenApiOperationDescriptor? OpenApi { get; set; }

--- a/src/JasperFx/Descriptors/HttpGraphUsage.cs
+++ b/src/JasperFx/Descriptors/HttpGraphUsage.cs
@@ -80,11 +80,8 @@ public class HttpGraphUsage : OptionsDescription
     /// </summary>
     public List<string> PolicyNames { get; set; } = new();
 
-    /// <summary>
-    /// Type names of middleware that may apply across the graph (the
-    /// <c>WolverineHttpOptions.Middleware</c> registry).
-    /// </summary>
-    public List<string> MiddlewareTypes { get; set; } = new();
+    // jasperfx#411: graph-level MiddlewareTypes (the WolverineHttpOptions.Middleware registry) was removed
+    // for API consistency with the per-chain pipeline-introspection removal.
 
     /// <summary>
     /// Names of tenant-detection strategies registered on the graph.

--- a/src/JasperFx/Descriptors/MiddlewareStepDescriptor.cs
+++ b/src/JasperFx/Descriptors/MiddlewareStepDescriptor.cs
@@ -1,29 +1,8 @@
 namespace JasperFx.Descriptors;
 
-/// <summary>
-/// One ordered step in a chain's middleware / postprocessor pipeline.
-/// </summary>
-public class MiddlewareStepDescriptor
-{
-    /// <summary>Type that owns the step (handler / middleware / policy).</summary>
-    public string TypeFullName { get; set; } = "";
-
-    /// <summary>Method name within the owning type.</summary>
-    public string MethodName { get; set; } = "";
-
-    /// <summary>
-    /// Step kind — <c>"Middleware"</c>, <c>"Postprocessor"</c>,
-    /// <c>"Validation"</c>, <c>"Audit"</c>, etc. Used for visual
-    /// grouping in the Pipeline tab.
-    /// </summary>
-    public string Kind { get; set; } = "";
-
-    /// <summary>
-    /// Compact display string for the row (e.g.
-    /// <c>"OrderHandler.Before(Order)"</c>).
-    /// </summary>
-    public string Description { get; set; } = "";
-}
+// jasperfx#411: MiddlewareStepDescriptor (one step in a chain's middleware/postprocessor pipeline) was
+// removed along with HttpChainDescriptor.Middleware/Postprocessors. Pipeline information is available on
+// demand via the chain's generated source code rather than mirrored into the descriptor payload.
 
 /// <summary>
 /// Narrow per-namespace prefix applied via Wolverine's


### PR DESCRIPTION
Closes #411. Removes pipeline-introspection fields from the HTTP descriptors that existed only to mirror data for CritterWatch — the same operator-facing pipeline information is available on demand via the chain's **generated source code** (`RequestHandlerSourceCode` in Wolverine.CritterWatch; the generated C# *is* the compiled pipeline), so the descriptor copies were redundant payload (~30–50 KB compressed for a ~163-endpoint topology, plus equivalent savings in every persisted `ServiceSummary` row downstream).

**Fix-version bump: 2.6.0 → 2.6.1.** Public-type change, landing in the 2.x rc window per the issue.

> Stacked on #410 (2.6.0 / #409). Base is `feat/409-dynamic-tenancy-admin-surface`; GitHub will auto-retarget this to `main` when #410 merges. Diff here is the single #411 commit.

## Removed
- `HttpChainDescriptor.Middleware`
- `HttpChainDescriptor.Postprocessors`
- `HttpChainDescriptor.ServiceDependencies`
- `MiddlewareStepDescriptor` (no remaining consumers; `NamespacePrefixDescriptor` and `ApiVersionDescriptor` in the same file are retained)
- `HttpGraphUsage.MiddlewareTypes` (graph-level, for API consistency)

## Verification
- Solution builds clean (confirms no in-repo consumers of the removed members).
- **CoreTests: 447/447 on net9.0 and net10.0.**

## Downstream (separate repos, coordinated after this ships)
- **Wolverine** drops the descriptor population in `HttpGraphUsageSource.cs` (`describeFrames` / `readServiceDependencies` helpers + lines 188/190/191).
- **CritterWatch** removes its `HttpChainDetailPage` Pipeline tab and regens TS messages + tooltips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)