### PR TITLE
fix(events): make bundled evolver generator double-load safe (#462)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -100,14 +100,20 @@ public partial class AllSync : SingleStreamProjection<MyAggregate, Guid>
         var (diagnostics, generatedSources) = RunGenerator(source);
 
         generatedSources.Length.ShouldBeGreaterThan(0);
-        var generated = generatedSources[0];
-        generated.ShouldContain("partial class AllSync");
-        generated.ShouldContain("override");
+        var generated = string.Join("\n", generatedSources);
+
+        // The dispatcher is now a standalone, file-scoped evolver registered via an assembly
+        // attribute rather than overridden members injected into the projection class. This keeps
+        // it safe when the generator loads twice (Marten + Polecat). See #462.
+        generated.ShouldContain("file sealed class AllSync_GuidEvolver");
+        generated.ShouldContain(
+            "[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.MyAggregate), typeof(global::Test.AllSync_GuidEvolver), typeof(global::Test.AllSync))]");
+        generated.ShouldContain("global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<global::Test.MyAggregate, global::System.Guid>");
         generated.ShouldContain("Evolve(");
-        generated.ShouldContain("Create(data)");
-        generated.ShouldContain("Apply(data,");
-        generated.ShouldContain("IncludeType<global::Test.CreateEvent>");
-        generated.ShouldContain("IncludeType<global::Test.MyEvent>");
+        generated.ShouldContain("_projection.Create(data)");
+        generated.ShouldContain("_projection.Apply(data,");
+        generated.ShouldContain("typeof(global::Test.CreateEvent)");
+        generated.ShouldContain("typeof(global::Test.MyEvent)");
     }
 
     [Fact]
@@ -208,8 +214,12 @@ public class Registration
         var (_, generatedSources) = RunGenerator(source);
         var allGenerated = string.Join("\n", generatedSources);
 
-        allGenerated.ShouldContain("partial class DiagnostiekActiviteitProjection");
-        allGenerated.ShouldNotContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.DiagnostiekActiviteit)");
+        // The partial projection owns the evolver for the aggregate (emitted as a file-scoped type
+        // registered against DiagnostiekActiviteit). The Snapshot<T>() call site must NOT additionally
+        // emit a redundant self-aggregating evolver for the same aggregate. See #462 / #293.
+        allGenerated.ShouldContain(
+            "[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.DiagnostiekActiviteit), typeof(global::Test.DiagnostiekActiviteitProjectionEvolver), typeof(global::Test.DiagnostiekActiviteitProjection))]");
+        allGenerated.ShouldContain("file sealed class DiagnostiekActiviteitProjectionEvolver");
         allGenerated.ShouldNotContain("DiagnostiekActiviteit_StringEvolver");
     }
 
@@ -633,7 +643,11 @@ public partial class StringQuestProjection : SingleStreamProjection<StringQuest,
         // accidentally compiles some other way still trips this assertion.
         var (_, generatedSources) = RunGenerator(source);
         var allGenerated = string.Join("\n", generatedSources);
-        allGenerated.ShouldContain("public override global::System.Threading.Tasks.ValueTask<(global::Test.StringQuest?,");
+        // The ShouldDelete dispatcher is now a file-scoped evolver implementing
+        // IGeneratedAsyncDetermineAction rather than an override on the projection. See #462.
+        allGenerated.ShouldContain("file sealed class StringQuestProjectionEvolver");
+        allGenerated.ShouldContain("global::JasperFx.Events.Aggregation.IGeneratedAsyncDetermineAction<global::Test.StringQuest, string>");
+        allGenerated.ShouldContain("public global::System.Threading.Tasks.ValueTask<(global::Test.StringQuest?,");
         allGenerated.ShouldContain("new global::System.Threading.Tasks.ValueTask<(global::Test.StringQuest?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Delete))");
     }
 
@@ -687,10 +701,16 @@ public class HostTests
         // Spot-check that the generated output actually wraps with the parent partial,
         // so a future regression can't sneak through by accidentally satisfying CS0115
         // some other way.
