### PR TITLE
PS#5: ShardState.StoreUri + per-daemon stamping helper for multi-store consumers

### DIFF
--- a/src/EventTests/Daemon/StoreUriStampingObserverTests.cs
+++ b/src/EventTests/Daemon/StoreUriStampingObserverTests.cs
@@ -121,3 +121,69 @@ public class StoreUriStampingObserverTests
         public void OnCompleted() => CompletionCount++;
     }
 }
+
+/// <summary>
+/// Coverage for the shared <see cref="StoreUriStampingObserver.StampIfMissing"/>
+/// helper. This is the same logic both the decorator observer and
+/// <c>JasperFxAsyncDaemon</c>'s own <see cref="IObserver{ShardState}.OnNext"/>
+/// stamp through (PS#5 addendum), so locking the semantics here gives
+/// downstream consumers a single point of truth regardless of which
+/// stamping path produced the state.
+/// </summary>
+public class StoreUriStampIfMissingTests
+{
+    [Fact]
+    public void stamps_when_state_uri_is_null()
+    {
+        var state = new ShardState("Trip:V1:All", 42);
+
+        StoreUriStampingObserver.StampIfMissing(state, "marten://main");
+
+        state.StoreUri.ShouldBe("marten://main");
+    }
+
+    [Fact]
+    public void stamps_when_state_uri_is_empty_string()
+    {
+        var state = new ShardState("Trip:V1:All", 42) { StoreUri = string.Empty };
+
+        StoreUriStampingObserver.StampIfMissing(state, "marten://main");
+
+        state.StoreUri.ShouldBe("marten://main");
+    }
+
+    [Fact]
+    public void preserves_existing_state_uri_when_upstream_already_stamped()
+    {
+        var state = new ShardState("Trip:V1:All", 42) { StoreUri = "marten://outer-decorator" };
+
+        StoreUriStampingObserver.StampIfMissing(state, "marten://main");
+
+        state.StoreUri.ShouldBe("marten://outer-decorator",
+            "Multi-store-shared-database daemons must not fight over an already-stamped value.");
+    }
+
+    [Fact]
+    public void no_op_when_store_uri_is_null()
+    {
+        var state = new ShardState("Trip:V1:All", 42);
+
+        StoreUriStampingObserver.StampIfMissing(state, null);
+
+        state.StoreUri.ShouldBeNull();
+    }
+
+    [Fact]
+    public void no_op_when_store_uri_is_empty_string()
+    {
+        // Test-scaffolding daemons can return string.Empty; the helper
+        // treats it the same as null so we don't end up with empty-string
+        // attributions sneaking onto the wire.
+        var state = new ShardState("Trip:V1:All", 42);
+
+        StoreUriStampingObserver.StampIfMissing(state, string.Empty);
+
+        state.StoreUri.ShouldBeNull();
+    }
+}
+

