### PR TITLE
Fix DI-activated projection evolver + multi-identity dispatcher (2.14.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.14.0</JasperFxVersion>
+        <JasperFxVersion>2.14.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -117,6 +117,53 @@ public partial class AllSync : SingleStreamProjection<MyAggregate, Guid>
     }
 
     [Fact]
+    public void di_activated_projection_without_parameterless_ctor_compiles()
+    {
+        // #4185 / CS7036 regression: a projection registered via AddProjectionWithServices has only a
+        // constructor with injected dependencies (no parameterless ctor). The evolver's private shadow
+        // instance must not be created with `new T()` — that won't compile. It is instantiated without
+        // running the constructor instead (RuntimeHelpers.GetUninitializedObject).
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class MyAggregate { public int Count { get; set; } }
+public class MyEvent { }
+public class CreateEvent { }
+public interface ISecondaryStore { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+
+public partial class DiActivated : SingleStreamProjection<MyAggregate, Guid>
+{
+    private readonly ISecondaryStore _secondaryStore;
+    public DiActivated(ISecondaryStore secondaryStore) { _secondaryStore = secondaryStore; }
+
+    public MyAggregate Create(CreateEvent e) => new MyAggregate();
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+";
+        var (_, generatedSources) = RunGenerator(source);
+        var generated = string.Join("\n", generatedSources);
+
+        // Shadow instance is created without invoking the (parameterized) constructor.
+        generated.ShouldContain("GetUninitializedObject(typeof(global::Test.DiActivated))");
+        generated.ShouldNotContain("new global::Test.DiActivated()");
+
+        // The generated evolver must compile — no CS7036 "no argument for required parameter".
+        var diagnostics = CompileWithGenerator(source);
+        diagnostics.ShouldNotContain(d => d.Id == "CS7036");
+    }
+
+    [Fact]
     public void partial_projection_for_required_member_aggregate_suppresses_snapshot_fallback()
     {
         var source = @"

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -107,7 +107,7 @@ internal static class EvolverCodeEmitter
         if (NeedsProjectionInstance(info))
         {
             sb.AppendLine($"    private {projectionFullName}? _projectionInstance;");
-            sb.AppendLine($"    private {projectionFullName} _projection => _projectionInstance ??= new {projectionFullName}();");
+            sb.AppendLine($"    private {projectionFullName} _projection => _projectionInstance ??= {BuildProjectionInstanceExpression(info.ClassSymbol, projectionFullName)};");
             sb.AppendLine();
         }
 
@@ -135,6 +135,31 @@ internal static class EvolverCodeEmitter
     private static bool NeedsProjectionInstance(CandidateInfo info)
     {
         return info.Methods.Any(m => !m.IsStatic && !m.IsOnAggregate);
+    }
+
+    /// <summary>
+    /// Builds the expression that creates the evolver's private "shadow" projection instance
+    /// (used only to invoke the projection's stateless instance Apply/Create/ShouldDelete event
+    /// methods). When the projection has a public parameterless constructor we just <c>new</c> it.
+    /// A DI-activated projection (registered via <c>AddProjectionWithServices</c>) has only a
+    /// constructor with injected dependencies and therefore no parameterless ctor — <c>new T()</c>
+    /// would not compile (#4185 / CS7036). In that case instantiate without running the constructor
+    /// (mirrors the aggregate no-parameterless-ctor fallback in
+    /// <see cref="BuildAggregateConstructorExpression"/>). Injected services are null on this shadow
+    /// instance, which is correct for the inline evolve path: event Apply/Create methods that
+    /// dereference injected services are not supported there.
+    /// </summary>
+    private static string BuildProjectionInstanceExpression(INamedTypeSymbol projectionType, string projectionFullName)
+    {
+        var hasPublicParameterless = projectionType.InstanceConstructors.Any(c =>
+            c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
+
+        if (hasPublicParameterless)
+        {
+            return $"new {projectionFullName}()";
+        }
+
+        return $"({projectionFullName})global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof({projectionFullName}))";
     }
 
     /// <summary>

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -164,14 +164,26 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
                 continue;
             }
 
-            // Aggregate-only (self-aggregating) evolver: acceptable fallback, but keep scanning in case
-            // a projection-specific registration for this exact projection appears later.
-            selected ??= attr;
+            // Aggregate-only (self-aggregating) evolver: acceptable fallback, but ONLY when its evolver
+            // implements a <TDoc, TId> generated contract for THIS identity type. When the same aggregate
+            // is registered against multiple identity types (#297 — e.g. AggregateStream<CountOfLetters>
+            // with both Guid and string ids) the generator emits one evolver per TId, all keyed on the
+            // aggregate type with a null ProjectionType. Selecting purely by aggregate type could pick the
+            // wrong-TId evolver, whose strongly-typed interface checks below would all fail, leaving _evolve
+            // unwired and tripping the "no source-generated dispatcher" backstop. Keep scanning in case a
+            // projection-specific registration for this exact projection appears later.
+            if (evolverImplementsIdentityContract(attr.EvolverType))
+            {
+                selected ??= attr;
+            }
         }
 
         if (selected != null)
         {
             var evolverType = selected.EvolverType;
+
+            // (selection above already guaranteed this for aggregate-only matches; a
+            // projection-specific match is bound to a single TId by construction.)
 
             // Check for IGeneratedSyncEvolver<TDoc, TId>. Skip this branch when
             // the projection has ShouldDelete methods — a plain SyncEvolver
@@ -305,6 +317,20 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="evolverType"/> implements one of the generated <c>&lt;TDoc, TId&gt;</c>
+    /// dispatcher contracts for THIS projection's identity type. Used to disambiguate the self-aggregating
+    /// fallback when one aggregate is registered against multiple identity types (#297) — only the evolver
+    /// emitted for the matching TId can actually be wired below.
+    /// </summary>
+    private static bool evolverImplementsIdentityContract(Type evolverType)
+    {
+        return typeof(IGeneratedSyncEvolver<TDoc, TId>).IsAssignableFrom(evolverType)
+               || typeof(IGeneratedSyncDetermineAction<TDoc, TId>).IsAssignableFrom(evolverType)
+               || typeof(IGeneratedAsyncDetermineAction<TDoc, TId>).IsAssignableFrom(evolverType)
+               || typeof(IGeneratedAsyncEvolver<TDoc, TId>).IsAssignableFrom(evolverType);
     }
 
     /// <summary>


### PR DESCRIPTION
Two event-sourcing codegen regressions that surface when Marten/Polecat adopt the 2.14.x line (Marten master deliberately pinned the older generator to avoid them). Found while publishing the document-diagnostics stack (#469).

## 1. Generator — DI-activated projection (CS7036)
A projection registered via `AddProjectionWithServices` has only a constructor with injected dependencies (no parameterless ctor). The `AggregateEvolver` generator created the evolver's private shadow projection instance with `new T()`, which fails to compile (CS7036) — e.g. Marten's #4185 `OrderProjection4185 : SingleStreamProjection` with an `IDocumentStore` ctor param. When there is no public parameterless ctor, the shadow instance is now created without running the constructor (`RuntimeHelpers.GetUninitializedObject`), mirroring the aggregate no-parameterless-ctor fallback. The shadow instance only invokes the projection's stateless Create/Apply event methods.

## 2. Runtime — multi-identity dispatcher (#297)
When one aggregate is registered against multiple identity types (e.g. `AggregateStream<CountOfLetters>` with both Guid and string ids), the generator emits one self-aggregating evolver per TId, all keyed on the aggregate type with a null `ProjectionType`. `tryUseAssemblyRegisteredEvolver` selected the fallback by aggregate type alone and could pick the wrong-TId evolver, whose strongly-typed `IGenerated*<TDoc,TId>` interface checks then all failed — leaving `_evolve` unwired and tripping the *"no source-generated dispatcher"* backstop. The fallback now only accepts an evolver implementing a `<TDoc, TId>` contract for the current identity type.

## Validation
- New generator regression test (`di_activated_projection_without_parameterless_ctor_compiles`); generator suite 24/24.
- Marten `Bug_4185` (generator) + `live_aggregation_with_string_identifiers` (runtime) both pass; full Marten **EventSourcingTests 1378/0/7** green against 2.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)