+        // The dispatcher for a nested projection is now a file-scoped, top-level evolver whose name
+        // encodes the containing-type chain (so two same-named nested projections in sibling parents
+        // don't collide), holding the nested projection by its fully-qualified name. No nesting / no
+        // injected override means the original CS0115/CS0111 failure modes can't recur. See #462 / #292.
         var (_, generatedSources) = RunGenerator(source);
         var allGenerated = string.Join("\n", generatedSources);
-        allGenerated.ShouldContain("partial class HostTests");
-        allGenerated.ShouldContain("partial class NestedProjection");
+        allGenerated.ShouldContain("file sealed class HostTests_NestedProjectionEvolver");
+        allGenerated.ShouldContain("new global::Test.HostTests.NestedProjection()");
+        allGenerated.ShouldContain(
+            "[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.Counted), typeof(global::Test.HostTests_NestedProjectionEvolver), typeof(global::Test.HostTests.NestedProjection))]");
     }
 
     // Regression for https://github.com/JasperFx/jasperfx/issues/293 — when a Marten consumer
@@ -1123,5 +1143,83 @@ public class MyAggregate
             .ToList();
 
         obsoleteFromGenerated.ShouldBeEmpty();
+    }
+
+    // Regression for https://github.com/JasperFx/jasperfx/issues/462 — the generator is bundled as a
+    // built-in analyzer inside BOTH Marten and Polecat, so a project referencing both stores loads the
+    // SAME incremental generator twice. Each instance emits the same dispatcher against the same source.
+    // When the dispatcher was injected as partial members of the user's projection class, the two copies
+    // collided with CS0111 (duplicate member); a self-aggregating evolver class collided with CS0101
+    // (duplicate type). Emitting the dispatcher as a `file`-scoped evolver makes each copy local to its
+    // own generated file, so two instances coexist without colliding. Two generator instances on one
+    // driver reproduce the double-load precisely.
+    [Fact]
+    public void generator_loaded_twice_does_not_produce_duplicate_member_or_type_errors()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class Wallet { public Guid Id { get; set; } public int Balance { get; set; } }
+public class Funded { public int Amount { get; set; } }
+public class Drained { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+
+// partial-projection path with ShouldDelete (the reported repro shape)
+public partial class WalletProjection : SingleStreamProjection<Wallet, Guid>
+{
+    public Wallet Create(Funded e) => new Wallet { Balance = e.Amount };
+    public void Apply(Funded e, Wallet w) { w.Balance += e.Amount; }
+    public bool ShouldDelete(Drained e) => true;
+}
+
+// self-aggregating path (separate evolver class)
+public class Tally
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public static Tally Create(Funded e) => new Tally();
+    public void Apply(Funded e) { Count++; }
+}
+";
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IEvent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Guid).Assembly.Location),
+        };
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Collections.dll")));
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // Two instances of the same generator == the analyzer bundled in two referenced packages.
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new AggregateEvolverGenerator(), new AggregateEvolverGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+
+        var collisionErrors = outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id is "CS0111" or "CS0101" or "CS0102")
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+
+        collisionErrors.ShouldBeEmpty();
     }
 }

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -36,10 +36,36 @@ internal static class EvolverCodeEmitter
         sb.AppendLine();
     }
 
+    /// <summary>
+    /// Emits the dispatcher for an aggregation projection subclass (e.g. a
+    /// <c>SingleStreamProjection&lt;TDoc, TId&gt;</c> subclass) as a standalone, file-scoped evolver
+    /// type registered via <see cref="GeneratedEvolverAttribute"/> — NOT as overridden members injected
+    /// into the user's projection class.
+    ///
+    /// The member-injection approach is unsafe when this generator is bundled as a built-in analyzer in
+    /// two referenced packages (e.g. Marten + Polecat) and therefore loads twice: each instance emits the
+    /// same partial members and the consumer build fails with CS0111. A <c>file</c>-scoped type is local
+    /// to its own generated file, so two instances emit two independent (and harmless) copies that never
+    /// collide. The runtime binds the projection to the evolver by scanning the assembly for the
+    /// registration attribute. See https://github.com/JasperFx/jasperfx/issues/462.
+    /// </summary>
     public static string EmitPartialProjection(CandidateInfo info)
     {
         var sb = new StringBuilder();
         AppendGeneratedFileHeader(sb);
+
+        var aggregateFullName = Fqn(info.AggregateType!);
+        var idFullName = Fqn(info.IdentityType!);
+        var projectionFullName = Fqn(info.ClassSymbol);
+        var evolverName = BuildUniqueEvolverName(info, "Evolver");
+
+        // Assembly attribute (must precede the namespace declaration). typeof the file-scoped evolver is
+        // legal here because the attribute lives in the same generated file as the type it references.
+        // The projection type is included so this evolver binds ONLY to this projection — another
+        // projection (or a no-op projection) over the same aggregate must not borrow it. See #462.
+        sb.AppendLine(
+            $"[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof({aggregateFullName}), typeof({GetFullyQualifiedEvolverName(info, evolverName)}), typeof({projectionFullName}))]");
+        sb.AppendLine();
 
         var ns = info.ClassSymbol.ContainingNamespace;
         if (!ns.IsGlobalNamespace)
@@ -48,54 +74,87 @@ internal static class EvolverCodeEmitter
             sb.AppendLine();
         }
 
