### PR TITLE
feat: metadata filters on DocumentQueryOptions + EventQuery (2.18.0) (#478)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.17.0</JasperFxVersion>
+        <JasperFxVersion>2.18.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events/EventQuery.cs
+++ b/src/JasperFx.Events/EventQuery.cs
@@ -6,6 +6,27 @@ public class EventQuery
     public string? StreamId { get; set; }
     public int PageNumber { get; set; } = 1;
     public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Optional exact-match filter on the event's correlation id metadata. Null applies no filter. Only
+    /// honored when the store advertises and captures the correlation id metadata column. See
+    /// JasperFx/CritterWatch #629.
+    /// </summary>
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Optional exact-match filter on the event's causation id metadata. Null applies no filter. Only
+    /// honored when the store advertises and captures the causation id metadata column. See
+    /// JasperFx/CritterWatch #629.
+    /// </summary>
+    public string? CausationId { get; set; }
+
+    /// <summary>
+    /// Optional exact-match filter on the event's user name metadata. Null applies no filter. Only honored
+    /// when the store advertises and captures the user name metadata column (cross-engine). See
+    /// JasperFx/CritterWatch #629.
+    /// </summary>
+    public string? UserName { get; set; }
 }
 
 public class PagedEvents

--- a/src/JasperFx/Documents/IDocumentStoreDiagnostics.cs
+++ b/src/JasperFx/Documents/IDocumentStoreDiagnostics.cs
@@ -48,6 +48,28 @@ public record DocumentQueryOptions(int PageNumber, int PageSize, string? IdEqual
     /// record stays binary-compatible. See JasperFx/CritterWatch EVENT_STORE_EXPLORER_PLAN §3.1.
     /// </summary>
     public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Optional exact-match filter on the document's correlation id metadata. Null applies no filter. Only
+    /// honored when the store advertises and captures the correlation id metadata column; otherwise ignored.
+    /// Added as an init-only member so the record stays binary-compatible. See JasperFx/CritterWatch #629.
+    /// </summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>
+    /// Optional exact-match filter on the document's causation id metadata. Null applies no filter. Only
+    /// honored when the store advertises and captures the causation id metadata column; otherwise ignored.
+    /// Added as an init-only member so the record stays binary-compatible. See JasperFx/CritterWatch #629.
+    /// </summary>
+    public string? CausationId { get; init; }
+
+    /// <summary>
+    /// Optional exact-match filter on the document's "last modified by" user metadata. Null applies no
+    /// filter. Only honored when the store advertises and captures the last-modified-by metadata column;
+    /// otherwise ignored. Added as an init-only member so the record stays binary-compatible. See
+    /// JasperFx/CritterWatch #629.
+    /// </summary>
+    public string? LastModifiedBy { get; init; }
 }
 
 /// <summary>A page of stored documents as raw JSON, with the total matching count for pager UIs.</summary>


### PR DESCRIPTION
Abstraction layer for the **metadata-filtered query** feature (CritterWatch — filter documents/events by the metadata the store actually captures). The store-agnostic filter contract that Marten + Polecat then implement.

## Changes
- **`DocumentQueryOptions`** (`JasperFx.Documents`) — add **init-only** metadata filters: `CorrelationId?`, `CausationId?`, `LastModifiedBy?` (`string?`, null = no filter). Init-only members keep the positional record binary-compatible — same pattern that added `TenantId`.
- **`EventQuery`** (`JasperFx.Events`) — add settable `CorrelationId?`, `CausationId?`, `UserName?` (mutable class, so additive props are safe).
- Bump `JasperFxVersion` to **2.18.0** for release.

v1 semantics (engine side): exact-match, AND-combined, only on opt-in columns the store advertises. Engine impl (Marten + Polecat) is tracked separately.

Closes #478. Tracked in JasperFx/CritterWatch#629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)