### PR TITLE
#420: persisted MaxConcurrentRebuildsPerDatabase default + capped rebuild fan-out regression test

### DIFF
--- a/src/EventTests/CommandLine/ProjectionInputTests.cs
+++ b/src/EventTests/CommandLine/ProjectionInputTests.cs
@@ -34,4 +34,35 @@ public class ProjectionInputTests
         new ProjectionInput { MaxConcurrentFlag = cap }
             .ResolveMaxDegreeOfParallelism().ShouldBe(-1);
     }
+
+    [Fact]
+    public void configured_store_default_applies_when_no_flag()
+    {
+        // jasperfx#420: with no --max-concurrent flag, the store's configured
+        // MaxConcurrentRebuildsPerDatabase default is honored.
+        new ProjectionInput().ResolveMaxDegreeOfParallelism(configuredDefault: 12).ShouldBe(12);
+    }
+
+    [Fact]
+    public void cli_flag_overrides_the_configured_store_default()
+    {
+        // A one-off operational --max-concurrent must win over the configured default.
+        new ProjectionInput { MaxConcurrentFlag = 4 }
+            .ResolveMaxDegreeOfParallelism(configuredDefault: 12).ShouldBe(4);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void non_positive_configured_default_is_unbounded(int configured)
+    {
+        // A store that reports a nonsensical default must not deadlock the rebuild.
+        new ProjectionInput().ResolveMaxDegreeOfParallelism(configured).ShouldBe(-1);
+    }
+
+    [Fact]
+    public void no_flag_and_no_configured_default_stays_unbounded()
+    {
+        new ProjectionInput().ResolveMaxDegreeOfParallelism(configuredDefault: null).ShouldBe(-1);
+    }
 }

--- a/src/EventTests/CommandLine/RebuildConcurrencyCapTests.cs
+++ b/src/EventTests/CommandLine/RebuildConcurrencyCapTests.cs
@@ -1,0 +1,92 @@
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+// jasperfx#420 acceptance: the per-database rebuild fan-out must never run more than the configured
+// cap of rebuild cells concurrently. We exercise the extracted ProjectionHost.RebuildProjectionsWithCapAsync
+// helper directly with an Interlocked peak-concurrency counter (the same instrumentation the issue calls
+// for) so the cap is verified without standing up a real event store / daemon.
+public class RebuildConcurrencyCapTests
+{
+    private static async Task<int> RunAndMeasurePeak(int cellCount, int cap)
+    {
+        var names = Enumerable.Range(0, cellCount).Select(i => $"cell-{i}").ToArray();
+
+        var current = 0;
+        var peak = 0;
+        var sync = new object();
+
+        await ProjectionHost.RebuildProjectionsWithCapAsync(names, cap, CancellationToken.None,
+            async (_, ct) =>
+            {
+                var now = Interlocked.Increment(ref current);
+                lock (sync)
+                {
+                    if (now > peak) peak = now;
+                }
+
+                // Hold the slot long enough that, were the cap not enforced, additional cells would
+                // pile in and push the observed peak above the cap.
+                await Task.Delay(15, ct);
+
+                Interlocked.Decrement(ref current);
+            });
+
+        return peak;
+    }
+
+    [Theory]
+    [InlineData(256, 4)]   // the issue's scenario: 8 projections x 32 tenants, cap 4
+    [InlineData(64, 1)]    // fully serialized
+    [InlineData(40, 8)]
+    public async Task never_exceeds_the_cap(int cellCount, int cap)
+    {
+        var peak = await RunAndMeasurePeak(cellCount, cap);
+        peak.ShouldBeLessThanOrEqualTo(cap);
+    }
+
+    [Fact]
+    public async Task actually_reaches_the_cap_when_there_is_enough_work()
+    {
+        // Guards against a false-pass where the cap "holds" only because nothing ever ran in parallel.
+        var peak = await RunAndMeasurePeak(cellCount: 256, cap: 4);
+        peak.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task all_cells_run_exactly_once()
+    {
+        var names = Enumerable.Range(0, 100).Select(i => $"cell-{i}").ToArray();
+        var seen = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+        await ProjectionHost.RebuildProjectionsWithCapAsync(names, 4, CancellationToken.None,
+            (name, _) =>
+            {
+                seen.Add(name);
+                return Task.CompletedTask;
+            });
+
+        seen.OrderBy(x => x).ShouldBe(names.OrderBy(x => x));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task non_positive_cap_runs_unbounded_without_deadlock(int cap)
+    {
+        // MaxDegreeOfParallelism = 0 throws; the helper must coerce non-positive to -1 (unbounded)
+        // so a misconfigured cap can never wedge a rebuild.
+        var names = Enumerable.Range(0, 20).Select(i => $"cell-{i}").ToArray();
+        var ran = 0;
+
+        await ProjectionHost.RebuildProjectionsWithCapAsync(names, cap, CancellationToken.None,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref ran);
+                return Task.CompletedTask;
+            });
+
+        ran.ShouldBe(20);
+    }
+}