-        // If the projection is declared inside another type (common in xUnit test
-        // files where the projection lives next to test methods), emit a matching
-        // chain of `partial class Container { ... }` wrappers so the generated
-        // partial merges with the user's source partial. See #292.
-        var containingTypes = GetContainingTypes(info.ClassSymbol);
-        foreach (var container in containingTypes)
+        string interfaceName;
+        if (info.HasShouldDelete)
         {
-            sb.AppendLine($"partial {ContainerKeyword(container)} {container.Name}{ContainerTypeParams(container)}");
-            sb.AppendLine("{");
+            interfaceName =
+                $"global::JasperFx.Events.Aggregation.IGeneratedAsyncDetermineAction<{aggregateFullName}, {idFullName}>";
+        }
+        else if (info.HasAnyAsync)
+        {
+            interfaceName =
+                $"global::JasperFx.Events.Aggregation.IGeneratedAsyncEvolver<{aggregateFullName}, {idFullName}>";
+        }
+        else
+        {
+            interfaceName =
+                $"global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<{aggregateFullName}, {idFullName}>";
         }
 
-        var className = info.ClassSymbol.Name;
-
-        // Include type parameters if the class is generic
-        var typeParams = "";
-        if (info.ClassSymbol.TypeParameters.Length > 0)
-        {
-            typeParams = "<" + string.Join(", ", info.ClassSymbol.TypeParameters.Select(t => t.Name)) + ">";
-        }
-
-        sb.AppendLine($"partial class {className}{typeParams}");
+        sb.AppendLine($"file sealed class {evolverName} : {interfaceName}");
         sb.AppendLine("{");
 
-        // Generate constructor that calls IncludeType<T>() for every event type
-        EmitConstructorWithIncludeTypes(sb, info, className);
+        // The dispatcher invokes the projection's own instance Apply/Create/ShouldDelete methods through
+        // a private projection instance. Aggregate-side and static methods are invoked directly, so the
+        // instance is only needed (and only emitted) when at least one method lives on the projection
+        // instance — avoiding a CS0169 "field never used" warning in warnings-as-errors consumer builds.
+        //
+        // The instance is created lazily, NOT in a field initializer: the projection's own constructor
+        // resolves this very evolver (via tryUseAssemblyRegisteredEvolver), so eagerly constructing the
+        // projection here would recurse projection -> evolver -> projection -> ... and StackOverflow. By
+        // the time a handler actually runs, the evolver's own construction has long completed, so the
+        // lazy create is safe and happens once.
+        if (NeedsProjectionInstance(info))
+        {
+            sb.AppendLine($"    private {projectionFullName}? _projectionInstance;");
+            sb.AppendLine($"    private {projectionFullName} _projection => _projectionInstance ??= new {projectionFullName}();");
+            sb.AppendLine();
+        }
+
+        EmitEventTypesProperty(sb, info);
         sb.AppendLine();
 
         if (info.HasShouldDelete)
         {
-            EmitDetermineActionAsyncOverride(sb, info);
+            EmitDetermineActionEvolverMethod(sb, info);
         }
         else if (info.HasAnyAsync)
         {
-            EmitEvolveAsyncOverride(sb, info);
+            EmitEvolveAsyncEvolverMethod(sb, info);
         }
         else
         {
-            EmitEvolveOverride(sb, info);
+            EmitEvolveEvolverMethod(sb, info);
         }
 
         sb.AppendLine("}");
 
