### PR TITLE
feat: DocumentQueryOptions.TenantId for tenant-scoped document diagnostics (2.17.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.16.0</JasperFxVersion>
+        <JasperFxVersion>2.17.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx/Documents/IDocumentStoreDiagnostics.cs
+++ b/src/JasperFx/Documents/IDocumentStoreDiagnostics.cs
@@ -39,7 +39,16 @@ public record DocumentTypeRef(string TypeName, string Alias, string SchemaName);
 /// optional <see cref="IdEquals"/> narrows to a single id. Room to grow simple criteria later without a
 /// signature break.
 /// </summary>
-public record DocumentQueryOptions(int PageNumber, int PageSize, string? IdEquals = null);
+public record DocumentQueryOptions(int PageNumber, int PageSize, string? IdEquals = null)
+{
+    /// <summary>
+    /// Optional tenant id to scope the query to. For conjoined tenancy the implementation filters by the
+    /// store's tenant column; for database-per-tenant it targets that tenant's physical database. Null
+    /// queries the default/main tenant. Added as an init-only member (not a positional parameter) so the
+    /// record stays binary-compatible. See JasperFx/CritterWatch EVENT_STORE_EXPLORER_PLAN §3.1.
+    /// </summary>
+    public string? TenantId { get; init; }
+}
 
 /// <summary>A page of stored documents as raw JSON, with the total matching count for pager UIs.</summary>
 public record DocumentQueryResult(IReadOnlyList<string> DocumentsJson, long TotalCount, int PageNumber, int PageSize);


### PR DESCRIPTION
Part of the CritterWatch Event Store / Document Store Explorer work (EVENT_STORE_EXPLORER_PLAN §3.1).

## Changes
- Add `DocumentQueryOptions.TenantId` (init-only member, binary-safe) so a monitoring console can scope `IDocumentStoreDiagnostics.QueryDocumentsAsync` to a tenant — conjoined (filter the tenant column) or database-per-tenant (target the tenant database), resolved by the implementing store.
- Bump `JasperFxVersion` → **2.17.0**.

The metadata-capabilities descriptors (`EventMetadataCapabilities` / `DocumentMetadataCapabilities`, #475) already merged via #476; **2.17.0** ships both that abstraction and `TenantId`.

## Release order
Publish **JasperFx 2.17.0 first** — Marten 9.12.0-alpha.1 + Polecat 4.7.0-alpha.1 reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
