### PR TITLE
Surface HWM timestamp + per-tenant dead letter counts (#449, #450)

### DIFF
--- a/src/EventTests/Daemon/DeadLetterCountDefaultsTests.cs
+++ b/src/EventTests/Daemon/DeadLetterCountDefaultsTests.cs
@@ -59,4 +59,33 @@ public class DeadLetterCountDefaultsTests
         var counts = await theDatabase.FetchDeadLetterCountsAsync();
         counts.ShouldBeEmpty();
     }
+
+    [Fact]
+    public async Task fetch_dead_letter_counts_for_null_tenant_delegates_to_store_global()
+    {
+        // jasperfx#450: the tenant overload with a null tenant is store-global and reuses today's behavior.
+        var counts = await theDatabase.FetchDeadLetterCountsAsync(tenantId: null);
+        counts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task fetch_dead_letter_counts_for_a_tenant_throws_when_not_partitioned()
+    {
+        // jasperfx#450: a non-partitioned store has no per-tenant dead-letter dimension, so the default throws.
+        await Should.ThrowAsync<NotSupportedException>(() => theDatabase.FetchDeadLetterCountsAsync("tenant-1"));
+    }
+
+    [Fact]
+    public void dead_letter_shard_count_tenant_id_defaults_to_null()
+    {
+        // jasperfx#450: null TenantId == store-global / not partitioned, the only behavior before partitioning.
+        new DeadLetterShardCount("Orders", "All", 3).TenantId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void dead_letter_shard_count_carries_tenant_id()
+    {
+        var count = new DeadLetterShardCount("Orders", "All", 3, "tenant-1");
+        count.TenantId.ShouldBe("tenant-1");
+    }
 }

--- a/src/EventTests/Daemon/HighWater/TenantedHighWaterCoordinatorTests.cs
+++ b/src/EventTests/Daemon/HighWater/TenantedHighWaterCoordinatorTests.cs
@@ -12,8 +12,12 @@ namespace EventTests.Daemon.HighWater;
 // downstream against a concrete store (marten#4596).
 public class TenantedHighWaterCoordinatorTests
 {
-    private static HighWaterStatistics stat(string tenantId, long current, long highest)
-        => new() { TenantId = tenantId, CurrentMark = current, HighestSequence = highest, LastMark = current };
+    private static HighWaterStatistics stat(string tenantId, long current, long highest, DateTimeOffset? timestamp = null)
+        => new()
+        {
+            TenantId = tenantId, CurrentMark = current, HighestSequence = highest, LastMark = current,
+            Timestamp = timestamp ?? default
+        };
 
     private static ISubscriptionAgent agentFor(ShardName name)
     {
@@ -96,6 +100,28 @@ public class TenantedHighWaterCoordinatorTests
 
         // The advancing tenant's agent still got its own mark even though another tenant went stale
         agents[2].Received().MarkHighWater(8);
+    }
+
+    [Fact]
+    public async Task poll_and_route_persists_each_tenants_mark_with_its_timestamp()
+    {
+        // jasperfx#449: the per-tenant high-water row must carry the per-tenant timestamp so a monitor
+        // reading AllProjectionProgress gets per-tenant staleness, not a store-global heuristic.
+        var t1At = new DateTimeOffset(2026, 6, 13, 1, 0, 0, TimeSpan.Zero);
+        var t2At = new DateTimeOffset(2026, 6, 13, 2, 0, 0, TimeSpan.Zero);
+
+        var detector = new FakeVectorDetector();
+        detector.Enqueue(new HighWaterVector([stat("t1", 10, 10, t1At), stat("t2", 20, 20, t2At)]));
+
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1", "t2"]);
+
+        await coordinator.PollAndRouteAsync(
+            [agentFor(ShardName.Compose("Orders", "All", "t1")), agentFor(ShardName.Compose("Orders", "All", "t2"))],
+            CancellationToken.None);
+
+        detector.PersistedTenantMarks.ShouldBe(
+            [("t1", 10L, t1At), ("t2", 20L, t2At)], ignoreOrder: true);
     }
 
     [Fact]

--- a/src/EventTests/Daemon/HighWater/VectorizedHighWaterTests.cs
+++ b/src/EventTests/Daemon/HighWater/VectorizedHighWaterTests.cs
@@ -147,8 +147,18 @@ internal class FakeVectorDetector : IHighWaterDetector
     public IReadOnlyCollection<string>? LastPolled { get; private set; }
     public int PollCount { get; private set; }
 
+    // jasperfx#449: per-tenant high-water marks persisted by the coordinator, with the timestamp it carried.
+    public List<(string TenantId, long Sequence, DateTimeOffset Timestamp)> PersistedTenantMarks { get; } = new();
+
     // Represents a partitioned store
     public bool SupportsTenantPartitioning => true;
+
+    public Task MarkHighWaterForTenantAsync(string tenantId, long sequence, DateTimeOffset timestamp,
+        CancellationToken token)
+    {
+        PersistedTenantMarks.Add((tenantId, sequence, timestamp));
+        return Task.CompletedTask;
+    }
 
     public void Enqueue(HighWaterVector vector) => _queued.Enqueue(vector);
     public void EnqueueFactory(Func<IReadOnlyCollection<string>, HighWaterVector> factory) => _factory = factory;

--- a/src/EventTests/Daemon/ShardStateTrackerTests.cs
+++ b/src/EventTests/Daemon/ShardStateTrackerTests.cs
@@ -94,6 +94,52 @@ public class ShardStateTrackerTests : IDisposable
     }
 
     [Fact]
+    public async Task mark_high_water_stamps_last_advanced_timestamp()
+    {
+        // jasperfx#449: the published HighWaterMark ShardState must carry "when the mark last advanced"
+        // so a monitor can compute seconds-since-advance server-side instead of a reconnect-resetting heuristic.
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        var advancedAt = new DateTimeOffset(2026, 6, 13, 1, 2, 3, TimeSpan.Zero);
+        await theTracker.MarkHighWaterAsync(1500, advancedAt);
+
+        await theTracker.Complete();
+
+        var state = observer.States.Last();
+        state.ShardName.ShouldBe("HighWaterMark");
+        state.Sequence.ShouldBe(1500);
+        state.LastAdvanced.ShouldBe(advancedAt);
+    }
+
+    [Fact]
+    public async Task mark_high_water_without_timestamp_leaves_last_advanced_null()
+    {
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        await theTracker.MarkHighWaterAsync(1500);
+
+        await theTracker.Complete();
+
+        observer.States.Last().LastAdvanced.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task mark_skipping_stamps_last_advanced_timestamp()
+    {
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        var advancedAt = new DateTimeOffset(2026, 6, 13, 4, 5, 6, TimeSpan.Zero);
+        await theTracker.MarkSkippingAsync(1000, 1100, advancedAt);
+
+        await theTracker.Complete();
+
+        observer.States.Last().LastAdvanced.ShouldBe(advancedAt);
+    }
+
+    [Fact]
     public void default_state_action_is_update()
     {
         new ShardState("foo", 22L)

--- a/src/JasperFx.Events/Daemon/DeadLetterShardCount.cs
+++ b/src/JasperFx.Events/Daemon/DeadLetterShardCount.cs
@@ -6,9 +6,15 @@ namespace JasperFx.Events.Daemon;
 ///     A count of stored projection/subscription dead letter events for a single shard.
 ///     <see cref="ProjectionName" /> aligns with <see cref="ShardName.Name" /> and
 ///     <see cref="ShardKey" /> aligns with <see cref="ShardName.ShardKey" />, matching how
-///     <see cref="DeadLetterEvent" /> records them. See jasperfx#356.
+///     <see cref="DeadLetterEvent" /> records them. Under <c>UseTenantPartitionedEvents</c> the same
+///     shard accumulates dead letters per tenant, so <see cref="TenantId" /> separates the counts that
+///     would otherwise collide on <c>{ProjectionName}:{ShardKey}</c>. See jasperfx#356, jasperfx#450.
 /// </summary>
 /// <param name="ProjectionName">The projection name (<see cref="ShardName.Name" />).</param>
 /// <param name="ShardKey">The shard key within the projection (<see cref="ShardName.ShardKey" />).</param>
 /// <param name="Count">The number of stored dead letter events for this shard.</param>
-public record DeadLetterShardCount(string ProjectionName, string ShardKey, long Count);
+/// <param name="TenantId">
+///     The tenant partition this count belongs to, or null for a store-global / non-partitioned count
+///     (the only behavior before per-tenant partitioning). See jasperfx#450.
+/// </param>
+public record DeadLetterShardCount(string ProjectionName, string ShardKey, long Count, string? TenantId = null);

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
@@ -60,7 +60,10 @@ public class HighWaterAgent: IDisposable
         _current = await _detector.Detect(_token).ConfigureAwait(false);
 
         await _tracker.PublishAsync(
-            new ShardState(ShardState.HighWaterMark, _current.CurrentMark) { Action = ShardAction.Started });
+            new ShardState(ShardState.HighWaterMark, _current.CurrentMark)
+            {
+                Action = ShardAction.Started, LastAdvanced = lastAdvancedFrom(_current)
+            });
 
         _loop = Task.Factory.StartNew(detectChanges, _token,
             TaskCreationOptions.LongRunning | TaskCreationOptions.AttachedToParent, TaskScheduler.Default);
@@ -85,7 +88,7 @@ public class HighWaterAgent: IDisposable
             if (_current == null || next.CurrentMark > _current.CurrentMark)
             {
                 _current = next;
-                await _tracker.MarkHighWaterAsync(_current.CurrentMark);
+                await _tracker.MarkHighWaterAsync(_current.CurrentMark, lastAdvancedFrom(_current));
             }
         }
         catch (Exception e)
@@ -172,7 +175,7 @@ public class HighWaterAgent: IDisposable
 
                     if (statistics.IncludesSkipping)
                     {
-                        await _tracker.MarkSkippingAsync(lastKnown, statistics.CurrentMark);
+                        await _tracker.MarkSkippingAsync(lastKnown, statistics.CurrentMark, lastAdvancedFrom(statistics));
                     }
                     
                     _skipping.Add(1);
@@ -226,10 +229,16 @@ public class HighWaterAgent: IDisposable
 
         _current = statistics;
 
-        await _tracker.MarkHighWaterAsync(statistics.CurrentMark);
+        await _tracker.MarkHighWaterAsync(statistics.CurrentMark, lastAdvancedFrom(statistics));
 
         await _daemonWakeup.WaitAsync(delayTime, _token).ConfigureAwait(false);
     }