-        foreach (var _ in containingTypes)
-        {
-            sb.AppendLine("}");
-        }
-
         return sb.ToString();
+    }
+
+    private static bool NeedsProjectionInstance(CandidateInfo info)
+    {
+        return info.Methods.Any(m => !m.IsStatic && !m.IsOnAggregate);
+    }
+
+    /// <summary>
+    /// The IGeneratedAsyncEvolver / IGeneratedAsyncDetermineAction contracts type the session as
+    /// <c>object</c> so the runtime stays free of the session generic parameter. The dispatch body
+    /// references a strongly-typed <c>session</c> local when (and only when) a handler actually takes an
+    /// IQuerySession — emitting an unused local otherwise would trip CS0219 in warnings-as-error consumer
+    /// builds. Mirrors the self-aggregating async path.
+    /// </summary>
+    private static void EmitSessionLocalIfNeeded(StringBuilder sb, CandidateInfo info)
+    {
+        var sessionParamType = info.Methods
+            .Where(m => m.HasSession)
+            .Select(m => m.Symbol.Parameters.FirstOrDefault(p => IsQuerySession(p.Type))?.Type)
+            .FirstOrDefault(t => t != null);
+
+        if (sessionParamType != null)
+        {
+            sb.AppendLine($"        var session = ({Fqn(sessionParamType)})sessionInput;");
+        }
     }
 
     private static string ContainerTypeParams(INamedTypeSymbol container)
@@ -119,23 +178,6 @@ internal static class EvolverCodeEmitter
         }
 
         return container.TypeKind == TypeKind.Struct ? "struct" : "class";
-    }
-
-    private static void EmitConstructorWithIncludeTypes(StringBuilder sb, CandidateInfo info, string className)
-    {
-        var eventTypes = info.Methods.Select(m => Fqn(m.EventType)).Distinct().ToList();
-        if (eventTypes.Count == 0) return;
-
-        // Skip if the class already has an explicit parameterless constructor
-        if (info.HasExistingParameterlessConstructor) return;
-
-        sb.AppendLine($"    public {className}()");
-        sb.AppendLine("    {");
-        foreach (var eventType in eventTypes)
-        {
-            sb.AppendLine($"        IncludeType<{eventType}>();");
-        }
-        sb.AppendLine("    }");
     }
 
     public static string EmitEventProjectionPartial(CandidateInfo info)
@@ -519,7 +561,7 @@ internal static class EvolverCodeEmitter
 
         if (info.HasShouldDelete)
         {
-            sb.AppendLine($"internal sealed class {evolverName} : global::JasperFx.Events.Aggregation.IGeneratedSyncDetermineAction<{aggregateFullName}, {idFullName}>");
+            sb.AppendLine($"file sealed class {evolverName} : global::JasperFx.Events.Aggregation.IGeneratedSyncDetermineAction<{aggregateFullName}, {idFullName}>");
             sb.AppendLine("{");
             EmitEventTypesProperty(sb, info);
             sb.AppendLine();
@@ -531,7 +573,7 @@ internal static class EvolverCodeEmitter
             // Task<T> Create(SomeEvent, IQuerySession)` that does a DB lookup
             // during creation). Emit IGeneratedAsyncEvolver so the runtime
             // can await each handler invocation. See #297.
-            sb.AppendLine($"internal sealed class {evolverName} : global::JasperFx.Events.Aggregation.IGeneratedAsyncEvolver<{aggregateFullName}, {idFullName}>");
+            sb.AppendLine($"file sealed class {evolverName} : global::JasperFx.Events.Aggregation.IGeneratedAsyncEvolver<{aggregateFullName}, {idFullName}>");
             sb.AppendLine("{");
             EmitEventTypesProperty(sb, info);
             sb.AppendLine();
@@ -539,7 +581,7 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.AppendLine($"internal sealed class {evolverName} : global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<{aggregateFullName}, {idFullName}>");
+            sb.AppendLine($"file sealed class {evolverName} : global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<{aggregateFullName}, {idFullName}>");
             sb.AppendLine("{");
             EmitEventTypesProperty(sb, info);
             sb.AppendLine();
@@ -592,7 +634,7 @@ internal static class EvolverCodeEmitter
             interfaceName = $"global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<{aggregateFullName}, {idFullName}>";
         }
 