--- a/src/EventTests/Daemon/RebuildCapDefaultsTests.cs
+++ b/src/EventTests/Daemon/RebuildCapDefaultsTests.cs
@@ -1,0 +1,29 @@
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#420 / epic #486 WS3: rebuild-cap configuration surface.
+public class RebuildCapDefaultsTests
+{
+    [Fact]
+    public void daemon_settings_default_is_null_meaning_store_derived()
+    {
+        // Null = "derive store-side" (Marten/Polecat fall back to pool-size / 8);
+        // JasperFx.Events itself treats null as unbounded because it has no pool signal.
+        new DaemonSettings().MaxConcurrentRebuildsPerDatabase.ShouldBeNull();
+    }
+
+    [Fact]
+    public void event_store_usage_field_defaults_to_null_and_round_trips()
+    {
+        // jasperfx#434: monitoring tools (CritterWatch#309) read the effective cap off
+        // the descriptor; null means "not populated" and consumers fall back to 1.
+        var usage = new EventStoreUsage();
+        usage.MaxConcurrentRebuildsPerDatabase.ShouldBeNull();
+
+        usage.MaxConcurrentRebuildsPerDatabase = 12;
+        usage.MaxConcurrentRebuildsPerDatabase.ShouldBe(12);
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionHost.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionHost.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -93,24 +94,22 @@ internal class ProjectionHost: IProjectionHost
 
         var watcherTask = watcher.Start();
 
-        var list = new List<Exception>();
-
         // jasperfx#420: cap the per-database rebuild fan-out so a wide store
         // (many projections, especially under per-tenant partitioning) cannot
-        // blow the connection pool / thrash the buffer cache. A non-positive or
-        // unset flag preserves the previous unbounded behavior.
-        var maxConcurrent = input.ResolveMaxDegreeOfParallelism();
-        var parallelOptions = new ParallelOptions
-        {
-            CancellationToken = _cancellation.Token,
-            MaxDegreeOfParallelism = maxConcurrent
-        };
+        // blow the connection pool / thrash the buffer cache. The --max-concurrent
+        // CLI flag wins; otherwise the store's configured default applies; otherwise
+        // the previous unbounded behavior. A non-positive value stays unbounded.
+        var maxConcurrent = input.ResolveMaxDegreeOfParallelism(store.MaxConcurrentRebuildsPerDatabase);
 
         AnsiConsole.MarkupLine(maxConcurrent > 0
             ? $"[grey]Rebuilding with a maximum of {maxConcurrent} concurrent projection(s) per database[/]"
             : "[grey]Rebuilding with unbounded concurrency per database[/]");
 
-        await Parallel.ForEachAsync(projectionNames, parallelOptions,
+        // Concurrent collection: with maxConcurrent > 1 the rebuild lambda runs on
+        // multiple threads, so a plain List<Exception>.Add would race/corrupt.
+        var errors = new ConcurrentBag<Exception>();
+
+        await RebuildProjectionsWithCapAsync(projectionNames, maxConcurrent, _cancellation.Token,
                 async (projectionName, token) =>
                 {
                     shardTimeout ??= 5.Minutes();
@@ -128,7 +127,7 @@ internal class ProjectionHost: IProjectionHost
                         AnsiConsole.WriteException(e);
                         AnsiConsole.WriteLine();
 
-                        list.Add(e);
+                        errors.Add(e);
                     }
                 })
             .ConfigureAwait(false);
@@ -138,12 +137,35 @@ internal class ProjectionHost: IProjectionHost
         watcher.Stop();
         await watcherTask.ConfigureAwait(false);
 
-        if (list.Any())
+        if (!errors.IsEmpty)
         {
-            throw new AggregateException(list);
+            throw new AggregateException(errors);
         }
 
         return RebuildStatus.Complete;
+    }
+
+    /// <summary>
+    /// jasperfx#420 — the per-database rebuild fan-out, capped at <paramref name="maxDegreeOfParallelism"/>
+    /// concurrent cells. Extracted so the cap is independently regression-testable: a non-positive value
+    /// means unbounded (<see cref="ParallelOptions.MaxDegreeOfParallelism"/> = -1; 0 would throw), and a
+    /// positive value guarantees no more than that many invocations of <paramref name="rebuildOne"/> run
+    /// at once.
+    /// </summary>
+    internal static Task RebuildProjectionsWithCapAsync(
+        IReadOnlyList<string> projectionNames,
+        int maxDegreeOfParallelism,
+        CancellationToken token,
+        Func<string, CancellationToken, Task> rebuildOne)
+    {
+        var parallelOptions = new ParallelOptions
+        {
+            CancellationToken = token,
+            MaxDegreeOfParallelism = maxDegreeOfParallelism > 0 ? maxDegreeOfParallelism : -1
+        };
+
+        return Parallel.ForEachAsync(projectionNames, parallelOptions,
+            async (projectionName, ct) => await rebuildOne(projectionName, ct).ConfigureAwait(false));
     }
 
     public async Task StartShardsAsync(EventStoreDatabaseIdentifier databaseIdentifier, string[] projectionNames)

--- a/src/JasperFx.Events/CommandLine/ProjectionInput.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionInput.cs
@@ -42,8 +42,19 @@ public class ProjectionInput: NetCoreInput
 
     /// <summary>
     /// jasperfx#420: resolve the effective <see cref="ParallelOptions.MaxDegreeOfParallelism"/> for the
-    /// per-database rebuild fan-out. A null or non-positive <see cref="MaxConcurrentFlag"/> yields -1
-    /// (unbounded), preserving the historical behavior.
+    /// per-database rebuild fan-out. Precedence: the <c>--max-concurrent</c> CLI flag wins for one-off
+    /// operational rebuilds; otherwise the store's configured
+    /// <see cref="IEventStore.MaxConcurrentRebuildsPerDatabase"/> default applies; otherwise the historical
+    /// unbounded behavior (<c>-1</c>). A non-positive value at any level is treated as unset/unbounded —
+    /// <see cref="ParallelOptions.MaxDegreeOfParallelism"/> of 0 throws, so we must never pass it through.
     /// </summary>
-    public int ResolveMaxDegreeOfParallelism() => MaxConcurrentFlag is > 0 ? MaxConcurrentFlag.Value : -1;
+    /// <param name="configuredDefault">
+    /// The store-supplied default cap (<see cref="IEventStore.MaxConcurrentRebuildsPerDatabase"/>), or null.
+    /// </param>
+    public int ResolveMaxDegreeOfParallelism(int? configuredDefault = null)
+    {
+        if (MaxConcurrentFlag is > 0) return MaxConcurrentFlag.Value;
+        if (configuredDefault is > 0) return configuredDefault.Value;
+        return -1;
+    }
 }

