### PR TITLE
Fix #419: route all ShardName construction through ShardName.Compose

### DIFF
--- a/src/EventTests/Projections/AsyncShardTests.cs
+++ b/src/EventTests/Projections/AsyncShardTests.cs
@@ -16,9 +16,26 @@ public class AsyncShardTests
             new EventFilterable());
 
         shard = shard.OverrideProjectionName("Bar");
-        
+
         shard.Name.Name.ShouldBe("Bar");
         shard.Name.ShardKey.ShouldBe("All");
         shard.Name.Version.ShouldBe(3U);
+    }
+
+    [Fact]
+    public void override_the_projection_name_preserves_tenant_binding()
+    {
+        // jasperfx#419: renaming the projection must not silently drop a tenant binding established
+        // upstream (e.g. by the per-tenant catch-up loop). Losing it collapses every tenant onto the
+        // same store-global progression row -> marten#4679 (23505 duplicate key).
+        var shard = new AsyncShard<FakeOperations, FakeSession>(new AsyncOptions(), ShardRole.Projection,
+            ShardName.Compose("Foo", "All", "tenant1", 3),
+            Substitute.For<ISubscriptionFactory<FakeOperations, FakeSession>>(), new EventFilterable());
+
+        shard = shard.OverrideProjectionName("Bar");
+
+        shard.Name.Name.ShouldBe("Bar");
+        shard.Name.TenantId.ShouldBe("tenant1");
+        shard.Name.Identity.ShouldBe("Bar:V3:All:tenant1");
     }
 }