-        sb.AppendLine($"internal sealed class {evolverName} : {interfaceName}");
+        sb.AppendLine($"file sealed class {evolverName} : {interfaceName}");
         sb.AppendLine("{");
 
         // Emit EventTypes property
@@ -866,13 +908,12 @@ internal static class EvolverCodeEmitter
 
     // --- Partial projection: Evolve (all sync, no ShouldDelete) ---
 
-    private static void EmitEvolveOverride(StringBuilder sb, CandidateInfo info)
+    private static void EmitEvolveEvolverMethod(StringBuilder sb, CandidateInfo info)
     {
         var docType = Fqn(info.AggregateType!);
         var idType = Fqn(info.IdentityType!);
 
-        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public override {docType}? Evolve({docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e)");
+        sb.AppendLine($"    public {docType}? Evolve({docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e)");
         sb.AppendLine("    {");
 
         var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
@@ -901,17 +942,17 @@ internal static class EvolverCodeEmitter
 
     // --- Partial projection: EvolveAsync (mixed sync/async, no ShouldDelete) ---
 
-    private static void EmitEvolveAsyncOverride(StringBuilder sb, CandidateInfo info)
+    private static void EmitEvolveAsyncEvolverMethod(StringBuilder sb, CandidateInfo info)
     {
         var docType = Fqn(info.AggregateType!);
         var idType = Fqn(info.IdentityType!);
-        var sessionType = info.QuerySessionType is { } qs ? Fqn(qs) : "object";
 
-        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public override async global::System.Threading.Tasks.ValueTask<{docType}?> EvolveAsync(");
-        sb.AppendLine($"        {docType}? snapshot, {idType} id, {sessionType} session,");
-        sb.AppendLine($"        global::JasperFx.Events.IEvent e, global::System.Threading.CancellationToken cancellation)");
+        sb.AppendLine($"    public async global::System.Threading.Tasks.ValueTask<{docType}?> EvolveAsync(");
+        sb.AppendLine($"        {docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e,");
+        sb.AppendLine($"        object sessionInput, global::System.Threading.CancellationToken cancellation)");
         sb.AppendLine("    {");
+
+        EmitSessionLocalIfNeeded(sb, info);
 
         var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
         var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
@@ -937,24 +978,22 @@ internal static class EvolverCodeEmitter
 
     // --- Partial projection: DetermineActionAsync (has ShouldDelete) ---
 
-    private static void EmitDetermineActionAsyncOverride(StringBuilder sb, CandidateInfo info)
+    private static void EmitDetermineActionEvolverMethod(StringBuilder sb, CandidateInfo info)
     {
         var docType = Fqn(info.AggregateType!);
         var idType = Fqn(info.IdentityType!);
-        var sessionType = info.QuerySessionType is { } qs ? Fqn(qs) : "object";
 
         var isAsync = info.HasAnyAsync;
         var asyncKeyword = isAsync ? "async " : "";
 
-        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public override {asyncKeyword}global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)> DetermineActionAsync(");
-        sb.AppendLine($"        {sessionType} session,");
+        sb.AppendLine($"    public {asyncKeyword}global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)> DetermineActionAsync(");
         sb.AppendLine($"        {docType}? snapshot,");
-        sb.AppendLine($"        {idType} identity,");
-        sb.AppendLine($"        global::JasperFx.Events.Aggregation.IIdentitySetter<{docType}, {idType}> identitySetter,");
+        sb.AppendLine($"        {idType} id,");
         sb.AppendLine($"        global::System.Collections.Generic.IReadOnlyList<global::JasperFx.Events.IEvent> events,");
+        sb.AppendLine("        object sessionInput,");
         sb.AppendLine("        global::System.Threading.CancellationToken cancellation)");
         sb.AppendLine("    {");
+        EmitSessionLocalIfNeeded(sb, info);
         sb.AppendLine("        var exists = snapshot != null;");
         sb.AppendLine("        foreach (var e in events)");
         sb.AppendLine("        {");
@@ -1687,9 +1726,17 @@ internal static class EvolverCodeEmitter
         {
             sb.Append($"{aggregateVar}.{method.MethodName}({args})");
         }
+        else if (method.IsStatic)
+        {
+            // Static Apply declared on the projection itself — invoke via the projection type.
+            sb.Append($"{Fqn(method.Symbol.ContainingType)}.{method.MethodName}({args})");
+        }
         else
         {
-            sb.Append($"{method.MethodName}({args})");
+            // Instance Apply on the projection — dispatched through the evolver's held
+            // projection instance now that the dispatcher is a standalone file-scoped type
+            // rather than an override injected into the projection class. See #462.
+            sb.Append($"_projection.{method.MethodName}({args})");
         }
     }
 
@@ -1711,7 +1758,7 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{method.MethodName}({args})");
+            sb.Append($"_projection.{method.MethodName}({args})");
         }
     }
 
@@ -1733,7 +1780,7 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{awaitPrefix}{method.MethodName}({args})");
+            sb.Append($"{awaitPrefix}_projection.{method.MethodName}({args})");
         }
     }
 
