### PR TITLE
Fix marten#4730 — aggregate cache double-applies after a failed/retried batch

### DIFF
--- a/src/EventTests/Daemon/AsyncOptionsTests.cs
+++ b/src/EventTests/Daemon/AsyncOptionsTests.cs
@@ -13,11 +13,13 @@ public class AsyncOptionsTests
     private readonly CancellationToken theToken = CancellationToken.None;
 
     [Fact]
-    public void cache_limit_per_tenant_defaults_to_a_meaningful_value()
+    public void cache_limit_per_tenant_is_disabled_by_default()
     {
-        // jasperfx#422: the aggregate cache is on by default now (was 0 == disabled), so most
-        // projections get a 2nd-level cache without explicit opt-in.
-        new AsyncOptions().CacheLimitPerTenant.ShouldBe(1000);
+        // marten#4730: the aggregate cache is OFF by default (reverted from the #422 default of
+        // 1000). With the cache enabled, a batch that failed and was retried/skipped could
+        // re-apply events on top of an already-mutated cached aggregate (double-apply). Caching is
+        // now opt-in, and when enabled it only populates after a successful commit.
+        new AsyncOptions().CacheLimitPerTenant.ShouldBe(0);
     }
 
     [Fact]

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 using ImTools;
 using JasperFx.Blocks;
@@ -17,6 +18,14 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
     private readonly ILogger _logger;
     private readonly IEventStore<TOperations, TQuerySession> _store;
     private ImHashMap<string, IAggregateCache<TId, TDoc>> _caches = ImHashMap<string, IAggregateCache<TId, TDoc>>.Empty;
+
+    // #4730: cache mutations from the current build, applied to the cache only AFTER the batch
+    // commits (ApplyPendingCacheUpdates). Reassigned per build, so a failed/uncommitted build
+    // leaves no mutations behind for a retry to read. Composite batches bypass this and write the
+    // cache during build (see _populateCacheImmediately) because downstream stages read upstream
+    // in-flight aggregates from the cache within the same batch (marten#4329).
+    private ConcurrentQueue<(IAggregateCache<TId, TDoc> Cache, TId Id, TDoc? Snapshot, bool Remove)> _pendingCacheUpdates = new();
+    private bool _populateCacheImmediately;
 
     public AggregationRunner(IEventStore<TOperations, TQuerySession> store, IEventDatabase database,
         IAggregationProjection<TDoc, TId, TOperations, TQuerySession> projection,
@@ -46,6 +55,15 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
     {
         Projection.StartBatch();
 
+        // #4730: discard any cache mutations from a prior build that did not commit (e.g. a build
+        // that threw, or a skip-and-rebuild attempt) before accumulating this build's mutations.
+        _pendingCacheUpdates = new();
+
+        // Composite member batches must populate the cache during build so a downstream stage can
+        // read an upstream stage's in-flight aggregate (marten#4329). Standalone (Individual)
+        // batches defer cache population until the batch commits.
+        _populateCacheImmediately = range.BatchBehavior == BatchBehavior.Composite;
+
         var batch = range.ActiveBatch as IProjectionBatch<TOperations, TQuerySession> ?? await _store.StartProjectionBatchAsync(range, _database, mode, Projection.Options, cancellation);
 
         if (SliceBehavior == SliceBehavior.JustInTime)
@@ -69,11 +87,10 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
 
         builder.OnError = (_, e) => exceptions.Add(e);
 
-        var caches = new List<IAggregateCache<TId, TDoc>>();
         var groups = range.Groups.OfType<SliceGroup<TDoc, TId>>().ToArray();
         foreach (var group in groups)
         {
-            await processBatchAsync(cancellation, batch, group, caches, builder);
+            await processBatchAsync(cancellation, batch, group, builder);
         }
 
         await builder.WaitForCompletionAsync().ConfigureAwait(false);
@@ -95,21 +112,12 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             throw new AggregateException(exceptions);
         }
 
-        // Composite projections defer compaction until every stage has run so a downstream
-        // stage can read the upstream stage's in-flight entities without them being evicted
-        // out from under it. CompositeExecution calls CompactCachesAsync after all stages
-        // complete. See JasperFx/marten#4329.
-        if (range.BatchBehavior != BatchBehavior.Composite)
-        {
-            try
-            {
-                foreach (var cache in caches) cache.CompactIfNecessary();
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, "Error trying to compact aggregate caches for {ProjectionName}", Projection.Name);
-            }
-        }
+        // #4730: for standalone (Individual) batches, both cache population and compaction are
+        // deferred to ApplyPendingCacheUpdates, which the execution calls only after the batch
+        // commits. Composite member batches populated the cache during build above and defer
+        // compaction until every stage has run (CompositeExecution calls CompactCachesAsync after
+        // all stages complete) so a downstream stage can read the upstream stage's in-flight
+        // entities without them being evicted out from under it. See JasperFx/marten#4329.
 
         await Projection.EndBatchAsync();
 
