### PR TITLE
Fix #424: add storage-agnostic IEventStoreInstrumentation abstraction

### DIFF
--- a/src/EventTests/IEventStoreInstrumentationTests.cs
+++ b/src/EventTests/IEventStoreInstrumentationTests.cs
@@ -1,0 +1,24 @@
+using JasperFx.Events;
+using Shouldly;
+
+namespace EventTests;
+
+public class IEventStoreInstrumentationTests
+{
+    // jasperfx#424: lock the storage-agnostic contract that Marten's EventGraph and Polecat's
+    // options implement so CritterWatch can flip extended progression tracking generically.
+    private class FakeInstrumentation : IEventStoreInstrumentation
+    {
+        public bool ExtendedProgressionEnabled { get; set; }
+    }
+
+    [Fact]
+    public void extended_progression_defaults_to_false_and_is_settable()
+    {
+        IEventStoreInstrumentation instrumentation = new FakeInstrumentation();
+        instrumentation.ExtendedProgressionEnabled.ShouldBeFalse();
+
+        instrumentation.ExtendedProgressionEnabled = true;
+        instrumentation.ExtendedProgressionEnabled.ShouldBeTrue();
+    }
+}

--- a/src/JasperFx.Events/IEventStoreInstrumentation.cs
+++ b/src/JasperFx.Events/IEventStoreInstrumentation.cs
@@ -1,0 +1,19 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Opt-in instrumentation toggles that an event store implementation exposes to monitoring
+/// consumers such as CritterWatch. Implemented by Marten's <c>EventGraph</c> and Polecat's
+/// equivalent options so that storage-agnostic tooling can enable the same monitoring UX across
+/// stores without referencing concrete store types. See jasperfx#424.
+/// </summary>
+public interface IEventStoreInstrumentation
+{
+    /// <summary>
+    /// When true, the event store extends its progression-tracking schema with CritterWatch-facing
+    /// columns (heartbeat, agent_status, pause_reason, running_on_node, warning_behind_threshold,
+    /// critical_behind_threshold) and the async daemon writes them from runtime state. The
+    /// shard-state selector reads them back into <see cref="JasperFx.Events.Projections.ShardState" />.
+    /// Defaults to false; consumers opt in.
+    /// </summary>
+    bool ExtendedProgressionEnabled { get; set; }
+}


### PR DESCRIPTION
Closes #424.

## What

Adds `IEventStoreInstrumentation` to `JasperFx.Events` — the storage-agnostic instrumentation contract from the issue sketch:

```csharp
public interface IEventStoreInstrumentation
{
    bool ExtendedProgressionEnabled { get; set; }
}
```

When enabled, an event store extends its progression-tracking schema with the six CritterWatch-facing columns (`heartbeat`, `agent_status`, `pause_reason`, `running_on_node`, `warning_behind_threshold`, `critical_behind_threshold`) and the daemon writes them from runtime state.

This gives the refactored `Wolverine.CritterWatch` core a JasperFx.Events abstraction to flip extended progression tracking generically, instead of reaching into Marten's `EventGraph.EnableExtendedProgressionTracking`. Marten and Polecat options will implement it; the `.Marten` / `.Polecat` satellite packages flip it at startup.

## Tests

`IEventStoreInstrumentationTests` locks the contract shape (property name + default false + settable). Full solution compiles clean in Release (net9.0/net10.0).

## Deliberately out of scope (follow-ups, other repos)

- Marten aliasing `EnableExtendedProgressionTracking` to the interface property (mostly mechanical — the 6-column schema already exists).
- Polecat's real implementation: grow the equivalent columns on its progression table, emit values from the daemon, read them in the shard-state selector (separate Polecat companion issue).
- CritterWatch consumer documentation pointing at the new abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)