@@ -1772,9 +1819,13 @@ internal static class EvolverCodeEmitter
         {
             sb.Append($"{awaitKeyword}snapshot.{method.MethodName}({args})");
         }
+        else if (method.IsStatic)
+        {
+            sb.Append($"{awaitKeyword}{Fqn(method.Symbol.ContainingType)}.{method.MethodName}({args})");
+        }
         else
         {
-            sb.Append($"{awaitKeyword}{method.MethodName}({args})");
+            sb.Append($"{awaitKeyword}_projection.{method.MethodName}({args})");
         }
     }
 

--- a/src/JasperFx.Events/Aggregation/GeneratedEvolverAttribute.cs
+++ b/src/JasperFx.Events/Aggregation/GeneratedEvolverAttribute.cs
@@ -2,7 +2,7 @@ namespace JasperFx.Events.Aggregation;
 
 /// <summary>
 /// Assembly-level attribute emitted by the source generator to register a generated evolver
-/// for a self-aggregating type.
+/// for a self-aggregating type or an aggregation projection subclass.
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 public class GeneratedEvolverAttribute : Attribute
@@ -13,6 +13,25 @@ public class GeneratedEvolverAttribute : Attribute
         EvolverType = evolverType;
     }
 
+    /// <summary>
+    /// Registers an evolver that is specific to a particular projection subclass. Several distinct
+    /// projections can target the same aggregate type with different dispatch logic, so an evolver
+    /// emitted for a projection subclass must only ever bind to that projection — not to any other
+    /// projection (or no-op projection) that happens to share the aggregate type. Self-aggregating
+    /// evolvers leave <see cref="ProjectionType"/> null and bind by aggregate type alone. See #462.
+    /// </summary>
+    public GeneratedEvolverAttribute(Type aggregateType, Type evolverType, Type projectionType)
+        : this(aggregateType, evolverType)
+    {
+        ProjectionType = projectionType;
+    }
+
     public Type AggregateType { get; }
     public Type EvolverType { get; }
+
+    /// <summary>
+    /// The concrete projection subclass this evolver dispatches to, or null for a self-aggregating
+    /// evolver that binds by aggregate type alone.
+    /// </summary>
+    public Type? ProjectionType { get; }
 }

