### PR TITLE
Fix marten#4721 — composite optimized rebuild self-deadlocks the command channel

### DIFF
--- a/src/EventTests/Daemon/SubscriptionAgent_optimized_rebuild_no_deadlock.cs
+++ b/src/EventTests/Daemon/SubscriptionAgent_optimized_rebuild_no_deadlock.cs
@@ -1,0 +1,89 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// Regression for marten#4721: the continuous-startup "optimized rebuild" for a composite
+// projection used to run INLINE inside the agent's single-consumer command-loop handler
+// (Apply for CommandType.Start). The replay posts one RangeCompleted command per page back
+// into the same bounded (capacity 10_000) command channel whose only reader is that very
+// handler — so once the channel filled, the post blocked, the reader was blocked awaiting it,
+// and the shard silently wedged at a batch boundary (idle: no query, no lock, no exception).
+//
+// The fix runs the rebuild on a task SEPARATE from the command-loop consumer, so the consumer
+// is free to drain those RangeCompleted posts. This test drives the agent through its real
+// command block (via StartAsync) with a replay executor that emits MORE pages than the channel
+// capacity; under the old inline code it deadlocks (LastCommitted never advances past 0 and the
+// test times out), under the fix it drains and catches up.
+public class SubscriptionAgent_optimized_rebuild_no_deadlock
+{
+    // Bigger than the Block<Command> bounded-channel capacity (10_000) so an inline replay would
+    // overflow the channel and self-deadlock.
+    private const int PageCount = 12_000;
+
+    [Fact]
+    public async Task optimized_rebuild_runs_off_the_command_loop_and_does_not_deadlock()
+    {
+        var execution = Substitute.For<ISubscriptionExecution>();
+        var replay = new FakeReplayExecutor(PageCount);
+
+        execution.TryBuildReplayExecutor(out Arg.Any<IReplayExecutor?>())
+            .Returns(call =>
+            {
+                call[0] = replay;
+                return true;
+            });
+
+        var agent = new SubscriptionAgent(new ShardName("Composite1"), new AsyncOptions(), TimeProvider.System,
+            Substitute.For<IEventLoader>(), execution, new ShardStateTracker(NullLogger.Instance),
+            Substitute.For<ISubscriptionMetrics>(), NullLogger.Instance);
+
+        // Floor 0 + a non-zero high water => the Start handler triggers the optimized rebuild.
+        var request = new SubscriptionExecutionRequest(0, ShardExecutionMode.Continuous, new ErrorHandlingOptions(),
+            new NulloDaemonRuntime()) { StartingHighWater = PageCount };
+
+        await agent.StartAsync(request);
+
+        // Wait for the off-consumer rebuild to drain every page through the command channel. Under
+        // the pre-fix inline implementation this never advances past 0 and the wait times out.
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        while (agent.LastCommitted < PageCount && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
+
+        agent.LastCommitted.ShouldBe(PageCount);
+        replay.Completed.ShouldBeTrue();
+
+        await agent.DisposeAsync();
+    }
+
+    private sealed class FakeReplayExecutor : IReplayExecutor
+    {
+        private readonly int _pages;
+
+        public FakeReplayExecutor(int pages)
+        {
+            _pages = pages;
+        }
+
+        public bool Completed { get; private set; }
+
+        public async Task StartAsync(SubscriptionExecutionRequest request, ISubscriptionController controller,
+            CancellationToken cancellation)
+        {
+            // Mimic CompositeReplayExecutor: one MarkSuccessAsync (== a RangeCompleted post back into
+            // the agent's command block) per page, all the way up to the ceiling.
+            for (var seq = 1; seq <= _pages; seq++)
+            {
+                await controller.MarkSuccessAsync(seq).ConfigureAwait(false);
+            }
+
+            Completed = true;
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/Command.cs
+++ b/src/JasperFx.Events/Daemon/Command.cs
@@ -14,6 +14,15 @@ public class Command
         return new Command { LastCommitted = ceiling, Type = CommandType.RangeCompleted };
     }
 
+    // #4721: signals that the off-consumer optimized rebuild has finished so the agent can
+    // resume continuous operation. Carries no sequence — the trailing RangeCompleted commands
+    // the rebuild already posted have advanced LastCommitted to the replay ceiling by the time
+    // this is processed (single-reader FIFO channel).
+    internal static Command ReplayCompleted()
+    {
+        return new Command { Type = CommandType.ReplayCompleted };
+    }
+
     public static Command HighWaterMarkUpdated(long sequence)
     {
         return new Command { HighWaterMark = sequence, Type = CommandType.HighWater };

--- a/src/JasperFx.Events/Daemon/CommandType.cs
+++ b/src/JasperFx.Events/Daemon/CommandType.cs
@@ -4,5 +4,9 @@ internal enum CommandType
 {
     Start,
     HighWater,
-    RangeCompleted
+    RangeCompleted,
+
+    // #4721: posted by the off-consumer optimized-rebuild task when it finishes, so the agent
+    // reconciles its in-memory marks and resumes continuous operation on the command-loop thread.
+    ReplayCompleted
 }

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -19,6 +19,14 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     private IDaemonRuntime _runtime = new NulloDaemonRuntime();
     private Timer? _heartbeatTimer;
 
+    // #4721: true while a continuous-startup optimized rebuild runs OFF the command-loop consumer.
+    // Only ever read/written on the command-loop thread (Apply), so it needs no synchronization.
+    // While set, the command loop keeps draining RangeCompleted/HighWater bookkeeping but does NOT
+    // start continuous loading, so the rebuild's MarkSuccessAsync posts cannot deadlock the bounded
+    // command channel and continuous loading cannot race the rebuild over the same events.
+    private bool _replaying;
+    private Task? _replayTask;
+
     public SubscriptionAgent(ShardName name, AsyncOptions options, TimeProvider timeProvider, IEventLoader loader,
         ISubscriptionExecution execution, ShardStateTracker tracker, ISubscriptionMetrics metrics, ILogger logger)
     {
@@ -304,39 +312,39 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
                 if (LastCommitted == 0 && HighWaterMark > 0 && _execution.TryBuildReplayExecutor(out var executor))
                 {
-                    try
+                    _logger.LogInformation("Starting optimized rebuild for projection/subscription {ShardName}",
+                        Name.Identity);
+                    var replayRequest =
+                        new SubscriptionExecutionRequest(0, ShardExecutionMode.CatchUp, ErrorOptions, _runtime);
+                    if (Name.TenantId != null)
                     {
-                        _logger.LogInformation("Starting optimized rebuild for projection/subscription {ShardName}",
-                            Name.Identity);
-                        var replayRequest =
-                            new SubscriptionExecutionRequest(0, ShardExecutionMode.CatchUp, ErrorOptions, _runtime);
-                        if (Name.TenantId != null)
-                        {
-                            // marten#4717: a tenant-scoped composite replays only to its own tenant's
-                            // high-water (this agent's seeded HighWaterMark), not the store-wide max.
-                            replayRequest = replayRequest with { StartingHighWater = HighWaterMark };
-                        }
-
-                        await executor
-                            .StartAsync(replayRequest, this, _cancellation.Token).ConfigureAwait(false);
-                        _logger.LogInformation(
-                            "Finished with optimized rebuild for projection/subscription {ShardName}, proceeding to normal, continuous operation",
-                            Name.Identity);
-
-                        // The executor has caught the shard up to the ceiling and persisted progression
-                        // (MarkSuccessAsync on its final page). Reconcile the agent's in-memory marks so the
-                        // post-switch fall-through doesn't redundantly re-load 0→HighWater into the block.
-                        LastEnqueued = LastCommitted = HighWaterMark;
+                        // marten#4717: a tenant-scoped composite replays only to its own tenant's
+                        // high-water (this agent's seeded HighWaterMark), not the store-wide max.
+                        replayRequest = replayRequest with { StartingHighWater = HighWaterMark };
                     }
-                    catch (Exception e)
-                    {
-                        _logger.LogError(e,
-                            "Error trying to perform an optimized rebuild/replay of subscription {ShardName}",
-                            Name.Identity);
-                    }
+
+                    // #4721: run the optimized rebuild OFF this command-loop consumer. The replay executor
+                    // posts a RangeCompleted command per page via MarkSuccessAsync; if we awaited it inline
+                    // here, those posts would pile up in the bounded command channel whose only reader is
+                    // THIS handler — once the channel fills (10k) the post blocks, the reader is blocked
+                    // awaiting it, and the shard silently wedges at a batch boundary. Running it on a
+                    // separate task frees this reader to drain those posts. The _replaying flag suppresses
+                    // continuous loading until the rebuild signals completion with Command.ReplayCompleted.
+                    _replaying = true;
+                    _replayTask = Task.Run(() => runOptimizedRebuildAsync(executor, replayRequest));
+                    return;
                 }
 
 
+                break;
+
+            case CommandType.ReplayCompleted:
+                // #4721: the off-consumer optimized rebuild finished. The trailing RangeCompleted posts it
+                // emitted have already advanced LastCommitted to the replay ceiling (FIFO, single reader),
+                // so align LastEnqueued and fall through to resume normal continuous operation — picking up
+                // any events that arrived past the replay ceiling while the rebuild was running.
+                _replaying = false;
+                LastEnqueued = LastCommitted;
                 break;
 
             case CommandType.RangeCompleted:
@@ -354,6 +362,14 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
         // Mind the gap!
         Metrics.UpdateGap(HighWaterMark, LastCommitted);
+
+        // #4721: while the off-consumer optimized rebuild is running we keep draining bookkeeping
+        // (above) but must NOT kick off continuous loading — otherwise the normal loader would race
+        // the rebuild over the same events. Command.ReplayCompleted clears the flag and falls through.
+        if (_replaying)
+        {
+            return;
+        }
 
         var inflight = LastEnqueued - LastCommitted;
 
@@ -390,6 +406,42 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
             {
                 await loadNextAsync().ConfigureAwait(false);
             }
+        }
+    }
+
+    // #4721: drives a continuous-startup optimized rebuild on a task SEPARATE from the command-loop
+    // consumer (see the CommandType.Start branch). Because this runs off the consumer, the replay
+    // executor's per-page MarkSuccessAsync posts are free to be drained by Apply, so the bounded
+    // command channel never deadlocks. On success it posts Command.ReplayCompleted so the agent
+    // resumes continuous operation on the command-loop thread; on failure it routes through the normal
+    // critical-failure path (which pauses/stops the shard and cancels), leaving _replaying moot.
+    private async Task runOptimizedRebuildAsync(IReplayExecutor executor, SubscriptionExecutionRequest replayRequest)
+    {
+        try
+        {
+            await executor.StartAsync(replayRequest, this, _cancellation.Token).ConfigureAwait(false);
+
+            // The replay executor swallows member failures and pauses/stops the agent rather than
+            // throwing. Only resume continuous operation if the shard is still healthy.
+            if (Status == AgentStatus.Running && !_cancellation.IsCancellationRequested)
+            {
+                _logger.LogInformation(
+                    "Finished with optimized rebuild for projection/subscription {ShardName}, proceeding to normal, continuous operation",
+                    Name.Identity);
+
+                await _commandBlock.PostAsync(Command.ReplayCompleted()).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+        {
+            // Shutting down -- nothing to do.
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Error trying to perform an optimized rebuild/replay of subscription {ShardName}",
+                Name.Identity);
+            await ReportCriticalFailureAsync(e).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
Fixes the root cause of JasperFx/marten#4721.

## Problem

Under `UseTenantPartitionedEvents` on a sharded conjoined store, composite projection rebuilds **silently freeze at a batch boundary** during continuous-startup — idle process, no exception, no pause, no active query, no lock. The stall seq varies per run (and Solo mode wedges *more* composites), and it does not reproduce on a fast local Postgres.

## Root cause — a re-entrant deadlock on the agent's bounded command channel

`SubscriptionAgent._commandBlock` is a `Block<Command>` = a **bounded channel, capacity 10_000, single reader**. The consumer runs `Apply` for each command.

On continuous startup, `Apply(CommandType.Start)` ran the **entire optimized rebuild inline** (`await executor.StartAsync(...)`) — on the command-loop consumer thread. Only `CompositeExecution` returns `true` from `TryBuildReplayExecutor`, which is why this is composite-specific.

`CompositeReplayExecutor` posts one `RangeCompleted` command **per page** back into that same channel via `MarkSuccessAsync`. With the only reader blocked inside `Apply(Start)` awaiting the replay, those posts piled up undrained; once the channel filled (10k), `PostAsync` blocked, the reader was blocked awaiting its own post → **self-deadlock**. Fast local runs finished before the channel filled; slow/high-latency deployments accumulated enough buffered commands (Completed + flooding HighWater) to hit the cap and hang — exactly the reported timing-sensitivity.

The explicit `projections rebuild` (`ReplayAsync`) path was already safe — it runs the executor off the consumer. Only the inline auto-rebuild deadlocked.

## Fix

Run the optimized rebuild on a task **separate from the command-loop consumer** so the consumer is free to drain the `RangeCompleted`/`HighWater` posts:

- a `_replaying` flag keeps the command loop draining bookkeeping while suppressing continuous loading (so the normal loader can't race the rebuild over the same events);
- a new `Command.ReplayCompleted`, posted by the rebuild task on completion, clears the flag and resumes continuous operation on the command-loop thread — picking up events that arrived past the replay ceiling during the rebuild;
- on failure the rebuild task routes through the normal critical-failure path.

## Test

`SubscriptionAgent_optimized_rebuild_no_deadlock` drives the agent through its real command block with a replay executor that emits **more pages than the channel capacity**. It deadlocks (times out) on the old inline code and passes with the fix. Full `EventTests` suite green (381).

🤖 Generated with [Claude Code](https://claude.com/claude-code)