### PR TITLE
Fix marten#4711 — projections rebuild (all) skips Live-lifecycle projections

### DIFF
--- a/src/JasperFx.Events/CommandLine/ProjectionController.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionController.cs
@@ -82,7 +82,14 @@ public class ProjectionController
 
             try
             {
-                var subscriptionNames = selection.Subscriptions.Select(x => x.Name).ToArray();
+                // #4711: a Live-lifecycle projection has no persisted state, so there is nothing to
+                // rebuild — and replaying it across the whole event store runs its aggregation over
+                // unrelated streams (which lack its events) and throws. Exclude Live here so both
+                // rebuild-all and an explicitly named Live projection are skipped. Inline and Async
+                // both have stored state and remain rebuildable.
+                var subscriptionNames = selection.Subscriptions
+                    .Where(x => x.Lifecycle != ProjectionLifecycle.Live)
+                    .Select(x => x.Name).ToArray();
                 var databaseIdentifier = new EventStoreDatabaseIdentifier(selection.Storage.SubjectUri, database);
                 var status = await _host.TryRebuildShardsAsync(databaseIdentifier, input, subscriptionNames ,shardTimeout).ConfigureAwait(false);
 


### PR DESCRIPTION
Fixes [JasperFx/marten#4711](https://github.com/JasperFx/marten/issues/4711).

## Problem
`projections rebuild` (rebuild-all) replays `ProjectionLifecycle.Live` projections. A Live projection has no persisted state, so rebuild-all should skip it — instead it is replayed across the whole event store and its aggregation logic throws on streams lacking its events.

## Root cause
The rebuild selection had no lifecycle filter. `ProjectionController.ExecuteRebuilds` built subscription names from the full selection, which includes Live projections (`ProjectionGraph.Describe` adds every source). `FilterForAsyncOnly` only runs on the continuous `run` path, never on rebuild.

## Fix
Exclude `ProjectionLifecycle.Live` in `ExecuteRebuilds` so rebuild-all and an explicitly named Live projection are both skipped. Inline and Async both have persisted state and remain rebuildable.

> No NuGet publish intended yet — to be bundled with other pending JasperFx changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)