### PR TITLE
Fix #441: GeneratedFlag.ToUsageDescription throws for nullable-enum flags (LogLevel?)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,6 +63,16 @@ jobs:
         run: ./build.sh test-command-line
         shell: bash
 
+      # Smoke test the usage/help renderer end-to-end. `help describe` renders a
+      # NetCoreInput-derived command, which exercises the nullable-enum --log-level
+      # flag that crashed usage rendering in jasperfx#441. A non-zero exit fails CI.
+      - name: smoke-test-help
+        if: ${{ success() || failure() }}
+        run: |
+          dotnet run --project src/CommandLineRunner --framework net9.0 -- help
+          dotnet run --project src/CommandLineRunner --framework net9.0 -- help describe
+        shell: bash
+
       - name: smoke-test-aot
         if: ${{ success() || failure() }}
         run: ./build.sh smoke-test-aot

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -65,13 +65,30 @@ jobs:
 
       # Smoke test the usage/help renderer end-to-end. `help describe` renders a
       # NetCoreInput-derived command, which exercises the nullable-enum --log-level
-      # flag that crashed usage rendering in jasperfx#441. A non-zero exit fails CI.
+      # flag that crashed usage rendering in jasperfx#441.
+      #
+      # NOTE: `help <command>` intentionally returns a non-zero exit code (it renders
+      # usage rather than running a command), so we do NOT gate on the exit code.
+      # Instead we fail only if usage rendering actually crashed -- #441 surfaced as an
+      # unhandled exception + stack trace in the output.
       - name: smoke-test-help
         if: ${{ success() || failure() }}
-        run: |
-          dotnet run --project src/CommandLineRunner --framework net9.0 -- help
-          dotnet run --project src/CommandLineRunner --framework net9.0 -- help describe
         shell: bash
+        run: |
+          fail=0
+          smoke() {
+            echo "::group::dotnet run -- $*"
+            output=$(dotnet run --project src/CommandLineRunner --framework net9.0 -- "$@" 2>&1) || true
+            echo "$output"
+            echo "::endgroup::"
+            if echo "$output" | grep -qE 'Unhandled exception|System\.[A-Za-z.]+Exception'; then
+              echo "::error::Usage rendering crashed for 'help $*' (see jasperfx#441)"
+              fail=1
+            fi
+          }
+          smoke help
+          smoke help describe
+          exit $fail
 
       - name: smoke-test-aot
         if: ${{ success() || failure() }}

--- a/src/CommandLineTests/GeneratedFlagTester.cs
+++ b/src/CommandLineTests/GeneratedFlagTester.cs
@@ -1,0 +1,40 @@
+using JasperFx.CommandLine.Parsing;
+using JasperFx.CommandLine.Parsing.Generated;
+using Shouldly;
+
+namespace CommandLineTests;
+
+public class GeneratedFlagTester
+{
+    public enum Color
+    {
+        Red,
+        Green,
+        Blue
+    }
+
+    private static FlagAliases Aliases() => new() { LongForm = "--color", ShortForm = "-c" };
+
+    [Fact]
+    public void usage_description_for_non_nullable_enum_lists_values()
+    {
+        var flag = new GeneratedFlag<Color>("ColorFlag", "the color", Aliases(),
+            (_, _) => { }, _ => Color.Red, isEnum: true);
+
+        flag.ToUsageDescription().ShouldBe("[-c, --color Red|Green|Blue]");
+    }
+
+    // jasperfx#441: the source generator constructs GeneratedFlag<SomeEnum?> with isEnum: true
+    // (IsEnum = isEnum || isNullableEnum). ToUsageDescription handed typeof(Nullable<SomeEnum>) to
+    // Enum.GetNames and threw "Type provided must be an Enum", which crashed help / invalid-usage
+    // rendering for every NetCoreInput-derived command (NetCoreInput.LogLevelFlag is LogLevel?).
+    [Fact]
+    public void usage_description_for_nullable_enum_resolves_underlying_type()
+    {
+        var flag = new GeneratedFlag<Color?>("ColorFlag", "the color", Aliases(),
+            (_, _) => { }, _ => Color.Red, isEnum: true);
+
+        Should.NotThrow(() => flag.ToUsageDescription())
+            .ShouldBe("[-c, --color Red|Green|Blue]");
+    }
+}

--- a/src/JasperFx/CommandLine/Parsing/Generated/GeneratedFlag.cs
+++ b/src/JasperFx/CommandLine/Parsing/Generated/GeneratedFlag.cs
@@ -49,7 +49,12 @@ public sealed class GeneratedFlag<T> : ITokenHandler
     {
         if (_isEnum)
         {
-            var enumValues = Enum.GetNames(typeof(T)).Join("|");
+            // _isEnum is computed from the underlying type, so a nullable-enum flag (T = SomeEnum?)
+            // lands here with typeof(T) == Nullable<SomeEnum>, which is not itself an enum.
+            // Enum.GetNames would throw "Type provided must be an Enum". Resolve the underlying
+            // enum type first. See jasperfx#441 (NetCoreInput.LogLevelFlag is LogLevel?).
+            var enumType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+            var enumValues = Enum.GetNames(enumType).Join("|");
             return $"[{_aliases} {enumValues}]";
         }
 


### PR DESCRIPTION
Closes #441.

## Bug

`GeneratedFlag<T>.ToUsageDescription()` threw `ArgumentException: Type provided must be an Enum.` for any **nullable-enum** flag. The source generator sets `isEnum: true` for nullable enums (`IsEnum = isEnum || isNullableEnum` in `InputParserGenerator`), so a `LogLevel?` flag becomes `GeneratedFlag<LogLevel?>` with `isEnum: true` — and `Enum.GetNames(typeof(LogLevel?))` (i.e. `Nullable<LogLevel>`) throws.

Since `NetCoreInput.LogLevelFlag` is `LogLevel?` and `NetCoreInput` backs essentially every host command, this crashed **`help`** and every **"Invalid usage"** path with an unhandled stack trace — which also masked the real argument-parsing error that triggered the usage render (e.g. Wolverine's `capabilities wolverine.json`).

## Fix

Resolve the underlying enum type before enumerating names (the issue's suggested, lower-risk fix):

```csharp
var enumType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
var enumValues = Enum.GetNames(enumType).Join("|");
```

## Tests

`GeneratedFlagTester` (new):
- `usage_description_for_nullable_enum_resolves_underlying_type` — `GeneratedFlag<Color?>` no longer throws and renders `[-c, --color Red|Green|Blue]` (fails before the fix).
- `usage_description_for_non_nullable_enum_lists_values` — guards the non-nullable path is unchanged.

Full `CommandLineTests` suite green (291), JasperFx core compiles clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)