+
+    // Surface "when the current mark was observed" (jasperfx#449) so a monitor can compute
+    // seconds-since-advance server-side. A default(DateTimeOffset) means the detector didn't
+    // supply a timestamp, so publish null rather than a misleading 0001-01-01.
+    private static DateTimeOffset? lastAdvancedFrom(HighWaterStatistics statistics)
+        => statistics.Timestamp == default ? null : statistics.Timestamp;
 
     private void TimerOnElapsed(object? sender, ElapsedEventArgs e)
     {
@@ -272,7 +281,7 @@ public class HighWaterAgent: IDisposable
         // Get out of here if you're at the initial, empty state
         if (initialHighMark == 1 && statistics.CurrentMark == 0)
         {
-            await _tracker.MarkHighWaterAsync(statistics.CurrentMark);
+            await _tracker.MarkHighWaterAsync(statistics.CurrentMark, lastAdvancedFrom(statistics));
             return;
         }
 
@@ -282,7 +291,7 @@ public class HighWaterAgent: IDisposable
             statistics = await _detector.DetectInSafeZone(_token).ConfigureAwait(false);
         }
 
-        await _tracker.MarkHighWaterAsync(statistics.CurrentMark);
+        await _tracker.MarkHighWaterAsync(statistics.CurrentMark, lastAdvancedFrom(statistics));
     }
 
     public async Task StopAsync()

