### PR TITLE
projections rebuild skips subscriptions + Live projections (1.0 backport, marten#4718)

### DIFF
--- a/src/EventTests/CommandLine/ProjectionSelectionTests.cs
+++ b/src/EventTests/CommandLine/ProjectionSelectionTests.cs
@@ -1,0 +1,71 @@
+using JasperFx.Events;
+using JasperFx.Events.CommandLine;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+// marten#4718 backport: `projections rebuild` must skip event subscriptions and
+// Live-lifecycle projections so a registered subscription's name never reaches
+// RebuildProjectionAsync -> TryFindProjection (which only searches projections
+// and throws "No registered projection matches the name '...'").
+public class ProjectionSelectionTests
+{
+    private static SubscriptionDescriptor Descriptor(string name, SubscriptionType type, ProjectionLifecycle lifecycle)
+        => new(type) { Name = name, Lifecycle = lifecycle };
+
+    private static ProjectionSelection SelectionWith(params SubscriptionDescriptor[] descriptors)
+    {
+        var selection = new ProjectionSelection(new EventStoreUsage(new Uri("marten://main"), new object()));
+        selection.Subscriptions.AddRange(descriptors);
+        return selection;
+    }
+
+    [Fact]
+    public void rebuildable_excludes_event_subscriptions()
+    {
+        var selection = SelectionWith(
+            Descriptor("RealProjection", SubscriptionType.SingleStreamProjection, ProjectionLifecycle.Async),
+            Descriptor("DriverSupportTeamEvents", SubscriptionType.Subscription, ProjectionLifecycle.Async));
+
+        var names = selection.RebuildableSubscriptions().Select(x => x.Name).ToArray();
+
+        names.ShouldBe(new[] { "RealProjection" });
+    }
+
+    [Fact]
+    public void rebuildable_excludes_live_projections()
+    {
+        var selection = SelectionWith(
+            Descriptor("AsyncProjection", SubscriptionType.MultiStreamProjection, ProjectionLifecycle.Async),
+            Descriptor("LiveProjection", SubscriptionType.SingleStreamProjection, ProjectionLifecycle.Live));
+
+        var names = selection.RebuildableSubscriptions().Select(x => x.Name).ToArray();
+
+        names.ShouldBe(new[] { "AsyncProjection" });
+    }
+
+    [Fact]
+    public void rebuildable_keeps_async_and_inline_projections_including_composites()
+    {
+        var selection = SelectionWith(
+            Descriptor("Async", SubscriptionType.SingleStreamProjection, ProjectionLifecycle.Async),
+            Descriptor("Inline", SubscriptionType.EventProjection, ProjectionLifecycle.Inline),
+            Descriptor("Composite", SubscriptionType.CompositeProjection, ProjectionLifecycle.Async));
+
+        var names = selection.RebuildableSubscriptions().Select(x => x.Name).ToArray();
+
+        names.ShouldBe(new[] { "Async", "Inline", "Composite" });
+    }
+
+    [Fact]
+    public void rebuildable_is_empty_when_only_a_subscription_is_registered()
+    {
+        // A subscription name passed explicitly to rebuild becomes a clean no-op.
+        var selection = SelectionWith(
+            Descriptor("OnlySubscription", SubscriptionType.Subscription, ProjectionLifecycle.Async));
+
+        selection.RebuildableSubscriptions().ShouldBeEmpty();
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionController.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionController.cs
@@ -82,7 +82,11 @@ public class ProjectionController
 
             try
             {
-                var subscriptionNames = selection.Subscriptions.Select(x => x.Name).ToArray();
+                // marten#4718: skip event subscriptions + Live projections — see
+                // ProjectionSelection.RebuildableSubscriptions. Without this, a
+                // registered subscription's name reaches RebuildProjectionAsync and
+                // throws "No registered projection matches the name '...'".
+                var subscriptionNames = selection.RebuildableSubscriptions().Select(x => x.Name).ToArray();
                 var databaseIdentifier = new EventStoreDatabaseIdentifier(selection.Storage.SubjectUri, database);
                 var status = await _host.TryRebuildShardsAsync(databaseIdentifier, input, subscriptionNames ,shardTimeout).ConfigureAwait(false);
 

--- a/src/JasperFx.Events/CommandLine/ProjectionSelection.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionSelection.cs
@@ -99,4 +99,21 @@ public class ProjectionSelection(EventStoreUsage storage)
 
         return selections.Where(x => x.Subscriptions.Any()).ToArray();
     }
+
+    // marten#4718 backport of the 9.x/2.x fix (jasperfx#438 / marten#4711): the
+    // `projections rebuild` path must skip event subscriptions and Live-lifecycle
+    // projections. A subscription (SubscriptionType.Subscription) is Async, so its
+    // name would otherwise be fed to the rebuild path -> RebuildProjectionAsync ->
+    // TryFindProjection, which only searches projections and throws
+    // "No registered projection matches the name '...'". Live projections likewise
+    // can't be rebuilt by the async daemon. They still run continuously and still
+    // appear in `projections list`; only rebuild skips them. A subscription name
+    // passed explicitly to rebuild becomes a clean no-op instead of a throw.
+    public IReadOnlyList<SubscriptionDescriptor> RebuildableSubscriptions()
+    {
+        return Subscriptions
+            .Where(x => x.SubscriptionType != SubscriptionType.Subscription
+                        && x.Lifecycle != ProjectionLifecycle.Live)
+            .ToArray();
+    }
 }

--- a/src/JasperFx.Events/JasperFx.Events.csproj
+++ b/src/JasperFx.Events/JasperFx.Events.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Foundational Event Store Abstractions and Projections for the Critter Stack</Description>
         <PackageId>JasperFx.Events</PackageId>
-        <Version>1.36.1</Version>
+        <Version>1.36.2</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Closes #459. Backport of the 2.x fix (jasperfx#438 / jasperfx#436) to the **1.0** line for **marten#4718** (Marten 8.0).

## Problem
On the 1.x line, `projections rebuild` throws when an event subscription is registered (e.g. Wolverine `PublishEventsToWolverine(...)` + `SubscribeFromPresent()`). A subscription is `Async`, so `ExecuteRebuilds` fed its name into `TryRebuildShardsAsync` → `RebuildProjectionAsync` → `TryFindProjection`, which only searches projections and throws `No registered projection matches the name '...'`.

## Fix
- `ProjectionSelection.RebuildableSubscriptions()` excludes `SubscriptionType.Subscription` and `ProjectionLifecycle.Live`.
- `ProjectionController.ExecuteRebuilds` builds the rebuild names from it.
- Subscriptions still run continuously and still appear in `projections list`; only **rebuild** skips them. An explicitly-named subscription is a clean no-op.

Bumps `JasperFx.Events` 1.36.1 → **1.36.2**.

## Tests
`ProjectionSelectionTests` (4 cases) — excludes subscriptions, excludes Live, keeps async/inline/composite projections, and is empty when only a subscription is registered. Green on net8/9/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)