### PR TITLE
Fix #422: default CacheLimitPerTenant to 1000

### DIFF
--- a/src/EventTests/Daemon/AsyncOptionsTests.cs
+++ b/src/EventTests/Daemon/AsyncOptionsTests.cs
@@ -13,6 +13,14 @@ public class AsyncOptionsTests
     private readonly CancellationToken theToken = CancellationToken.None;
 
     [Fact]
+    public void cache_limit_per_tenant_defaults_to_a_meaningful_value()
+    {
+        // jasperfx#422: the aggregate cache is on by default now (was 0 == disabled), so most
+        // projections get a 2nd-level cache without explicit opt-in.
+        new AsyncOptions().CacheLimitPerTenant.ShouldBe(1000);
+    }
+
+    [Fact]
     public async Task determine_starting_position_if_rebuild()
     {
         var options = new AsyncOptions();

--- a/src/JasperFx.Events/Projections/AsyncOptions.cs
+++ b/src/JasperFx.Events/Projections/AsyncOptions.cs
@@ -48,11 +48,13 @@ public class AsyncOptions
     public bool TeardownDataOnRebuild { get; set; } = true;
 
     /// <summary>
-    /// If more than 0 (the default), this is the maximum number of aggregates
-    /// that will be cached in a 2nd level, most recently used cache during async
-    /// projection. Use this to potentially improve async projection throughput
+    /// The maximum number of aggregates that will be cached per tenant in a 2nd level,
+    /// most recently used cache during async projection. Defaults to 1000 to give most
+    /// projections a meaningful cache for typical batch working sets and improve async
+    /// projection throughput. Increase for rebuild-heavy/cache-friendly workloads; set to
+    /// 0 to disable the aggregate cache entirely (e.g. memory-constrained processes).
     /// </summary>
-    public int CacheLimitPerTenant { get; set; } = 0;
+    public int CacheLimitPerTenant { get; set; } = 1000;
 
     /// <summary>
     ///     Add explicit teardown rule to delete all documents of type T


### PR DESCRIPTION
Closes #422.

## What

Changes `AsyncOptions.CacheLimitPerTenant` default from `0` to `1000`.

At `0`, `AggregationRunner` builds a `NulloAggregateCache` — i.e. **no aggregate caching at all**. So most users got zero 2nd-level caching by default and every snapshot pre-fetch was a fresh DB round-trip. `1000` is small enough to be safe for any aggregate's memory profile, large enough to cover typical batch working sets.

## Behavior change

Daemon processes now use more memory per tenant. Documented in the XML doc: increase for cache-friendly/rebuild-heavy workloads; set `CacheLimitPerTenant = 0` to opt back out (e.g. memory-constrained containers).

## Tests

- No existing test depended on the `0` default — the two tests exercising the cache (`MultiStreamProjectionTests`) already set `1000` explicitly.
- Added `cache_limit_per_tenant_defaults_to_a_meaningful_value` guarding the new default.
- Full `EventTests` (364) + `EventStoreTests` (72) green; Release build clean.

## Note

Per the issue, the recommended value should ultimately be confirmed by Phase E (#4684) measurements on Marten's ScaleTesting harness. `1000` is the issue's defensible flat default; adjust later if the measurements point elsewhere. Marten 9.x release-notes/changelog entry for this behavior change is a Marten-repo follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)