### PR TITLE
Fix #420: cap concurrent projection rebuilds per database

### DIFF
--- a/src/EventTests/CommandLine/ProjectionInputTests.cs
+++ b/src/EventTests/CommandLine/ProjectionInputTests.cs
@@ -1,0 +1,37 @@
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+public class ProjectionInputTests
+{
+    [Fact]
+    public void unset_max_concurrent_is_unbounded()
+    {
+        // jasperfx#420: no flag preserves the historical unbounded fan-out (-1 == unbounded for
+        // ParallelOptions.MaxDegreeOfParallelism).
+        new ProjectionInput().ResolveMaxDegreeOfParallelism().ShouldBe(-1);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(64)]
+    public void positive_max_concurrent_is_honored(int cap)
+    {
+        new ProjectionInput { MaxConcurrentFlag = cap }
+            .ResolveMaxDegreeOfParallelism().ShouldBe(cap);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-5)]
+    public void non_positive_max_concurrent_falls_back_to_unbounded(int cap)
+    {
+        // A nonsensical override must not deadlock the rebuild (MaxDegreeOfParallelism = 0 throws);
+        // treat it as "unbounded".
+        new ProjectionInput { MaxConcurrentFlag = cap }
+            .ResolveMaxDegreeOfParallelism().ShouldBe(-1);
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionHost.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionHost.cs
@@ -95,7 +95,22 @@ internal class ProjectionHost: IProjectionHost
 
         var list = new List<Exception>();
 
-        await Parallel.ForEachAsync(projectionNames, _cancellation.Token,
+        // jasperfx#420: cap the per-database rebuild fan-out so a wide store
+        // (many projections, especially under per-tenant partitioning) cannot
+        // blow the connection pool / thrash the buffer cache. A non-positive or
+        // unset flag preserves the previous unbounded behavior.
+        var maxConcurrent = input.ResolveMaxDegreeOfParallelism();
+        var parallelOptions = new ParallelOptions
+        {
+            CancellationToken = _cancellation.Token,
+            MaxDegreeOfParallelism = maxConcurrent
+        };
+
+        AnsiConsole.MarkupLine(maxConcurrent > 0
+            ? $"[grey]Rebuilding with a maximum of {maxConcurrent} concurrent projection(s) per database[/]"
+            : "[grey]Rebuilding with unbounded concurrency per database[/]");
+
+        await Parallel.ForEachAsync(projectionNames, parallelOptions,
                 async (projectionName, token) =>
                 {
                     shardTimeout ??= 5.Minutes();

--- a/src/JasperFx.Events/CommandLine/ProjectionInput.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionInput.cs
@@ -35,4 +35,15 @@ public class ProjectionInput: NetCoreInput
 
     [Description("If specified, advances the projection high water mark to the latest event sequence")]
     public bool AdvanceFlag { get; set; }
+
+    [Description("Maximum number of projections to rebuild concurrently within a single database. Caps the per-database rebuild fan-out for one-off operational rebuilds. Default is unbounded.")]
+    [FlagAlias("max-concurrent", longAliasOnly: true)]
+    public int? MaxConcurrentFlag { get; set; }
+
+    /// <summary>
+    /// jasperfx#420: resolve the effective <see cref="ParallelOptions.MaxDegreeOfParallelism"/> for the
+    /// per-database rebuild fan-out. A null or non-positive <see cref="MaxConcurrentFlag"/> yields -1
+    /// (unbounded), preserving the historical behavior.
+    /// </summary>
+    public int ResolveMaxDegreeOfParallelism() => MaxConcurrentFlag is > 0 ? MaxConcurrentFlag.Value : -1;
 }


### PR DESCRIPTION
Closes #420.

## What

Adds a `--max-concurrent` flag to `dotnet run -- projections rebuild` and applies it as the `MaxDegreeOfParallelism` of the per-database rebuild fan-out in `ProjectionHost.TryRebuildShardsAsync`.

Previously the fan-out over projections within a database was an **unbounded** `Parallel.ForEachAsync`. On a wide store — many projections, especially under `UseTenantPartitionedEvents` where each projection further fans out per tenant — that could spawn enough concurrent rebuild agents to exhaust the connection pool, thrash the buffer cache, and contend on `mt_event_progression`.

- A null / non-positive flag preserves the historical unbounded behavior (`MaxDegreeOfParallelism = -1`).
- The effective cap is logged at rebuild start so operators can confirm the throttle is active.
- `ProjectionInput.ResolveMaxDegreeOfParallelism()` centralizes the flag→cap mapping and is unit tested (7 cases: unset, positive, and the `0`/negative degenerate cases that would otherwise throw).

## Tests

`ProjectionInputTests` — unset → unbounded; positive cap honored; non-positive falls back to unbounded. Full solution compiles clean in Release (net9.0/net10.0).

## Deliberately out of scope (Marten-side follow-up, can't run in this repo)

The issue's central config knob `StoreOptions.Events.MaxConcurrentRebuildsPerDatabase` and its `NpgsqlConnectionPoolSize / 8` derived default live on Marten's `EventGraph`/`StoreOptions` — they depend on Npgsql/Marten types not present in JasperFx. So does the `EnableExtendedProgressionTracking` interaction analysis and the Postgres-backed 8-projection × 32-tenant cap regression test. This PR delivers the JasperFx-side honoring mechanism (CLI flag + fan-out cap + logging); the per-tenant layer is already parameterized via `CrossTenantRebuild.maxParallelism` for Marten's daemon to thread the same cap through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)