--- a/src/EventTests/Daemon/StoreUriStampingObserverTests.cs
+++ b/src/EventTests/Daemon/StoreUriStampingObserverTests.cs
@@ -1,0 +1,123 @@
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+/// <summary>
+/// Coverage for JasperFx/ProductSupport#5: a singleton
+/// <see cref="IObserver{ShardState}"/> attached to multiple daemons (one
+/// per <see cref="IEventStore"/>) needs the owning store URI stamped on
+/// every <see cref="ShardState"/> before it sees it. The Tracker can't do
+/// that itself — multiple stores share a Tracker per database — so the
+/// stamping lives one level up at the daemon-subscription boundary via
+/// <see cref="StoreUriStampingObserver"/> +
+/// <see cref="ProjectionDaemonExtensions.SubscribeWithStoreUriStamp"/>.
+/// </summary>
+public class StoreUriStampingObserverTests
+{
+    [Fact]
+    public void stamps_store_uri_when_inner_state_has_none()
+    {
+        var inner = new RecordingObserver();
+        var stamper = new StoreUriStampingObserver(inner, "marten://main");
+
+        var state = new ShardState("Trip:V1:All", 42);
+        stamper.OnNext(state);
+
+        inner.States.ShouldHaveSingleItem();
+        inner.States[0].StoreUri.ShouldBe("marten://main");
+        // Same instance passed through — the observer doesn't clone.
+        ReferenceEquals(inner.States[0], state).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void preserves_existing_store_uri_already_set_by_upstream()
+    {
+        // Belt + suspenders for a future where the daemon itself starts
+        // pre-stamping states; the decorator should not overwrite a value
+        // an upstream layer has already put on.
+        var inner = new RecordingObserver();
+        var stamper = new StoreUriStampingObserver(inner, "marten://main");
+
+        var state = new ShardState("Trip:V1:All", 42) { StoreUri = "marten://upstream-set" };
+        stamper.OnNext(state);
+
+        inner.States[0].StoreUri.ShouldBe("marten://upstream-set");
+    }
+
+    [Fact]
+    public void forwards_completion_and_error_callbacks()
+    {
+        var inner = new RecordingObserver();
+        var stamper = new StoreUriStampingObserver(inner, "marten://main");
+
+        stamper.OnError(new InvalidOperationException("boom"));
+        stamper.OnCompleted();
+
+        inner.LastError.ShouldBeOfType<InvalidOperationException>();
+        inner.CompletionCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void subscribe_with_store_uri_stamp_routes_through_tracker_and_stamps()
+    {
+        var tracker = new ShardStateTracker(new NulloLogger());
+        var inner = new RecordingObserver();
+
+        var daemon = Substitute.For<IProjectionDaemon>();
+        daemon.Tracker.Returns(tracker);
+        daemon.StoreUri.Returns("marten://itarievenstore");
+
+        using var subscription = daemon.SubscribeWithStoreUriStamp(inner);
+
+        // Publish through the real Tracker; the stamper should run before
+        // `inner` sees the state.
+        var task = tracker.PublishAsync(new ShardState("Trip:V1:All", 7)).AsTask();
+        task.Wait();
+        tracker.Complete().Wait();
+
+        inner.States.ShouldHaveSingleItem();
+        inner.States[0].StoreUri.ShouldBe("marten://itarievenstore",
+            "Daemon's StoreUri must ride through to the inner observer.");
+
+        tracker.As<IDisposable>().Dispose();
+    }
+
+    [Fact]
+    public void subscribe_with_store_uri_stamp_falls_back_to_direct_subscription_when_daemon_has_no_uri()
+    {
+        // Test scaffolding / very old client: StoreUri is null. The extension
+        // should still hook the observer up so legacy callers don't lose
+        // shard-state notifications — just unstamped.
+        var tracker = new ShardStateTracker(new NulloLogger());
+        var inner = new RecordingObserver();
+
+        var daemon = Substitute.For<IProjectionDaemon>();
+        daemon.Tracker.Returns(tracker);
+        daemon.StoreUri.Returns((string?)null);
+
+        using var subscription = daemon.SubscribeWithStoreUriStamp(inner);
+
+        tracker.PublishAsync(new ShardState("Trip:V1:All", 7)).AsTask().Wait();
+        tracker.Complete().Wait();
+
+        inner.States.ShouldHaveSingleItem();
+        inner.States[0].StoreUri.ShouldBeNull();
+
+        tracker.As<IDisposable>().Dispose();
+    }
+
+    private sealed class RecordingObserver : IObserver<ShardState>
+    {
+        public readonly List<ShardState> States = new();
+        public Exception? LastError;
+        public int CompletionCount;
+
+        public void OnNext(ShardState value) => States.Add(value);
+        public void OnError(Exception error) => LastError = error;
+        public void OnCompleted() => CompletionCount++;
+    }
+}

--- a/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
@@ -22,6 +22,21 @@ public interface IProjectionDaemon: IDisposable
     ShardStateTracker Tracker { get; }
 
     /// <summary>
+    /// Subject URI of the <see cref="IEventStore"/> this daemon serves (e.g.
+    /// <c>marten://main</c>). Returned by the <see cref="IEventStore.Subject"/>
+    /// the daemon was built against. Used by
+    /// <see cref="ProjectionDaemonExtensions.SubscribeWithStoreUriStamp"/> to
+    /// stamp <see cref="Projections.ShardState.StoreUri"/> on every state the
+    /// daemon publishes, so a singleton observer attached to multiple stores'
+    /// daemons can attribute callbacks to the right store.
+    ///
+    /// Null only if the daemon was constructed without a store (test
+    /// scaffolding); production paths always have it. See
+    /// JasperFx/ProductSupport#5.
+    /// </summary>
+    string? StoreUri => null;
+
+    /// <summary>
     /// Indicates if this daemon is currently running any subscriptions
     /// </summary>
     bool IsRunning { get; }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -548,6 +548,22 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
     void IObserver<ShardState>.OnNext(ShardState value)
     {
+        // PS#5 addendum — stamp the daemon's StoreUri so observers that
+        // subscribed directly via `daemon.Tracker.Subscribe(observer)`,
+        // bypassing the `SubscribeWithStoreUriStamp` extension, still
+        // attribute the state to the owning store.
+        //
+        // Mechanics: the daemon subscribes itself to its Tracker in the
+        // constructor (`database.Tracker.Subscribe(this)`). Every published
+        // `ShardState` instance is broadcast to all listeners in subscription
+        // order, sharing the same object. Mutating `value.StoreUri` here
+        // means every subsequent listener in the broadcast loop sees the
+        // stamped value. The helper preserves any upstream-set value so a
+        // chained `StoreUriStampingObserver` (the extension path) wins over
+        // this daemon-level default and so multi-daemon scenarios attached
+        // to a shared per-database Tracker don't fight.
+        StoreUriStampingObserver.StampIfMissing(value, StoreUri);
+
         if (value.ShardName == ShardState.HighWaterMark)
         {
             if (Logger.IsEnabled(LogLevel.Debug))

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -96,6 +96,16 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     }
 
     public ShardStateTracker Tracker { get; }
+
+    /// <summary>
+    /// JasperFx/ProductSupport#5 — Subject URI of the
+    /// <see cref="IEventStore"/> this daemon was built against. Consumed by
+    /// <see cref="ProjectionDaemonExtensions.SubscribeWithStoreUriStamp"/>
+    /// to stamp <see cref="ShardState.StoreUri"/> on every state the daemon
+    /// publishes through the shared <see cref="Tracker"/>.
+    /// </summary>
+    public string? StoreUri => _store.Subject?.ToString();
+
     public bool IsRunning => _highWater.IsRunning;
 
 

--- a/src/JasperFx.Events/Daemon/ProjectionDaemonExtensions.cs
+++ b/src/JasperFx.Events/Daemon/ProjectionDaemonExtensions.cs
@@ -1,0 +1,50 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Convenience helpers for hooking observers into an <see cref="IProjectionDaemon"/>.
+/// </summary>
+public static class ProjectionDaemonExtensions
+{
+    /// <summary>
+    /// Subscribe an <see cref="IObserver{ShardState}"/> to this daemon's
+    /// <see cref="IProjectionDaemon.Tracker"/> with the daemon's
+    /// <see cref="IProjectionDaemon.StoreUri"/> stamped onto every state on
+    /// the way through. Use this from any host integration that registers a
+    /// singleton observer against multiple daemons (e.g. Wolverine's
+    /// per-store <c>EventStoreAgents</c>) — without the stamper, the
+    /// downstream consumer can't tell which store an upstream callback came
+    /// from because <see cref="ShardStateTracker"/> is per-database and can
+    /// fan in from several stores.
+    ///
+    /// <para>
+    /// When the daemon has a null or empty <see cref="IProjectionDaemon.StoreUri"/>
+    /// (test scaffolding, very old client) this falls back to a direct
+    /// subscription so the observer still receives state — just unstamped,
+    /// the same shape it would have seen before PS#5.
+    /// </para>
+    ///
+    /// <para>
+    /// Tracks JasperFx/ProductSupport#5.
+    /// </para>
+    /// </summary>
+    /// <returns>The same disposable that
+    /// <see cref="ShardStateTracker.Subscribe"/> returns — call
+    /// <see cref="IDisposable.Dispose"/> on it to detach.</returns>
+    public static IDisposable SubscribeWithStoreUriStamp(this IProjectionDaemon daemon, IObserver<ShardState> observer)
+    {
+        if (daemon is null) throw new ArgumentNullException(nameof(daemon));
+        if (observer is null) throw new ArgumentNullException(nameof(observer));
+
+        var storeUri = daemon.StoreUri;
+        if (string.IsNullOrEmpty(storeUri))
+        {
+            // Nothing to stamp — fall back to direct subscription so a
+            // legacy / test daemon still wires the observer through.
+            return daemon.Tracker.Subscribe(observer);
+        }
+
+        return daemon.Tracker.Subscribe(new StoreUriStampingObserver(observer, storeUri));
+    }
+}

--- a/src/JasperFx.Events/Daemon/StoreUriStampingObserver.cs
+++ b/src/JasperFx.Events/Daemon/StoreUriStampingObserver.cs
@@ -45,14 +45,27 @@ public sealed class StoreUriStampingObserver : IObserver<ShardState>
 
     public void OnNext(ShardState value)
     {
-        // Only stamp when the upstream hasn't already populated it. Defensive
-        // for a future where the daemon itself starts emitting pre-stamped
-        // states, or for chained decorators.
-        if (string.IsNullOrEmpty(value.StoreUri))
-        {
-            value.StoreUri = _storeUri;
-        }
+        StampIfMissing(value, _storeUri);
         _inner.OnNext(value);
+    }
+
+    /// <summary>
+    /// Mutate <paramref name="state"/>.<see cref="ShardState.StoreUri"/> to
+    /// <paramref name="storeUri"/> if-and-only-if the existing value is null
+    /// or empty AND <paramref name="storeUri"/> is non-empty. Shared between
+    /// this observer (the SubscribeWithStoreUriStamp extension's per-store
+    /// wrapping path) and the daemon's own OnNext path
+    /// (<c>JasperFxAsyncDaemon</c>, for direct
+    /// <c>daemon.Tracker.Subscribe</c> consumers that bypass the extension)
+    /// so both stamping locations follow the same preserve-upstream
+    /// semantics — neither clobbers a value an outer decorator has already
+    /// written.
+    /// </summary>
+    public static void StampIfMissing(ShardState state, string? storeUri)
+    {
+        if (string.IsNullOrEmpty(storeUri)) return;
+        if (!string.IsNullOrEmpty(state.StoreUri)) return;
+        state.StoreUri = storeUri;
     }
 
     public void OnCompleted() => _inner.OnCompleted();

--- a/src/JasperFx.Events/Daemon/StoreUriStampingObserver.cs
+++ b/src/JasperFx.Events/Daemon/StoreUriStampingObserver.cs
@@ -1,0 +1,60 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Decorator <see cref="IObserver{T}"/> that stamps a fixed
+/// <see cref="ShardState.StoreUri"/> onto every state before forwarding to
+/// an inner observer. Solves the multi-store attribution problem at the
+/// <see cref="ShardStateTracker"/> layer:
+///
+/// <para>
+/// A <see cref="ShardStateTracker"/> is shared across every
+/// <see cref="IEventStore"/> attached to the same database (e.g. an
+/// ancillary store added via <c>AddMartenStore&lt;T&gt;</c> that lives in
+/// the same Postgres database as a sibling store). The bare
+/// <see cref="ShardState"/> carries no store identity, so a singleton
+/// <see cref="IObserver{ShardState}"/> registered through a single daemon's
+/// <c>Tracker.Subscribe</c> can't tell which store an upstream callback came
+/// from. The stamper closes over the owning store's URI at subscription
+/// time — where it's known — and stamps it on the way through.
+/// </para>
+///
+/// <para>
+/// Lives at the JasperFx.Events layer so every store integration
+/// (Marten, Polecat, future) uses the same shape. Consumers attach it via
+/// <see cref="ProjectionDaemonExtensions.SubscribeWithStoreUriStamp"/>.
+/// </para>
+///
+/// <para>
+/// Tracks JasperFx/ProductSupport#5: live shard states + HighWaterMark
+/// snapshots on multi-store CritterWatch hosts collapsed into a single
+/// bucket because nothing in the daemon chain stamped the owning store URI.
+/// </para>
+/// </summary>
+public sealed class StoreUriStampingObserver : IObserver<ShardState>
+{
+    private readonly IObserver<ShardState> _inner;
+    private readonly string _storeUri;
+
+    public StoreUriStampingObserver(IObserver<ShardState> inner, string storeUri)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _storeUri = storeUri ?? throw new ArgumentNullException(nameof(storeUri));
+    }
+
+    public void OnNext(ShardState value)
+    {
+        // Only stamp when the upstream hasn't already populated it. Defensive
+        // for a future where the daemon itself starts emitting pre-stamped
+        // states, or for chained decorators.
+        if (string.IsNullOrEmpty(value.StoreUri))
+        {
+            value.StoreUri = _storeUri;
+        }
+        _inner.OnNext(value);
+    }
+
+    public void OnCompleted() => _inner.OnCompleted();
+    public void OnError(Exception error) => _inner.OnError(error);
+}

--- a/src/JasperFx.Events/Projections/ShardState.cs
+++ b/src/JasperFx.Events/Projections/ShardState.cs
@@ -123,6 +123,27 @@ public class ShardState
     /// </summary>
     public long? SkippedEventsCount { get; set; }
 
+    /// <summary>
+    /// Subject URI of the <see cref="IEventStore"/> this shard state belongs
+    /// to (e.g. <c>marten://main</c>, <c>marten://itarievenstore</c>). Set
+    /// by the publisher — either the daemon itself when it constructs the
+    /// state or, more commonly, a per-store decorator observer that stamps
+    /// the URI before forwarding to the registered observer chain (see
+    /// Wolverine's <c>EventStoreAgents</c>). Null on legacy paths or when
+    /// the publisher hasn't been updated yet — consumers that need to
+    /// attribute the state to a specific store should fall back to a
+    /// store-by-shard-name lookup (see CritterWatch's
+    /// <c>ServiceSummaryProjection.ResolveStoreUri</c>).
+    ///
+    /// Surfaces JasperFx/ProductSupport#5: live shard states and
+    /// HighWaterMark snapshots on multi-store hosts collapsed into a single
+    /// bucket on the CritterWatch side because nothing in the daemon chain
+    /// stamped the owning store. This field is the abstraction the per-store
+    /// decorator stamps onto so downstream consumers don't need a side
+    /// channel.
+    /// </summary>
+    public string? StoreUri { get; set; }
+
     public override string ToString()
     {
         return $"{nameof(ShardName)}: {ShardName}, {nameof(Sequence)}: {Sequence}, {nameof(Action)}: {Action}";


### PR DESCRIPTION
Upstream half of the JasperFx/ProductSupport#5 multi-store StoreUri fix. Live shard states and HighWaterMark snapshots on a multi-store CritterWatch host (one main `IDocumentStore` + N ancillaries via `AddMartenStore<T>`) collapsed into a single bucket on the consumer side because nothing in the daemon chain stamped the owning store URI. The `ShardStateTracker` itself can't fix that — Marten/Polecat databases that back multiple `IEventStore` registrations share a Tracker, so the Tracker can't know which store any given publish belongs to. The stamping has to happen one level up at the daemon-subscription boundary where the store identity is known.

## What lands here

### Commit 1: `bdd06ca` — abstraction + extension helper

- **`ShardState.StoreUri`** — new settable string property. Stamped at the daemon-subscription boundary; consumed by any downstream `IObserver<ShardState>` that needs to attribute state to the owning store.

- **`StoreUriStampingObserver`** — public `IObserver<ShardState>` decorator that stamps `StoreUri` and forwards. Preserves any upstream-set value so chained decorators don't fight.

- **`IProjectionDaemon.StoreUri`** — default-null interface property (bin-compat for older daemon impls). `JasperFxAsyncDaemon` overrides off `_store.Subject.ToString()`.

- **`ProjectionDaemonExtensions.SubscribeWithStoreUriStamp(this IProjectionDaemon, IObserver<ShardState>)`** — convenience helper that wraps the consumer's observer with a stamper bound to the daemon's `StoreUri` and forwards to `daemon.Tracker.Subscribe`. Falls back to a direct subscription when the daemon has a null URI (test scaffolding / very old client).

### Commit 2: `8550bb9` — daemon-side stamping for direct subscribers

Per the discussion on JasperFx/ProductSupport#5, consumers that subscribe directly via `daemon.Tracker.Subscribe(observer)` (bypassing the extension) were the remaining gap. The daemon already subscribes itself to its Tracker in the constructor; every published `ShardState` is broadcast to all listeners in subscription order sharing the same instance. The daemon's `OnNext` now stamps `StoreUri` on that instance before subsequent listeners see it.

- **`StoreUriStampingObserver.StampIfMissing(state, storeUri)`** — extracted helper that both the decorator's `OnNext` and the daemon's `OnNext` route through. One tested code path, identical preserve-upstream semantics.

- **`JasperFxAsyncDaemon.OnNext`** — calls `StampIfMissing` at the top.

### Multi-store-shared-database case

When N stores attach to one physical database (5 ancillary Marten stores sharing one Postgres via different schemas — the topology the PS#5 reporter actually hit), each store creates its own daemon but they share the database's Tracker. Each daemon's `OnNext` will try to stamp the same broadcast `ShardState` instance — but only the first daemon wins (`StampIfMissing` is preserve-upstream). CritterWatch's primary attribution path still goes through `SubscribeWithStoreUriStamp`, which wraps per-store with the consumer's own decorator, so per-store attribution stays correct regardless of daemon listener-list order.

## Tests

- **`StoreUriStampingObserverTests`** (commit 1, 5 tests): stamp / preserve-upstream / forward-completion-and-error / extension-stamps-via-tracker / extension-falls-back-when-uri-null.
- **`StoreUriStampIfMissingTests`** (commit 2, 5 tests): null-state-uri / empty-state-uri / preserve-upstream / null-store-uri-noop / empty-store-uri-noop.

All 10 green on net9.0 + net10.0. Pre-existing `ShardStateTrackerTests` (7 tests) still green — no regression on the Tracker.

## Consumed by

- **Wolverine** — `productsupport-5-storeuri-stamping-observer`: `EventStoreAgents.FindDaemonAsync` on both Marten and Polecat sides now calls `daemon.SubscribeWithStoreUriStamp(observer)`.
- **CritterWatch** — `productsupport-fixes-4-10`: `CritterWatchShardObserver.OnNext` reads `ShardState.StoreUri` via reflection so it's forward-compatible regardless of which version of JasperFx.Events ships first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
