### PR TITLE
Add Profile.ResourceMigrationFailureMode (opt-in: don't crash startup on resource/migration failure)

### DIFF
--- a/docs/configuration/jasperfx-options.md
+++ b/docs/configuration/jasperfx-options.md
@@ -33,6 +33,42 @@ public static void ConfigureOptions(IServiceCollection services)
 | `RequiredFiles` | `string[]` | `[]` | Files that must exist at startup |
 | `RememberedApplicationAssembly` | `Assembly?` | `null` | Override the detected application assembly |
 
+## Profiles
+
+Settings that should differ between development and production live on a `Profile`. `JasperFxOptions`
+exposes a `Development` and a `Production` profile, and selects one as the `ActiveProfile` at startup
+based on the hosting environment (`Development` when `IHostEnvironment.IsDevelopment()`, otherwise
+`Production`).
+
+```csharp
+services.AddJasperFx(opts =>
+{
+    // Fail fast locally so developers see migration problems immediately (this is the default)
+    opts.Development.ResourceMigrationFailureMode = ResourceMigrationFailureMode.FailFast;
+
+    // In production, don't let a transient startup migration failure crash the process
+    opts.Production.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+});
+```
+
+### ResourceMigrationFailureMode
+
+Controls what happens when a resource (database schema/migration, message broker objects, etc.) fails to
+set up or migrate during application startup through the resource setup hosted service
+(`AddResourceSetupOnStartup`, or `ApplyAllDatabaseChangesOnStartup` in the Critter Stack tools).
+
+| Value | Behavior |
+|-------|----------|
+| `FailFast` (default) | A startup resource/migration failure throws and aborts application startup. |
+| `ContinueOnFailures` | Startup resource/migration failures are logged but do not stop the application from starting. |
+
+`ContinueOnFailures` is intended for production multi-replica deployments. During a rolling deploy,
+several replicas can race for the migration advisory lock; a replica that loses the race would otherwise
+fail with "Unable to attain a global lock in time order to apply database changes" and crash-loop, even
+though the winning replica's committed migration has already made the schema current. With
+`ContinueOnFailures` that replica logs the failure and starts up against the now-current schema instead
+of crash-looping.
+
 ## RequireFile
 
 Tell JasperFx that a file path is required. This adds a file-exists check to environment tests:

--- a/src/CommandLineTests/Resources/ResourceMigrationFailureModeTests.cs
+++ b/src/CommandLineTests/Resources/ResourceMigrationFailureModeTests.cs
@@ -1,0 +1,58 @@
+using JasperFx;
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Environment;
+using JasperFx.Resources;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using Xunit;
+
+namespace CommandLineTests.Resources;
+
+public class ResourceMigrationFailureModeTests
+{
+    // A system part whose resource discovery always fails — the simplest way to force the
+    // ResourceSetupHostService to collect a startup exception.
+    private sealed class ThrowingSystemPart : ISystemPart
+    {
+        public string Title => "throwing";
+        public Uri SubjectUri { get; } = new("system://throwing");
+        public Task WriteToConsole() => Task.CompletedTask;
+        public ValueTask<IReadOnlyList<IStatefulResource>> FindResources() =>
+            throw new InvalidOperationException("boom");
+        public Task AssertEnvironmentAsync(IServiceProvider services, EnvironmentCheckResults results,
+            CancellationToken token) => Task.CompletedTask;
+    }
+
+    private static ResourceSetupHostService BuildService(params JasperFxOptions[] options) =>
+        new(new ResourceSetupOptions(), new ISystemPart[] { new ThrowingSystemPart() },
+            NullLogger<ResourceSetupHostService>.Instance, Array.Empty<IResourceCreator>(), options);
+
+    [Fact]
+    public async Task fail_fast_is_the_default_and_aborts_startup()
+    {
+        var service = BuildService(new JasperFxOptions());
+
+        await Should.ThrowAsync<AggregateException>(() => service.StartAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task continue_on_failures_lets_startup_proceed()
+    {
+        var options = new JasperFxOptions();
+        // ActiveProfile defaults to the Development profile (it is the same object reference).
+        options.Development.ResourceMigrationFailureMode = ResourceMigrationFailureMode.ContinueOnFailures;
+
+        var service = BuildService(options);
+
+        // Must NOT throw — the failure is logged and startup proceeds.
+        await service.StartAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task falls_back_to_fail_fast_when_no_jasperfx_options_registered()
+    {
+        var service = BuildService(); // no JasperFxOptions resolved
+
+        await Should.ThrowAsync<AggregateException>(() => service.StartAsync(CancellationToken.None));
+    }
+}

--- a/src/JasperFx/Profile.cs
+++ b/src/JasperFx/Profile.cs
@@ -23,6 +23,15 @@ public class Profile
     public AutoCreate ResourceAutoCreate { get; set; } = AutoCreate.CreateOrUpdate;
 
     /// <summary>
+    ///     Controls whether a resource setup or migration failure during application startup (via the
+    ///     resource setup hosted service) aborts startup. Defaults to <see cref="JasperFx.ResourceMigrationFailureMode.FailFast"/>.
+    ///     Set to <see cref="JasperFx.ResourceMigrationFailureMode.ContinueOnFailures"/> — typically only on the
+    ///     <c>Production</c> profile — so that, e.g., a replica that loses the migration lock during a
+    ///     rolling deploy logs the failure and continues starting up rather than crash-looping.
+    /// </summary>
+    public ResourceMigrationFailureMode ResourceMigrationFailureMode { get; set; } = ResourceMigrationFailureMode.FailFast;
+
+    /// <summary>
     /// Add an assertion at bootstrapping time to assert that all expected pre-generated
     /// types from code generation already exist in the application assembly. Default is false.
     /// </summary>

--- a/src/JasperFx/ResourceMigrationFailureMode.cs
+++ b/src/JasperFx/ResourceMigrationFailureMode.cs
@@ -1,0 +1,24 @@
+namespace JasperFx;
+
+/// <summary>
+/// Controls what happens when a resource (database schema / migration, message broker objects, etc.)
+/// fails to set up or migrate during application startup via the resource setup hosted service.
+/// Configured per <see cref="Profile"/> so it can differ between development and production.
+/// </summary>
+public enum ResourceMigrationFailureMode
+{
+    /// <summary>
+    /// A resource setup or migration failure at startup aborts application startup by throwing.
+    /// This is the default and is usually the right choice for development (fail fast).
+    /// </summary>
+    FailFast,
+
+    /// <summary>
+    /// Resource setup or migration failures at startup are logged but do NOT prevent the application
+    /// from starting. Useful in production multi-replica deployments where, for example, a replica that
+    /// loses the migration lock during a rolling deploy would otherwise crash-loop even though the
+    /// winning replica's committed migration makes the schema current. The application starts and
+    /// operates against whatever state is current.
+    /// </summary>
+    ContinueOnFailures
+}

--- a/src/JasperFx/Resources/ResourceSetupHostService.cs
+++ b/src/JasperFx/Resources/ResourceSetupHostService.cs
@@ -15,13 +15,21 @@ public class ResourceSetupHostService : IHostedService
     private readonly IResourceCreator[] _creators;
     private readonly ResourceSetupOptions _options;
     private readonly ISystemPart[] _parts;
+    private readonly JasperFxOptions? _jasperFxOptions;
 
-    public ResourceSetupHostService(ResourceSetupOptions options, IEnumerable<ISystemPart> parts, ILogger<ResourceSetupHostService> logger, IEnumerable<IResourceCreator> creators)
+    public ResourceSetupHostService(ResourceSetupOptions options, IEnumerable<ISystemPart> parts,
+        ILogger<ResourceSetupHostService> logger, IEnumerable<IResourceCreator> creators,
+        IEnumerable<JasperFxOptions> jasperFxOptions)
     {
         _parts = parts.ToArray();
         _options = options;
         _logger = logger;
         _creators = creators.ToArray();
+
+        // Optional: JasperFxOptions is registered whenever the JasperFx host integration is used (the
+        // normal case). Resolving it via IEnumerable keeps standalone AddResourceSetupOnStartup usage
+        // working even when JasperFxOptions was never registered — in which case we fall back to FailFast.
+        _jasperFxOptions = jasperFxOptions.FirstOrDefault();
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -64,7 +72,22 @@ public class ResourceSetupHostService : IHostedService
 
         if (exceptions.Any())
         {
-            throw new AggregateException(exceptions);
+            var aggregate = new AggregateException(exceptions);
+
+            // The active profile may opt to keep the application starting up despite resource/migration
+            // failures (e.g. a replica that loses the migration lock during a rolling deploy). The default
+            // is FailFast, which throws and aborts startup as before.
+            var failureMode = _jasperFxOptions?.ActiveProfile.ResourceMigrationFailureMode
+                              ?? ResourceMigrationFailureMode.FailFast;
+
+            if (failureMode == ResourceMigrationFailureMode.ContinueOnFailures)
+            {
+                _logger.LogError(aggregate,
+                    "One or more resources failed to set up or migrate during startup. Continuing startup anyway because the active profile's ResourceMigrationFailureMode is ContinueOnFailures.");
+                return;
+            }
+
+            throw aggregate;
         }
     }
 


### PR DESCRIPTION
First (foundational) piece of the multi-repo "wait-instead-of-crash" startup behavior requested in [marten#4750](https://github.com/JasperFx/marten/issues/4750). Weasel and Marten changes follow and will consume this.

## What

- New enum `ResourceMigrationFailureMode { FailFast, ContinueOnFailures }`.
- New `Profile.ResourceMigrationFailureMode` property (default `FailFast`), so the behavior can vary between the `Development` and `Production` profiles.
- `ResourceSetupHostService` now reads the **active** profile's mode when resource setup produced failures:
  - `FailFast` (default, **unchanged** behavior): throw the `AggregateException` and abort startup.
  - `ContinueOnFailures`: log the aggregate and let the application start anyway.
- Covers resource/migration failures of **any kind** (database schema, broker objects, etc.), since it gates the generic `ResourceSetupHostService` failure path.
- `JasperFxOptions` is resolved optionally (`IEnumerable<JasperFxOptions>`) so standalone `AddResourceSetupOnStartup` usage without `JasperFxOptions` registered still falls back to `FailFast`.

## Why

Multi-replica rolling deploys: several pods race for the migration advisory lock at startup. The loser fails with *"Unable to attain a global lock in time order to apply database changes"* and crash-loops, even though the winning replica's committed migration already made the schema current. `Production.ResourceMigrationFailureMode = ContinueOnFailures` lets that replica log the failure and start up against the now-current schema.

```csharp
services.AddJasperFx(opts =>
{
    opts.Development.ResourceMigrationFailureMode = ResourceMigrationFailureMode.FailFast;       // default
    opts.Production.ResourceMigrationFailureMode  = ResourceMigrationFailureMode.ContinueOnFailures;
});
```

## Tests

`ResourceMigrationFailureModeTests` — FailFast throws, ContinueOnFailures does not, and the no-`JasperFxOptions` fallback throws. Green on net9.0 + net10.0; `JasperFxOptions`/`Profile`/describe tests unaffected.

## Docs

Added a "Profiles" section to `docs/configuration/jasperfx-options.md` documenting the profile model and `ResourceMigrationFailureMode`.

> Note: the `Documentation PRs` markdownlint check may be red repo-wide right now — the `markdownlint-cli:latest` docker tag has bumped to a stricter ruleset (MD013/MD033/MD060) that the entire existing docs corpus trips. The new docs follow existing house style; happy to fold in a lint-config fix separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)