--- a/src/JasperFx.Events/Daemon/HighWater/IHighWaterDetector.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/IHighWaterDetector.cs
@@ -50,4 +50,17 @@ public interface IHighWaterDetector
     /// Partitioned stores override this to write a per-tenant high-water row keyed on the tenant.
     /// </summary>
     Task MarkHighWaterForTenantAsync(string tenantId, long sequence, CancellationToken token) => Task.CompletedTask;
+
+    /// <summary>
+    /// Persist a per-tenant high-water mark together with the timestamp at which that mark was observed
+    /// (jasperfx#449), so a monitor reading <c>AllProjectionProgress</c> can compute per-tenant
+    /// "seconds since the high water mark last advanced" authoritatively under
+    /// <c>UseTenantPartitionedEvents</c>. The default implementation delegates to the timestamp-less
+    /// <see cref="MarkHighWaterForTenantAsync(string,long,CancellationToken)" />, so a store that only
+    /// overrode the original overload keeps persisting marks exactly as before; partitioned stores
+    /// override this to also write the per-tenant timestamp onto the progression row.
+    /// </summary>
+    Task MarkHighWaterForTenantAsync(string tenantId, long sequence, DateTimeOffset timestamp,
+        CancellationToken token)
+        => MarkHighWaterForTenantAsync(tenantId, sequence, token);
 }

