### PR TITLE
feat(events): add ProjectionErrorHandlingDescriptor to EventStoreUsage

### DIFF
--- a/src/EventTests/Descriptors/EventStoreUsageTests.cs
+++ b/src/EventTests/Descriptors/EventStoreUsageTests.cs
@@ -224,6 +224,53 @@ public class EventStoreUsageTests
 
         usage.MaxEventSequence.ShouldBe(123_456L);
     }
+
+    [Fact]
+    public void projection_error_handling_descriptors_default_to_null()
+    {
+        // JasperFx/ProductSupport#3: null means "not populated by this
+        // implementation" so CritterWatch can fall back to a policy-agnostic
+        // copy rather than imply skip-and-DLQ behavior on older monitored
+        // services.
+        new EventStoreUsage().ProjectionErrors.ShouldBeNull();
+        new EventStoreUsage().ProjectionRebuildErrors.ShouldBeNull();
+        new EventStoreUsage(new Uri("marten://main"), new MyThing()).ProjectionErrors.ShouldBeNull();
+        new EventStoreUsage(new Uri("marten://main"), new MyThing()).ProjectionRebuildErrors.ShouldBeNull();
+    }
+
+    [Fact]
+    public void projection_error_handling_descriptors_round_trip()
+    {
+        var usage = new EventStoreUsage
+        {
+            // Normal-run: JasperFx.Events 2.0 default — skip-and-DLQ on Apply,
+            // skip serialization errors, stop on unknown events.
+            ProjectionErrors = new ProjectionErrorHandlingDescriptor
+            {
+                SkipApplyErrors = true,
+                SkipUnknownEvents = false,
+                SkipSerializationErrors = true
+            },
+            // Rebuild-mode: tighter — every class of error stops the rebuild,
+            // matching the JasperFx.Events 2.0 RebuildErrors defaults.
+            ProjectionRebuildErrors = new ProjectionErrorHandlingDescriptor
+            {
+                SkipApplyErrors = false,
+                SkipUnknownEvents = false,
+                SkipSerializationErrors = false
+            }
+        };
+
+        usage.ProjectionErrors.ShouldNotBeNull();
+        usage.ProjectionErrors.SkipApplyErrors.ShouldBeTrue();
+        usage.ProjectionErrors.SkipUnknownEvents.ShouldBeFalse();
+        usage.ProjectionErrors.SkipSerializationErrors.ShouldBeTrue();
+
+        usage.ProjectionRebuildErrors.ShouldNotBeNull();
+        usage.ProjectionRebuildErrors.SkipApplyErrors.ShouldBeFalse();
+        usage.ProjectionRebuildErrors.SkipUnknownEvents.ShouldBeFalse();
+        usage.ProjectionRebuildErrors.SkipSerializationErrors.ShouldBeFalse();
+    }
 }
 
 public class MyThing

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -98,6 +98,31 @@ public class EventStoreUsage : OptionsDescription
     public long? MaxEventSequence { get; set; }
 
     /// <summary>
+    /// Async-daemon error-handling configuration for normal projection runs —
+    /// mirror of <c>StoreOptions.Projections.Errors</c>. Drives whether
+    /// monitoring tools surface per-event dead-letter affordances (when
+    /// <see cref="ProjectionErrorHandlingDescriptor.SkipApplyErrors"/> is true)
+    /// or a "shard halts on error" indicator (when false). Null when the
+    /// implementation hasn't populated it; tools should fall back to a
+    /// policy-agnostic copy in that case.
+    /// </summary>
+    /// <remarks>
+    /// See JasperFx/ProductSupport#3 for the operator-side motivation:
+    /// stop-on-error apps were being shown a "view related dead letters"
+    /// button that would never return data.
+    /// </remarks>
+    public ProjectionErrorHandlingDescriptor? ProjectionErrors { get; set; }
+
+    /// <summary>
+    /// Async-daemon error-handling configuration for projection rebuilds —
+    /// mirror of <c>StoreOptions.Projections.RebuildErrors</c>. Separate from
+    /// <see cref="ProjectionErrors"/> because rebuilds default to stop-on-error
+    /// even when normal runs skip — operators rebuilding need to know whether
+    /// a poison-pill event will halt the rebuild.
+    /// </summary>
+    public ProjectionErrorHandlingDescriptor? ProjectionRebuildErrors { get; set; }
+
+    /// <summary>
     /// Populates AgentUris on each async SubscriptionDescriptor based on the
     /// agent URI pattern: {agentScheme}://{identity.Type}/{identity.Name}/{databaseId}/{shardName.RelativeUrl}
     /// </summary>

