### PR TITLE
feat(events): store-agnostic delete of a progression row by raw shard identity (#473)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.15.0</JasperFxVersion>
+        <JasperFxVersion>2.16.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/Daemon/DeleteProjectionProgressByShardNameDefaultsTests.cs
+++ b/src/EventTests/Daemon/DeleteProjectionProgressByShardNameDefaultsTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class DeleteProjectionProgressByShardNameDefaultsTests
+{
+    // A bare IEventDatabase that does NOT override DeleteProjectionProgressByShardNameAsync,
+    // so the call exercises the default interface implementation added for jasperfx#473.
+    // Stores that don't support raw shard-identity progression deletes must signal that
+    // loudly rather than silently no-op, so the default throws NotSupportedException.
+    private sealed class BareEventDatabase : IEventDatabase
+    {
+        public string Identifier => throw new NotImplementedException();
+        public Uri DatabaseUri => throw new NotImplementedException();
+        public ShardStateTracker Tracker => throw new NotImplementedException();
+        public string StorageIdentifier => throw new NotImplementedException();
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
+            => throw new NotImplementedException();
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    // An IEventDatabase that DOES override the new member, capturing the raw identity it was
+    // handed. Proves the abstraction targets the exact shard identity store-agnostically and
+    // that an implementer's override is honored over the throwing default.
+    private sealed class CapturingEventDatabase : IEventDatabase
+    {
+        public string? DeletedIdentity { get; private set; }
+
+        public Task DeleteProjectionProgressByShardNameAsync(string shardIdentity, CancellationToken token = default)
+        {
+            DeletedIdentity = shardIdentity;
+            return Task.CompletedTask;
+        }
+
+        public string Identifier => throw new NotImplementedException();
+        public Uri DatabaseUri => throw new NotImplementedException();
+        public ShardStateTracker Tracker => throw new NotImplementedException();
+        public string StorageIdentifier => throw new NotImplementedException();
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
+            => throw new NotImplementedException();
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task default_throws_not_supported_so_stores_must_opt_in()
+    {
+        IEventDatabase database = new BareEventDatabase();
+        await Should.ThrowAsync<NotSupportedException>(
+            () => database.DeleteProjectionProgressByShardNameAsync("claim_lines:V9:All"));
+    }
+
+    [Fact]
+    public async Task override_receives_the_raw_shard_identity_verbatim()
+    {
+        var database = new CapturingEventDatabase();
+        await database.DeleteProjectionProgressByShardNameAsync("claim_lines:V9:All");
+        database.DeletedIdentity.ShouldBe("claim_lines:V9:All");
+    }
+}

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -95,6 +95,26 @@ public interface IEventDatabase
                 "Per-tenant AllProjectionProgress is not implemented on this IEventDatabase. Use an event store that implements per-tenant partitioning.");
 
     /// <summary>
+    ///     Delete a single projection-progression row by its raw shard-name
+    ///     <see cref="ShardName.Identity" /> (e.g. <c>claim_lines:V9:All</c>), independent of whether a
+    ///     matching projection is still registered in the running application. This is the store-agnostic,
+    ///     DI-reachable companion to the read side (<see cref="AllProjectionProgress(CancellationToken)" />,
+    ///     <see cref="ProjectionProgressFor" />) and is the eject path for an <em>orphaned</em> shard — a
+    ///     renamed/versioned/removed projection, or a shard left behind by a topology change — whose row can
+    ///     no longer be dropped through the registered-projection-keyed
+    ///     <c>IEventStore&lt;,&gt;.DeleteProjectionProgressAsync</c> (which resolves its argument against the
+    ///     registered projections and so cannot target an unregistered identity).
+    ///     The match is on the exact shard identity, <em>not</em> a projection name or prefix. The default
+    ///     implementation throws <see cref="NotSupportedException" />; event stores (Marten, Polecat) override
+    ///     this to delete the row directly, bypassing any registered-projection lookup. See jasperfx#473.
+    /// </summary>
+    /// <param name="shardIdentity">The raw <see cref="ShardName.Identity" /> of the progression row to delete.</param>
+    /// <param name="token"></param>
+    Task DeleteProjectionProgressByShardNameAsync(string shardIdentity, CancellationToken token = default)
+        => throw new NotSupportedException(
+            "DeleteProjectionProgressByShardNameAsync is not implemented on this IEventDatabase. Use an event store (Marten or Polecat) that supports deleting a projection-progression row by its raw shard identity.");
+
+    /// <summary>
     ///     Count the stored dead letter events for a single projection/subscription shard. With
     ///     <c>SkipApplyErrors</c> on (the JasperFx.Events 2.0 default), a failed <c>Apply()</c> is
     ///     recorded as a <see cref="DeadLetterEvent" /> and the shard keeps advancing, so the


### PR DESCRIPTION
Closes #473.

## What

Adds `IEventDatabase.DeleteProjectionProgressByShardNameAsync(string shardIdentity, CancellationToken token)` — a store-agnostic, DI-reachable way to delete a single projection-progression row by its raw `ShardName.Identity` (e.g. `claim_lines:V9:All`), independent of whether a matching projection is still registered in the running app.

## Why

The only existing abstraction, `IEventStore<TOperations,TQuerySession>.DeleteProjectionProgressAsync`, has two problems for the orphan/unregistered-shard eject case:

1. It's only on the **generic** `IEventStore<,>`, whose type parameters are Marten/Polecat session types that store-agnostic consumers (Wolverine.CritterWatch) can't name — reachable only by reflection.
2. It resolves its `subscriptionName` against the **registered** projections, so on Marten it **throws `ArgumentOutOfRangeException`** for exactly the orphan case (renamed/versioned/removed projection, or a shard left behind by a topology change) — the one scenario where an operator most needs to drop the stale row.

The new member lives on the non-generic, store-agnostic `IEventDatabase`, which is already DI-reachable (via `IEventStore.AllDatabases()`) and already hosts the progression **read** side (`AllProjectionProgress`, `ProjectionProgressFor`). It matches on the **exact shard identity**, not a projection name or prefix.

## Behavior

The default implementation throws `NotSupportedException` so a store that can't honor a raw-identity delete signals it loudly rather than silently no-opping (a silent no-op on a delete is dangerous). Marten and Polecat will override it to delete the row directly, bypassing the registered-projection lookup.

## Downstream

Unblocks **JasperFx/CritterWatch#476 Part 1** ("Eject Shard" operator action).

## Tests

`DeleteProjectionProgressByShardNameDefaultsTests` covers the throwing default and that an implementer's override receives the raw identity verbatim.

## Version

Bumps `JasperFxVersion` 2.15.0 → 2.16.0 (minor — additive interface member with a default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)