### PR TITLE
WIP marten#4717 — per-tenant continuous daemon progression under per-tenant event partitioning

### DIFF
--- a/src/JasperFx.Events/Daemon/HighWater/IHighWaterDetector.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/IHighWaterDetector.cs
@@ -41,4 +41,13 @@ public interface IHighWaterDetector
         var global = await DetectInSafeZone(token).ConfigureAwait(false);
         return HighWaterVector.ForGlobal(global);
     }
+
+    /// <summary>
+    /// Persist a per-tenant high-water mark so each tenant's progress is durable across daemon restarts
+    /// (marten#4717). Under per-tenant event partitioning each tenant's seq_id comes from its own
+    /// sequence, so a single store-global high-water row cannot represent multiple tenants. The default
+    /// implementation is a no-op, so non-partitioned detectors keep compiling and behaving unchanged.
+    /// Partitioned stores override this to write a per-tenant high-water row keyed on the tenant.
+    /// </summary>
+    Task MarkHighWaterForTenantAsync(string tenantId, long sequence, CancellationToken token) => Task.CompletedTask;
 }

--- a/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
@@ -16,11 +16,13 @@ namespace JasperFx.Events.Daemon.HighWater;
 public class TenantedHighWaterCoordinator
 {
     private readonly VectorizedHighWaterMonitor _monitor;
+    private readonly IHighWaterDetector _detector;
     private readonly ILogger _logger;
 
     public TenantedHighWaterCoordinator(IHighWaterDetector detector, ILogger? logger = null)
     {
         _monitor = new VectorizedHighWaterMonitor(detector, logger);
+        _detector = detector;
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -65,6 +67,24 @@ public class TenantedHighWaterCoordinator
                 if (agent.Name.TenantId == reading.TenantId)
                 {
                     agent.MarkHighWater(reading.Statistics.CurrentMark);
+                }
+            }
+
+            // marten#4717: persist a durable per-tenant high-water row so each tenant's mark survives
+            // a daemon restart (the store-global HighWaterMark row cannot represent multiple tenants).
+            // No-op for detectors that don't override the write.
+            if (reading.TenantId != null && reading.Statistics.CurrentMark > 0)
+            {
+                try
+                {
+                    await _detector
+                        .MarkHighWaterForTenantAsync(reading.TenantId, reading.Statistics.CurrentMark, token)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error persisting per-tenant high-water mark for tenant {TenantId}",
+                        reading.TenantId);
                 }
             }
         }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -119,6 +119,16 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             }
 
             var highWaterMark = HighWaterMark();
+
+            // marten#4717: a tenant-scoped continuous agent must advance against its OWN tenant's
+            // high-water, not the store-global mark — each tenant's seq_id is independent, so seeding a
+            // tenant agent with the global mark makes it over-run to the max tenant's height. StartAllAsync
+            // primes the per-tenant ceilings before starting agents; fall back to 0 until first polled.
+            if (_tenantHighWater != null && agent.Name.TenantId != null)
+            {
+                highWaterMark = _tenantHighWater.CeilingFor(agent.Name.TenantId) ?? 0L;
+            }
+
             var position = await agent
                 .Options
                 .DetermineStartingPositionAsync(highWaterMark, agent.Name, mode, Database, _cancellation.Token)
@@ -133,8 +143,16 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
                 ? _store.ContinuousErrors
                 : _store.RebuildErrors;
 
-            await agent.StartAsync(new SubscriptionExecutionRequest(position.Floor, mode, errorOptions, this))
-                .ConfigureAwait(false);
+            var request = new SubscriptionExecutionRequest(position.Floor, mode, errorOptions, this);
+            if (_tenantHighWater != null && agent.Name.TenantId != null)
+            {
+                // marten#4717: seed the tenant agent's ceiling from its own high-water. The agent's
+                // high-water can only be raised after start (a lower MarkHighWater is ignored), so this
+                // must be passed at start or the agent over-runs to the store-global mark.
+                request = request with { StartingHighWater = highWaterMark };
+            }
+
+            await agent.StartAsync(request).ConfigureAwait(false);
             agent.MarkHighWater(highWaterMark);
 
             _agents = _agents.AddOrUpdate(agent.Name.Identity, agent);
@@ -317,14 +335,60 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         var agents = new List<ISubscriptionAgent>();
 
