### PR TITLE
Allow DatabaseId to round-trip an empty database name

### DIFF
--- a/src/CoreTests/Descriptors/DatabaseIdTests.cs
+++ b/src/CoreTests/Descriptors/DatabaseIdTests.cs
@@ -32,11 +32,31 @@ public class DatabaseIdTests
     [Theory]
     [InlineData("one")]
     [InlineData("one,two")]
-    [InlineData("one.")]
     [InlineData(".one")]
     public void try_parse_sad_path(string text)
     {
         DatabaseId.TryParse(text, out var id).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void try_parse_empty_database_name()
+    {
+        // A connection string with no Database= yields a DatabaseId with an empty Name; its
+        // serialized form ("localhost.") must round-trip rather than be rejected. See wolverine#3170.
+        DatabaseId.TryParse("localhost.", out var id).ShouldBeTrue();
+        id.Server.ShouldBe("localhost");
+        id.Name.ShouldBe("");
+    }
+
+    [Fact]
+    public void ctor_with_empty_name_round_trips_through_parse()
+    {
+        var id = new DatabaseId("localhost", "");
+
+        DatabaseId.TryParse(id.Identity, out var fromIdentity).ShouldBeTrue();
+        fromIdentity.ShouldBe(id);
+
+        DatabaseId.Parse(id.ToString()).ShouldBe(id);
     }
 
     [Fact]

--- a/src/JasperFx/Descriptors/DatabaseId.cs
+++ b/src/JasperFx/Descriptors/DatabaseId.cs
@@ -17,7 +17,12 @@ public record DatabaseId(string Server, string Name)
     public static bool TryParse(string text, out DatabaseId id)
     {
         var separator = text.LastIndexOf('.');
-        if (separator <= 0 || separator == text.Length - 1)
+
+        // A leading separator (empty server) or no separator at all is malformed, but a trailing
+        // separator is a legitimate empty database name. The ctor accepts an empty Name (e.g. a
+        // Postgres connection string with no Database= yields one), so Parse must round-trip it
+        // rather than throwing when the agent URI is parsed back. See wolverine#3170.
+        if (separator <= 0)
         {
             id = default!;
             return false;


### PR DESCRIPTION
## Problem

Reported in [JasperFx/wolverine#3170](https://github.com/JasperFx/wolverine/issues/3170). A Postgres connection string with no database, e.g. `Host=localhost;Port=9432;Username=app;Password=app`, produces a Marten database whose `DatabaseName` is empty. Wolverine builds an event-subscription agent URI from `new DatabaseId(serverName, "")`, whose serialized form is `localhost.` (empty name → trailing dot). When the agent is started, Wolverine parses that URI segment back with `DatabaseId.Parse(...)`:

```
System.FormatException: Invalid database id 'localhost.'
   at JasperFx.Descriptors.DatabaseId.Parse(String text) in DatabaseId.cs:line 14
   at Wolverine.Runtime.Agents.EventSubscriptionAgentFamily.BuildAgentAsync(...)
```

The agent (`event-subscriptions://marten/main/localhost./everything/all`) never starts.

## Root cause

`DatabaseId`'s constructor accepts an empty `Name`, but `TryParse` rejected the serialized form via the `separator == text.Length - 1` guard (trailing dot). So the ctor and `Parse` disagreed — a `DatabaseId` the ctor happily creates could not round-trip through `ToString()`/`Identity` → `Parse`.

## Fix

Relax `TryParse` to treat a **trailing** separator as a legitimate empty database name, while still rejecting a **leading** separator (empty server) and input with no separator at all:

```csharp
var separator = text.LastIndexOf('.');
if (separator <= 0)   // was: separator <= 0 || separator == text.Length - 1
{
    id = default!;
    return false;
}
```

Escaping already guarantees the only literal `.` in a well-formed serialization is the separator, so `"localhost."` unambiguously parses to `("localhost", "")`.

### Behavior change

`"one."` (and any trailing-dot string) now parses to an empty name instead of being rejected. The existing `try_parse_sad_path` theory case for `"one."` is moved into new happy-path coverage; `".one"` (empty server) and `"one"` (no separator) remain rejected.

## Tests

- `try_parse_empty_database_name` — `"localhost."` parses to `("localhost", "")`.
- `ctor_with_empty_name_round_trips_through_parse` — the reporter's scenario: a ctor-built empty-name `DatabaseId` round-trips through both `Identity` and `ToString()`.

All `DatabaseIdTests` pass on net9.0 and net10.0.

## Downstream

Once released, [wolverine#3170](https://github.com/JasperFx/wolverine/issues/3170) is fixed by bumping Wolverine's `JasperFx` package reference (currently 2.13.0) to the release containing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)