### PR TITLE
Add ImplementationType + AggregateType (TypeDescriptor) to SubscriptionDescriptor (#464)

### DIFF
--- a/src/JasperFx.Events/Descriptors/SubscriptionDescriptor.cs
+++ b/src/JasperFx.Events/Descriptors/SubscriptionDescriptor.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using JasperFx.Core;
 using JasperFx.Descriptors;
+using JasperFx.Events.Aggregation;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
@@ -28,6 +29,15 @@ public class SubscriptionDescriptor : OptionsDescription
         Version = subject.Version;
         ShardNames = subject.ShardNames();
         Lifecycle = subject.Lifecycle;
+
+        // The CLR type that implements this projection/subscription, plus — for self-aggregating
+        // projections (Snapshot<T> / SingleStreamProjection<T>) — the aggregate/document type, so
+        // consumers can display "what .NET type implements this projection".
+        ImplementationType = TypeDescriptor.For(subject.ImplementationType);
+        if (subject is IAggregateProjection aggregate)
+        {
+            AggregateType = TypeDescriptor.For(aggregate.AggregateType);
+        }
 
         if (Lifecycle == ProjectionLifecycle.Async)
         {
@@ -83,6 +93,15 @@ public class SubscriptionDescriptor : OptionsDescription
     public uint Version { get; set; }
 
     public List<EventDescriptor> Events { get; set; } = new();
+
+    /// <summary>The CLR type that implements this projection/subscription.</summary>
+    public TypeDescriptor? ImplementationType { get; set; }
+
+    /// <summary>
+    /// For self-aggregating projections (Snapshot&lt;T&gt; / SingleStreamProjection&lt;T&gt;), the
+    /// aggregate/document type T. Null for non-aggregating subscriptions/projections.
+    /// </summary>
+    public TypeDescriptor? AggregateType { get; set; }
 
     /// <summary>
     /// Agent URIs that would be assigned for each shard of this subscription


### PR DESCRIPTION
Closes #464.

Adds two nullable `TypeDescriptor` properties to `SubscriptionDescriptor` — `ImplementationType` (the projection/subscription's implementing CLR type) and `AggregateType` (for self-aggregating `Snapshot<T>` / `SingleStreamProjection<T>`, the document type `T`) — populated in the `(ISubscriptionSource, IEventStore)` ctor from the already-present `subject.ImplementationType` and `IAggregateProjection.AggregateType`.

**Binary-safe:** `SubscriptionDescriptor` is a `class` with settable properties (not a positional record), so adding properties is non-breaking. Because every projection/subscription source funnels through this ctor via `ProjectionGraph.Describe`, **Marten and Polecat pick it up with no store-side code change** (verification tests tracked in JasperFx/marten#4772, JasperFx/polecat#203).

Motivating consumer: CritterWatch wants an "Implementation Type" column on its Projections view (verified end-to-end via a local-nuget build — the new fields flow through `ServiceCapabilities` into CritterWatch's generated wire model).

Branch is based on the `V2.13.1` tag (CritterWatch's pin) for local-nuget verification; rebase onto `main` as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)