--- a/src/JasperFx.Events/Daemon/DaemonSettings.cs
+++ b/src/JasperFx.Events/Daemon/DaemonSettings.cs
@@ -130,4 +130,18 @@ public class DaemonSettings: IReadOnlyDaemonSettings
     /// store × database). Zero or negative disables the governor.
     /// </summary>
     public int MaxConcurrentBatchWritesPerDatabase { get; set; } = 4;
+
+    /// <summary>
+    /// jasperfx#420 (epic #486 WS3): cap on how many projection rebuild cells — the
+    /// (projection × tenant/shard) cross product — may run concurrently within one database
+    /// during a rebuild operation. Rebuild only; continuous catch-up is governed by
+    /// <see cref="MaxConcurrentEventLoadsPerDatabase"/> and
+    /// <see cref="MaxConcurrentBatchWritesPerDatabase"/> instead. Null means "derive a
+    /// default store-side" — concrete stores fall back to a value derived from the
+    /// connection pool size (Marten/Polecat use <c>max(1, poolSize / 8)</c>) via their
+    /// <see cref="IEventStore.MaxConcurrentRebuildsPerDatabase"/> override; JasperFx.Events
+    /// itself is store-agnostic and treats null as unbounded. Zero or negative disables the
+    /// cap. The <c>projections rebuild --max-concurrent</c> CLI flag overrides per operation.
+    /// </summary>
+    public int? MaxConcurrentRebuildsPerDatabase { get; set; }
 }

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -166,6 +166,18 @@ public class EventStoreUsage : OptionsDescription
     public ProjectionErrorHandlingDescriptor? ProjectionRebuildErrors { get; set; }
 
     /// <summary>
