### PR TITLE
JasperFx.Events: dead-letter row drill-in + per-tenant daemon parity (CritterWatch)

### DIFF
--- a/src/JasperFx.Events/Daemon/DeadLetterEvent.cs
+++ b/src/JasperFx.Events/Daemon/DeadLetterEvent.cs
@@ -19,6 +19,7 @@ public class DeadLetterEvent
         ExceptionMessage = ex.Message;
 
         EventSequence = e.Sequence;
+        TenantId = e.TenantId;
 
         ExceptionType = ex.InnerException?.GetType()!.NameInCode()!;
     }
@@ -30,6 +31,16 @@ public class DeadLetterEvent
     public string ExceptionMessage { get; set; }
     public string ExceptionType { get; set; }
     public long EventSequence { get; set; }
+
+    /// <summary>
+    /// The tenant of the failing event (jasperfx#450 / CritterWatch#381). Under
+    /// <c>UseTenantPartitionedEvents</c> the same projection shard accumulates dead letters per
+    /// tenant; this records which tenant each dead letter belongs to so per-tenant counts don't
+    /// collide on <c>{ProjectionName}:{ShardName}</c>. A plain data column — the dead-letter table
+    /// stays store-global / <c>TenancyStyle.Single</c> (it is not a tenant boundary). On a
+    /// non-partitioned store this is simply the failing event's default tenant id.
+    /// </summary>
+    public string? TenantId { get; set; }
 
     public override string ToString()
     {

--- a/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
@@ -153,6 +153,23 @@ public interface IProjectionDaemon: IDisposable
     Task StopAgentAsync(ShardName shardName, Exception? ex = null);
 
     /// <summary>
+    ///     Pauses (hard-stops) the running shard(s) of a single projection for a single tenant
+    ///     partition, leaving every other tenant's shard running. A null <paramref name="tenantId" />
+    ///     pauses the projection store-globally (all of its shards). Daemons that implement per-tenant
+    ///     event partitioning override this; the default throws for a non-null tenant. Resume with
+    ///     <see cref="StartAgentAsync(ShardName, CancellationToken)" /> or <see cref="StartAllAsync" />.
+    ///     Unlike <see cref="StopAgentAsync(ShardName, Exception)" />, the caller does not need to know
+    ///     the exact shard identity (shard key / version) — the shards are matched by projection name and
+    ///     tenant. See CritterWatch#303.
+    /// </summary>
+    Task PauseShardAsync(string projectionName, string? tenantId, CancellationToken token)
+        => tenantId == null
+            ? throw new NotImplementedException(
+                "Store-global PauseShardAsync is not implemented on this IProjectionDaemon.")
+            : throw new NotSupportedException(
+                "Per-tenant PauseShardAsync is not implemented on this IProjectionDaemon. Use an event store that implements per-tenant partitioning.");
+
+    /// <summary>
     ///     Starts all known projections shards
     /// </summary>
     /// <returns></returns>

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -690,18 +690,82 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     public Task RebuildProjectionAsync(string projectionName, string? tenantId, TimeSpan shardTimeout,
         CancellationToken token)
     {
-        if (tenantId == null)
+        if (tenantId != null)
         {
-            return RebuildProjectionAsync(projectionName, shardTimeout, token);
+            if (_projections.TryFindProjection(projectionName, out var perTenantSource))
+            {
+                return rebuildProjectionForTenant(perTenantSource, tenantId, shardTimeout, token);
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(projectionName),
+                $"No registered projection matches the name '{projectionName}'. Available names are {_projections.AllProjectionNames().Join(", ")}");
         }
 
-        if (_projections.TryFindProjection(projectionName, out var source))
+        // CritterWatch#303 / #371: store-global rebuild (null tenant). Under per-tenant event
+        // partitioning the store-global mt_events_sequence is stale, so the plain store-global rebuild
+        // gates on Tracker.HighWaterMark==0 and aborts — it would visit NO tenant's shard. Fan out and
+        // rebuild every registered tenant's shard instead, exactly as CatchUpAsync does. Non-partitioned
+        // stores (no ICrossTenantRebuildSource / no tenant high-water) fall through to the unchanged
+        // store-global rebuild, so single-tenant behavior is byte-for-byte.
+        if (_tenantHighWater != null && Database is ICrossTenantRebuildSource crossTenantSource
+            && _projections.TryFindProjection(projectionName, out var source))
         {
-            return rebuildProjectionForTenant(source, tenantId, shardTimeout, token);
+            return rebuildProjectionAllTenants(crossTenantSource, source, shardTimeout, token);
         }
 
-        throw new ArgumentOutOfRangeException(nameof(projectionName),
-            $"No registered projection matches the name '{projectionName}'. Available names are {_projections.AllProjectionNames().Join(", ")}");
+        return RebuildProjectionAsync(projectionName, shardTimeout, token);
+    }
+
+    // CritterWatch#303 / #371: visit EVERY registered tenant's shard for a store-global rebuild under
+    // partitioning, reusing the per-tenant rebuild that scopes teardown + ceiling to (shard, tenant).
+    // Tenant enumeration mirrors catchUpPerTenantAsync. With no tenants registered yet, fall back to the
+    // store-global rebuild (a no-op when the high-water is 0).
+    private async Task rebuildProjectionAllTenants(
+        ICrossTenantRebuildSource crossTenantSource,
+        IProjectionSource<TOperations, TQuerySession> source,
+        TimeSpan shardTimeout,
+        CancellationToken token)
+    {
+        var tenants = await crossTenantSource
+            .FindRebuildTenantsAsync(source.Name, token).ConfigureAwait(false);
+
+        if (tenants.Count == 0)
+        {
+            await RebuildProjectionAsync(source.Name, shardTimeout, token).ConfigureAwait(false);
+            return;
+        }
+
+        foreach (var tenantId in tenants)
+        {
+            if (token.IsCancellationRequested) return;
+            await rebuildProjectionForTenant(source, tenantId, shardTimeout, token).ConfigureAwait(false);
+        }
+    }
+
+    // CritterWatch#303: per-tenant (or store-global) shard pause. A null tenant stops every shard of the
+    // projection; a non-null tenant stops only that tenant's shard(s). The running agents are matched by
+    // (projection name [, tenant]) — exactly the filter the per-tenant rebuild uses — so the caller never
+    // has to reconstruct the shard identity/version. Each match is routed through StopAgentAsync, which
+    // stops, drains, and REMOVES the agent from the running set (so CurrentAgents()/StatusFor reflect the
+    // pause immediately), unlike the rebuild-internal hard-stop that leaves the agent in place for the
+    // rebuild to replace. Resume via StartAllAsync.
+    public async Task PauseShardAsync(string projectionName, string? tenantId, CancellationToken token)
+    {
+        if (!_projections.TryFindProjection(projectionName, out _))
+        {
+            throw new ArgumentOutOfRangeException(nameof(projectionName),
+                $"No registered projection matches the name '{projectionName}'. Available names are {_projections.AllProjectionNames().Join(", ")}");
+        }
+
+        var targets = CurrentAgents()
+            .Where(x => x.Name.Name == projectionName && (tenantId == null || x.Name.TenantId == tenantId))
+            .Select(x => x.Name.Identity)
+            .ToArray();
+
+        foreach (var identity in targets)
+        {
+            await StopAgentAsync(identity).ConfigureAwait(false);
+        }
     }
 
     private async Task rebuildProjection(IProjectionSource<TOperations, TQuerySession> source, TimeSpan shardTimeout, CancellationToken token)

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -108,6 +108,25 @@ public interface IEventDatabase
         => Task.FromResult(0L);
 
     /// <summary>
+    ///     Fetch the stored dead letter event rows for a single projection/subscription shard — the
+    ///     drill-in companion to <see cref="CountDeadLetterEventsAsync" />. Returns the most recent
+    ///     failures first (by event sequence), paged via <paramref name="offset" /> /
+    ///     <paramref name="limit" />. A null <paramref name="tenantId" /> spans every tenant sharing the
+    ///     database; under <c>UseTenantPartitionedEvents</c> pass a tenant to scope to one partition (the
+    ///     dead-letter table stays store-global but each row records the failing event's tenant).
+    ///     The default implementation returns an empty list as a stand-in; event stores that persist
+    ///     dead letters should override this. See CritterWatch#369.
+    /// </summary>
+    /// <param name="shard">The projection/subscription shard whose dead-letter rows to fetch.</param>
+    /// <param name="tenantId">Tenant partition to scope to. Null spans the whole database.</param>
+    /// <param name="offset">Number of rows to skip (paging).</param>
+    /// <param name="limit">Maximum number of rows to return (paging).</param>
+    /// <param name="token"></param>
+    Task<IReadOnlyList<DeadLetterEvent>> QueryDeadLetterEventsAsync(ShardName shard, string? tenantId,
+        int offset, int limit, CancellationToken token = default)
+        => Task.FromResult<IReadOnlyList<DeadLetterEvent>>([]);
+
+    /// <summary>
     ///     Fetch the stored dead letter event counts for this database, one row per shard
     ///     (<see cref="DeadLetterShardCount.ProjectionName" /> + <see cref="DeadLetterShardCount.ShardKey" />).
     ///     Mirrors the "give me every row" shape of <see cref="AllProjectionProgress(CancellationToken)" />.


### PR DESCRIPTION
Three additive JasperFx.Events changes that came out of CritterWatch's Polecat/SQL Server + per-tenant work. All are additive (default interface methods / new optional surface); no behavior change for existing consumers. Marten + Polecat implement the new `IEventDatabase` method downstream.

### 1. `DeadLetterEvent.TenantId` (follow-up to #450)
#451 surfaced per-tenant dead-letter *counts* (`DeadLetterShardCount.TenantId` + the tenant-aware `FetchDeadLetterCountsAsync`). This captures the failing event's `TenantId` on the `DeadLetterEvent` record itself so the per-tenant fetch (and the new row query below) can filter on it. The table stays store-global; the column is plain data.

### 2. Tenant-aware `PauseShardAsync` + store-global rebuild fan-out (CritterWatch#303)
- `IProjectionDaemon.PauseShardAsync(projectionName, tenantId, ct)` — pauses only the named tenant's shard(s) (null tenant = the whole projection), matching agents by `(Name[, TenantId])` and routing each through `StopAgentAsync` (stop + drain + remove), so `CurrentAgents()`/`StatusFor` reflect the pause immediately. Default interface method throws on stores without per-tenant partitioning.
- Null-tenant `RebuildProjectionAsync` now fans out across every registered tenant under per-tenant partitioning — the store-global `mt_events_sequence` is stale in that mode, so the plain store-global rebuild gates on `HighWaterMark == 0` and would visit no tenant's shard. Gated on `ICrossTenantRebuildSource` + the tenant high-water (mirrors `CatchUpAsync`), so non-partitioned stores are byte-for-byte unchanged.

### 3. `IEventDatabase.QueryDeadLetterEventsAsync` — dead-letter row drill-in (CritterWatch#369)
The companion to `CountDeadLetterEventsAsync`: fetch the actual dead-letter event rows for a shard (id, sequence, exception type/message, timestamp, tenant), most-recent-first, paged, optionally scoped to one tenant. Default interface method returns empty so stores without dead-letter persistence are unaffected.

Verified end-to-end via CritterWatch's Marten + Polecat tests + the Marten `per_tenant_rebuild_isolation` / `daemon_in_depth_under_partitioning` suites (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)