--- a/src/EventTests/Projections/Composite/CompositeProjectionReplayTests.cs
+++ b/src/EventTests/Projections/Composite/CompositeProjectionReplayTests.cs
@@ -142,6 +142,42 @@ public class CompositeProjectionReplayTests
         await batch.Received(1).ExecuteAsync(Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public void member_stages_inherit_a_store_global_parent_binding()
+    {
+        // jasperfx#419: with no tenant on the parent composite shard, member stages stay store-global,
+        // byte-for-byte with the pre-refactor behavior.
+        var stage = new ProjectionStage<FakeOperations, FakeSession>(1);
+        stage.Add(new FakeReplayMember("A", canParticipate: true));
+        stage.Add(new FakeReplayMember("B", canParticipate: true));
+
+        var parent = ShardName.Compose("Composite", version: 2);
+        var executionStage = stage.BuildExecution(theStore, theDatabase, NullLogger.Instance, parent);
+
+        foreach (var execution in executionStage.Executions)
+        {
+            execution.ShardName.TenantId.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void member_stages_inherit_the_parent_tenant_binding()
+    {
+        // jasperfx#419 root cause of marten#4679: when the composite is caught up/rebuilt for a single
+        // tenant, the parent ShardName carries that tenant id. Each member stage's ShardName MUST inherit
+        // it -- otherwise every per-tenant member writes the same store-global mt_event_progression row
+        // and the second tenant's INSERT trips 23505.
+        var stage = new ProjectionStage<FakeOperations, FakeSession>(1);
+        stage.Add(new FakeReplayMember("A", canParticipate: true));
+        stage.Add(new FakeReplayMember("B", canParticipate: true));
+
+        var parent = ShardName.Compose("Composite", tenantId: "tenant1", version: 2);
+        var executionStage = stage.BuildExecution(theStore, theDatabase, NullLogger.Instance, parent);
+
+        executionStage.Executions.Select(x => x.ShardName.Identity)
+            .ShouldBe(["A:All:tenant1", "B:All:tenant1"]);
+    }
+
     private CompositeExecution<FakeOperations, FakeSession> buildExecution(bool replayEligible)
         => new(new ShardName("Composite", ShardName.All, 0), new AsyncOptions(), theStore, theDatabase,
             Substitute.For<IJasperFxProjection<FakeOperations>>(), NullLogger.Instance,

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -74,7 +74,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
 
     public Type ImplementationType => GetType();
     public SubscriptionType Type { get; }
-    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public ShardName[] ShardNames() => [ShardName.Compose(Name, version: Version)];
 
     private static readonly string[] methodNames = [nameof(DetermineAction), nameof(DetermineActionAsync), nameof(Evolve), nameof(EvolveAsync)];
     
@@ -369,7 +369,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
     {
         return
         [
-            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, new ShardName(Name, ShardName.All, Version), this, this)
+            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, ShardName.Compose(Name, version: Version), this, this)
         ];
     }
 

--- a/src/JasperFx.Events/Projections/AsyncShard.cs
+++ b/src/JasperFx.Events/Projections/AsyncShard.cs
@@ -12,6 +12,6 @@ public record AsyncShard<TOperations, TQuerySession>(
 {
     public AsyncShard<TOperations, TQuerySession> OverrideProjectionName(string projectionName)
     {
-        return this with { Name = new ShardName(projectionName, Name.ShardKey, Name.Version) };
+        return this with { Name = ShardName.Compose(projectionName, Name.ShardKey, Name.TenantId, Name.Version) };
     }
 }

--- a/src/JasperFx.Events/Projections/Composite/CompositeProjection.cs
+++ b/src/JasperFx.Events/Projections/Composite/CompositeProjection.cs
@@ -49,7 +49,7 @@ public class CompositeProjection<TOperations, TQuerySession> : ProjectionBase, I
             return false;
         }
 
-        var shardName = new ShardName(Name, ShardName.All, Version);
+        var shardName = ShardName.Compose(Name, version: Version);
         var execution = this.As<ISubscriptionFactory<TOperations, TQuerySession>>()
             .BuildExecution(store, database, Logger ?? NullLogger.Instance, shardName);
 
@@ -80,7 +80,7 @@ public class CompositeProjection<TOperations, TQuerySession> : ProjectionBase, I
 
     ShardName[] ISubscriptionSource.ShardNames()
     {
-        return [new(Name, ShardName.All, Version)];
+        return [ShardName.Compose(Name, version: Version)];
     }
 
     Type ISubscriptionSource.ImplementationType => GetType();
@@ -100,21 +100,21 @@ public class CompositeProjection<TOperations, TQuerySession> : ProjectionBase, I
     ISubscriptionExecution ISubscriptionFactory<TOperations, TQuerySession>.BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory,
         ShardName shardName)
     {
-        var executionStages = Stages.Select(x => x.BuildExecution(store, database, loggerFactory)).ToArray();
+        var executionStages = Stages.Select(x => x.BuildExecution(store, database, loggerFactory, shardName)).ToArray();
         return new CompositeExecution<TOperations, TQuerySession>(shardName, Options, store, database, this,
             loggerFactory.CreateLogger(GetType()), executionStages, IsEligibleForReplay());
     }
 
     ISubscriptionExecution ISubscriptionFactory<TOperations, TQuerySession>.BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILogger logger, ShardName shardName)
     {
-        var executionStages = Stages.Select(x => x.BuildExecution(store, database, logger)).ToArray();
+        var executionStages = Stages.Select(x => x.BuildExecution(store, database, logger, shardName)).ToArray();
         return new CompositeExecution<TOperations, TQuerySession>(shardName, Options, store, database, this,
             logger, executionStages, IsEligibleForReplay());
     }
 
     IReadOnlyList<AsyncShard<TOperations, TQuerySession>> ISubscriptionSource<TOperations, TQuerySession>.Shards()
     {
-        var shardName = new ShardName(Name, ShardName.All, Version);
+        var shardName = ShardName.Compose(Name, version: Version);
         return
         [
             new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, shardName, this, this)

--- a/src/JasperFx.Events/Projections/Composite/ProjectionStage.cs
+++ b/src/JasperFx.Events/Projections/Composite/ProjectionStage.cs
@@ -32,11 +32,15 @@ public class ProjectionStage<TOperations, TQuerySession>(int order)
 
     public IReadOnlyList<IProjectionSource<TOperations, TQuerySession>> Projections => _projections;
 
-    public ExecutionStage BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory)
+    public ExecutionStage BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory, ShardName parent)
     {
         var executions = Projections.Select(projection =>
         {
-            var shardName = new ShardName(projection.Name, ShardName.All, projection.Version);
+            // jasperfx#419: propagate the parent composite's tenant binding to every member stage.
+            // When the composite is caught up/rebuilt for a single tenant the parent ShardName carries
+            // that tenant id; dropping it here (a bare store-global constructor) was the marten#4679
+            // root cause -- every per-tenant member wrote the same store-global progression row.
+            var shardName = ShardName.Compose(projection.Name, tenantId: parent.TenantId, version: projection.Version);
             return projection.As<ISubscriptionFactory<TOperations, TQuerySession>>()
                 .BuildExecution(store, database, loggerFactory, shardName);
         }).ToArray();
@@ -44,11 +48,13 @@ public class ProjectionStage<TOperations, TQuerySession>(int order)
         return new ExecutionStage(executions);
     }
 