+    /// Effective per-database concurrent rebuild cap — the store's resolved
+    /// <see cref="IEventStore.MaxConcurrentRebuildsPerDatabase"/> (configured via
+    /// <c>DaemonSettings.MaxConcurrentRebuildsPerDatabase</c>, jasperfx#420). Null when
+    /// the implementation hasn't populated it; monitoring tools should fall back to a
+    /// conservative default (typically 1).
+    /// </summary>
+    /// <remarks>
+    /// See JasperFx/CritterWatch#309 for the orchestration consumer (jasperfx#434).
+    /// </remarks>
+    public int? MaxConcurrentRebuildsPerDatabase { get; set; }
+
+    /// <summary>
     /// Which event/stream metadata this store actually captures — drives
     /// store-aware event/stream query facets in consumers (e.g. CritterWatch)
     /// without sniffing engine-specific config. Null when the implementation

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -38,6 +38,17 @@ public interface IEventStore
     bool HasMultipleTenants { get; }
 
     /// <summary>
+    ///     jasperfx#420 — the configured default cap on how many projection rebuild cells may run
+    ///     concurrently within a single database during a rebuild operation. <c>null</c> means
+    ///     "unbounded" to JasperFx.Events, which is store-agnostic and has no notion of a connection
+    ///     pool. Concrete stores SHOULD override this to a derived default (Marten/Polecat derive it
+    ///     from the Npgsql connection pool size — <c>max(1, poolSize / 8)</c>). The <c>projections
+    ///     rebuild --max-concurrent</c> CLI flag overrides this per operation; see
+    ///     <see cref="CommandLine.ProjectionInput.ResolveMaxDegreeOfParallelism" />.
+    /// </summary>
+    int? MaxConcurrentRebuildsPerDatabase => null;
+
+    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read


### PR DESCRIPTION
Advances jasperfx#420 (cap concurrent projection rebuilds per database) — epic #486 WS3 remainder. The `--max-concurrent` CLI flag + projection-level cap already landed on `main`; this PR adds the **configured-default** half, the **regression test** the acceptance criteria call for, and (post-2.22.0 refresh) reconciles the surface with the WS2/WS3 daemon governors.

## What's here

