### PR TITLE
Fix marten#4729 follow-up — composite downstream fan-out must survive rebuild (set slice.Snapshot in every mode)

### DIFF
--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -298,10 +298,17 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         // See issue JasperFx/marten#4093.
         maybeArchiveStream(storage, slice, ownsStream: slice.Snapshot != null || snapshot != null);
 
+        // Set the resulting aggregate on the slice in EVERY mode. A composite stage fans an
+        // Updated<TDoc> event to its downstream stages via MarkSliceAction, which only emits when
+        // slice.Snapshot is non-null. Gating this on Continuous (as the side effects below are)
+        // meant a composite rebuild/catch-up produced no upstream snapshot, so downstream stages
+        // lost the synthetic Updated<TDoc>/References<T> events and threw NREs. The side effects
+        // themselves (RaiseSideEffects -> raised events / published messages) stay Continuous-only
+        // so a rebuild does not re-emit them. See marten#4729.
+        slice.Snapshot = snapshot;
+
         if (mode == ShardExecutionMode.Continuous)
         {
-            // Need to set the aggregate in case it didn't exist upfront
-            slice.Snapshot = snapshot;
             await processPossibleSideEffects(batch, operations, slice).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
## Problem (regression from #447 / 2.9.12)

#447 made the optimized composite rebuild propagate the composite's `ShardExecutionMode` down to its member executions, so a composite **rebuild** stops re-firing member side effects (marten#4729). That change is correct, but it surfaced a latent coupling that breaks **multi-stage** composites.

In `AggregationRunner.ApplyChangesAsync`:

```csharp
if (mode == ShardExecutionMode.Continuous)
{
    slice.Snapshot = snapshot;                  // ← only set in Continuous
    await processPossibleSideEffects(batch, operations, slice);
}
```

A composite stage fans an `Updated<TDoc>` event to its **downstream** stages via `EventRange.MarkSliceAction`, which only emits when `slice.Snapshot` is non-null. Before #447 the members always ran in `Continuous` (the enum default), so the snapshot was always set and the fan-out worked even while the parent rebuilt. After #447 the members correctly run in `CatchUp`/`Rebuild` — but now `slice.Snapshot` is never set during a composite rebuild/catch-up, so downstream stages lose the synthetic `Updated<TDoc>` / `References<T>` events and throw `NullReferenceException`.

Repro (with 2.9.12): Marten `DaemonTests.Composites.multi_stage_projections` — `end_to_end` and `downstream_lookups_survive_tiny_upstream_cache` fail with an NRE in the downstream `AppointmentDetailsProjection` (null snapshot). Green at 2.9.11, red at 2.9.12.

## Fix

Decouple the snapshot assignment from the side-effect publishing:

```csharp
slice.Snapshot = snapshot;                      // every mode — needed for composite fan-out

if (mode == ShardExecutionMode.Continuous)
{
    await processPossibleSideEffects(batch, operations, slice);
}
```

- Always setting `slice.Snapshot` is safe for standalone projections: `AllRecordedActions()` / `Updates` is consumed only by the composite `ExecutionStage` (and one unit test), never by Marten.
- `processPossibleSideEffects` (raised events + published messages) stays `Continuous`-only, so a rebuild still does not re-emit side effects — marten#4729 stays fixed.

## Verification

- JasperFx `EventTests` composite + `EventRange` unit tests green.
- Built local 2.9.13 packages and ran them against Marten `DaemonTests.Composites` (all 11) + `side_effects_in_aggregations` + the new marten#4729 composite-rebuild regression test — all green. The multi-stage downstream fan-out scenario is an integration-level concern (real DB + synthetic events); Marten's `multi_stage_projections` is the cross-repo regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)