@@ -133,12 +141,66 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         return Task.CompletedTask;
     }
 
+    // #4730: flush the cache mutations built up during the just-committed batch. Only called by the
+    // execution AFTER the batch commits, so the cache reflects committed state only — a failed or
+    // retried build never reaches here and its mutations are discarded at the next BuildBatchAsync.
+    // (No-op for composite member batches, which wrote the cache during build and left this empty.)
+    public void ApplyPendingCacheUpdates()
+    {
+        while (_pendingCacheUpdates.TryDequeue(out var update))
+        {
+            if (update.Remove)
+            {
+                update.Cache.TryRemove(update.Id);
+            }
+            else
+            {
+                update.Cache.Store(update.Id, update.Snapshot!);
+            }
+        }
+
+        try
+        {
+            foreach (var pair in _caches.Enumerate())
+            {
+                pair.Value.CompactIfNecessary();
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error trying to compact aggregate caches for {ProjectionName}", Projection.Name);
+        }
+    }
+
+    private void storeInCache(IAggregateCache<TId, TDoc> cache, TId id, TDoc snapshot)
+    {
+        if (_populateCacheImmediately)
+        {
+            cache.Store(id, snapshot);
+        }
+        else
+        {
+            _pendingCacheUpdates.Enqueue((cache, id, snapshot, false));
+        }
+    }
+
+    private void removeFromCache(IAggregateCache<TId, TDoc> cache, TId id)
+    {
+        if (_populateCacheImmediately)
+        {
+            cache.TryRemove(id);
+        }
+        else
+        {
+            _pendingCacheUpdates.Enqueue((cache, id, default, true));
+        }
+    }
+
     private async Task processBatchAsync(CancellationToken cancellation, IProjectionBatch<TOperations, TQuerySession> batch, SliceGroup<TDoc, TId> group,
-        List<IAggregateCache<TId, TDoc>> caches, Block<EventSliceExecution> builder)
+        Block<EventSliceExecution> builder)
     {
         var operations = batch.SessionForTenant(group.TenantId);
         var cache = CacheFor(group.TenantId);
-        caches.Add(cache);
 
         var needToBeFetched = new List<EventSlice<TDoc, TId>>();
         var storage = await operations.FetchProjectionStorageAsync<TDoc, TId>(group.TenantId, cancellation);
@@ -243,28 +305,30 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             await processPossibleSideEffects(batch, operations, slice).ConfigureAwait(false);
         }
 
+        // #4730: cache mutations route through storeInCache/removeFromCache so that for standalone
+        // (Individual) batches they are deferred until ApplyPendingCacheUpdates runs after commit.
         switch (action)
         {
             case ActionType.Delete:
-                cache.TryRemove(slice.Id);
+                removeFromCache(cache, slice.Id);
                 storage.Delete(slice.Id);
                 break;
             case ActionType.Store:
-                cache.Store(slice.Id, snapshot!);
+                storeInCache(cache, slice.Id, snapshot!);
                 storage.StoreProjection(snapshot!, lastEvent, Projection.Scope);
                 break;
             case ActionType.HardDelete:
-                cache.TryRemove(slice.Id);
+                removeFromCache(cache, slice.Id);
                 storage.HardDelete(snapshot!);
                 break;
             case ActionType.UnDeleteAndStore:
                 storage.UnDelete(snapshot!);
-                cache.Store(slice.Id, snapshot!);
+                storeInCache(cache, slice.Id, snapshot!);
                 storage.StoreProjection(snapshot!, lastEvent, Projection.Scope);
                 break;
             case ActionType.StoreThenSoftDelete:
                 storage.StoreProjection(snapshot!, lastEvent, Projection.Scope);
-                cache.TryRemove(slice.Id);
+                removeFromCache(cache, slice.Id);
                 storage.Delete(slice.Id);
                 break;
         }

--- a/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
+++ b/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
@@ -226,6 +226,11 @@ public class GroupedProjectionExecution : ISubscriptionExecution
             // probably deserves a full circuit break
             await batch.ExecuteAsync(_cancellation.Token).ConfigureAwait(false);
 
+            // #4730: the batch committed, so it is now safe to publish this build's aggregate-cache
+            // mutations. A build/commit that failed never reaches here, so its mutations are
+            // discarded and a retry rebuilds from committed state instead of double-applying.
+            _runner.ApplyPendingCacheUpdates();
+
             await range.Agent.MarkSuccessAsync(range.SequenceCeiling);
 
             if (Mode == ShardExecutionMode.Continuous)

