### PR TITLE
EventStoreUsage carries a human-facing DisplayName (#458)

### DIFF
--- a/src/EventTests/Descriptors/EventStoreUsageTests.cs
+++ b/src/EventTests/Descriptors/EventStoreUsageTests.cs
@@ -66,6 +66,45 @@ public class EventStoreUsageTests
     }
 
     [Fact]
+    public void display_name_for_default_store_is_main()
+    {
+        // jasperfx#458: the default store's SubjectUri host is "main" — render
+        // it as the title-cased "Main" rather than leaning on Subject (the impl
+        // type name).
+        new EventStoreUsage(new Uri("marten://main"), new MyThing())
+            .DisplayName.ShouldBe("Main");
+    }
+
+    [Fact]
+    public void display_name_for_ancillary_store_is_the_clean_identifier()
+    {
+        // jasperfx#458: ancillary stores get the clean identifier from the URI
+        // host (the marker/interface name, lower-cased by Uri) instead of
+        // Marten.DynamicStores.I{T}Implementation that Subject carries.
+        new EventStoreUsage(new Uri("marten://itarievenstore"), new MyThing())
+            .DisplayName.ShouldBe("itarievenstore");
+    }
+
+    [Fact]
+    public void display_name_is_settable_for_richer_casing()
+    {
+        // Uri lower-cases the host, so stores can override DisplayName to supply
+        // the original casing of the marker interface.
+        var usage = new EventStoreUsage(new Uri("marten://itarievenstore"), new MyThing())
+        {
+            DisplayName = "ITarievenStore"
+        };
+
+        usage.DisplayName.ShouldBe("ITarievenStore");
+    }
+
+    [Fact]
+    public void display_name_defaults_to_main_on_parameterless_ctor()
+    {
+        new EventStoreUsage().DisplayName.ShouldBe("Main");
+    }
+
+    [Fact]
     public void populate_agent_uris_for_async_subscriptions()
     {
         var store = new FakeEventStore();

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -40,11 +40,54 @@ public class EventStoreUsage : OptionsDescription
 
         Subject = subject.GetType().FullNameInCode();
         SubjectUri = subjectUri;
+        DisplayName = DeriveDisplayName(subjectUri);
         Version = subject.GetType().Assembly.GetName().Version?.ToString();
+    }
+
+    /// <summary>
+    /// Derive a human-facing store label from the clean <see cref="SubjectUri"/>
+    /// — the URI's host segment, with the default store's <c>main</c> rendered
+    /// as <c>"Main"</c>. Returns <c>"Main"</c> when there is no host.
+    /// </summary>
+    private static string DeriveDisplayName(Uri subjectUri)
+    {
+        var host = subjectUri?.Host;
+        if (string.IsNullOrEmpty(host))
+        {
+            return "Main";
+        }
+
+        return string.Equals(host, "main", StringComparison.OrdinalIgnoreCase) ? "Main" : host;
     }
 
     public string Version { get; set; }
     public Uri SubjectUri { get; set; }
+
+    /// <summary>
+    /// Human-facing label for this event store, distinct from the type-name
+    /// <see cref="OptionsDescription.Subject"/>. For the default store this is
+    /// <c>"Main"</c>; for ancillary stores it is the store's clean identifier
+    /// (the interface/marker name, e.g. <c>ITarievenStore</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="OptionsDescription.Subject"/> follows the OptionsDescription
+    /// convention of being the subject's CLR type name
+    /// (<c>Marten.DocumentStore</c>, or <c>Marten.DynamicStores.I{T}Implementation</c>
+    /// for ancillary stores) — correct as an identity but not something a
+    /// monitoring tool should render as a store label. <see cref="DisplayName"/>
+    /// gives consumers (e.g. CritterWatch's projection "Store" column) a clean
+    /// label without having to scheme-strip <see cref="SubjectUri"/> themselves.
+    /// See jasperfx#458.
+    /// </para>
+    /// <para>
+    /// Auto-derived from <see cref="SubjectUri"/> in the constructor, but
+    /// settable so an event store can supply richer casing (the URI host is
+    /// always lower-cased, so <c>marten://ITarievenStore</c> arrives as
+    /// <c>itarievenstore</c>). Mirrors <c>DocumentStoreUsage.StoreName</c>.
+    /// </para>
+    /// </remarks>
+    public string DisplayName { get; set; } = "Main";
     public DatabaseUsage Database { get; set; }
     public List<EventDescriptor> Events { get; set; } = new();
     public List<SubscriptionDescriptor> Subscriptions { get; set; } = new();


### PR DESCRIPTION
Closes #458.

## Problem

`EventStoreUsage.Subject` is set to `subject.GetType().FullNameInCode()` — the correct OptionsDescription convention, but not human-facing:

- Main store → `Marten.DocumentStore`
- Ancillary `AddMartenStore<ITarievenStore>()` → `Marten.DynamicStores.ITarievenStoreImplementation`

Monitoring consumers that want to *display* which store a projection/subscription belongs to had to special-case scheme-stripping the `SubjectUri` (`marten://main`, `marten://itarievenstore`) to render a store label (CritterWatch ProductSupport #27).

## Change

Add a first-class `DisplayName` to `EventStoreUsage`, distinct from the type-name `Subject`:

- Auto-derived in the constructor from the clean `SubjectUri` — the URI host segment, with the default store's `main` rendered as `"Main"` — so consumers always get a clean label without scheme-stripping.
- Stays settable so an event store can supply richer casing (`Uri` lower-cases the host, so `marten://ITarievenStore` arrives as `itarievenstore`).
- Mirrors the existing `DocumentStoreUsage.StoreName` semantics ("Main" for the default, registered name for ancillary stores).

`Subject` is unchanged — it remains the CLR type name per the OptionsDescription convention.

## Tests

Added coverage in `EventStoreUsageTests` for: default store → `"Main"`, ancillary store → clean identifier, settable override for casing, and parameterless-ctor default. All 16 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)