### PR TITLE
feat(events): broaden HandlerRelationshipDescriptor with publisher kind/origin (2.11.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.10.0</JasperFxVersion>
+        <JasperFxVersion>2.11.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/EventModeling/HandlerRelationshipDescriptorTests.cs
+++ b/src/EventTests/EventModeling/HandlerRelationshipDescriptorTests.cs
@@ -59,9 +59,103 @@ public class HandlerRelationshipDescriptorTests
         descriptor.EmittedEvents.ShouldBeEmpty();
     }
 
+    [Fact]
+    public void kind_defaults_to_handler_and_origin_is_null()
+    {
+        // The historical positional-constructor shape must keep meaning
+        // "a handler triggered by MessageType" so existing emitted manifests
+        // round-trip unchanged after the 2.11 broadening.
+        var descriptor = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            new[] { PlacedEvent },
+            Aggregate);
+
+        descriptor.Kind.ShouldBe(PublisherKind.Handler);
+        descriptor.Origin.ShouldBeNull();
+    }
+
+    [Fact]
+    public void handler_is_the_default_enum_member()
+    {
+        // Handler must be the zero value so default-initialized / deserialized
+        // descriptors land on the historical behavior.
+        ((int)PublisherKind.Handler).ShouldBe(0);
+    }
+
+    [Fact]
+    public void can_describe_an_http_endpoint_publisher()
+    {
+        var descriptor = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            new[] { PlacedEvent },
+            TargetAggregate: null)
+        {
+            Kind = PublisherKind.HttpEndpoint,
+            Origin = new PublisherOrigin
+            {
+                HttpRoute = "/orders/{id}",
+                HttpMethod = "POST",
+                Label = "POST /orders/{id}"
+            }
+        };
+
+        descriptor.Kind.ShouldBe(PublisherKind.HttpEndpoint);
+        descriptor.Origin.ShouldNotBeNull();
+        descriptor.Origin!.HttpRoute.ShouldBe("/orders/{id}");
+        descriptor.Origin.HttpMethod.ShouldBe("POST");
+        descriptor.Origin.Label.ShouldBe("POST /orders/{id}");
+        // The positional inputs are still intact alongside the new metadata.
+        descriptor.HandlerType.ShouldBe(Handler);
+        descriptor.EmittedEvents.Single().ShouldBe(PlacedEvent);
+    }
+
+    [Fact]
+    public void can_describe_a_projection_side_effect_publisher()
+    {
+        var projection = TypeDescriptor.For(typeof(OrderProjection));
+
+        var descriptor = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            new[] { ShippedEvent },
+            TargetAggregate: null)
+        {
+            Kind = PublisherKind.ProjectionSideEffect,
+            Origin = new PublisherOrigin { ProjectionType = projection }
+        };
+
+        descriptor.Kind.ShouldBe(PublisherKind.ProjectionSideEffect);
+        descriptor.Origin!.ProjectionType.ShouldBe(projection);
+    }
+
+    [Fact]
+    public void with_expression_preserves_new_metadata()
+    {
+        // record `with` copies must carry Kind/Origin so consumers that
+        // rewrite a descriptor don't silently drop the publisher classification.
+        var original = new HandlerRelationshipDescriptor(
+            Handler,
+            Command,
+            new[] { PlacedEvent },
+            Aggregate)
+        {
+            Kind = PublisherKind.DirectBusCall,
+            Origin = new PublisherOrigin { Label = "IMessageBus.PublishAsync" }
+        };
+
+        var copy = original with { TargetAggregate = null };
+
+        copy.Kind.ShouldBe(PublisherKind.DirectBusCall);
+        copy.Origin!.Label.ShouldBe("IMessageBus.PublishAsync");
+        copy.TargetAggregate.ShouldBeNull();
+    }
+
     private record Order;
     private record PlaceOrder;
     private record OrderPlaced;
     private record OrderShipped;
     private record PlaceOrderHandler;
