### PR TITLE
Harden composite atomic-batch invariant (defense-in-depth for marten#4751)

### DIFF
--- a/src/EventTests/Projections/Composite/ExecutionStageTests.cs
+++ b/src/EventTests/Projections/Composite/ExecutionStageTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Projections.Composite;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Projections.Composite;
+
+// #4751: a composite's member stages must record progress and accumulate their read-model writes into
+// the SAME ProjectionBatch as the parent composite, so the members' progression + writes commit
+// atomically together with the composite shard's own progression in a single batch.ExecuteAsync().
+// If a member ever ran against its own batch, the composite shard's progression could commit ahead of
+// the member read models, which is the premature "non-stale" hazard behind #4751. ExecutionStage.
+// ExecuteDownstreamAsync now asserts the shared-batch invariant; this pins it.
+public class ExecutionStageTests
+{
+    [Fact]
+    public async Task members_record_and_process_against_the_shared_composite_batch()
+    {
+        var agent = Substitute.For<ISubscriptionAgent>();
+        var batch = Substitute.For<IProjectionBatch>();
+
+        var parent = new EventRange(ShardName.Compose("Cmp"), 0, 5, agent)
+        {
+            Events = new List<IEvent>(),
+            ActiveBatch = batch
+        };
+
+        var seenBatches = new ConcurrentBag<IProjectionBatch?>();
+
+        ISubscriptionExecution member(string name)
+        {
+            var execution = Substitute.For<ISubscriptionExecution>();
+            execution.ShardName.Returns(ShardName.Compose(name));
+            execution.ProcessRangeAsync(Arg.Any<EventRange>()).Returns(ci =>
+            {
+                seenBatches.Add(ci.Arg<EventRange>().ActiveBatch);
+                return Task.CompletedTask;
+            });
+            return execution;
+        }
+
+        var stage = new ExecutionStage([member("CmpTrip"), member("CmpTripCount")]);
+
+        // Must NOT throw the #4751 shared-batch guard.
+        await stage.ExecuteDownstreamAsync(parent);
+
+        // Every member processed against the SAME composite batch instance, and each recorded its
+        // progress into that batch — so progression and writes are committed together, never split.
+        seenBatches.Count.ShouldBe(2);
+        seenBatches.ShouldAllBe(b => ReferenceEquals(b, batch));
+        await batch.Received(2).RecordProgress(Arg.Any<EventRange>());
+    }
+}

--- a/src/JasperFx.Events/Projections/Composite/ExecutionStage.cs
+++ b/src/JasperFx.Events/Projections/Composite/ExecutionStage.cs
@@ -15,6 +15,21 @@ public record ExecutionStage(ISubscriptionExecution[] Executions)
                 var cloned = range.CloneForExecutionLeaf(execution.ShardName);
                 cloned.BatchBehavior = BatchBehavior.Composite;
 
+                // #4751 guard: a composite member MUST record its progress and accumulate its read-model
+                // writes into the SAME ProjectionBatch as the parent composite, so that the member's
+                // progression and its writes commit atomically together with the composite shard's own
+                // progression in the single batch.ExecuteAsync(). If a future change ever gave a member its
+                // own batch, the composite shard's progression could advance ahead of the member read
+                // models — which is exactly the premature "non-stale" hazard behind #4751. This is an
+                // invariant assertion, not a behavior change: CloneForExecutionLeaf already shares the
+                // parent's ActiveBatch instance.
+                if (!ReferenceEquals(cloned.ActiveBatch, range.ActiveBatch))
+                {
+                    throw new InvalidOperationException(
+                        $"Composite member '{execution.ShardName.Identity}' is not writing into the shared composite batch; " +
+                        "its progression could commit ahead of its read-model writes (#4751).");
+                }
+
                 // Need to record the individual progress even though it's locked together
                 await cloned.ActiveBatch!.RecordProgress(cloned);
 


### PR DESCRIPTION
Defense-in-depth companion for [JasperFx/marten#4751](https://github.com/JasperFx/marten/issues/4751). The Marten-side fix (per-tenant `WaitForNonStaleData`, marten#4764) already resolves the reported symptom; this guarantees the underlying invariant at the JasperFx layer so it can't silently regress.

## Background

A composite projection's member stages record progress **and** accumulate their read-model writes into the **same** `ProjectionBatch` as the parent composite (`ExecutionStage.ExecuteDownstreamAsync` → `cloned.ActiveBatch!.RecordProgress(...)` + `execution.ProcessRangeAsync(...)`, where `CloneForExecutionLeaf` shares the parent's `ActiveBatch`). So every member's progression + writes commit atomically with the composite shard's own progression in the single `batch.ExecuteAsync()`. That atomicity is exactly what lets a non-stale wait keyed on the composite shard's per-tenant progression be backed by committed member read models.

## Change

Add an explicit invariant guard in `ExecutionStage.ExecuteDownstreamAsync`:

```csharp
if (!ReferenceEquals(cloned.ActiveBatch, range.ActiveBatch))
{
    throw new InvalidOperationException(... "(#4751)");
}
```

This is an **assertion, not a behavior change** — `CloneForExecutionLeaf` already shares the instance, so it's always true today. If a future refactor ever gave a member its own batch, the composite progression could commit ahead of the member read models (the #4751 premature-"non-stale" hazard); this fails fast instead of producing a subtle staleness bug.

## Tests

`ExecutionStageTests` pins the shared-batch behavior (members process + record progress against the same `ProjectionBatch` instance). Green on net9.0 + net10.0; existing composite tests unaffected. Also verified end-to-end via a local pack consumed by a Marten branch running the marten#4751 repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)