--- a/src/JasperFx.Events/Daemon/IGroupedProjectionRunner.cs
+++ b/src/JasperFx.Events/Daemon/IGroupedProjectionRunner.cs
@@ -27,4 +27,13 @@ public interface IGroupedProjectionRunner : IAsyncDisposable
     /// can read in-flight upstream entities without losing them to mid-batch eviction.
     /// </summary>
     Task CompactCachesAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Apply the aggregate-cache mutations produced by the most recent batch build now that the
+    /// batch has successfully committed. Caching is "populate on commit": a build that throws or a
+    /// batch that fails to commit must NOT leave mutated aggregates in the cache, otherwise a
+    /// retry/skip rebuild would re-apply events on top of an already-updated cached aggregate
+    /// (see marten#4730). No-op for runners that don't keep a cache.
+    /// </summary>
+    void ApplyPendingCacheUpdates() { }
 }

--- a/src/JasperFx.Events/Projections/AsyncOptions.cs
+++ b/src/JasperFx.Events/Projections/AsyncOptions.cs
@@ -49,12 +49,14 @@ public class AsyncOptions
 
     /// <summary>
     /// The maximum number of aggregates that will be cached per tenant in a 2nd level,
-    /// most recently used cache during async projection. Defaults to 1000 to give most
-    /// projections a meaningful cache for typical batch working sets and improve async
-    /// projection throughput. Increase for rebuild-heavy/cache-friendly workloads; set to
-    /// 0 to disable the aggregate cache entirely (e.g. memory-constrained processes).
+    /// most recently used cache during async projection. Defaults to 0 (the aggregate cache
+    /// is disabled) so async projection behavior matches re-fetching committed state from the
+    /// database on every batch. Set to a positive number to opt into the cache for
+    /// cache-friendly/rebuild-heavy workloads; with the cache on, entries are only populated
+    /// after the owning batch commits, so a failed/retried batch cannot double-apply
+    /// (see marten#4730).
     /// </summary>
-    public int CacheLimitPerTenant { get; set; } = 1000;
+    public int CacheLimitPerTenant { get; set; } = 0;
 
     /// <summary>
     ///     Add explicit teardown rule to delete all documents of type T


### PR DESCRIPTION
Fixes the root cause of [JasperFx/marten#4730](https://github.com/JasperFx/marten/issues/4730).

## Problem

An async aggregate projection double-applies a control stream's event when **another** stream in the same page throws during apply (e.g. an out-of-order Update-before-Create). Confirmed reproduction: the control stream's value comes out **2×** expected. Worked in Marten 9.6, broke in 9.7.

## Root cause — the aggregate cache is not transactional

`AsyncOptions.CacheLimitPerTenant` was switched **on by default** in 2.9.0 (#422: `0` → `1000`). `AggregationRunner.ApplyChangesAsync` writes the mutated aggregate into the in-memory cache (`cache.Store`) **during batch build — before the batch commits**. `processBatchAsync` reads it back via `cache.TryFind` instead of re-fetching committed state.

When a build fails and is retried/skipped — `GroupedProjectionExecution.buildBatchWithSkipping` skips the poison event (the out-of-order `ApplyEventException`) and **rebuilds the range** — the rebuild finds the already-mutated aggregate in the cache and applies the slice's events **again**. The cache is owned by the runner, not the batch, so discarding the failed batch doesn't clear it. Pre-2.9.0 the cache was off, so every build re-fetched committed state and retries were idempotent.

## Fix

1. **Default off** — `CacheLimitPerTenant` defaults back to `0`. Caching is opt-in again.
2. **Populate on commit** — for standalone (`Individual`) batches the runner now buffers cache mutations and applies them only **after** `batch.ExecuteAsync` succeeds (`ApplyPendingCacheUpdates`). A failed build/commit leaves the cache untouched and the buffer is dropped at the next build, so a retry rebuilds from committed state. Composite member batches keep writing the cache during build (`BatchBehavior.Composite`) because downstream stages read upstream in-flight aggregates within the same batch (#4329).

## Validation

- `AsyncOptionsTests` updated to assert disabled-by-default.
- Full `EventTests` suite green (381).
- **End-to-end against Marten's daemon** (issue's exact repro, run via a local package build): **fails** on current behavior; **passes** with the cache off (default) **and** with the cache explicitly enabled (`CacheLimitPerTenant = 1000`) — proving populate-on-commit, not just the default flip. A broader DaemonTests slice (composites + rebuilds, 41 tests) stays green.

A Marten-side regression test (`Bug_4730`) + the package bump will follow once this is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)