### PR TITLE
projections rebuild must skip subscriptions (Wolverine PublishEventsToWolverine / SubscribeFromPresent)

### DIFF
--- a/src/EventTests/CommandLine/ProjectionRebuildSelectionTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRebuildSelectionTests.cs
@@ -1,0 +1,123 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.CommandLine;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+// Verifies which subscriptions the `projections rebuild` command actually feeds to the host:
+//   - #4711: Live-lifecycle projections are skipped (no persisted state to rebuild).
+//   - subscriptions (SubscriptionType.Subscription, e.g. Wolverine's PublishEventsToWolverine) are
+//     skipped — they have no projected state, the daemon's RebuildProjectionAsync only resolves
+//     PROJECTION names (so a subscription name throws "No registered projection matches..."), and a
+//     rebuild would re-publish every historical event (contrary to SubscribeFromPresent()).
+//   - Inline and Async PROJECTIONS remain rebuildable.
+public class ProjectionRebuildSelectionTests : IProjectionHost
+{
+    private readonly ProjectionController theController;
+    private string[] _rebuiltNames = [];
+
+    public ProjectionRebuildSelectionTests()
+    {
+        theController = new ProjectionController(this, new NulloConsoleView());
+    }
+
+    private static SubscriptionDescriptor descriptor(string name, ProjectionLifecycle lifecycle, SubscriptionType type)
+    {
+        return new SubscriptionDescriptor(type)
+        {
+            Name = name,
+            Lifecycle = lifecycle,
+            ShardNames = [new ShardName(name)]
+        };
+    }
+
+    private EventStoreUsage usageWith(params SubscriptionDescriptor[] subscriptions)
+    {
+        var usage = new EventStoreUsage
+        {
+            SubjectUri = new Uri("marten://main"),
+            Database = new DatabaseUsage
+            {
+                Cardinality = DatabaseCardinality.Single,
+                MainDatabase = new DatabaseDescriptor { Identifier = "*Default*" }
+            }
+        };
+
+        usage.Subscriptions.AddRange(subscriptions);
+        return usage;
+    }
+
+    [Fact]
+    public async Task rebuild_all_skips_subscriptions_and_live_but_keeps_projections()
+    {
+        _usages =
+        [
+            usageWith(
+                descriptor("AsyncProjection", ProjectionLifecycle.Async, SubscriptionType.SingleStreamProjection),
+                descriptor("InlineProjection", ProjectionLifecycle.Inline, SubscriptionType.MultiStreamProjection),
+                descriptor("LiveProjection", ProjectionLifecycle.Live, SubscriptionType.SingleStreamProjection),
+                descriptor("WolverineRelay", ProjectionLifecycle.Async, SubscriptionType.Subscription))
+        ];
+
+        await theController.Execute(new ProjectionInput { Action = ProjectionAction.rebuild });
+
+        _rebuiltNames.ShouldBe(["AsyncProjection", "InlineProjection"], ignoreOrder: true);
+        _rebuiltNames.ShouldNotContain("WolverineRelay");
+        _rebuiltNames.ShouldNotContain("LiveProjection");
+    }
+
+    [Fact]
+    public async Task named_rebuild_of_a_subscription_is_skipped()
+    {
+        _usages =
+        [
+            usageWith(
+                descriptor("WolverineRelay", ProjectionLifecycle.Async, SubscriptionType.Subscription))
+        ];
+
+        await theController.Execute(new ProjectionInput
+        {
+            Action = ProjectionAction.rebuild, ProjectionFlag = "WolverineRelay"
+        });
+
+        _rebuiltNames.ShouldBeEmpty();
+    }
+
+    #region IProjectionHost test double
+
+    private IReadOnlyList<EventStoreUsage> _usages = [];
+
+    public Task<IReadOnlyList<EventStoreUsage>> AllStoresAsync() => Task.FromResult(_usages);
+
+    public void ListenForUserTriggeredExit() { }
+
+    public Task<RebuildStatus> TryRebuildShardsAsync(EventStoreDatabaseIdentifier databaseIdentifier,
+        ProjectionInput input, string[] names, TimeSpan? shardTimeout = null)
+    {
+        _rebuiltNames = names;
+        return Task.FromResult(RebuildStatus.Complete);
+    }
+
+    public Task StartShardsAsync(EventStoreDatabaseIdentifier databaseIdentifier, string[] projectionNames)
+        => Task.CompletedTask;
+
+    public Task WaitForExitAsync() => Task.CompletedTask;
+
+    public Task AdvanceHighWaterMarkToLatestAsync(ProjectionSelection selection, CancellationToken none)
+        => Task.CompletedTask;
+
+    #endregion
+}
+
+internal class NulloConsoleView : IConsoleView
+{
+    public void DisplayNoStoresMessage() { }
+    public void ListShards(IReadOnlyList<EventStoreUsage> usages) { }
+    public void DisplayEmptyEventsMessage(EventStoreDatabaseIdentifier usage) { }
+    public void DisplayNoAsyncProjections() { }
+    public void DisplayRebuildIsComplete() { }
+    public void DisplayInvalidShardTimeoutValue() { }
+    public void WriteStartingToRebuildProjections(ProjectionSelection selection, string databaseName) { }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionController.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using JasperFx.Core;
+using JasperFx.Events.Descriptors;
 using JasperFx.Events.Projections;
 using Spectre.Console;
 
@@ -87,8 +88,17 @@ public class ProjectionController
                 // unrelated streams (which lack its events) and throws. Exclude Live here so both
                 // rebuild-all and an explicitly named Live projection are skipped. Inline and Async
                 // both have stored state and remain rebuildable.
+                //
+                // Also exclude pure subscriptions (SubscriptionType.Subscription, e.g. Wolverine's
+                // PublishEventsToWolverine): a subscription has no persisted projected state to rebuild,
+                // it is a forward-only event relay, and the daemon's RebuildProjectionAsync only resolves
+                // PROJECTION names (TryFindProjection searches the projection list, not subscriptions), so
+                // feeding a subscription name into a rebuild throws "No registered projection matches...".
+                // Rebuilding a subscription would also re-publish every historical event — never desired,
+                // and directly contrary to a SubscribeFromPresent() registration.
                 var subscriptionNames = selection.Subscriptions
                     .Where(x => x.Lifecycle != ProjectionLifecycle.Live)
+                    .Where(x => x.SubscriptionType != SubscriptionType.Subscription)
                     .Select(x => x.Name).ToArray();
                 var databaseIdentifier = new EventStoreDatabaseIdentifier(selection.Storage.SubjectUri, database);
                 var status = await _host.TryRebuildShardsAsync(databaseIdentifier, input, subscriptionNames ,shardTimeout).ConfigureAwait(false);


### PR DESCRIPTION
## Problem
A client registered a Wolverine subscription:
```csharp
.PublishEventsToWolverine("DriverSupportTeamEvents", o =>
{
    o.PublishEvent<PermanentProfitCenterChanged>();
    o.PublishEvent<PermanentManagerChanged>();
    o.Options.SubscribeFromPresent();
})
```
…and `dotnet run -- projections rebuild` **blows up** because the command tries to rebuild the subscription.

## Root cause
`PublishEventsToWolverine` registers a real **subscription** (`opts.Projections.Subscribe(new WolverineSubscriptionRunner(...))`, `SubscriptionType.Subscription`). The rebuild selection in `ProjectionController.ExecuteRebuilds` only excluded **Live**-lifecycle projections (#4711). A subscription is `Async`, so its name was handed to `IProjectionHost.TryRebuildShardsAsync` → `daemon.RebuildProjectionAsync(name)`. That resolves names via `ProjectionGraph.TryFindProjection`, which searches the **projection** list only (never `_subscriptions`), so it throws:

> `No registered projection matches the name 'DriverSupportTeamEvents'`

## Fix
Exclude `SubscriptionType.Subscription` from the rebuild selection (alongside the existing Live exclusion). A subscription has no persisted projected state to rebuild — it is a forward-only relay — and rebuilding it would re-publish every historical event, directly contrary to a `SubscribeFromPresent()` registration.

`run` (continuous) and `list` are unchanged: subscriptions still run and still appear in `projections list`; only **rebuild** skips them (and a subscription name passed explicitly to rebuild is now a clean no-op instead of a throw).

## Test
`ProjectionRebuildSelectionTests` uses a fake `IProjectionHost` capturing the names handed to `TryRebuildShardsAsync`:
- rebuild-all keeps `Async` + `Inline` projections and skips both a `Subscription` and a `Live` projection;
- a named rebuild of a subscription is a no-op.

RED before the fix (rebuild list included the subscription), green after. Confirms both the new subscription exclusion and the prior #4711 Live exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)