### PR TITLE
Fix #432: duplicate hintName when projection/aggregate is split across partials

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -1014,4 +1014,47 @@ public record MyTypeIncremented(int Amount);
         allGenerated.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.MyType)");
         diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error).ShouldBeFalse();
     }
+
+    // jasperfx#432: a self-aggregating `record` (or class) whose Create and Apply methods are split
+    // across SEPARATE partial declarations triggered Pipeline 1 once per declaration. Each candidate
+    // carries the full (symbol-based) method set, so emitting both produced the same hintName twice and
+    // the driver raised CS8785 "the hintName '...Evolver.g.cs' ... must be unique". One evolver per
+    // aggregate type must be emitted regardless of how many partial declarations contribute methods.
+    [Fact]
+    public void self_aggregating_record_split_across_partials_emits_single_evolver()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public partial record MyEntity(Guid Id, string Value);
+
+public record Creation(string InitialValue);
+
+public record Mutation(string NewValue);
+
+public partial record MyEntity
+{
+    public static MyEntity Create(IEvent<Creation> evt) => new(evt.StreamId, evt.Data.InitialValue);
+}
+
+public partial record MyEntity
+{
+    public static MyEntity Apply(Mutation evt, MyEntity entity) => entity with { Value = evt.NewValue };
+}
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        // No CS8785 (generator-failed) and no duplicate-hintName fallout
+        diagnostics.ShouldNotContain(d => d.Id == "CS8785");
+        diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error).ShouldBeFalse();
+
+        // Exactly one evolver for MyEntity, and it dispatches BOTH the Create and the Apply events
+        var evolvers = generatedSources.Where(s => s.Contains("MyEntityEvolver")).ToArray();
+        evolvers.Length.ShouldBe(1);
+        evolvers[0].ShouldContain("global::Test.Creation");
+        evolvers[0].ShouldContain("global::Test.Mutation");
+    }
 }

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -295,10 +295,19 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
     {
         var seen = new HashSet<string>();
 
-        // Pipeline 1 candidates have priority
+        // Pipeline 1 candidates have priority.
+        //
+        // A self-aggregating type (or projection subclass) whose Apply/Create/etc. methods are
+        // split across multiple `partial` declarations surfaces one candidate PER declaration that
+        // carries a conventional method (jasperfx#432). Method collection is symbol-based
+        // (classSymbol.GetMembers()), so every candidate for the same type already holds the full,
+        // identical method set — emitting more than one would re-add the same hintName and trip the
+        // driver's "hintName must be unique" guard (CS8785). Dedupe by symbol so each aggregate type
+        // emits exactly one evolver regardless of how many partial declarations contribute methods.
         foreach (var info in direct)
         {
             if (info == null) continue;
+            if (!seen.Add(SymbolKey(info.ClassSymbol))) continue;
             MarkSeen(seen, info);
             Execute(spc, info);
         }


### PR DESCRIPTION
Closes #432.

## Reproduction (added first, confirmed it still fails on current `main`)

The issue's exact sample — a self-aggregating `record` with `Create` in one `partial` declaration and `Apply` in another — makes the generator throw:

```
CSC : warning CS8785: Generator 'AggregateEvolverGenerator' failed to generate source.
... ArgumentException ... 'The hintName 'global__MyEntity_global__System_GuidEvolver.g.cs'
of the added source file must be unique within a generator.'
```

Added `self_aggregating_record_split_across_partials_emits_single_evolver` to the SG test project; it reproduces the CS8785 against the unpatched generator. (So this is **not** already fixed by recent SG changes.)

## Root cause

`AggregateEvolverGenerator`'s Pipeline 1 syntax provider matches **each** partial declaration that carries a conventional method (`IsCandidateClass` inspects that declaration's own members). For a type split across declarations, that's one `CandidateInfo` per method-bearing declaration.

Method collection in `AggregateAnalyzer.Analyze` is **symbol-based** (`classSymbol.GetMembers()`), so every candidate for the same type already holds the *full, identical* method set. But `ExecuteCombined`'s Pipeline 1 loop called `Execute` for **every** direct candidate without deduping — so it emitted the same hintName twice → CS8785.

## Fix

Dedupe Pipeline 1 by symbol key (`seen.Add(SymbolKey(...))`), mirroring how Pipelines 2/3 already dedupe. Each aggregate type now emits exactly one evolver, and because the method set comes from the whole symbol, that single evolver still dispatches every event.

```csharp
foreach (var info in direct)
{
    if (info == null) continue;
    if (!seen.Add(SymbolKey(info.ClassSymbol))) continue; // <-- added
    MarkSeen(seen, info);
    Execute(spc, info);
}
```

This also covers a partial **projection subclass** split across files (same double-emit shape via `EmitPartialProjection`).

## Tests

Full SG suite green (21/21), including the new regression test asserting no CS8785, exactly one `MyEntity` evolver, and that it dispatches both the `Creation` and `Mutation` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)