--- a/src/JasperFx.Events/Aggregation/IGeneratedAsyncDetermineAction.cs
+++ b/src/JasperFx.Events/Aggregation/IGeneratedAsyncDetermineAction.cs
@@ -1,0 +1,22 @@
+using JasperFx.Events.Daemon;
+
+namespace JasperFx.Events.Aggregation;
+
+/// <summary>
+/// Interface for source-generated evolvers that handle ShouldDelete-bearing projections whose
+/// Apply/Create/ShouldDelete methods are async and/or require an IQuerySession. This is the
+/// async sibling of <see cref="IGeneratedSyncDetermineAction{TDoc,TId}"/>.
+///
+/// It exists so the partial-projection dispatcher can be emitted as a standalone, file-scoped
+/// evolver type (registered via <see cref="GeneratedEvolverAttribute"/>) instead of as
+/// overridden members on the user's projection class. Emitting members into the user's class is
+/// not safe when the generator is bundled in two referenced packages (e.g. Marten + Polecat) and
+/// loads twice -- the duplicate members trip CS0111. See https://github.com/JasperFx/jasperfx/issues/462.
+/// </summary>
+public interface IGeneratedAsyncDetermineAction<TDoc, TId> where TDoc : notnull where TId : notnull
+{
+    ValueTask<(TDoc?, ActionType)> DetermineActionAsync(TDoc? snapshot, TId id, IReadOnlyList<IEvent> events,
+        object session, CancellationToken cancellation);
+
+    Type[] EventTypes { get; }
+}

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -132,13 +132,46 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
         var hasShouldDelete = _application.HasShouldDeleteMethods();
         var docType = typeof(TDoc);
 
-        // Scan the aggregate's assembly for GeneratedEvolverAttribute registrations
-        var attrs = docType.Assembly.GetCustomAttributes<GeneratedEvolverAttribute>();
-        foreach (var attr in attrs)
+        // Scan both the aggregate's assembly AND the projection's own assembly for
+        // GeneratedEvolverAttribute registrations. For a self-aggregating type these are the
+        // same assembly. For a partial projection whose aggregate lives in a different assembly
+        // than the projection subclass (the common domain-library + composition-root split), the
+        // generator emits the registration into the *projection's* assembly, so the aggregate's
+        // assembly alone is not enough. The file-scoped evolver the generator now emits replaced
+        // the old "inject an override into the user's class" approach, which travelled with the
+        // projection instance regardless of assembly; scanning the projection assembly preserves
+        // that reach. See https://github.com/JasperFx/jasperfx/issues/462.
+        // Select the single best-matching registration before dispatching. An evolver emitted for a
+        // specific projection subclass (ProjectionType set) must bind ONLY to that projection — several
+        // projections can target the same aggregate with different dispatch logic, and a no-op projection
+        // sharing the aggregate must NOT borrow another projection's evolver (that would skip validation
+        // and mis-dispatch). A projection-specific match wins; a self-aggregating (ProjectionType null)
+        // registration is the fallback. See #462.
+        GeneratedEvolverAttribute? selected = null;
+        foreach (var attr in collectGeneratedEvolverAttributes(docType))
         {
             if (attr.AggregateType != docType) continue;
 
-            var evolverType = attr.EvolverType;
+            if (attr.ProjectionType != null)
+            {
+                if (attr.ProjectionType == GetType())
+                {
+                    selected = attr;
+                    break;
+                }
+
+                // A projection-specific evolver for a DIFFERENT projection — never ours.
+                continue;
+            }
+
+            // Aggregate-only (self-aggregating) evolver: acceptable fallback, but keep scanning in case
+            // a projection-specific registration for this exact projection appears later.
+            selected ??= attr;
+        }
+
+        if (selected != null)
+        {
+            var evolverType = selected.EvolverType;
 
             // Check for IGeneratedSyncEvolver<TDoc, TId>. Skip this branch when
             // the projection has ShouldDelete methods — a plain SyncEvolver
@@ -221,6 +254,22 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 return true;
             }
 
+            // Check for IGeneratedAsyncDetermineAction<TDoc, TId> — ShouldDelete projections whose
+            // Apply/Create/ShouldDelete handlers are async and/or need an IQuerySession. The generated
+            // DetermineActionAsync iterates the whole slice and already wraps each failing event in an
+            // ApplyEventException (preserving the per-event seam the daemon's SkipApplyErrors handler
+            // relies on), so the runtime calls it once with the full list. See #462.
+            var asyncDetermineActionInterface = typeof(IGeneratedAsyncDetermineAction<TDoc, TId>);
+            if (asyncDetermineActionInterface.IsAssignableFrom(evolverType))
+            {
+                var evolver = (IGeneratedAsyncDetermineAction<TDoc, TId>)Activator.CreateInstance(evolverType)!;
+                _generatedEvolverEventTypes = evolver.EventTypes;
+                _buildAction = (session, snapshot, id, _, events, ct) =>
+                    evolver.DetermineActionAsync(snapshot, id, events, session!, ct);
+                _evolve = evolveDefaultAsync; // not used when _buildAction is set, but must be non-null
+                return true;
+            }
+
             // Check for IGeneratedAsyncEvolver<TDoc, TId> — Evolve/EvolveAsync on self-aggregating types, no ShouldDelete arm
             var asyncEvolverInterface = typeof(IGeneratedAsyncEvolver<TDoc, TId>);
             if (!hasShouldDelete && asyncEvolverInterface.IsAssignableFrom(evolverType))