-    public ExecutionStage BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILogger logger) 
+    public ExecutionStage BuildExecution(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILogger logger, ShardName parent)
     {
         var executions = Projections.Select(projection =>
         {
-            var shardName = new ShardName(projection.Name, ShardName.All, projection.Version);
+            // jasperfx#419: see the loggerFactory overload above -- the parent tenant binding must reach
+            // every member stage's ShardName so per-tenant progression rows stay distinct.
+            var shardName = ShardName.Compose(projection.Name, tenantId: parent.TenantId, version: projection.Version);
             return projection.As<ISubscriptionFactory<TOperations, TQuerySession>>()
                 .BuildExecution(store, database, logger, shardName);
         }).ToArray();

--- a/src/JasperFx.Events/Projections/ContainerScoped/ProjectionSourceWrapperBase.cs
+++ b/src/JasperFx.Events/Projections/ContainerScoped/ProjectionSourceWrapperBase.cs
@@ -58,7 +58,7 @@ public abstract class ProjectionSourceWrapperBase<TSource, TOperations, TQuerySe
     }
 
     public SubscriptionType Type { get; private set; }
-    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public ShardName[] ShardNames() => [ShardName.Compose(Name, version: Version)];
     public Type ImplementationType => typeof(TSource);
 
     public Type ProjectionType { get; }
@@ -67,7 +67,7 @@ public abstract class ProjectionSourceWrapperBase<TSource, TOperations, TQuerySe
     {
         return
         [
-            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, new ShardName(base.Name, ShardName.All, Version), this, this)
+            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, ShardName.Compose(base.Name, version: Version), this, this)
         ];
     }
 

--- a/src/JasperFx.Events/Projections/ContainerScoped/ScopedProjectionWrapper.cs
+++ b/src/JasperFx.Events/Projections/ContainerScoped/ScopedProjectionWrapper.cs
@@ -74,7 +74,7 @@ public class ScopedProjectionWrapper<TProjection, TOperations, TQuerySession> : 
     }
 
     public SubscriptionType Type { get; }
-    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public ShardName[] ShardNames() => [ShardName.Compose(Name, version: Version)];
     public Type ImplementationType => typeof(TProjection);
 
     public Task ApplyAsync(TOperations operations, IEnumerable<StreamAction> streams, CancellationToken cancellation)
@@ -99,7 +99,7 @@ public class ScopedProjectionWrapper<TProjection, TOperations, TQuerySession> : 
         return
         [
             new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection,
-                new ShardName(base.Name, ShardName.All, base.Version), this, this)
+                ShardName.Compose(base.Name, version: base.Version), this, this)
         ];
     }
 

--- a/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
+++ b/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
@@ -42,7 +42,7 @@ public abstract class JasperFxEventProjectionBase<TOperations, TQuerySession> :
     }
 
     public SubscriptionType Type => SubscriptionType.EventProjection;
-    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public ShardName[] ShardNames() => [ShardName.Compose(Name, version: Version)];
     public Type ImplementationType => GetType();
 
     public virtual SubscriptionDescriptor Describe(IEventStore store)
@@ -54,7 +54,7 @@ public abstract class JasperFxEventProjectionBase<TOperations, TQuerySession> :
     {
         return
         [
-            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, new ShardName(Name, ShardName.All, Version), this, this)
+            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection, ShardName.Compose(Name, version: Version), this, this)
         ];
     }
 

--- a/src/JasperFx.Events/Projections/ProjectionWrapper.cs
+++ b/src/JasperFx.Events/Projections/ProjectionWrapper.cs
@@ -76,7 +76,7 @@ public class ProjectionWrapper<TOperations, TQuerySession> :
 
     public ShardName[] ShardNames()
     {
-        return [new ShardName(Name, ShardName.All, Version)];
+        return [ShardName.Compose(Name, version: Version)];
     }
 
     public Type ImplementationType => _projection.GetType();
@@ -91,7 +91,7 @@ public class ProjectionWrapper<TOperations, TQuerySession> :
         return
         [
             new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection,
-                new ShardName(Name, "All", Version), this, this)
+                ShardName.Compose(Name, version: Version), this, this)
         ];
     }
 

