### PR TITLE
Fix EventPage.CalculateCeiling crash on fully-skipped batch (marten#4663) [1.0]

### DIFF
--- a/src/EventTests/Projections/EventPageTests.cs
+++ b/src/EventTests/Projections/EventPageTests.cs
@@ -1,0 +1,48 @@
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Projections;
+
+public class EventPageTests
+{
+    [Fact]
+    public void calculate_ceiling_when_page_is_full_uses_last_sequence()
+    {
+        var page = new EventPage(0)
+        {
+            new Event<AEvent>(new AEvent()) { Sequence = 4 },
+            new Event<AEvent>(new AEvent()) { Sequence = 5 }
+        };
+
+        page.CalculateCeiling(2, 1000);
+
+        page.Ceiling.ShouldBe(5);
+    }
+
+    [Fact]
+    public void calculate_ceiling_when_page_is_not_full_uses_high_water_mark()
+    {
+        var page = new EventPage(0)
+        {
+            new Event<AEvent>(new AEvent()) { Sequence = 4 }
+        };
+
+        page.CalculateCeiling(10, 1000);
+
+        page.Ceiling.ShouldBe(1000);
+    }
+
+    [Fact]
+    public void calculate_ceiling_when_full_batch_was_entirely_skipped_does_not_throw()
+    {
+        // Reproduces https://github.com/JasperFx/marten/issues/4663 -- every event in a
+        // full batch was skipped, so the page is empty. CalculateCeiling must not call
+        // Last() on the empty page; it should fall back to the high water mark.
+        var page = new EventPage(0);
+
+        Should.NotThrow(() => page.CalculateCeiling(10, 1000, skippedEvents: 10));
+
+        page.Ceiling.ShouldBe(1000);
+    }
+}

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>1.36.0</Version>
+        <Version>1.36.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/JasperFx.Events/Projections/EventPage.cs
+++ b/src/JasperFx.Events/Projections/EventPage.cs
@@ -14,7 +14,12 @@ public class EventPage: List<IEvent>
 
     public void CalculateCeiling(int batchSize, long highWaterMark, int skippedEvents = 0)
     {
-        Ceiling = (Count + skippedEvents) == batchSize
+        // Count == 0 happens when every event in a full batch was skipped (e.g. error
+        // handling is configured to skip serialization/application/unknown event errors).
+        // There is no last event to read a sequence from, so fall back to the high water
+        // mark and let the daemon make progress rather than throwing on an empty page. See
+        // https://github.com/JasperFx/marten/issues/4663
+        Ceiling = (Count + skippedEvents) == batchSize && Count > 0
             ? this.Last().Sequence
             : highWaterMark;
     }


### PR DESCRIPTION
Backport of #416 to the **1.0** branch.

## Problem

`EventPage.CalculateCeiling` calls `this.Last().Sequence` whenever `(Count + skippedEvents) == batchSize`. When error handling is configured to skip events (serialization/application/unknown event errors) and **every** event in a full batch is skipped, the page is empty (`Count == 0`) while `Count + skippedEvents == batchSize`. `Last()` then throws `System.InvalidOperationException: Sequence contains no elements`, crashing projection rebuilds.

Reported in [JasperFx/marten#4663](https://github.com/JasperFx/marten/issues/4663) (Marten v8.37.2, small batch sizes, event skipping, optimized rebuilds, HotCold daemon).

## Fix

Guard the `Last()` access with `&& Count > 0`. When the page is entirely skipped events, fall back to the high water mark so the daemon keeps making progress instead of throwing.

## Commits

1. The fix + `EventPageTests` regression coverage (passes on net8.0/9.0/10.0).
2. Bump `JasperFx.Events` package version `1.36.0` → `1.36.1`.

Fixes JasperFx/marten#4663

🤖 Generated with [Claude Code](https://claude.com/claude-code)