### PR TITLE
Fix #432 regression — self-aggregating projection dispatcher dropped (2.9.5)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.9.4</JasperFxVersion>
+        <JasperFxVersion>2.9.5</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -302,12 +302,24 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         // carries a conventional method (jasperfx#432). Method collection is symbol-based
         // (classSymbol.GetMembers()), so every candidate for the same type already holds the full,
         // identical method set — emitting more than one would re-add the same hintName and trip the
-        // driver's "hintName must be unique" guard (CS8785). Dedupe by symbol so each aggregate type
+        // driver's "hintName must be unique" guard (CS8785). Dedupe so each (aggregate type, identity)
         // emits exactly one evolver regardless of how many partial declarations contribute methods.
+        //
+        // The dedupe MUST use a set distinct from `seen`: `seen` is the cross-pipeline coordination set
+        // and MarkSeen seeds it with BOTH the class symbol AND (for partial projections) the aggregate
+        // type. jasperfx#432's original `seen.Add(SymbolKey(ClassSymbol))` guard therefore falsely
+        // skipped a self-aggregating type whose key had already been added to `seen` by an earlier
+        // candidate's MarkSeen (e.g. a projection subclass aggregating that same type) — dropping its
+        // dispatcher entirely and surfacing at runtime as "No source-generated dispatcher found" for a
+        // self-aggregating SingleStreamProjection<T, TId>. Keyed by (type, identity) to match the
+        // emitted hintName granularity so distinct identities each still emit.
+        var directEmitted = new HashSet<string>();
         foreach (var info in direct)
         {
             if (info == null) continue;
-            if (!seen.Add(SymbolKey(info.ClassSymbol))) continue;
+            var emitKey = SymbolKey(info.ClassSymbol) + "::" +
+                          (info.IdentityType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? "");
+            if (!directEmitted.Add(emitKey)) continue;
             MarkSeen(seen, info);
             Execute(spc, info);
         }


### PR DESCRIPTION
## Problem
Published **2.9.3 and 2.9.4** break self-aggregating single-stream projections: at runtime they throw

> `No source-generated dispatcher found for SingleStreamProjection<T, TId>`

This regresses a core Marten pattern (e.g. `SingleStreamProjection<SimpleAggregate, Guid>`) — surfaced when bumping Marten to 2.9.4 (JasperFx/marten#4714); Marten's `EventSourcingTests` pass on 2.9.2 and fail on 2.9.4.

## Root cause
#432 (2.9.3) added a Pipeline-1 dedupe in `AggregateEvolverGenerator.ExecuteCombined` to avoid emitting the same evolver hintName twice when a type's `Apply`/`Create` methods are split across multiple `partial` declarations (CS8785). The guard reused the **cross-pipeline `seen` set**:

```csharp
if (!seen.Add(SymbolKey(info.ClassSymbol))) continue;
MarkSeen(seen, info);
```

But `MarkSeen` seeds `seen` with the class symbol **and** (for partial projections) the aggregate type. So a self-aggregating type whose key was already added to `seen` by an earlier candidate's `MarkSeen` (e.g. a projection subclass aggregating that same type) had its Pipeline-1 emission **falsely skipped** — no evolver generated.

## Fix
Dedupe Pipeline-1 emissions in a set **distinct from `seen`**, keyed by `(type, identity)` to match the emitted hintName granularity, while still calling `MarkSeen` for cross-pipeline coordination. Preserves #432's partial-split dedupe; restores emission for self-aggregating types.

## Verification
- `JasperFx.Events.SourceGenerator.Tests` **21/21** (incl. #432's partial-split regression test).
- Marten `EventSourcingTests` Aggregation **228/230** (2 pre-existing skips) and `TenantPartitionedEventsTests` **186/186** against a local 2.9.5 build — both RED on 2.9.4.

Bumps to **2.9.5**. (Recommend yanking/superseding 2.9.3 & 2.9.4 given the regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)