-        foreach (var shard in _store.AllShards())
+        if (_tenantHighWater != null && Database is ICrossTenantRebuildSource crossTenantSource)
         {
-            agents.Add(buildAgentForShard(shard));
+            // marten#4717: under per-tenant event partitioning each tenant's events draw seq_id from its
+            // own mt_events_sequence_{suffix} starting at 1, so a single store-global <Projection>:All
+            // shard cannot track multiple tenants. Fan out one continuous agent per (shard, tenant) —
+            // exactly the shape catchUpPerTenantAsync / rebuildProjectionForTenant already use — so each
+            // tenant's projection advances against its own high-water and persists its own
+            // <Projection>:All:<tenant> progression row. OnNext + pollTenantHighWaterAsync already route
+            // each tenant's mark to its TenantId-bearing agents.
+            await buildPerTenantContinuousAgents(crossTenantSource, agents).ConfigureAwait(false);
+
+            // Prime the per-tenant ceilings BEFORE starting the agents so each tenant agent seeds from
+            // its own high-water (tryStartAgentAsync reads CeilingFor) rather than the store-global mark.
+            // PollAsync populates the monitor's ceilings directly from pg_sequences, independent of the
+            // store-global high-water agent, so the readings are available even pre-start.
+            await pollTenantHighWaterAsync().ConfigureAwait(false);
         }
-        
+        else
+        {
+            foreach (var shard in _store.AllShards())
+            {
+                agents.Add(buildAgentForShard(shard));
+            }
+        }
+
         foreach (var agent in agents)
         {
             await tryStartAgentAsync(agent, ShardExecutionMode.Continuous).ConfigureAwait(false);
+        }
+    }
+
+    // marten#4717: build one continuous agent per (shard, tenant), enumerating tenants from the store's
+    // ICrossTenantRebuildSource (mt_tenant_partitions). A projection with no registered tenants yet keeps
+    // its store-global agent so it still runs (there are no events to process until a tenant exists).
+    private async Task buildPerTenantContinuousAgents(
+        ICrossTenantRebuildSource crossTenantSource, List<ISubscriptionAgent> agents)
+    {
+        foreach (var shard in _store.AllShards())
+        {
+            var tenants = await crossTenantSource
+                .FindRebuildTenantsAsync(shard.Name.Name, _cancellation.Token).ConfigureAwait(false);
+
+            if (tenants.Count == 0)
+            {
+                agents.Add(buildAgentForShard(shard));
+                continue;
+            }
+
+            foreach (var tenantId in tenants)
+            {
+                _tenantHighWater!.PolledTenants.Activate(tenantId);
+                var tenantShard = shard with { Name = shard.Name.ForTenant(tenantId) };
+                agents.Add(buildAgentForShard(tenantShard));
+            }
         }
     }
 

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -180,7 +180,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
         ErrorOptions = request.ErrorHandling;
         _runtime = request.Runtime;
 
