### PR TITLE
Fix marten#4729 — propagate composite Mode to member executions so rebuilds suppress side effects

### DIFF
--- a/src/EventTests/Projections/Composite/CompositeProjectionReplayTests.cs
+++ b/src/EventTests/Projections/Composite/CompositeProjectionReplayTests.cs
@@ -143,6 +143,57 @@ public class CompositeProjectionReplayTests
     }
 
     [Fact]
+    public async Task members_inherit_the_composite_mode_so_rebuilds_suppress_side_effects()
+    {
+        // marten#4729: member executions default to ShardExecutionMode.Continuous and are never set by
+        // CompositeReplayExecutor (which only assigns the parent's Mode). The optimized composite rebuild
+        // therefore ran members in Continuous and fired their side effects (RaiseSideEffects ->
+        // PublishMessage/AppendEvent), unlike the classic single-stream rebuild. CompositeExecution must
+        // propagate its Mode down to every member as part of building the batch.
+        var batch = Substitute.For<IProjectionBatch<FakeOperations, FakeSession>>();
+        batch.ExecuteAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        batch.RecordProgress(Arg.Any<EventRange>()).Returns(ValueTask.CompletedTask);
+
+        theStore.StartProjectionBatchAsync(Arg.Any<EventRange>(), Arg.Any<IEventDatabase>(),
+                Arg.Any<ShardExecutionMode>(), Arg.Any<AsyncOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IProjectionBatch<FakeOperations, FakeSession>>(batch));
+        theStore.ErrorHandlingOptions(Arg.Any<ShardExecutionMode>())
+            .Returns(new ErrorHandlingOptions { SkipApplyErrors = false });
+
+        var member1 = buildMemberExecution("Member1");
+        var member2 = buildMemberExecution("Member2");
+        var member3 = buildMemberExecution("Member3");
+
+        var stages = new[]
+        {
+            new ExecutionStage([member1, member2]),
+            new ExecutionStage([member3])
+        };
+
+        var execution = new CompositeExecution<FakeOperations, FakeSession>(
+            new ShardName("Composite", ShardName.All, 0), new AsyncOptions(), theStore, theDatabase,
+            Substitute.For<IJasperFxProjection<FakeOperations>>(), NullLogger.Instance, stages)
+        {
+            Mode = ShardExecutionMode.Rebuild
+        };
+
+        var agent = Substitute.For<ISubscriptionAgent>();
+        agent.Metrics.Returns(Substitute.For<ISubscriptionMetrics>());
+
+        var range = new EventRange(agent, 0, 5)
+        {
+            Events = "ab".ToLetterEventsWithWrapper().ToList()
+        };
+
+        await execution.ProcessRangeAsync(range);
+
+        // Every member ran in the composite's mode, so AggregationRunner suppresses side effects in a rebuild
+        member1.Mode.ShouldBe(ShardExecutionMode.Rebuild);
+        member2.Mode.ShouldBe(ShardExecutionMode.Rebuild);
+        member3.Mode.ShouldBe(ShardExecutionMode.Rebuild);
+    }
+
+    [Fact]
     public void member_stages_inherit_a_store_global_parent_binding()
     {
         // jasperfx#419: with no tenant on the parent composite shard, member stages stay store-global,

--- a/src/JasperFx.Events/Projections/Composite/CompositeExecution.cs
+++ b/src/JasperFx.Events/Projections/Composite/CompositeExecution.cs
@@ -45,6 +45,17 @@ public class CompositeExecution<TOperations, TQuerySession> : ProjectionExecutio
 
             foreach (var stage in _inners)
             {
+                // marten#4729: member executions default to ShardExecutionMode.Continuous and are never
+                // touched by CompositeReplayExecutor (which only sets the parent's Mode). Without this the
+                // optimized composite rebuild would run members in Continuous and fire their side effects
+                // (RaiseSideEffects -> PublishMessage/AppendEvent), unlike the classic single-stream rebuild.
+                // Propagating the composite's Mode keeps members in CatchUp/Rebuild during a rebuild
+                // (side effects suppressed) and in Continuous during genuine continuous operation.
+                foreach (var execution in stage.Executions)
+                {
+                    execution.Mode = Mode;
+                }
+
                 await stage.ExecuteDownstreamAsync(range);
             }
 


### PR DESCRIPTION
## Problem

Fixes JasperFx/marten#4729.

Side effects (`RaiseSideEffects` → `PublishMessage`/`AppendEvent`) fire during the **optimized composite rebuild** but are correctly suppressed in classic single-stream rebuilds. A `CompositeProjectionFor` whose member publishes a message would re-publish it on every rebuild — an asymmetry with the equivalent `SingleStreamProjection`, and the path that triggered the #4727 deadlock.

## Root cause

The side-effect gate in `AggregationRunner.ApplyChangesAsync` is:

```csharp
if (mode == ShardExecutionMode.Continuous)
    await processPossibleSideEffects(batch, operations, slice);
```

`ShardExecutionMode.Continuous` is enum value `0` — the default for any un-set field.

During an optimized composite rebuild:

1. `SubscriptionAgent` builds the replay request with `ShardExecutionMode.CatchUp`.
2. `CompositeReplayExecutor.StartAsync` sets `_execution.Mode = request.Mode` on **only the parent** `CompositeExecution`.
3. Members (`GroupedProjectionExecution`, dispatched via `ExecutionStage.ExecuteDownstreamAsync` → `member.ProcessRangeAsync`) keep their own default `Mode = Continuous` — it was never propagated.
4. `GroupedProjectionExecution.buildBatchAsync` calls `_runner.BuildBatchAsync(range, Mode, …)` with the member's `Continuous`, so `AggregationRunner` fires side effects.

The classic single-stream rebuild has no nesting, so its one execution gets `Mode = Rebuild` directly — pinned by Marten's `side_effects_do_not_happen_in_rebuilds`. Both `CatchUp` and `Rebuild` suppress (the gate is `== Continuous` only), so this fix is symmetric with single-stream first-catch-up behavior.

## Fix

`CompositeExecution.buildBatchWithNoSkippingAsync` — the single shared batch-build entry point for **both** continuous and replay paths — now propagates the composite's `Mode` to every member before dispatching the stage:

```csharp
foreach (var execution in stage.Executions)
{
    execution.Mode = Mode;
}
```

Members run in `CatchUp`/`Rebuild` during a rebuild (side effects suppressed) and in `Continuous` during genuine continuous operation.

## Tests

- New unit test `members_inherit_the_composite_mode_so_rebuilds_suppress_side_effects` in `CompositeProjectionReplayTests` — verified **RED without the fix, GREEN with it**.
- Full composite + optimized-rebuild suite green.

## Follow-up

A Marten-side end-to-end regression test (composite member publishing in `RaiseSideEffects`, asserting publish during continuous run but not during `RebuildProjectionAsync`) will land in a Marten PR once this is published and Marten bumps the JasperFx version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)