### PR TITLE
feat: carry composite stage number + parent name on ShardName

### DIFF
--- a/src/EventTests/ShardNameTests.cs
+++ b/src/EventTests/ShardNameTests.cs
@@ -147,4 +147,31 @@ public class ShardNameTests
         scoped.Identity.ShouldBe("Foo:All:tenant1");
         scoped.ForTenant(null).TenantId.ShouldBeNull();
     }
+
+    [Fact]
+    public void composite_stage_metadata_is_null_by_default()
+    {
+        var name = ShardName.Compose("Member", "All");
+        name.StageNumber.ShouldBeNull();
+        name.CompositeParentName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void for_composite_stage_attaches_metadata_without_touching_identity()
+    {
+        var name = ShardName.Compose("Member", "All", version: 2);
+        var identityBefore = name.Identity;
+        var urlBefore = name.RelativeUrl;
+
+        var tagged = name.ForCompositeStage(3, "OrderComposite");
+
+        // Fluent: returns the same instance.
+        tagged.ShouldBeSameAs(name);
+        tagged.StageNumber.ShouldBe((uint)3);
+        tagged.CompositeParentName.ShouldBe("OrderComposite");
+
+        // Metadata only — the progression-row key (Identity) and URL are unchanged.
+        tagged.Identity.ShouldBe(identityBefore);
+        tagged.RelativeUrl.ShouldBe(urlBefore);
+    }
 }

--- a/src/JasperFx.Events/Projections/Composite/ProjectionStage.cs
+++ b/src/JasperFx.Events/Projections/Composite/ProjectionStage.cs
@@ -40,7 +40,10 @@ public class ProjectionStage<TOperations, TQuerySession>(int order)
             // When the composite is caught up/rebuilt for a single tenant the parent ShardName carries
             // that tenant id; dropping it here (a bare store-global constructor) was the marten#4679
             // root cause -- every per-tenant member wrote the same store-global progression row.
-            var shardName = ShardName.Compose(projection.Name, tenantId: parent.TenantId, version: projection.Version);
+            var shardName = ShardName.Compose(projection.Name, tenantId: parent.TenantId, version: projection.Version)
+                // Tag the member with its composite parent name + stage ordinal so monitors can
+                // group a composite drill-in by stage. Metadata only — Identity is unchanged.
+                .ForCompositeStage((uint)Order, parent.Name);
             return projection.As<ISubscriptionFactory<TOperations, TQuerySession>>()
                 .BuildExecution(store, database, loggerFactory, shardName);
         }).ToArray();
@@ -54,7 +57,10 @@ public class ProjectionStage<TOperations, TQuerySession>(int order)
         {
             // jasperfx#419: see the loggerFactory overload above -- the parent tenant binding must reach
             // every member stage's ShardName so per-tenant progression rows stay distinct.
-            var shardName = ShardName.Compose(projection.Name, tenantId: parent.TenantId, version: projection.Version);
+            var shardName = ShardName.Compose(projection.Name, tenantId: parent.TenantId, version: projection.Version)
+                // Tag the member with its composite parent name + stage ordinal so monitors can
+                // group a composite drill-in by stage. Metadata only — Identity is unchanged.
+                .ForCompositeStage((uint)Order, parent.Name);
             return projection.As<ISubscriptionFactory<TOperations, TQuerySession>>()
                 .BuildExecution(store, database, logger, shardName);
         }).ToArray();

--- a/src/JasperFx.Events/Projections/ShardName.cs
+++ b/src/JasperFx.Events/Projections/ShardName.cs
@@ -9,6 +9,33 @@ public class ShardName
 {
     public const string All = "All";
 
+    /// <summary>
+    ///     When this shard is a member of a composite projection, the 1-based ordinal of the
+    ///     <c>ProjectionStage</c> it runs in (stages run sequentially; members within a stage run
+    ///     in parallel). Null for non-composite shards. Set via <see cref="ForCompositeStage" />
+    ///     when the composite machinery composes each member's shard — metadata only, it does NOT
+    ///     participate in <see cref="Identity" /> so progression-row keys are unchanged.
+    /// </summary>
+    public uint? StageNumber { get; private set; }
+
+    /// <summary>
+    ///     When this shard is a member of a composite projection, the name of the parent composite.
+    ///     Null for non-composite shards. See <see cref="StageNumber" />.
+    /// </summary>
+    public string? CompositeParentName { get; private set; }
+
+    /// <summary>
+    ///     Attach composite-membership metadata (parent composite name + stage ordinal) to this
+    ///     shard. Additive + fluent so it doesn't disturb <see cref="Compose" />/the constructors
+    ///     or <see cref="Identity" />. Returns the same instance for call-site chaining.
+    /// </summary>
+    public ShardName ForCompositeStage(uint stageNumber, string compositeParentName)
+    {
+        StageNumber = stageNumber;
+        CompositeParentName = compositeParentName;
+        return this;
+    }
+
 
     [JsonConstructor]
     public ShardName(string name, string shardKey, uint version, string? tenantId)


### PR DESCRIPTION
## Why

Composite projections run member projections in numbered stages, but a composite member's `ShardName` carried no stage info. A monitor reading `IProjectionDaemon.CurrentAgents()` (CritterWatch) therefore can't group a composite drill-in by stage.

## What

Additive, metadata-only fields on `ShardName`:
- `uint? StageNumber` — 1-based stage ordinal (null for non-composite shards)
- `string? CompositeParentName` — parent composite name (null otherwise)

Set via a fluent `ForCompositeStage(stageNumber, parentName)`. `ProjectionStage.BuildExecution` (both overloads) tags each member shard when composing it — the stage `Order` and parent `ShardName` are already in scope.

## Compatibility

- **`Identity` / `RelativeUrl` are unchanged** — the metadata does not participate in them, so progression-row keys are byte-for-byte identical.
- **Purely additive** — new properties + one method; `Compose`/constructors untouched. Binary-compatible, so Marten/Polecat pick it up via a version float with **no code change**.

## Tests

`ShardNameTests`: metadata is null by default; `ForCompositeStage` attaches the stage + parent and is fluent (same instance) **without changing Identity/RelativeUrl**. Full ShardName suite green on net9 + net10 (25/25).

## Consumer

CritterWatch reads `agent.Name.StageNumber` from `CurrentAgents()` to populate a `ShardStateSnapshot.CompositeStage*` field for a composite drill-in (CritterWatch#365). Needs a JasperFx.Events publish to consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)