--- a/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
@@ -72,13 +72,15 @@ public class TenantedHighWaterCoordinator
 
             // marten#4717: persist a durable per-tenant high-water row so each tenant's mark survives
             // a daemon restart (the store-global HighWaterMark row cannot represent multiple tenants).
-            // No-op for detectors that don't override the write.
+            // jasperfx#449: carry the per-tenant timestamp through so the persisted row exposes
+            // per-tenant staleness. No-op for detectors that don't override the write.
             if (reading.TenantId != null && reading.Statistics.CurrentMark > 0)
             {
                 try
                 {
                     await _detector
-                        .MarkHighWaterForTenantAsync(reading.TenantId, reading.Statistics.CurrentMark, token)
+                        .MarkHighWaterForTenantAsync(reading.TenantId, reading.Statistics.CurrentMark,
+                            reading.Statistics.Timestamp, token)
                         .ConfigureAwait(false);
                 }
                 catch (Exception e)

--- a/src/JasperFx.Events/Daemon/ShardStateTracker.cs
+++ b/src/JasperFx.Events/Daemon/ShardStateTracker.cs
@@ -79,17 +79,34 @@ public class ShardStateTracker: IObservable<ShardState>, IObserver<ShardState>, 
 
     public ValueTask MarkHighWaterAsync(long sequence)
     {
-        return PublishAsync(new ShardState(ShardState.HighWaterMark, sequence));
+        return MarkHighWaterAsync(sequence, null);
     }
-    
-    public ValueTask MarkSkippingAsync(long lastKnownGoodHighWaterMark, long newHighWaterMark)
+
+    /// <summary>
+    /// Publish a new high water mark and stamp the moment that mark was observed so a daemon
+    /// consumer / ShardState reader can compute "seconds since the high water mark last advanced"
+    /// authoritatively, rather than falling back to a client-side heuristic that resets on reconnect.
+    /// A null <paramref name="lastAdvanced" /> leaves <see cref="ShardState.LastAdvanced" /> unset
+    /// (the pre-jasperfx#449 behavior). See jasperfx#449.
+    /// </summary>
+    public ValueTask MarkHighWaterAsync(long sequence, DateTimeOffset? lastAdvanced)
+    {
+        return PublishAsync(new ShardState(ShardState.HighWaterMark, sequence)
+        {
+            LastAdvanced = lastAdvanced
+        });
+    }
+
+    public ValueTask MarkSkippingAsync(long lastKnownGoodHighWaterMark, long newHighWaterMark,
+        DateTimeOffset? lastAdvanced = null)
     {
         var skipped = newHighWaterMark - lastKnownGoodHighWaterMark;
         return PublishAsync(new ShardState(ShardState.HighWaterMark, newHighWaterMark)
         {
             PreviousGoodMark = lastKnownGoodHighWaterMark,
             Action = ShardAction.Skipped,
-            SkippedEventsCount = skipped > 0 ? skipped : null
+            SkippedEventsCount = skipped > 0 ? skipped : null,
+            LastAdvanced = lastAdvanced
         });
     }
 

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -117,4 +117,22 @@ public interface IEventDatabase
     /// <param name="token"></param>
     Task<IReadOnlyList<DeadLetterShardCount>> FetchDeadLetterCountsAsync(CancellationToken token = default)
         => Task.FromResult<IReadOnlyList<DeadLetterShardCount>>([]);
+
+    /// <summary>
+    ///     Fetch the stored dead letter event counts for a single tenant partition, one row per shard.
+    ///     A null <paramref name="tenantId" /> is store-global and delegates to the tenant-less overload
+    ///     (today's behavior). Under <c>UseTenantPartitionedEvents</c> the same shard accumulates dead
+    ///     letters per tenant; event stores that implement per-tenant partitioning override this to group
+    ///     by tenant and stamp <see cref="DeadLetterShardCount.TenantId" /> so a consumer keying by
+    ///     <c>{ProjectionName}:{ShardKey}</c> no longer collapses the counts across tenants. The default
+    ///     throws for a non-null tenant. See jasperfx#450.
+    /// </summary>
+    /// <param name="tenantId">Tenant partition to scope counts to. Null means store-global.</param>
+    /// <param name="token"></param>
+    Task<IReadOnlyList<DeadLetterShardCount>> FetchDeadLetterCountsAsync(string? tenantId,
+        CancellationToken token = default)
+        => tenantId == null
+            ? FetchDeadLetterCountsAsync(token)
+            : throw new NotSupportedException(
+                "Per-tenant FetchDeadLetterCountsAsync is not implemented on this IEventDatabase. Use an event store that implements per-tenant partitioning.");
 }


