### PR TITLE
feat(descriptors): advertise event/document metadata capabilities (#475)

### DIFF
--- a/src/CoreTests/Descriptors/DocumentStoreUsageTests.cs
+++ b/src/CoreTests/Descriptors/DocumentStoreUsageTests.cs
@@ -47,6 +47,64 @@ public class DocumentStoreUsageTests
             () => new DocumentStoreUsage(new Uri("marten://main"), null!));
     }
 
+    [Fact]
+    public void document_metadata_capabilities_default_to_null()
+    {
+        // jasperfx#475: until the implementing store populates it, consumers
+        // must be able to tell "capabilities unknown" apart from "everything off".
+        new DocumentStoreUsage(new Uri("marten://main"), new FakeDocumentStore())
+            .DocumentMetadata.ShouldBeNull();
+    }
+
+    [Fact]
+    public void document_metadata_capabilities_default_flags()
+    {
+        // Common document metadata -> default true; the opt-in tracking columns
+        // (correlation/causation/last-modified-by) -> default false.
+        var capabilities = new DocumentMetadataCapabilities();
+
+        capabilities.StoreType.ShouldBe("");
+
+        capabilities.Version.ShouldBeTrue();
+        capabilities.LastModified.ShouldBeTrue();
+        capabilities.TenantId.ShouldBeTrue();
+        capabilities.SoftDelete.ShouldBeTrue();
+
+        capabilities.CorrelationId.ShouldBeFalse();
+        capabilities.CausationId.ShouldBeFalse();
+        capabilities.LastModifiedBy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void document_metadata_capabilities_round_trip_through_json()
+    {
+        var usage = new DocumentStoreUsage(new Uri("marten://main"), new FakeDocumentStore())
+        {
+            DocumentMetadata = new DocumentMetadataCapabilities
+            {
+                StoreType = "Marten",
+                CorrelationId = true,
+                CausationId = true,
+                LastModifiedBy = true,
+                // Flip a couple of the otherwise-common flags off to prove they
+                // serialize as set, not as their defaults.
+                SoftDelete = false,
+                TenantId = false
+            }
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(usage);
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<DocumentStoreUsage>(json)!;
+
+        roundTripped.DocumentMetadata.ShouldNotBeNull();
+        roundTripped.DocumentMetadata.StoreType.ShouldBe("Marten");
+        roundTripped.DocumentMetadata.CorrelationId.ShouldBeTrue();
+        roundTripped.DocumentMetadata.CausationId.ShouldBeTrue();
+        roundTripped.DocumentMetadata.LastModifiedBy.ShouldBeTrue();
+        roundTripped.DocumentMetadata.SoftDelete.ShouldBeFalse();
+        roundTripped.DocumentMetadata.TenantId.ShouldBeFalse();
+    }
+
     /// <summary>
     /// Stand-in for Marten's DocumentStore — exposes the kind of runtime
     /// handles (IStorage / IAdvanced / IDiagnostics / IOptions) that used to

--- a/src/EventTests/Descriptors/EventStoreUsageTests.cs
+++ b/src/EventTests/Descriptors/EventStoreUsageTests.cs
@@ -310,6 +310,68 @@ public class EventStoreUsageTests
         usage.ProjectionRebuildErrors.SkipUnknownEvents.ShouldBeFalse();
         usage.ProjectionRebuildErrors.SkipSerializationErrors.ShouldBeFalse();
     }
+
+    [Fact]
+    public void event_metadata_capabilities_default_to_null()
+    {
+        // jasperfx#475: until the implementing store populates it, consumers
+        // must be able to tell "capabilities unknown" apart from "everything off".
+        new EventStoreUsage(new Uri("marten://main"), new MyThing())
+            .EventMetadata.ShouldBeNull();
+    }
+
+    [Fact]
+    public void event_metadata_capabilities_round_trip_through_json()
+    {
+        var usage = new EventStoreUsage(new Uri("marten://main"), new MyThing())
+        {
+            EventMetadata = new EventMetadataCapabilities
+            {
+                StoreType = "Marten",
+                CorrelationId = true,
+                CausationId = true,
+                Headers = true,
+                UserName = true,
+                // Flip a couple of the otherwise-universal stream flags off to
+                // prove they serialize as set, not as their defaults.
+                Archived = false,
+                TenantId = false
+            }
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(usage);
+        var roundTripped = System.Text.Json.JsonSerializer.Deserialize<EventStoreUsage>(json)!;
+
+        roundTripped.EventMetadata.ShouldNotBeNull();
+        roundTripped.EventMetadata.StoreType.ShouldBe("Marten");
+        roundTripped.EventMetadata.CorrelationId.ShouldBeTrue();
+        roundTripped.EventMetadata.CausationId.ShouldBeTrue();
+        roundTripped.EventMetadata.Headers.ShouldBeTrue();
+        roundTripped.EventMetadata.UserName.ShouldBeTrue();
+        roundTripped.EventMetadata.Archived.ShouldBeFalse();
+        roundTripped.EventMetadata.TenantId.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void event_metadata_capabilities_default_flags()
+    {
+        // Event metadata flags are opt-in columns -> default false; stream
+        // metadata flags are effectively universal -> default true.
+        var capabilities = new EventMetadataCapabilities();
+
+        capabilities.StoreType.ShouldBe("");
+
+        capabilities.CorrelationId.ShouldBeFalse();
+        capabilities.CausationId.ShouldBeFalse();
+        capabilities.Headers.ShouldBeFalse();
+        capabilities.UserName.ShouldBeFalse();
+
+        capabilities.StreamAggregateType.ShouldBeTrue();
+        capabilities.StreamVersion.ShouldBeTrue();
+        capabilities.StreamTimestamps.ShouldBeTrue();
+        capabilities.TenantId.ShouldBeTrue();
+        capabilities.Archived.ShouldBeTrue();
+    }
 }
 
 public class MyThing

--- a/src/JasperFx.Events/Descriptors/EventMetadataCapabilities.cs
+++ b/src/JasperFx.Events/Descriptors/EventMetadataCapabilities.cs
@@ -1,0 +1,97 @@
+namespace JasperFx.Events.Descriptors;
+
+/// <summary>
+/// Store-agnostic description of <em>which</em> event and stream metadata an event
+/// store actually captures. Surfaced on <see cref="EventStoreUsage.EventMetadata"/>
+/// so store-aware consumers (notably CritterWatch) can gate event/stream query
+/// facets by what the store really persists, instead of sniffing engine-specific
+/// configuration (Marten's <c>MetadataConfig</c>, Polecat's event options).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <strong>event</strong> metadata flags (<see cref="CorrelationId"/>,
+/// <see cref="CausationId"/>, <see cref="Headers"/>, <see cref="UserName"/>) are
+/// opt-in columns and so default to <see langword="false"/> — the implementing
+/// store maps them from its own metadata configuration.
+/// </para>
+/// <para>
+/// The <strong>stream</strong> metadata flags
+/// (<see cref="StreamAggregateType"/>, <see cref="StreamVersion"/>,
+/// <see cref="StreamTimestamps"/>, <see cref="TenantId"/>, <see cref="Archived"/>)
+/// are effectively universal across both engines today and default to
+/// <see langword="true"/>; the implementing store overrides any it does not
+/// capture.
+/// </para>
+/// <para>
+/// See jasperfx#475. <see cref="UserName"/> is currently Marten-only (Polecat
+/// parity tracked at JasperFx/polecat#237) — the descriptor lets consumers gate
+/// that facet cleanly until parity lands.
+/// </para>
+/// </remarks>
+public class EventMetadataCapabilities
+{
+    /// <summary>
+    /// Engine discriminator for the store that produced this descriptor
+    /// (e.g. <c>"Marten"</c>, <c>"Polecat"</c>). Lets consumers branch on the
+    /// concrete engine where the uniform flags are not enough.
+    /// </summary>
+    public string StoreType { get; set; } = "";
+
+    /// <summary>
+    /// The event store captures a per-event correlation id column.
+    /// Maps from Marten's <c>MetadataConfig.CorrelationIdEnabled</c> /
+    /// Polecat's <c>EnableCorrelationId</c>.
+    /// </summary>
+    public bool CorrelationId { get; set; }
+
+    /// <summary>
+    /// The event store captures a per-event causation id column.
+    /// Maps from Marten's <c>MetadataConfig.CausationIdEnabled</c> /
+    /// Polecat's <c>EnableCausationId</c>.
+    /// </summary>
+    public bool CausationId { get; set; }
+
+    /// <summary>
+    /// The event store captures a per-event headers column.
+    /// Maps from Marten's <c>MetadataConfig.HeadersEnabled</c> /
+    /// Polecat's <c>EnableHeaders</c>.
+    /// </summary>
+    public bool Headers { get; set; }
+
+    /// <summary>
+    /// The event store captures a per-event user-name column.
+    /// Maps from Marten's <c>MetadataConfig.UserNameEnabled</c>; currently
+    /// Marten-only (Polecat parity: JasperFx/polecat#237).
+    /// </summary>
+    public bool UserName { get; set; }
+
+    /// <summary>
+    /// The streams table exposes a queryable aggregate-type column. Universal
+    /// across both engines today; defaults to <see langword="true"/>.
+    /// </summary>
+    public bool StreamAggregateType { get; set; } = true;
+
+    /// <summary>
+    /// The streams table exposes a queryable version column. Universal across
+    /// both engines today; defaults to <see langword="true"/>.
+    /// </summary>
+    public bool StreamVersion { get; set; } = true;
+
+    /// <summary>
+    /// The streams table exposes queryable created/updated timestamp columns.
+    /// Universal across both engines today; defaults to <see langword="true"/>.
+    /// </summary>
+    public bool StreamTimestamps { get; set; } = true;
+
+    /// <summary>
+    /// The streams table exposes a queryable tenant-id column. Universal across
+    /// both engines today; defaults to <see langword="true"/>.
+    /// </summary>
+    public bool TenantId { get; set; } = true;
+
+    /// <summary>
+    /// The streams table exposes a queryable archived/soft-deleted flag.
+    /// Universal across both engines today; defaults to <see langword="true"/>.
+    /// </summary>
+    public bool Archived { get; set; } = true;
+}

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -166,6 +166,15 @@ public class EventStoreUsage : OptionsDescription
     public ProjectionErrorHandlingDescriptor? ProjectionRebuildErrors { get; set; }
 
     /// <summary>
+    /// Which event/stream metadata this store actually captures — drives
+    /// store-aware event/stream query facets in consumers (e.g. CritterWatch)
+    /// without sniffing engine-specific config. Null when the implementation
+    /// hasn't populated it; tools should treat that as "capabilities unknown".
+    /// See jasperfx#475.
+    /// </summary>
+    public EventMetadataCapabilities? EventMetadata { get; set; }
+
+    /// <summary>
     /// Populates AgentUris on each async SubscriptionDescriptor based on the
     /// agent URI pattern: {agentScheme}://{identity.Type}/{identity.Name}/{databaseId}/{shardName.RelativeUrl}
     /// </summary>

--- a/src/JasperFx/Descriptors/DocumentMetadataCapabilities.cs
+++ b/src/JasperFx/Descriptors/DocumentMetadataCapabilities.cs
@@ -1,0 +1,77 @@
+namespace JasperFx.Descriptors;
+
+/// <summary>
+/// Store-agnostic description of <em>which</em> document metadata an event/document
+/// store actually captures. Surfaced on <see cref="DocumentStoreUsage.DocumentMetadata"/>
+/// so store-aware consumers (notably CritterWatch) can gate faceted document-query
+/// options by what the store really persists, instead of sniffing engine-specific
+/// configuration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Parallel to <c>JasperFx.Events.Descriptors.EventMetadataCapabilities</c> but a
+/// <strong>separate</strong> block: even within one engine the metadata captured
+/// for documents can differ from what is captured for events, so a single block
+/// cannot represent both (see jasperfx#475).
+/// </para>
+/// <para>
+/// <see cref="Version"/>, <see cref="LastModified"/>, <see cref="TenantId"/> and
+/// <see cref="SoftDelete"/> are the common document-metadata columns and default
+/// to <see langword="true"/>; the implementing store overrides any it does not
+/// capture. The optional, opt-in columns (<see cref="CorrelationId"/>,
+/// <see cref="CausationId"/>, <see cref="LastModifiedBy"/>) default to
+/// <see langword="false"/> and are turned on only where the document config
+/// enables them.
+/// </para>
+/// </remarks>
+public class DocumentMetadataCapabilities
+{
+    /// <summary>
+    /// Engine discriminator for the store that produced this descriptor
+    /// (e.g. <c>"Marten"</c>, <c>"Polecat"</c>). Lets consumers branch on the
+    /// concrete engine where the uniform flags are not enough.
+    /// </summary>
+    public string StoreType { get; set; } = "";
+
+    /// <summary>
+    /// Documents carry a queryable version column. Common metadata; defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool Version { get; set; } = true;
+
+    /// <summary>
+    /// Documents carry a queryable last-modified timestamp. Common metadata;
+    /// defaults to <see langword="true"/>.
+    /// </summary>
+    public bool LastModified { get; set; } = true;
+
+    /// <summary>
+    /// Documents carry a queryable tenant-id column. Common metadata; defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool TenantId { get; set; } = true;
+
+    /// <summary>
+    /// Documents expose a soft-delete flag (and deletion timestamp) rather than
+    /// being hard-deleted. Common metadata; defaults to <see langword="true"/>.
+    /// </summary>
+    public bool SoftDelete { get; set; } = true;
+
+    /// <summary>
+    /// Documents capture a correlation-id column — only where the document
+    /// metadata config enables it; defaults to <see langword="false"/>.
+    /// </summary>
+    public bool CorrelationId { get; set; }
+
+    /// <summary>
+    /// Documents capture a causation-id column — only where the document
+    /// metadata config enables it; defaults to <see langword="false"/>.
+    /// </summary>
+    public bool CausationId { get; set; }
+
+    /// <summary>
+    /// Documents capture a last-modified-by (user name) column — only where the
+    /// document metadata config enables it; defaults to <see langword="false"/>.
+    /// </summary>
+    public bool LastModifiedBy { get; set; }
+}

--- a/src/JasperFx/Descriptors/DocumentStoreUsage.cs
+++ b/src/JasperFx/Descriptors/DocumentStoreUsage.cs
@@ -131,4 +131,15 @@ public class DocumentStoreUsage : OptionsDescription
     /// <c>Storage.AllDocumentMappings</c>.
     /// </summary>
     public List<DocumentMappingDescriptor> Documents { get; set; } = new();
+
+    /// <summary>
+    /// Which document metadata this store actually captures — drives store-aware
+    /// document query facets in consumers (e.g. CritterWatch) without sniffing
+    /// engine-specific config. Separate from the event-store's
+    /// <c>EventMetadataCapabilities</c> because per-document metadata can differ
+    /// from per-event metadata within the same engine. Null when the
+    /// implementation hasn't populated it; tools should treat that as
+    /// "capabilities unknown". See jasperfx#475.
+    /// </summary>
+    public DocumentMetadataCapabilities? DocumentMetadata { get; set; }
 }


### PR DESCRIPTION
Closes #475.

Adds store-agnostic **metadata-capability descriptors** so an event/document store can advertise *which* event/stream and document metadata it actually captures. Consumers (notably [CritterWatch](https://github.com/JasperFx/CritterWatch)) can then drive store-aware query facets off the `JasperFx.Events` / `JasperFx` abstractions instead of sniffing engine-specific config (Marten's `MetadataConfig`, Polecat's event options).

## What's here

- **`EventMetadataCapabilities`** (`JasperFx.Events.Descriptors`) surfaced on `EventStoreUsage.EventMetadata`.
  - Opt-in **event** flags — `CorrelationId`, `CausationId`, `Headers`, `UserName` — default `false`.
  - Largely-universal **stream** flags — `StreamAggregateType`, `StreamVersion`, `StreamTimestamps`, `TenantId`, `Archived` — default `true`.
  - `StoreType` engine discriminator.
- **`DocumentMetadataCapabilities`** (`JasperFx.Descriptors`) surfaced on `DocumentStoreUsage.DocumentMetadata`.
  - Kept a **separate** block per the scope-broadening comment on #475: per-document metadata can differ from per-event metadata within one engine, so a single block can't represent both.
  - Common columns — `Version`, `LastModified`, `TenantId`, `SoftDelete` — default `true`; opt-in tracking columns — `CorrelationId`, `CausationId`, `LastModifiedBy` — default `false`.

Both blocks default to **null** on their usage descriptor so consumers can distinguish "capabilities unknown" (store hasn't populated it yet) from "everything off".

## Scope

This PR is the **abstraction only** — the `JasperFx`/`JasperFx.Events` surface. Mapping from `MetadataConfig` / event options lands downstream in Marten and Polecat (`UserName` is Marten-only today; Polecat parity tracked at JasperFx/polecat#237).

## Tests

- `EventStoreUsageTests`: null default, default-flag matrix, JSON round-trip.
- `DocumentStoreUsageTests`: null default, default-flag matrix, JSON round-trip.

All new tests pass. (The 4 pre-existing `populate_agent_uris_*` failures in `EventStoreUsageTests` fail on `main` too — unrelated NSubstitute mock issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
