### PR TITLE
fix(generator): dispatch DI projections through partial-class override (marten#4787)

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -117,12 +117,17 @@ public partial class AllSync : SingleStreamProjection<MyAggregate, Guid>
     }
 
     [Fact]
-    public void di_activated_projection_without_parameterless_ctor_compiles()
+    public void di_activated_projection_without_parameterless_ctor_dispatches_through_partial_override()
     {
-        // #4185 / CS7036 regression: a projection registered via AddProjectionWithServices has only a
-        // constructor with injected dependencies (no parameterless ctor). The evolver's private shadow
-        // instance must not be created with `new T()` — that won't compile. It is instantiated without
-        // running the constructor instead (RuntimeHelpers.GetUninitializedObject).
+        // marten#4787: a projection registered via AddProjectionWithServices has only a constructor
+        // with injected dependencies (no parameterless ctor). The pre-fix emission built the
+        // evolver's private shadow projection via RuntimeHelpers.GetUninitializedObject — which
+        // compiled (closing the original #4185 CS7036 hole) but left injected fields null at runtime,
+        // NREing the first time a convention method dereferenced one.
+        // The fix emits a [GeneratedCode]-attributed override (Evolve / EvolveAsync /
+        // DetermineActionAsync) directly into the user's partial class. Dispatch binds to `this`
+        // (the DI-built instance), so injected fields are populated. The file-scoped Evolver and the
+        // [assembly: GeneratedEvolver(...)] attribute are NOT emitted for this case.
         var source = @"
 using System;
 using JasperFx.Events;
@@ -154,11 +159,27 @@ public partial class DiActivated : SingleStreamProjection<MyAggregate, Guid>
         var (_, generatedSources) = RunGenerator(source);
         var generated = string.Join("\n", generatedSources);
 
-        // Shadow instance is created without invoking the (parameterized) constructor.
-        generated.ShouldContain("GetUninitializedObject(typeof(global::Test.DiActivated))");
+        // No shadow-instance escape hatch — the override dispatches on `this`.
+        generated.ShouldNotContain("GetUninitializedObject(typeof(global::Test.DiActivated))");
         generated.ShouldNotContain("new global::Test.DiActivated()");
+        generated.ShouldNotContain("_projection.Create");
+        generated.ShouldNotContain("_projection.Apply");
 
-        // The generated evolver must compile — no CS7036 "no argument for required parameter".
+        // No file-scoped Evolver class and no GeneratedEvolver assembly attribute — the runtime
+        // selects the partial-class override via isOverridden() before tryUseAssemblyRegisteredEvolver
+        // ever runs, so the file-scoped path is unreachable for this case.
+        generated.ShouldNotContain("file sealed class");
+        generated.ShouldNotContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver");
+
+        // Partial-class override on the user's class, marked [GeneratedCode] so
+        // AssembleAndAssertValidity's isSourceGeneratedOverride() accepts it.
+        generated.ShouldContain("partial class DiActivated");
+        generated.ShouldContain("[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
+        // Either Evolve (sync, no session/ShouldDelete) or EvolveAsync would do — the projection
+        // here is sync with no ShouldDelete, so expect the sync Evolve override.
+        generated.ShouldContain("public override global::Test.MyAggregate? Evolve(");
+
+        // The generated override must compile — no CS7036 "no argument for required parameter".
         var diagnostics = CompileWithGenerator(source);
         diagnostics.ShouldNotContain(d => d.Id == "CS7036");
     }

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -51,6 +51,22 @@ internal static class EvolverCodeEmitter
     /// </summary>
     public static string EmitPartialProjection(CandidateInfo info)
     {
+        // marten#4787: when a projection requires a DI-resolved instance for its conventional
+        // Apply/Create/ShouldDelete methods (it has at least one instance-on-projection handler AND
+        // no public parameterless constructor), the file-scoped Evolver dispatcher silently NREs on
+        // any deref of an injected field — its shadow projection is built via
+        // RuntimeHelpers.GetUninitializedObject, which skips the constructor. Route to the alternative
+        // emission that adds an override directly to the user's partial class so `this` (the DI-built
+        // instance) handles dispatch and injected fields are populated. Stateless / parameterless-ctor
+        // / aggregate-only / static-only projections keep the file-scoped Evolver — no perf regression
+        // for the cases that don't need DI.
+        if (NeedsProjectionInstance(info)
+            && !HasPublicParameterlessCtor(info.ClassSymbol)
+            && info.IsPartial)
+        {
+            return EmitPartialProjectionWithDIOverride(info);
+        }
+
         var sb = new StringBuilder();
         AppendGeneratedFileHeader(sb);
 
@@ -138,6 +154,286 @@ internal static class EvolverCodeEmitter
     }
 
     /// <summary>
+    /// marten#4787 alternative dispatch: emit the projection's Evolve / EvolveAsync /
+    /// DetermineActionAsync as a [GeneratedCode]-attributed override directly into the user's
+    /// <em>partial</em> projection class. The body switches on event type and calls the conventional
+    /// methods bare (binding to <c>this</c>), so the DI-resolved projection instance handles
+    /// dispatch and every injected field is populated. We deliberately skip the
+    /// <c>[assembly: GeneratedEvolver(...)]</c> registration and the <c>file sealed class</c> Evolver
+    /// — the runtime's <c>isOverridden(...)</c> precedence (<c>JasperFxAggregationProjectionBase</c>
+    /// lines 82-114) prefers a user/SG override on the class over the assembly-registered Evolver,
+    /// so the dispatcher routes through this method and never recreates the shadow instance whose
+    /// null injected fields caused the regression.
+    /// </summary>
+    private static string EmitPartialProjectionWithDIOverride(CandidateInfo info)
+    {
+        var sb = new StringBuilder();
+        AppendGeneratedFileHeader(sb);
+
+        var ns = info.ClassSymbol.ContainingNamespace;
+        if (!ns.IsGlobalNamespace)
+        {
+            sb.AppendLine($"namespace {ns.ToDisplayString()};");
+            sb.AppendLine();
+        }
+
+        // Mirror EmitEventProjectionPartial: open containing-type partial declarations (handles
+        // a projection nested inside a record/class, e.g. `record Foo { partial class Projector ... }`).
+        var containingTypes = GetContainingTypes(info.ClassSymbol);
+        foreach (var container in containingTypes)
+        {
+            sb.AppendLine($"partial {ContainerKeyword(container)} {container.Name}{ContainerTypeParams(container)}");
+            sb.AppendLine("{");
+        }
+
+        var className = info.ClassSymbol.Name;
+        var typeParams = "";
+        if (info.ClassSymbol.TypeParameters.Length > 0)
+        {
+            typeParams = "<" + string.Join(", ", info.ClassSymbol.TypeParameters.Select(t => t.Name)) + ">";
+        }
+
+        sb.AppendLine($"partial class {className}{typeParams}");
+        sb.AppendLine("{");
+
+        if (info.HasShouldDelete)
+        {
+            EmitDetermineActionAsOverride(sb, info);
+        }
+        else if (info.HasAnyAsync)
+        {
+            EmitEvolveAsyncAsOverride(sb, info);
+        }
+        else
+        {
+            EmitEvolveAsOverride(sb, info);
+        }
+
+        sb.AppendLine("}");
+
+        foreach (var _ in containingTypes)
+        {
+            sb.AppendLine("}");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// marten#4787: synchronous, no-ShouldDelete partial-class override. Matches the virtual at
+    /// <c>JasperFxAggregationProjectionBase.Runtime.cs:175</c>:
+    /// <c>public virtual TDoc? Evolve(TDoc? snapshot, TId id, IEvent e)</c>.
+    /// </summary>
+    private static void EmitEvolveAsOverride(StringBuilder sb, CandidateInfo info)
+    {
+        var docType = Fqn(info.AggregateType!);
+        var idType = Fqn(info.IdentityType!);
+
+        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
+        sb.AppendLine($"    public override {docType}? Evolve({docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e)");
+        sb.AppendLine("    {");
+
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
+
+        sb.AppendLine("        if (snapshot == null)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            switch (e.Data)");
+        sb.AppendLine("            {");
+        EmitNullSnapshotCases(sb, info, createMethods, applyMethods, "                ", dispatchOnThis: true);
+        sb.AppendLine("                default: return null;");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+
+        sb.AppendLine("        switch (e.Data)");
+        sb.AppendLine("        {");
+        EmitNonNullSnapshotCases(sb, info, applyMethods, "            ", dispatchOnThis: true);
+        sb.AppendLine("            default: return snapshot;");
+        sb.AppendLine("        }");
+
+        sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// marten#4787: async / session-using, no-ShouldDelete partial-class override. Matches the
+    /// virtual at <c>JasperFxAggregationProjectionBase.Runtime.cs:142</c>:
+    /// <c>public virtual ValueTask&lt;TDoc?&gt; EvolveAsync(TDoc? snapshot, TId id, TQuerySession session, IEvent e, CancellationToken cancellation)</c>.
+    /// The override binds the strongly-typed <c>TQuerySession</c> directly, so user handlers that
+    /// take an <c>IQuerySession</c> parameter consume <c>session</c> without a cast (no equivalent
+    /// of <see cref="EmitSessionLocalIfNeeded"/> required here).
+    /// </summary>
+    private static void EmitEvolveAsyncAsOverride(StringBuilder sb, CandidateInfo info)
+    {
+        var docType = Fqn(info.AggregateType!);
+        var idType = Fqn(info.IdentityType!);
+        var querySessionType = Fqn(info.QuerySessionType!);
+
+        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
+        sb.AppendLine($"    public override async global::System.Threading.Tasks.ValueTask<{docType}?> EvolveAsync(");
+        sb.AppendLine($"        {docType}? snapshot, {idType} id, {querySessionType} session, global::JasperFx.Events.IEvent e,");
+        sb.AppendLine($"        global::System.Threading.CancellationToken cancellation)");
+        sb.AppendLine("    {");
+
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
+
+        sb.AppendLine("        if (snapshot == null)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            switch (e.Data)");
+        sb.AppendLine("            {");
+        EmitNullSnapshotCasesAsync(sb, info, createMethods, applyMethods, "                ", dispatchOnThis: true);
+        sb.AppendLine("                default: return null;");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+
+        sb.AppendLine("        switch (e.Data)");
+        sb.AppendLine("        {");
+        EmitNonNullSnapshotCasesAsync(sb, info, applyMethods, "            ", dispatchOnThis: true);
+        sb.AppendLine("            default: return snapshot;");
+        sb.AppendLine("        }");
+
+        sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// marten#4787: ShouldDelete-aware partial-class override. Matches the virtual at
+    /// <c>JasperFxAggregationProjectionBase.Runtime.cs:93</c>:
+    /// <c>public virtual ValueTask&lt;(TDoc?, ActionType)&gt; DetermineActionAsync(TQuerySession session, TDoc? snapshot, TId identity, IIdentitySetter&lt;TDoc, TId&gt; identitySetter, IReadOnlyList&lt;IEvent&gt; events, CancellationToken cancellation)</c>.
+    /// Body mirrors the file-scoped <see cref="EmitDetermineActionEvolverMethod"/> verbatim, with
+    /// <c>dispatchOnThis: true</c> swapping every <c>_projection.</c> instance call for a bare call
+    /// on <c>this</c>. Per-event ApplyEventException wrapping is preserved because the runtime
+    /// dispatches DetermineActionAsync as a single call (no <c>evolveDefaultAsync</c>-style per-event
+    /// catch wrapper above us).
+    /// </summary>
+    private static void EmitDetermineActionAsOverride(StringBuilder sb, CandidateInfo info)
+    {
+        var docType = Fqn(info.AggregateType!);
+        var idType = Fqn(info.IdentityType!);
+        var querySessionType = Fqn(info.QuerySessionType!);
+        var isAsync = info.HasAnyAsync;
+        var asyncKeyword = isAsync ? "async " : "";
+
+        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
+        sb.AppendLine($"    public override {asyncKeyword}global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)> DetermineActionAsync(");
+        sb.AppendLine($"        {querySessionType} session,");
+        sb.AppendLine($"        {docType}? snapshot,");
+        sb.AppendLine($"        {idType} identity,");
+        sb.AppendLine($"        global::JasperFx.Events.Aggregation.IIdentitySetter<{docType}, {idType}> identitySetter,");
+        sb.AppendLine($"        global::System.Collections.Generic.IReadOnlyList<global::JasperFx.Events.IEvent> events,");
+        sb.AppendLine($"        global::System.Threading.CancellationToken cancellation)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        var exists = snapshot != null;");
+        sb.AppendLine("        foreach (var e in events)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            try");
+        sb.AppendLine("            {");
+        sb.AppendLine("            switch (e.Data)");
+        sb.AppendLine("            {");
+
+        var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
+        var shouldDeleteByEventType = shouldDeleteMethods
+            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
+            .OrderByDescending(g => GetTypeDepth(g.Key))
+            .ToList();
+        var shouldDeleteEventTypes = new HashSet<ITypeSymbol>(
+            shouldDeleteMethods.Select(m => m.EventType), SymbolEqualityComparer.Default);
+        var ctorDeleteEventTypes = info.ConstructorDeleteEventTypes
+            .Where(t => !shouldDeleteEventTypes.Contains(t))
+            .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
+            .OrderByDescending(t => GetTypeDepth(t))
+            .ToList();
+
+        foreach (var group in shouldDeleteByEventType)
+        {
+            var eventTypeName = Fqn(group.Key);
+            var dataVar = "data";
+            sb.AppendLine($"                case {eventTypeName} {dataVar}:");
+            sb.Append("                    if (snapshot != null && (");
+            bool first = true;
+            foreach (var method in group)
+            {
+                if (!first) sb.Append(" || ");
+                first = false;
+                EmitShouldDeleteCall(sb, method, dataVar, dispatchOnThis: true);
+            }
+            sb.AppendLine("))");
+            sb.AppendLine("                        snapshot = null;");
+            sb.AppendLine("                    break;");
+        }
+        foreach (var eventType in ctorDeleteEventTypes)
+        {
+            sb.AppendLine($"                case {Fqn(eventType)}:");
+            sb.AppendLine("                    snapshot = null;");
+            sb.AppendLine("                    break;");
+        }
+
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
+        foreach (var method in createMethods)
+        {
+            var eventTypeName = Fqn(method.EventType);
+            sb.AppendLine($"                case {eventTypeName} data when snapshot == null:");
+            sb.Append("                    snapshot = ");
+            EmitCreateCall(sb, method, "data", "e", isAsync, dispatchOnThis: true);
+            sb.AppendLine(";");
+            sb.AppendLine("                    break;");
+        }
+
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
+        foreach (var method in applyMethods)
+        {
+            var eventTypeName = Fqn(method.EventType);
+            bool hasCreateForType = createMethods.Any(c =>
+                SymbolEqualityComparer.Default.Equals(c.EventType, method.EventType));
+
+            if (hasCreateForType)
+            {
+                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
+            }
+            else if (info.HasDefaultConstructor)
+            {
+                sb.AppendLine($"                case {eventTypeName} data:");
+                sb.AppendLine($"                    snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
+            }
+            else
+            {
+                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
+            }
+
+            sb.Append("                    ");
+            EmitApplyCallStatement(sb, method, "data", "e", isAsync, dispatchOnThis: true);
+            sb.AppendLine("                    break;");
+        }
+
+        sb.AppendLine("            }");
+        sb.AppendLine("            }");
+        sb.AppendLine("            catch (global::JasperFx.Events.Daemon.ApplyEventException)");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw;");
+        sb.AppendLine("            }");
+        sb.AppendLine("            catch (global::System.Exception __ex)");
+        sb.AppendLine("                when (!global::JasperFx.Events.Projections.ProjectionExceptions.IsExceptionTransient(__ex))");
+        sb.AppendLine("            {");
+        sb.AppendLine("                throw new global::JasperFx.Events.Daemon.ApplyEventException(e, __ex);");
+        sb.AppendLine("            }");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        if (snapshot == null)");
+        if (!isAsync)
+        {
+            sb.AppendLine($"            return exists ? new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Delete)) : new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Nothing));");
+            sb.AppendLine($"        return new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((snapshot, global::JasperFx.Events.Daemon.ActionType.Store));");
+        }
+        else
+        {
+            sb.AppendLine($"            return exists ? (null, global::JasperFx.Events.Daemon.ActionType.Delete) : (null, global::JasperFx.Events.Daemon.ActionType.Nothing);");
+            sb.AppendLine($"        return (snapshot, global::JasperFx.Events.Daemon.ActionType.Store);");
+        }
+        sb.AppendLine("    }");
+    }
+
+    /// <summary>
     /// Builds the expression that creates the evolver's private "shadow" projection instance
     /// (used only to invoke the projection's stateless instance Apply/Create/ShouldDelete event
     /// methods). When the projection has a public parameterless constructor we just <c>new</c> it.
@@ -145,22 +441,45 @@ internal static class EvolverCodeEmitter
     /// constructor with injected dependencies and therefore no parameterless ctor — <c>new T()</c>
     /// would not compile (#4185 / CS7036). In that case instantiate without running the constructor
     /// (mirrors the aggregate no-parameterless-ctor fallback in
-    /// <see cref="BuildAggregateConstructorExpression"/>). Injected services are null on this shadow
-    /// instance, which is correct for the inline evolve path: event Apply/Create methods that
-    /// dereference injected services are not supported there.
+    /// <see cref="BuildAggregateConstructorExpression"/>). Note: the DI-projection path is no longer
+    /// reached for partial projections — see <see cref="EmitPartialProjectionWithDIOverride"/> for the
+    /// alternative emission used when convention methods need DI-injected dependencies at runtime
+    /// (marten#4787). This shadow-instance path is preserved only as a defensive fallback (e.g. a
+    /// non-partial projection that somehow reaches this branch) — generated dispatch through such a
+    /// shadow would still NRE on any deref of an injected service, but the new emission path
+    /// covers the supported partial-projection case correctly.
     /// </summary>
     private static string BuildProjectionInstanceExpression(INamedTypeSymbol projectionType, string projectionFullName)
     {
-        var hasPublicParameterless = projectionType.InstanceConstructors.Any(c =>
-            c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
-
-        if (hasPublicParameterless)
+        if (HasPublicParameterlessCtor(projectionType))
         {
             return $"new {projectionFullName}()";
         }
 
         return $"({projectionFullName})global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof({projectionFullName}))";
     }
+
+    /// <summary>
+    /// True when the projection class declares a <c>public</c> parameterless constructor (or has no
+    /// explicit constructors, so the implicit default counts). The opposite (a projection whose only
+    /// public ctor takes DI-resolved parameters) is the trigger for the partial-class override emission
+    /// path that fixes marten#4787 — dispatching events through a <c>RuntimeHelpers.GetUninitializedObject</c>
+    /// shadow leaves injected fields null and NREs the first time a convention method dereferences one.
+    /// </summary>
+    private static bool HasPublicParameterlessCtor(INamedTypeSymbol projectionType)
+    {
+        return projectionType.InstanceConstructors.Any(c =>
+            c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
+    }
+
+    /// <summary>
+    /// Prefix used when emitting a call to an instance convention method on the projection. Inside the
+    /// file-scoped Evolver dispatcher it's <c>_projection.</c> (the shadow instance held by the Evolver).
+    /// Inside a partial-class override on the user's projection itself it's empty — the call binds to
+    /// <c>this</c> implicitly, which is the DI-resolved instance with injected fields populated. See
+    /// <see cref="EmitPartialProjectionWithDIOverride"/> and marten#4787.
+    /// </summary>
+    private static string InstanceCallPrefix(bool dispatchOnThis) => dispatchOnThis ? string.Empty : "_projection.";
 
     /// <summary>
     /// The IGeneratedAsyncEvolver / IGeneratedAsyncDetermineAction contracts type the session as
@@ -1545,7 +1864,8 @@ internal static class EvolverCodeEmitter
     // --- Null snapshot case generation (sync) ---
 
     private static void EmitNullSnapshotCases(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent)
+        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent,
+        bool dispatchOnThis = false)
     {
         // For each event type with a Create method
         foreach (var method in createMethods)
@@ -1555,13 +1875,13 @@ internal static class EvolverCodeEmitter
             {
                 sb.AppendLine($"{indent}case {eventTypeName}:");
                 sb.Append($"{indent}    return ");
-                EmitCreateCallSync(sb, method, null, "e");
+                EmitCreateCallSync(sb, method, null, "e", dispatchOnThis);
             }
             else
             {
                 sb.AppendLine($"{indent}case {eventTypeName} data:");
                 sb.Append($"{indent}    return ");
-                EmitCreateCallSync(sb, method, "data", "e");
+                EmitCreateCallSync(sb, method, "data", "e", dispatchOnThis);
             }
 
             sb.AppendLine(";");
@@ -1595,7 +1915,7 @@ internal static class EvolverCodeEmitter
                 sb.AppendLine($"{indent}{{");
                 sb.AppendLine($"{indent}    var s = {ctorExpression};");
                 sb.Append($"{indent}    ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s");
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s", dispatchOnThis);
                 sb.AppendLine(";");
                 sb.AppendLine($"{indent}    return s;");
                 sb.AppendLine($"{indent}}}");
@@ -1604,7 +1924,7 @@ internal static class EvolverCodeEmitter
             {
                 // Returns aggregate - pass new instance
                 sb.Append($"{indent}    return ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, ctorExpression);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, ctorExpression, dispatchOnThis);
                 sb.AppendLine(";");
             }
         }
@@ -1613,7 +1933,8 @@ internal static class EvolverCodeEmitter
     // --- Null snapshot case generation (async) ---
 
     private static void EmitNullSnapshotCasesAsync(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent)
+        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent,
+        bool dispatchOnThis = false)
     {
         foreach (var method in createMethods)
         {
@@ -1629,7 +1950,7 @@ internal static class EvolverCodeEmitter
                 sb.Append($"{indent}    return ");
             }
 
-            EmitCreateCall(sb, method, method.UsesIEventWrapper ? null : "data", "e", true);
+            EmitCreateCall(sb, method, method.UsesIEventWrapper ? null : "data", "e", true, dispatchOnThis);
             sb.AppendLine(";");
         }
 
@@ -1649,7 +1970,7 @@ internal static class EvolverCodeEmitter
             sb.AppendLine($"{indent}    var s = {BuildAggregateConstructorExpression(info.AggregateType!)};");
             var awaitPrefix = method.IsAsync ? "await " : "";
             sb.Append($"{indent}    {awaitPrefix}");
-            EmitApplyCallExpression(sb, method, "data", "e", true, "s");
+            EmitApplyCallExpression(sb, method, "data", "e", true, "s", dispatchOnThis);
             sb.AppendLine(";");
             sb.AppendLine($"{indent}    return s;");
             sb.AppendLine($"{indent}}}");
@@ -1659,7 +1980,7 @@ internal static class EvolverCodeEmitter
     // --- Non-null snapshot case generation (sync) ---
 
     private static void EmitNonNullSnapshotCases(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> applyMethods, string indent)
+        List<ConventionalMethodInfo> applyMethods, string indent, bool dispatchOnThis = false)
     {
         foreach (var method in applyMethods)
         {
@@ -1677,14 +1998,14 @@ internal static class EvolverCodeEmitter
             if (method.IsVoid && !method.ReturnsAggregate)
             {
                 sb.Append($"{indent}    ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "snapshot", dispatchOnThis);
                 sb.AppendLine(";");
                 sb.AppendLine($"{indent}    return snapshot;");
             }
             else
             {
                 sb.Append($"{indent}    return ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "snapshot", dispatchOnThis);
                 sb.AppendLine(";");
             }
         }
@@ -1693,7 +2014,7 @@ internal static class EvolverCodeEmitter
     // --- Non-null snapshot case generation (async) ---
 
     private static void EmitNonNullSnapshotCasesAsync(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> applyMethods, string indent)
+        List<ConventionalMethodInfo> applyMethods, string indent, bool dispatchOnThis = false)
     {
         foreach (var method in applyMethods)
         {
@@ -1705,13 +2026,13 @@ internal static class EvolverCodeEmitter
                 if (method.ReturnsAggregate)
                 {
                     sb.Append($"{indent}    return await ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
                     sb.AppendLine(";");
                 }
                 else
                 {
                     sb.Append($"{indent}    await ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
                     sb.AppendLine(";");
                     sb.AppendLine($"{indent}    return snapshot;");
                 }
@@ -1726,13 +2047,13 @@ internal static class EvolverCodeEmitter
                 if (method.ReturnsAggregate)
                 {
                     sb.Append($"{indent}    return ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
                     sb.AppendLine(";");
                 }
                 else
                 {
                     sb.Append($"{indent}    ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
                     sb.AppendLine(";");
                     sb.AppendLine($"{indent}    return snapshot;");
                 }
@@ -1743,7 +2064,8 @@ internal static class EvolverCodeEmitter
     // --- Call expression helpers ---
 
     private static void EmitApplyCallExpression(StringBuilder sb, ConventionalMethodInfo method,
-        string? dataVar, string eventVar, bool includeSessionAndCancellation, string aggregateVar = "snapshot")
+        string? dataVar, string eventVar, bool includeSessionAndCancellation, string aggregateVar = "snapshot",
+        bool dispatchOnThis = false)
     {
         var args = BuildApplyArgs(method, dataVar, eventVar, includeSessionAndCancellation, aggregateVar);
 
@@ -1758,15 +2080,16 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            // Instance Apply on the projection — dispatched through the evolver's held
-            // projection instance now that the dispatcher is a standalone file-scoped type
-            // rather than an override injected into the projection class. See #462.
-            sb.Append($"_projection.{method.MethodName}({args})");
+            // Instance Apply on the projection — dispatched through the evolver's held projection
+            // instance for the file-scoped dispatcher (default path, #462) or directly on `this` when
+            // the override lives on the user's partial projection class (the DI-safe path,
+            // marten#4787, see EmitPartialProjectionWithDIOverride).
+            sb.Append($"{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
         }
     }
 
     private static void EmitCreateCallSync(StringBuilder sb, ConventionalMethodInfo method,
-        string? dataVar, string eventVar)
+        string? dataVar, string eventVar, bool dispatchOnThis = false)
     {
         var args = BuildCreateArgs(method, dataVar, eventVar, false);
 
@@ -1783,12 +2106,12 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"_projection.{method.MethodName}({args})");
+            sb.Append($"{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
         }
     }
 
     private static void EmitCreateCall(StringBuilder sb, ConventionalMethodInfo method,
-        string? dataVar, string eventVar, bool isAsync)
+        string? dataVar, string eventVar, bool isAsync, bool dispatchOnThis = false)
     {
         var args = BuildCreateArgs(method, dataVar, eventVar, isAsync);
         var awaitPrefix = method.IsAsync && isAsync ? "await " : "";
@@ -1805,12 +2128,12 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{awaitPrefix}_projection.{method.MethodName}({args})");
+            sb.Append($"{awaitPrefix}{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
         }
     }
 
     private static void EmitApplyCallStatement(StringBuilder sb, ConventionalMethodInfo method,
-        string dataVar, string eventVar, bool isAsync)
+        string dataVar, string eventVar, bool isAsync, bool dispatchOnThis = false)
     {
         if (method.IsAsync && isAsync)
         {
@@ -1831,11 +2154,12 @@ internal static class EvolverCodeEmitter
             }
         }
 
-        EmitApplyCallExpression(sb, method, dataVar, eventVar, isAsync);
+        EmitApplyCallExpression(sb, method, dataVar, eventVar, isAsync, dispatchOnThis: dispatchOnThis);
         sb.AppendLine(";");
     }
 
-    private static void EmitShouldDeleteCall(StringBuilder sb, ConventionalMethodInfo method, string dataVar)
+    private static void EmitShouldDeleteCall(StringBuilder sb, ConventionalMethodInfo method, string dataVar,
+        bool dispatchOnThis = false)
     {
         var args = BuildShouldDeleteArgs(method, dataVar);
         var awaitKeyword = method.IsAsync ? "await " : "";
@@ -1850,7 +2174,7 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{awaitKeyword}_projection.{method.MethodName}({args})");
+            sb.Append($"{awaitKeyword}{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
         }
     }
 


### PR DESCRIPTION
Fixes the runtime regression introduced by #470 / 2.14.1's GetUninitializedObject shadow-instance fallback. Reported in [marten#4787](https://github.com/JasperFx/marten/issues/4787).

## Root cause

The 2.14.1 fallback in EvolverCodeEmitter.BuildProjectionInstanceExpression (EvolverCodeEmitter.cs:152-163) closed CS7036 for DI-only-ctor projections at compile time, but the file-scoped Evolver it produced built its private shadow projection via RuntimeHelpers.GetUninitializedObject — bypassing the constructor entirely. Every conventional Apply / Create / ShouldDelete then dispatched through that shadow, so any deref of a constructor-injected field NRE'd. The reporter's null-conditional masked it as silent zero events.

## Fix shape

When the projection has at least one instance-on-projection convention method AND no public parameterless ctor AND is partial, emit a [GeneratedCode]-attributed override (Evolve / EvolveAsync / DetermineActionAsync — picked by HasShouldDelete / HasAnyAsync exactly like the existing file-scoped Evolver) directly into the user's partial class. Body uses bare convention-method calls so dispatch binds to `this` — the DI-built instance with all injected fields populated.

For this path the [assembly: GeneratedEvolver(...)] attribute and the file sealed class Evolver are NOT emitted — the runtime's isOverridden(...) precedence (JasperFxAggregationProjectionBase.cs:82-114) picks up the partial-class override before tryUseAssemblyRegisteredEvolver ever runs, so the file-scoped path is unreachable for this case.

Stateless / parameterless-ctor / aggregate-only / static-only projections keep the file-scoped Evolver verbatim — no perf or shape change for the cases that don't need DI.

## Plumbing

- New helpers: HasPublicParameterlessCtor, InstanceCallPrefix, three EmitXAsOverride entry points, EmitPartialProjectionWithDIOverride.
- dispatchOnThis flag threaded through EmitCreateCallSync / EmitCreateCall / EmitApplyCallExpression / EmitApplyCallStatement / EmitShouldDeleteCall and the four Null/NonNull/{Sync,Async} case generators. When true, instance calls emit bare method names (binding to `this`); when false (default), they emit the existing `_projection.` prefix for the file-scoped Evolver path — so the existing emission is unchanged for everything except DI projections.

## Test

- di_activated_projection_without_parameterless_ctor_compiles → renamed to di_activated_projection_without_parameterless_ctor_dispatches_through_partial_override. Assertion flipped: source must NOT contain GetUninitializedObject / file sealed class / [assembly: GeneratedEvolver] / _projection.Create / _projection.Apply for a DI projection; MUST contain a partial class DiActivated with a [GeneratedCode] override Evolve(...) on it. Compile check (no CS7036) preserved.
- 24/24 AggregateEvolverGeneratorTests green.
- Verified locally against marten#4787 Bug_4787_di_projection_with_instance_apply (9 cases — Apply/Create/ShouldDelete × Singleton/Scoped/Transient): all pass; before this all 9 failed with NRE through the shadow instance.
- Marten regression sweep on net10 against a locally-packed build of this branch: 71/71 ContainerScopedProjectionTests + 1411/1411 EventSourcingTests + 198/198 DaemonTests all green.

## Marten consumption

Follow-up Marten PR will bump JasperFx.Events to the version this ships in, promote the repro to the regression suite, and close marten#4787.