+    private record OrderProjection;
 }

--- a/src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs
@@ -37,4 +37,28 @@ public sealed record HandlerRelationshipDescriptor(
     TypeDescriptor HandlerType,
     TypeDescriptor MessageType,
     IReadOnlyList<TypeDescriptor> EmittedEvents,
-    TypeDescriptor? TargetAggregate);
+    TypeDescriptor? TargetAggregate)
+{
+    /// <summary>
+    /// How the emitting code is triggered. Defaults to <see cref="PublisherKind.Handler"/>
+    /// — the historical behavior where the trigger is the incoming <see cref="MessageType"/>.
+    /// Non-<c>Handler</c> kinds (HTTP/gRPC endpoints, projection side-effects, scheduled work)
+    /// carry their trigger detail in <see cref="Origin"/>.
+    /// </summary>
+    /// <remarks>
+    /// Added in JasperFx 2.11 as an additive <c>init</c> property so existing precompiled
+    /// callers that use the positional constructor keep working unchanged
+    /// (the descriptor remains binary-compatible). Lets the CritterWatch event-model
+    /// graph distinguish a message-driven handler from a route-driven endpoint or a
+    /// projection side-effect that publishes without an inbound message.
+    /// </remarks>
+    public PublisherKind Kind { get; init; } = PublisherKind.Handler;
+
+    /// <summary>
+    /// Polymorphic trigger origin for non-message publishers — the HTTP route + verb,
+    /// gRPC service + method, or projection that initiates the emission. Null when
+    /// <see cref="Kind"/> is <see cref="PublisherKind.Handler"/>, in which case the
+    /// trigger is the <see cref="MessageType"/>.
+    /// </summary>
+    public PublisherOrigin? Origin { get; init; }
+}

--- a/src/JasperFx.Events/EventModeling/PublisherKind.cs
+++ b/src/JasperFx.Events/EventModeling/PublisherKind.cs
@@ -1,0 +1,40 @@
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Classifies how a <see cref="HandlerRelationshipDescriptor"/>'s emitting code is
+/// triggered, so the CritterWatch event-model graph can lane and label publishers
+/// that don't fit the classic "handler reacts to an inbound message" shape.
+/// </summary>
+/// <remarks>
+/// Added in JasperFx 2.11. Default-valued (<see cref="Handler"/> is <c>0</c>) so the
+/// historical positional-constructor descriptors deserialize/round-trip unchanged.
+/// </remarks>
+public enum PublisherKind
+{
+    /// <summary>
+    /// Reacts to an incoming message — the trigger is the descriptor's
+    /// <c>MessageType</c>. The historical, default behavior.
+    /// </summary>
+    Handler,
+
+    /// <summary>An HTTP endpoint (e.g. Wolverine.Http route). Trigger detail lives in the origin's route + verb.</summary>
+    HttpEndpoint,
+
+    /// <summary>A gRPC service method. Trigger detail lives in the origin's service + method.</summary>
+    GrpcEndpoint,
+
+    /// <summary>
+    /// An explicit, non-cascading bus call (<c>IMessageBus</c> / <c>IMessageContext</c>
+    /// publish or send) that originates a message outside a handler-return cascade.
+    /// </summary>
+    DirectBusCall,
+
+    /// <summary>A projection side-effect that publishes messages while applying events (e.g. <c>RaiseSideEffects</c>).</summary>
+    ProjectionSideEffect,
+
+    /// <summary>A scheduled or recurring trigger with no inbound message.</summary>
+    Scheduled,
+
+    /// <summary>An external or otherwise unclassified trigger.</summary>
+    External
+}