-        await _commandBlock.PostAsync(Command.Started(_tracker.HighWaterMark, request.Floor));
+        await _commandBlock.PostAsync(Command.Started(request.StartingHighWater ?? _tracker.HighWaterMark, request.Floor));
         await _tracker.PublishAsync(new ShardState(Name, request.Floor)
         {
             Action = ShardAction.Started,
@@ -308,10 +308,17 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
                     {
                         _logger.LogInformation("Starting optimized rebuild for projection/subscription {ShardName}",
                             Name.Identity);
+                        var replayRequest =
+                            new SubscriptionExecutionRequest(0, ShardExecutionMode.CatchUp, ErrorOptions, _runtime);
+                        if (Name.TenantId != null)
+                        {
+                            // marten#4717: a tenant-scoped composite replays only to its own tenant's
+                            // high-water (this agent's seeded HighWaterMark), not the store-wide max.
+                            replayRequest = replayRequest with { StartingHighWater = HighWaterMark };
+                        }
+
                         await executor
-                            .StartAsync(
-                                new SubscriptionExecutionRequest(0, ShardExecutionMode.CatchUp, ErrorOptions, _runtime),
-                                this, _cancellation.Token).ConfigureAwait(false);
+                            .StartAsync(replayRequest, this, _cancellation.Token).ConfigureAwait(false);
                         _logger.LogInformation(
                             "Finished with optimized rebuild for projection/subscription {ShardName}, proceeding to normal, continuous operation",
                             Name.Identity);

--- a/src/JasperFx.Events/Daemon/SubscriptionExecutionRequest.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionExecutionRequest.cs
@@ -4,4 +4,14 @@ public record SubscriptionExecutionRequest(
     long Floor,
     ShardExecutionMode Mode,
     ErrorHandlingOptions ErrorHandling,
-    IDaemonRuntime Runtime);
+    IDaemonRuntime Runtime)
+{
+    /// <summary>
+    /// marten#4717: the high-water ceiling the agent should start from. Null (default) uses the
+    /// store-global ShardStateTracker mark — today's behavior. A tenant-scoped continuous agent passes
+    /// its OWN tenant's high-water so it does not over-run to the store-global (max-tenant) mark; the
+    /// agent's high-water can only be raised afterward (see SubscriptionAgent), so seeding it correctly
+    /// at start is essential.
+    /// </summary>
+    public long? StartingHighWater { get; init; }
+}

--- a/src/JasperFx.Events/Projections/Composite/CompositeReplayExecutor.cs
+++ b/src/JasperFx.Events/Projections/Composite/CompositeReplayExecutor.cs
@@ -49,7 +49,12 @@ internal class CompositeReplayExecutor : IReplayExecutor
 
         _execution.Mode = request.Mode;
 
-        var ceiling = await _database.FetchHighestEventSequenceNumber(cancellation).ConfigureAwait(false);
+        // marten#4717: a tenant-scoped composite must replay only up to ITS tenant's high-water, supplied
+        // via StartingHighWater. A store-global composite (StartingHighWater == null) keeps reading the
+        // store-wide max(seq_id) from mt_events — the marten#4705 fix that made single-tenant partitioned
+        // composites replay past the never-advanced global mt_events_sequence.
+        var ceiling = request.StartingHighWater
+            ?? await _database.FetchHighestEventSequenceNumber(cancellation).ConfigureAwait(false);
         var floor = request.Floor;
 
         if (ceiling <= floor)


### PR DESCRIPTION
**Draft** — the single-database multi-tenant case is implemented and verified; a sharded per-shard regression remains (see below). Opening for design review. Do not publish.

Fixes the JasperFx side of [JasperFx/marten#4717](https://github.com/JasperFx/marten/issues/4717).

## Problem
Under `UseTenantPartitionedEvents` each tenant's events draw `seq_id` from its own `mt_events_sequence_{suffix}` starting at 1, so seq_ids overlap across tenants. The continuous daemon started **one store-global `<Projection>:All` agent per projection** and persisted a single store-global `HighWaterMark` — so multiple tenants on one database could not be tracked independently (every projection row pinned to the max tenant's height). Per-tenant infrastructure existed but was read/route-only for high-water and rebuild-only for progression.

## Changes
- **`StartAllAsync`** fans out one continuous agent per `(shard, tenant)` when the store partitions per tenant (`Database is ICrossTenantRebuildSource`), enumerating tenants via `FindRebuildTenantsAsync` + `ShardName.ForTenant` (mirrors the existing `catchUpPerTenantAsync` / `rebuildProjectionForTenant` shape). Ceilings are primed before start.
- **`tryStartAgentAsync`** seeds a tenant agent's starting high-water from its own tenant ceiling via a new `SubscriptionExecutionRequest.StartingHighWater`. A tenant agent's high-water can only be raised after start (`MarkHighWater` ignores a lower value), so seeding at start is required — otherwise it over-runs to the store-global mark.
- **`CompositeReplayExecutor`** uses `StartingHighWater` for tenant shards instead of the store-wide `max(seq_id)`; store-global composites keep the marten#4705 `FetchHighestEventSequenceNumber` path.
- **`TenantedHighWaterCoordinator.PollAndRouteAsync`** persists a durable per-tenant high-water row each poll via a new `IHighWaterDetector.MarkHighWaterForTenantAsync` (default no-op; Marten implements it to write `HighWaterMark:<tenant>`).

## Verified (single DB, 2 tenants of heights 20 and 12; composite + standalone)
Per-tenant rows at each tenant's own height:
```
20 bug4717-composite:All:t_a   12 bug4717-composite:All:t_b
20 Bug4717Count/Trip/Standalone:All:t_a   12 …:All:t_b
20 HighWaterMark:t_a           12 HighWaterMark:t_b
```
(Marten `Bug_4717_per_tenant_progression`, via a local-feed build.)

## ⚠️ Known regression (blocking — not yet fixed)
The **sharded per-shard** scenario (Marten `sharded_daemon_per_shard_progression`, single event per tenant) regresses: the per-tenant agents don't materialize the projection (doc null / no progression row). Full per-tenant suite 184/186. Suspected: per-tenant ceiling priming timing and/or `WaitForNonStaleData` not tracking per-tenant agents in the sharded daemon. Must be resolved before this leaves draft.

## Marten side (separate)
`HighWaterDetector.MarkHighWaterForTenantAsync` + un-skipping `Bug_4717_per_tenant_progression` land in Marten once this is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)