- **`DaemonSettings.MaxConcurrentRebuildsPerDatabase`** (`int?`, default `null`) — the configuration knob, sitting beside the shipped `MaxConcurrentEventLoadsPerDatabase` / `MaxConcurrentBatchWritesPerDatabase` governors (#495/#496). Because Marten's `ProjectionOptions` derives from `DaemonSettings` via `ProjectionGraph`, this *is* `StoreOptions.Projections.MaxConcurrentRebuildsPerDatabase` — the exact surface jasperfx#434 and marten#4710 describe. `null` = "derive store-side"; zero/negative disables the cap.
- **`IEventStore.MaxConcurrentRebuildsPerDatabase`** — store-agnostic resolved default read by the CLI rebuild path (default-interface-member so out-of-tree stores keep compiling). JasperFx.Events has no notion of a connection pool, so concrete stores override this to consult the knob and fall back to a pool-derived default (Marten/Polecat: `max(1, poolSize / 8)`).
- **`EventStoreUsage.MaxConcurrentRebuildsPerDatabase`** (`int?`) — the descriptor field jasperfx#434 asked for (that issue was closed but the field never actually landed; delivered here) so CritterWatch#309's dispatcher can read the effective cap off the wire.
- **`ProjectionInput.ResolveMaxDegreeOfParallelism(int? configuredDefault)`** — precedence: `--max-concurrent` CLI flag (one-off ops override) **>** store configured default **>** unbounded. Non-positive at any level is coerced to `-1`, because `ParallelOptions.MaxDegreeOfParallelism = 0` throws and would wedge a rebuild.
- **`ProjectionHost.TryRebuildShardsAsync`** now passes `store.MaxConcurrentRebuildsPerDatabase` through, and the capped fan-out is extracted to `internal static RebuildProjectionsWithCapAsync(...)` so the cap is independently testable.
- **Latent-bug fix:** the per-cell error collection moves from `List<Exception>` to `ConcurrentBag<Exception>`. With a cap > 1 the rebuild lambda runs on multiple threads, so the prior `List.Add(e)` inside `Parallel.ForEachAsync` raced — only reachable now that the loop is actually capped/parallel.

## Tests (463 green, net9.0 + net10.0)

- Resolution precedence: flag wins over default; default applies with no flag; non-positive flag/default and null default all fall back to unbounded.
- **Instrumented peak-concurrency regression** (`RebuildConcurrencyCapTests`): 256 cells (8 projections × 32 tenants) at cap 4 — peak concurrency, tracked via `Interlocked`, never exceeds 4 **and actually reaches 4** (guards against a false pass where nothing ran in parallel); cap 1 serializes; non-positive cap runs unbounded without deadlock; every cell runs exactly once.
- Surface pins (`RebuildCapDefaultsTests`): knob defaults null (= store-derived), descriptor field defaults null and round-trips.

## Relationship to the shipped 2.22.0 governors

The WS2/WS3 governors (`MaxConcurrentEventLoadsPerDatabase`, `MaxConcurrentBatchWritesPerDatabase`) bound **continuous catch-up**; this cap bounds the **rebuild fan-out** — the batchy one-off operation. `CrossTenantRebuild.RebuildEverywhereAsync` already got its bounded `maxParallelism = 4` default in #496; this PR does not change it.

## Follow-up (out of scope here)

- Marten/Polecat override `MaxConcurrentRebuildsPerDatabase` to consult the knob + derive `max(1, NpgsqlConnectionPoolSize / 8)`, and populate the `EventStoreUsage` field in `TryCreateUsage` (marten#4710) — next PR in this train.
- Extend the cap to the intra-projection tenant/shard cross-product fan-out in `JasperFxAsyncDaemon` (today's cap is projection-level).
- Docs in `rebuilding.md` (two-layer concurrency model, default derivation, CLI override) + cross-refs from the multi-tenancy / `UseTenantPartitionedEvents` docs.

Companion CritterWatch orchestration story: JasperFx/CritterWatch#309 (depends on this cap being honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