### PR DESCRIPTION
Implements jasperfx#449 and jasperfx#450 in a single PR. Both are additive, non-breaking default-interface changes; the Marten/Polecat store sides are filed separately.

## #449 — Surface the high-water timestamp on the published `ShardState`

A monitor (CritterWatch) wants a server-authoritative "the high water mark hasn't advanced in N seconds" signal, but the published `ShardState(HighWaterMark, …)` carried no timestamp, forcing a client-side heuristic that resets on every reconnect.

- `ShardStateTracker` gains `MarkHighWaterAsync(long sequence, DateTimeOffset? lastAdvanced)` and a `lastAdvanced` argument on `MarkSkippingAsync`, stamping `ShardState.LastAdvanced` (the same field projection shards already use).
- `HighWaterAgent` threads the detector's `HighWaterStatistics.Timestamp` ("when the current mark was observed") through every publish — `StartAsync`, the initial detect, `markProgressAsync`, the skip path, and `CheckNowAsync`. A `default(DateTimeOffset)` (detector supplied none) publishes `null` rather than a misleading `0001-01-01`.
- **Per-tenant (`UseTenantPartitionedEvents`):** `IHighWaterDetector` gains a timestamp-carrying `MarkHighWaterForTenantAsync(tenantId, sequence, timestamp, token)` overload that defaults to delegating to the existing one (so a store overriding only the original keeps persisting marks). `TenantedHighWaterCoordinator` now passes the per-tenant reading's timestamp so partitioned stores can expose per-tenant staleness via `AllProjectionProgress`.

## #450 — Per-tenant dead-letter counts

Under partitioning the same shard accumulates dead letters per tenant, so a consumer keying by `{ProjectionName}:{ShardKey}` collapses the counts across tenants.

- Added `string? TenantId` to `DeadLetterShardCount` (null = store-global / not partitioned).
- Added a tenant-scoped `FetchDeadLetterCountsAsync(string? tenantId, CancellationToken)` overload on `IEventDatabase`, mirroring the existing `AllProjectionProgress(string? tenantId, …)` pattern — null delegates to today's store-global behavior, non-null throws `NotSupportedException` on non-partitioned stores.

## Tests

Added focused unit coverage: timestamp stamping on `MarkHighWaterAsync`/`MarkSkippingAsync`, per-tenant timestamp persistence in `TenantedHighWaterCoordinator`, and the new `DeadLetterShardCount.TenantId` + tenant `FetchDeadLetterCountsAsync` defaults. 29 targeted tests pass.

Consumers: CritterWatch#375 (HWM staleness) and CritterWatch#381/#371 (per-tenant dead letters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)