### PR TITLE
feat(events): IEventStoreInstrumentation.AppendObserver for runtime append observation (2.15.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.14.2</JasperFxVersion>
+        <JasperFxVersion>2.15.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events/IEventStoreInstrumentation.cs
+++ b/src/JasperFx.Events/IEventStoreInstrumentation.cs
@@ -16,4 +16,22 @@ public interface IEventStoreInstrumentation
     /// Defaults to false; consumers opt in.
     /// </summary>
     bool ExtendedProgressionEnabled { get; set; }
+
+    /// <summary>
+    /// Optional observer invoked with the events appended in each successful unit-of-work commit
+    /// (e.g. Marten/Polecat <c>SaveChanges</c>), letting storage-agnostic lifecycle tooling such as
+    /// CritterWatch record runtime-observed "appends" edges. Each <see cref="IEvent" /> carries the
+    /// data such an observer needs — event type, stream id/key, aggregate type, tenant id, and
+    /// timestamp — so no store-specific projection is required.
+    /// </summary>
+    /// <remarks>
+    /// A default no-op implementation keeps existing event stores source-compatible until they opt in;
+    /// an implementing store stores the delegate and invokes it (best-effort, after commit) with the
+    /// events it just appended. Combine observers with <c>+=</c>. See CritterWatch#500.
+    /// </remarks>
+    Action<IReadOnlyList<IEvent>>? AppendObserver
+    {
+        get => null;
+        set { }
+    }
 }


### PR DESCRIPTION
Broadens the storage-agnostic `IEventStoreInstrumentation` surface with an optional **`AppendObserver`** — an `Action<IReadOnlyList<IEvent>>?` invoked with the events appended in each successful unit-of-work commit (Marten/Polecat `SaveChanges`).

This is the upstream half of CritterWatch#500 Phase 4: it lets the lifecycle assembler's satellite record runtime-observed `appends` edges (handler/endpoint → event → stream/aggregate) without referencing concrete store types. Each `IEvent` already carries everything the observer needs — event type, stream id/key, aggregate type, tenant id, timestamp.

- Added as a **default interface member** (no-op default) so existing `IEventStoreInstrumentation` implementers stay source-compatible until they opt in.
- Marten and Polecat (polecat#213) implement it symmetrically — store the delegate and invoke it best-effort after commit.
- Version bumped to **2.15.0** (non-breaking feature addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)