@@ -256,6 +305,29 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Gathers <see cref="GeneratedEvolverAttribute"/> registrations from the aggregate's assembly and,
+    /// when different, the concrete projection's own assembly. A partial projection whose aggregate is
+    /// declared in another assembly has its generated evolver registered alongside the projection, not
+    /// the aggregate, so both must be consulted. See #462.
+    /// </summary>
+    private IEnumerable<GeneratedEvolverAttribute> collectGeneratedEvolverAttributes(Type docType)
+    {
+        foreach (var attr in docType.Assembly.GetCustomAttributes<GeneratedEvolverAttribute>())
+        {
+            yield return attr;
+        }
+
+        var projectionAssembly = GetType().Assembly;
+        if (projectionAssembly != docType.Assembly)
+        {
+            foreach (var attr in projectionAssembly.GetCustomAttributes<GeneratedEvolverAttribute>())
+            {
+                yield return attr;
+            }
+        }
     }
 
 


### PR DESCRIPTION
Fixes #462.

## Problem

`JasperFx.Events.SourceGenerator` is bundled as a built-in analyzer inside **both** Marten and Polecat. A project referencing both stores loads the *same* incremental generator twice. The generator emitted each aggregation projection's dispatcher as **partial members of the user's projection class** (and self-aggregating evolvers as `internal sealed` types), so two analyzer instances produced byte-identical declarations and the consumer build failed with **CS0111** (duplicate member) / **CS0101** (duplicate type). No in-generator dedup can help — two analyzer *instances* can't coordinate.

## Fix (Option 1 from the issue)

Emit the dispatcher as a standalone **`file`-scoped** evolver type registered via `[GeneratedEvolver]`, instead of injecting overrides into the user's class. A `file` type is local to its own generated file, so two instances emit independent, non-colliding copies. The runtime already binds projections to evolvers by scanning for the registration attribute (first-match-wins, `AllowMultiple`).

### Changes
- **Partial aggregation projections** now emit a `file sealed` evolver implementing `IGeneratedSyncEvolver` / `IGeneratedAsyncEvolver` / **`IGeneratedAsyncDetermineAction`** (new interface for async + ShouldDelete + session), dispatching to a **lazily-created** projection instance for instance methods. Lazy is required — the projection's own constructor resolves this very evolver, so eager construction would recurse projection → evolver → projection → … and StackOverflow.
- **`GeneratedEvolverAttribute`** carries an optional `ProjectionType` so a projection-specific evolver binds **only** to that projection. Several projections (or a no-op projection) can share an aggregate type without borrowing each other's dispatcher; self-aggregating evolvers leave it null and bind by aggregate type alone.
- **`tryUseAssemblyRegisteredEvolver`** now scans the projection's assembly in addition to the aggregate's, preserving reach for the domain-library + composition-root split that the old per-instance override handled implicitly.
- **Self-aggregating** evolver classes changed `internal` → `file` for the same double-load safety.

## Tests
- New regression test runs **two generator instances over one compilation** and asserts no CS0111/CS0101 — the exact double-load repro.
- Existing source-generator text-shape tests updated to the new file-scoped emission.
- Full local validation: `JasperFx.Events.SourceGenerator.Tests` 23/23, `EventTests` net-neutral vs `main` (7 pre-existing `Descriptors.*` failures, unrelated), `EventStoreTests` 72/72, plus the CI gates (`compile`, `test-core`, `test-codegen`, `test-command-line`) green.

## Out of scope
`EventProjection.ApplyAsync` dispatch is a distinct mechanism with no assembly-attribute runtime path; it remains override-based and is still double-load-unsafe. Tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)