--- a/src/JasperFx.Events/Descriptors/ProjectionErrorHandlingDescriptor.cs
+++ b/src/JasperFx.Events/Descriptors/ProjectionErrorHandlingDescriptor.cs
@@ -1,0 +1,49 @@
+namespace JasperFx.Events.Descriptors;
+
+/// <summary>
+/// Diagnostic mirror of <see cref="JasperFx.Events.Daemon.ErrorHandlingOptions"/>.
+/// Carries the configured async-daemon error-skipping policy as a plain wire
+/// shape so monitoring tools (e.g. CritterWatch) can render the policy and
+/// decide whether to surface per-event dead-letter affordances vs. a
+/// "shard halts on error" indicator. See JasperFx/ProductSupport#3.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All three flags mirror the daemon's runtime behaviour: when a flag is
+/// <see langword="true"/> the daemon skips the offending event (routing
+/// failures to the Wolverine DLQ where applicable) and keeps the shard
+/// advancing; when <see langword="false"/> the daemon stops the shard on
+/// that class of error and the operator has to fix and restart.
+/// </para>
+/// <para>
+/// Surfaced once per store via <see cref="EventStoreUsage.ProjectionErrors"/>
+/// (the normal-run config) and <see cref="EventStoreUsage.ProjectionRebuildErrors"/>
+/// (the rebuild-mode config). Marten and Polecat both expose the same
+/// <c>StoreOptions.Projections.Errors</c> / <c>.RebuildErrors</c> split, so the
+/// descriptor pair maps one-to-one onto the store config.
+/// </para>
+/// </remarks>
+public class ProjectionErrorHandlingDescriptor
+{
+    /// <summary>
+    /// Should the daemon skip "poison pill" events that fail in user projection
+    /// code? Mirror of <see cref="JasperFx.Events.Daemon.ErrorHandlingOptions.SkipApplyErrors"/>.
+    /// </summary>
+    /// <remarks>
+    /// JasperFx.Events 2.0 default for normal-run is <see langword="true"/>;
+    /// the rebuild-mode default is <see langword="false"/>.
+    /// </remarks>
+    public bool SkipApplyErrors { get; set; }
+
+    /// <summary>
+    /// Should the daemon skip events whose type can't be resolved when fetched?
+    /// Mirror of <see cref="JasperFx.Events.Daemon.ErrorHandlingOptions.SkipUnknownEvents"/>.
+    /// </summary>
+    public bool SkipUnknownEvents { get; set; }
+
+    /// <summary>
+    /// Should the daemon skip events that experience serialization errors?
+    /// Mirror of <see cref="JasperFx.Events.Daemon.ErrorHandlingOptions.SkipSerializationErrors"/>.
+    /// </summary>
+    public bool SkipSerializationErrors { get; set; }
+}


### PR DESCRIPTION
## What

Adds a nullable diagnostic mirror of `JasperFx.Events.Daemon.ErrorHandlingOptions` to `EventStoreUsage` so monitoring tools can read the async-daemon error policy off the wire without sniffing into store-specific internals.

Two nullable fields on `EventStoreUsage`:

| Field | Mirrors |
|---|---|
| `ProjectionErrors` | `StoreOptions.Projections.Errors` (normal-run config) |
| `ProjectionRebuildErrors` | `StoreOptions.Projections.RebuildErrors` (rebuild-mode config — separate because rebuilds default to stop-on-error even when normal runs skip) |

Each is typed as the new `ProjectionErrorHandlingDescriptor`:

```csharp
public class ProjectionErrorHandlingDescriptor
{
    public bool SkipApplyErrors { get; set; }
    public bool SkipUnknownEvents { get; set; }
    public bool SkipSerializationErrors { get; set; }
}
```

`null` means the implementation hasn't populated it — older Marten / Polecat versions, or any future implementor that hasn't wired the fields yet. Monitoring tools should fall back to policy-agnostic copy in that case, not assume skip-and-DLQ.

## Why

JasperFx/ProductSupport#3 reports that CritterWatch's projection detail page surfaces a *"projection failures are stored in Wolverine's dead letter queue → View Related Dead Letters"* affordance regardless of policy. For apps that disable `SkipApplyErrors` (the daemon's stop-on-error path) that section points at an empty DLQ and misleads the operator about how to recover.

Today the policy isn't available off the wire — only via direct `StoreOptions.Projections.Errors` access inside the monitored process. Adding the mirror here makes it a first-class piece of `EventStoreUsage`, so CritterWatch (and any other monitoring consumer) can render policy-appropriate UI.

## Companion PRs

- Marten: PR to populate the fields in `IEventStore.TryCreateUsage`.
- Polecat: same for Polecat's `DocumentStore.EventStore.cs`.
- CritterWatch: bumps pins + makes the projection detail page read the policy and render conditionally.

## Verification

- `dotnet test src/EventTests --filter "FullyQualifiedName~EventStoreUsageTests"` — 12 passed (was 10, +2 covering the defaults and round-trip on the new fields).
- No existing test changes; both new fields are additive (`null` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)