--- a/src/JasperFx.Events/EventModeling/PublisherOrigin.cs
+++ b/src/JasperFx.Events/EventModeling/PublisherOrigin.cs
@@ -1,0 +1,46 @@
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Polymorphic trigger origin for a <see cref="HandlerRelationshipDescriptor"/> whose
+/// <see cref="HandlerRelationshipDescriptor.Kind"/> is not
+/// <see cref="PublisherKind.Handler"/> — i.e. publishers initiated by something other
+/// than an inbound message (an HTTP route, a gRPC method, a projection side-effect,
+/// or scheduled work).
+/// </summary>
+/// <remarks>
+/// Modeled as a single flat record with optional, kind-specific fields rather than a
+/// type hierarchy so it round-trips cleanly through both the source generator's emitted
+/// C# literals and the JSON wire to the CritterWatch SPA without polymorphic-serialization
+/// ceremony. Only the fields relevant to the owning descriptor's
+/// <see cref="PublisherKind"/> are populated; the rest stay null. Added in JasperFx 2.11.
+/// </remarks>
+public sealed record PublisherOrigin
+{
+    /// <summary>The HTTP route template (e.g. <c>/orders/{id}</c>) for <see cref="PublisherKind.HttpEndpoint"/>.</summary>
+    public string? HttpRoute { get; init; }
+
+    /// <summary>The HTTP verb (e.g. <c>POST</c>) for <see cref="PublisherKind.HttpEndpoint"/>.</summary>
+    public string? HttpMethod { get; init; }
+
+    /// <summary>The gRPC service name for <see cref="PublisherKind.GrpcEndpoint"/>.</summary>
+    public string? GrpcService { get; init; }
+
+    /// <summary>The gRPC method name for <see cref="PublisherKind.GrpcEndpoint"/>.</summary>
+    public string? GrpcMethod { get; init; }
+
+    /// <summary>
+    /// The projection CLR type that raises the side-effect for
+    /// <see cref="PublisherKind.ProjectionSideEffect"/>.
+    /// </summary>
+    public TypeDescriptor? ProjectionType { get; init; }
+
+    /// <summary>
+    /// A human-friendly label for the trigger when no structured field fits
+    /// (e.g. a cron expression for <see cref="PublisherKind.Scheduled"/> or a free-form
+    /// description for <see cref="PublisherKind.External"/>). Optional even for the kinds
+    /// above, where it can carry a pre-rendered display string like <c>"POST /orders"</c>.
+    /// </summary>
+    public string? Label { get; init; }
+}


### PR DESCRIPTION
## What

Additive, **binary-compatible** broadening of `HandlerRelationshipDescriptor` (the event-model diagnostic descriptor the CritterWatch source generator emits and the swim-lane consumes) — CritterWatch#396 Phase 1.

- **`PublisherKind`** enum — `Handler` (default, `= 0`), `HttpEndpoint`, `GrpcEndpoint`, `DirectBusCall`, `ProjectionSideEffect`, `Scheduled`, `External`.
- **`PublisherOrigin`** record — polymorphic trigger detail for non-message publishers (HTTP route+verb, gRPC service+method, projection type, free-form label). Flat record (not a hierarchy) so it round-trips cleanly through both source-gen C# literals and the JSON wire.
- `HandlerRelationshipDescriptor` gains `Kind`/`Origin` as **`init` body properties, not positional params** — the positional constructor signature is unchanged, so precompiled callers (Marten / Polecat / Wolverine) need **no rebuild**. `Kind` defaults to `Handler`, so existing emitted manifests round-trip unchanged.

## Why init-props, not positional params

JasperFx.Events 2.10.0's `DeadLetterShardCount` positional-record param addition was binary-breaking (`MissingMethodException` from precompiled callers), forcing Marten/Polecat rebuilds. This change deliberately stays additive to avoid that.

## Version

`JasperFxVersion` 2.10.0 → 2.11.0 (JasperFx, JasperFx.Events, both source-generator packages). `JasperFx.RuntimeCompiler` stays pinned at 5.0.0.

## Tests

`HandlerRelationshipDescriptorTests` extended: Kind defaults to Handler / Origin null, `Handler == 0`, HTTP-endpoint + projection-side-effect descriptors, and `with`-expression metadata preservation. 8/8 green on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)