--- a/src/JasperFx.Events/Subscriptions/JasperFxSubscriptionBase.cs
+++ b/src/JasperFx.Events/Subscriptions/JasperFxSubscriptionBase.cs
@@ -44,7 +44,7 @@ public abstract class JasperFxSubscriptionBase<TOperations, TQuerySession, TSubs
 
     public SubscriptionType Type => SubscriptionType.Subscription;
     public ProjectionLifecycle Lifecycle => ProjectionLifecycle.Async;
-    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public ShardName[] ShardNames() => [ShardName.Compose(Name, version: Version)];
 
     public Type ImplementationType => GetType();
 
@@ -62,7 +62,7 @@ public abstract class JasperFxSubscriptionBase<TOperations, TQuerySession, TSubs
     {
         return
         [
-            new(Options, ShardRole.Subscription, new ShardName(Name, ShardName.All, Version), this, this)
+            new(Options, ShardRole.Subscription, ShardName.Compose(Name, version: Version), this, this)
         ];
     }
 

--- a/src/JasperFx.Events/Subscriptions/ScopedSubscriptionServiceWrapper.cs
+++ b/src/JasperFx.Events/Subscriptions/ScopedSubscriptionServiceWrapper.cs
@@ -93,13 +93,13 @@ internal class ScopedSubscriptionServiceWrapper<T, TOperations, TQuerySession, T
     public string Name { get; set; }
     public SubscriptionType Type => SubscriptionType.Subscription;
     public ProjectionLifecycle Lifecycle => ProjectionLifecycle.Async;
-    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public ShardName[] ShardNames() => [ShardName.Compose(Name, version: Version)];
 
     public IReadOnlyList<AsyncShard<TOperations, TQuerySession>> Shards()
     {
         return
         [
-            new(Options, ShardRole.Subscription, new ShardName(Name, "All", Version), this, this)
+            new(Options, ShardRole.Subscription, ShardName.Compose(Name, version: Version), this, this)
         ];
     }
 


### PR DESCRIPTION
Closes #419.

## What

Enforces the issue's design principle — `ShardName.Compose` / `ForTenant` are the **canonical** producers of shard and progression-row identities — by replacing every hand-rolled `new ShardName(name, All, version)` in `JasperFx.Events` with `ShardName.Compose`. A call path with no tenant id to pass now becomes visibly suspect instead of silently emitting a store-global identity.

### Root-cause fix for marten#4679 (`23505 duplicate key ... pk_mt_event_progression`)

`CompositeProjection.BuildExecution` received a (possibly tenant-bound) `ShardName`, but `ProjectionStage.BuildExecution` ignored it and reconstructed **store-global** member shard names — dropping the tenant binding the per-tenant catch-up loop had established. Every per-tenant member then wrote the same `{Member}:All` progression row, so the second tenant's INSERT tripped 23505.

The parent composite's tenant binding now propagates to every member stage (`ProjectionStage.BuildExecution` takes the parent `ShardName` and composes members with `tenantId: parent.TenantId`).

### Also fixed

`AsyncShard.OverrideProjectionName` discarded `TenantId` when renaming a projection — another binding-loss site the audit principle catches.

## Refactored call sites (~14)

`AsyncShard`, `JasperFxAggregationProjectionBase`, `JasperFxEventProjectionBase`, `ProjectionWrapper` (incl. the literal `"All"`), `ProjectionSourceWrapperBase`, `ScopedProjectionWrapper`, `ScopedSubscriptionServiceWrapper` (incl. literal `"All"`), `JasperFxSubscriptionBase`, `CompositeProjection`, `ProjectionStage`.

## Tests

- `member_stages_inherit_the_parent_tenant_binding` — members become `A:All:tenant1`, `B:All:tenant1`.
- `member_stages_inherit_a_store_global_parent_binding` — store-global parent keeps members store-global (byte-for-byte with prior behavior).
- `override_the_projection_name_preserves_tenant_binding`.

Full `EventTests` suite green (357), solution compiles clean in Release for net9.0/net10.0.

## Deliberately out of scope (Marten-side, can't run in this repo)

- `InsertProjectionProgress` `ON CONFLICT (name) DO NOTHING` defense-in-depth.
- The Postgres-backed end-to-end #4679 regression test (`UseTenantPartitionedEvents` + conjoined, 3+ tenants, `ForceAllMartenDaemonActivityToCatchUpAsync`).
- The `catchUpPerTenantAsync` per-tenant loop gate: the issue marks it "TBD by implementer", and that loop intentionally binds store-global shards per tenant (the marten#4665 fix). Changing it safely needs the Postgres repro to validate, so it's left for the Marten-side follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)