### PR TITLE
docs: document the partial requirement for source-generated projection dispatch

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -113,7 +113,9 @@ JasperFx.Events.SourceGenerator; there is no runtime fallback.
 Two escape hatches if the generated dispatcher is not what you want:
 
 1. **Override the evolver directly.** Implementing `Evolve` / `EvolveAsync` / `DetermineAction` / `DetermineActionAsync` bypasses the generated dispatcher — no `partial` required.
-2. **Verify the generator actually ran.** It ships inside the Marten and Polecat NuGet packages, so confirm the project reference does not exclude the `analyzers` asset, then do a clean build. See [Publishing AOT with JasperFx](./codegen/aot.md) for the troubleshooting entry.
+2. **Confirm the generator ran.** It is delivered as a Roslyn analyzer and must run in the assembly that *defines the aggregate type*; make sure that reference does not strip the `analyzers` asset, then do a clean build.
+
+**How the analyzer reaches your build is product-specific** — each product's own migration guide carries the consumer-facing detail, and they do not deliver it identically. Marten ships `JasperFx.Events.SourceGenerator` inside the `Marten` NuGet package, so a plain `Marten` reference is enough; Marten's migration guide documents the full consumer story — the _No runtime reflection fallback_ admonition, the `public`-method requirement, and the exact `InvalidProjectionException` site — at [martendb.io/migration-guide.html#inline-lambda-projection-removal](https://martendb.io/migration-guide.html#inline-lambda-projection-removal). Other consumers may deliver the generator through a different package (or require an explicit analyzer reference) — consult that product's guide. The cross-stack AOT walkthrough is [Publishing AOT with JasperFx](./codegen/aot.md).
 
 #### `UnknownTenantIdException.TenantId` exposed as a property
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -77,6 +77,44 @@ public Task ApplyAsync(TOperations operations,
 
 [#220](https://github.com/JasperFx/jasperfx/issues/220). The enum (`Inline` / `Async`) is canonical in `JasperFx.Events.Projections` now; pre-2.0 each consuming product carried its own copy. If your code references `Polecat.Projections.SnapshotLifecycle` or `Marten.Events.Projections.SnapshotLifecycle` (the product-side aliases), update to `JasperFx.Events.Projections.SnapshotLifecycle`. The product-side wrappers are aliased for transitional source-compat where possible.
 
+> `ProjectionLifecycle` (the `Inline` / `Async` / `Live` enum passed to `Projections.Add<T>(...)`) moved to the same `JasperFx.Events.Projections` namespace for the same reason. `using JasperFx.Events.Projections;` covers both.
+
+#### Convention-based projection subclasses must be declared `partial`
+
+Conventional `Apply` / `Create` / `ShouldDelete` methods on a **projection subclass** — one that derives from `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, or `EventProjection` — are now dispatched by the compile-time `JasperFx.Events.SourceGenerator`. Pre-2.0 they were dispatched by runtime reflection; **in 2.0 there is no runtime reflection fallback.** For the generator to emit its `[GeneratedEvolver]` dispatcher, the projection class must be declared `partial`, and its convention methods must be `public`.
+
+```csharp
+// before (JasperFx.Events 1.x) — reflection dispatched the conventional methods
+public class TripProjection : SingleStreamProjection<Trip, Guid>
+{
+    public Trip Create(IEvent<TripStarted> e) => new() { Id = e.StreamId };
+    public void Apply(Travel e, Trip trip) => trip.Traveled += e.TotalDistance();
+}
+
+// after (JasperFx.Events 2.0) — `partial` lets the source generator emit the dispatcher
+public partial class TripProjection : SingleStreamProjection<Trip, Guid>
+{
+    public Trip Create(IEvent<TripStarted> e) => new() { Id = e.StreamId };
+    public void Apply(Travel e, Trip trip) => trip.Traveled += e.TotalDistance();
+}
+```
+
+A non-`partial` subclass with conventional methods fails fast at projection registration (e.g. inside `AddMarten(opts => opts.Projections.Add<TripProjection>(...))`) rather than on first event dispatch:
+
+```
+JasperFx.Events.Projections.InvalidProjectionException:
+No source-generated dispatcher found for TripProjection. Conventional
+Apply/Create/ShouldDelete methods are dispatched by the compile-time
+JasperFx.Events.SourceGenerator; there is no runtime fallback.
+```
+
+**Self-aggregating snapshot types do _not_ need `partial`.** A type that carries its own `Apply`/`Create` methods and is registered via `Snapshot<T>` (or the single-arg `SingleStreamProjection<T>` / `AggregateStream<T>` self-aggregation forms) is handled without a projection subclass and needs no `partial` keyword.
+
+Two escape hatches if the generated dispatcher is not what you want:
+
+1. **Override the evolver directly.** Implementing `Evolve` / `EvolveAsync` / `DetermineAction` / `DetermineActionAsync` bypasses the generated dispatcher — no `partial` required.
+2. **Verify the generator actually ran.** It ships inside the Marten and Polecat NuGet packages, so confirm the project reference does not exclude the `analyzers` asset, then do a clean build. See [Publishing AOT with JasperFx](./codegen/aot.md) for the troubleshooting entry.
+
 #### `UnknownTenantIdException.TenantId` exposed as a property
 
 [#224](https://github.com/JasperFx/jasperfx/issues/224) / [#240](https://github.com/JasperFx/jasperfx/pull/240). The exception now carries a public read-only `TenantId` property so consumers can `catch (UnknownTenantIdException ex) { ex.TenantId }` without parsing the message string. The single-argument constructor signature is unchanged; the new property is populated automatically. Purely additive — no caller-side migration needed unless you were custom-deriving from the type.


### PR DESCRIPTION
## What

Adds a migration-guide subsection documenting that **convention-based projection subclasses must be declared `partial`** in the 2.0 wave — their `Apply`/`Create`/`ShouldDelete` dispatch is now source-generated (`JasperFx.Events.SourceGenerator`) with **no runtime reflection fallback**. The `partial`/`public` requirement and the fail-fast both live at the JasperFx.Events layer (`JasperFxAggregationProjectionBase.AssembleAndAssertValidity` → `InvalidProjectionException`), so the foundation guide is the right home for the foundation-level statement.

## Relationship to the product docs (already covered downstream)

Marten's migration guide already documents the **consumer-facing** detail thoroughly — the `No runtime reflection fallback` admonition, the `public`-method requirement, the subclass-vs-self-aggregating distinction, and the exact `InvalidProjectionException` at `DocumentStore.For(...)`:
https://martendb.io/migration-guide.html#inline-lambda-projection-removal

This PR is deliberately **not** a duplicate of that. It states the requirement at the JasperFx layer (where the generator and the fail-fast actually live) and **cross-links to Marten's guide** for the consumer specifics, so the stack reads coherently top-down.

## Scope: encountered with Marten; Polecat not asserted

This surfaced building a first projection on **Marten 9** (via `WolverineFx.Http.Marten` 6.8.0) — `partial` was the sole fix; the generator was already present transitively because Marten ships `JasperFx.Events.SourceGenerator` inside the `Marten` package ([marten#4557](https://github.com/JasperFx/marten/issues/4557)).

I deliberately did **not** assert Marten/Polecat parity. A look at Polecat 4.2.1 shows the delivery story differs: its main `Polecat` package ships its own `Polecat.CodeGeneration` analyzer, and `JasperFx.Events.SourceGenerator` is referenced only in Polecat's *own* test/smoke projects — so a Polecat consumer's experience (which package delivers the generator, the registration entry point) is **not verified here**. The doc states the foundation requirement universally but points to **each product's own migration guide** for delivery specifics rather than describing how Polecat behaves. Flagging for a Polecat maintainer to confirm/extend.

## What's in it

- New "Convention-based projection subclasses must be declared `partial`" subsection: before/after example, the verbatim `InvalidProjectionException`, the self-aggregating-snapshot exception (no `partial` needed), the two escape hatches, and a product-neutral "how the analyzer reaches your build is product-specific" note that cross-links Marten.
- A one-line note that `ProjectionLifecycle` (alongside the already-documented `SnapshotLifecycle`) moved to `JasperFx.Events.Projections`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
