### PR TITLE
Per-tenant agent distribution + database-affine assignment surface (wolverine#3280, marten#4806)

### DIFF
--- a/src/EventTests/AgentDistributionDefaultTests.cs
+++ b/src/EventTests/AgentDistributionDefaultTests.cs
@@ -16,10 +16,9 @@ public class AgentDistributionDefaultTests
 {
     // A bare IEventStore that overrides none of the agent-distribution members, so the assertions below
     // exercise the default interface implementations. A store that does not opt in must behave exactly as
-    // before: one agent per shard×database (DistributesAgentsPerTenant false), even per-agent spreading
-    // (GroupAgentAssignmentsByDatabase false), and no fan-out bound (MaxNodesPerDatabaseForAgents 1).
-    // See jasperfx/wolverine#3280 and JasperFx/marten#4806. Everything else throws — those members are
-    // never invoked here.
+    // before: one agent per shard×database (DistributesAgentsPerTenant false) and even per-agent spreading
+    // (GroupAgentAssignmentsByDatabase false). See jasperfx/wolverine#3280 and JasperFx/marten#4806.
+    // Everything else throws — those members are never invoked here.
     private sealed class BareEventStore : IEventStore
     {
         public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
@@ -59,11 +58,5 @@ public class AgentDistributionDefaultTests
     public void group_agent_assignments_by_database_defaults_to_false()
     {
         theStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void max_nodes_per_database_for_agents_defaults_to_one()
-    {
-        theStore.MaxNodesPerDatabaseForAgents.ShouldBe(1);
     }
 }

--- a/src/EventTests/AgentDistributionDefaultTests.cs
+++ b/src/EventTests/AgentDistributionDefaultTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests;
+
+public class AgentDistributionDefaultTests
+{
+    // A bare IEventStore that overrides none of the agent-distribution members, so the assertions below
+    // exercise the default interface implementations. A store that does not opt in must behave exactly as
+    // before: one agent per shard×database (DistributesAgentsPerTenant false), even per-agent spreading
+    // (GroupAgentAssignmentsByDatabase false), and no fan-out bound (MaxNodesPerDatabaseForAgents 1).
+    // See jasperfx/wolverine#3280 and JasperFx/marten#4806. Everything else throws — those members are
+    // never invoked here.
+    private sealed class BareEventStore : IEventStore
+    {
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private readonly IEventStore theStore = new BareEventStore();
+
+    [Fact]
+    public void distributes_agents_per_tenant_defaults_to_false()
+    {
+        theStore.DistributesAgentsPerTenant.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void group_agent_assignments_by_database_defaults_to_false()
+    {
+        theStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void max_nodes_per_database_for_agents_defaults_to_one()
+    {
+        theStore.MaxNodesPerDatabaseForAgents.ShouldBe(1);
+    }
+}

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -251,6 +251,18 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             {
                 await td.DisposeAsync().ConfigureAwait(false);
             }
+            else if (tenantStarted)
+            {
+                // wolverine#3280: unlike StartAllAsync (which primes every tenant's ceiling before
+                // starting its agents), Wolverine-managed distribution starts each tenant agent
+                // individually here — so its ceiling is not yet known and tryStartAgentAsync seeds it at
+                // high-water 0. The per-tenant poll only re-runs on a *global* high-water tick, which the
+                // store broadcasts only when the store-global mark CHANGES (HighWaterAgent publishes only on
+                // change); once it is stable (e.g. a node that starts after catch-up), no tick follows and
+                // the freshly-started agent would sit idle at 0 forever. Drive one poll now so it is routed
+                // its own tenant's mark and advances.
+                await pollTenantHighWaterAsync().ConfigureAwait(false);
+            }
 
             return;
         }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -227,6 +227,34 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
 
 
+        // wolverine#3280: a per-tenant identity ("<proj>:All:<tenant>", or versioned
+        // "<proj>:V{n}:All:<tenant>") is requested individually under node-distributed daemons
+        // (Wolverine-managed distribution). AllShards() only carries the store-global identities, so
+        // resolve the BASE shard and fan out a per-tenant agent — the same shape
+        // buildPerTenantContinuousAgents uses — activating the tenant in the high-water coordinator so it
+        // advances against its own mark and persists its own <proj>:All:<tenant> progression row.
+        if (ShardName.TryParse(shardName, out var requested) && requested?.TenantId != null)
+        {
+            var baseIdentity = ShardName.Compose(requested.Name, requested.ShardKey, null, requested.Version).Identity;
+            var baseShard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == baseIdentity);
+            if (baseShard == null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(shardName),
+                    $"Unknown shard name '{shardName}'. Value options are {_store.AllShards().Select(x => x.Name.Identity).Join(", ")}");
+            }
+
+            _tenantHighWater?.PolledTenants.Activate(requested.TenantId);
+            var tenantShard = baseShard with { Name = baseShard.Name.ForTenant(requested.TenantId) };
+            var tenantAgent = buildAgentForShard(tenantShard);
+            var tenantStarted = await tryStartAgentAsync(tenantAgent, ShardExecutionMode.Continuous).ConfigureAwait(false);
+            if (!tenantStarted && tenantAgent is IAsyncDisposable td)
+            {
+                await td.DisposeAsync().ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         var shard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == shardName);
         if (shard == null)
         {

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -58,10 +58,22 @@ public interface IEventStore
     ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
     ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
     ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
-    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. See
-    ///     JasperFx/marten#4806.
+    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. The fan-out is
+    ///     bounded by <see cref="MaxNodesPerDatabaseForAgents" />. See JasperFx/marten#4806.
     /// </summary>
     bool GroupAgentAssignmentsByDatabase => false;
+
+    /// <summary>
+    ///     Upper bound, when <see cref="GroupAgentAssignmentsByDatabase" /> is on, on how many nodes a single
+    ///     shard database's agents may be spread across. This is the "mix" between strict affinity and even
+    ///     spreading: <c>1</c> pins every database to one node (fewest connections, but a heavy database is
+    ///     serialized on a single node's pool); a higher value lets a database's per-tenant agents fan out
+    ///     across up to N least-loaded nodes for more parallelism, at the cost of that database being reached
+    ///     by up to N nodes (so its server-side connection ceiling becomes N × per-node pool). A database with
+    ///     fewer tenants than N naturally uses fewer nodes. Choose N so <c>databases × N × pool</c> stays
+    ///     under the server's max_connections. Default 1 (strict affinity). See JasperFx/marten#4806.
+    /// </summary>
+    int MaxNodesPerDatabaseForAgents => 1;
 
     /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -50,6 +50,20 @@ public interface IEventStore
     bool DistributesAgentsPerTenant => false;
 
     /// <summary>
+    ///     When true, a node-distributed async daemon should assign the per-(shard, tenant) agents with
+    ///     <b>database affinity</b> — every agent for the same shard database is placed on the same node —
+    ///     rather than spreading individual agents evenly by count. This complements
+    ///     <see cref="DistributesAgentsPerTenant" /> (which fans agents out per tenant): with many tenants
+    ///     scattered across many shard databases, an even per-agent spread makes every node open a
+    ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
+    ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
+    ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
+    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. See
+    ///     JasperFx/marten#4806.
+    /// </summary>
+    bool GroupAgentAssignmentsByDatabase => false;
+
+    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -58,22 +58,10 @@ public interface IEventStore
     ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
     ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
     ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
-    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. The fan-out is
-    ///     bounded by <see cref="MaxNodesPerDatabaseForAgents" />. See JasperFx/marten#4806.
+    ///     false (even per-agent distribution). Only meaningful for sharded-database stores.
+    ///     See JasperFx/marten#4806.
     /// </summary>
     bool GroupAgentAssignmentsByDatabase => false;
-
-    /// <summary>
-    ///     Upper bound, when <see cref="GroupAgentAssignmentsByDatabase" /> is on, on how many nodes a single
-    ///     shard database's agents may be spread across. This is the "mix" between strict affinity and even
-    ///     spreading: <c>1</c> pins every database to one node (fewest connections, but a heavy database is
-    ///     serialized on a single node's pool); a higher value lets a database's per-tenant agents fan out
-    ///     across up to N least-loaded nodes for more parallelism, at the cost of that database being reached
-    ///     by up to N nodes (so its server-side connection ceiling becomes N × per-node pool). A database with
-    ///     fewer tenants than N naturally uses fewer nodes. Choose N so <c>databases × N × pool</c> stays
-    ///     under the server's max_connections. Default 1 (strict affinity). See JasperFx/marten#4806.
-    /// </summary>
-    int MaxNodesPerDatabaseForAgents => 1;
 
     /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -38,6 +38,18 @@ public interface IEventStore
     bool HasMultipleTenants { get; }
 
     /// <summary>
+    ///     When true, a node-distributed async daemon (e.g. Wolverine-managed event-subscription
+    ///     distribution) must fan out one subscription agent per (shard, tenant) rather than a single
+    ///     store-global agent per (shard, database). Required for stores where multiple tenants are
+    ///     co-located in one database and each tenant draws its own event sequence (sharded databases +
+    ///     per-tenant event partitioning): a single store-global high-water cannot track tenants whose
+    ///     independent sequences overlap, so a lagging tenant's later appends would fall below it and be
+    ///     skipped. Default false (one agent per shard×database) — correct for store-global, single-database
+    ///     per-tenant partitioning, and database-per-tenant stores. See jasperfx/wolverine#3280.
+    /// </summary>
+    bool DistributesAgentsPerTenant => false;
+
+    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read


### PR DESCRIPTION
Foundational piece of the per-tenant agent distribution work for sharded + tenant-partitioned event stores. Addresses JasperFx/wolverine#3280 and carries the store-agnostic surface for JasperFx/marten#4806.

**Problem.** Under node-distributed daemons (Wolverine-managed event-subscription distribution), agents are distributed per (shard × database). With `MultiTenantedWithShardedDatabases` + `UseTenantPartitionedEvents`, multiple tenants are co-located in one shard database, each drawing its own event sequence — a single store-global agent (and high-water mark) per database cannot track them, so a lagging tenant's appends fall below the shared mark and are skipped.

**What's here** (default interface members — zero impact on stores that don't opt in):

- `IEventStore.DistributesAgentsPerTenant` (default `false`): signals that a node-distributed daemon must fan out one agent per (shard, tenant). Store-global, single-database per-tenant partitioning, and database-per-tenant behavior is unchanged.
- `JasperFxAsyncDaemon.StartAgentAsync(string)` detects a tenant-bearing identity (`ShardName.TryParse` → non-null `TenantId`), resolves the base shard, activates the tenant in the high-water coordinator, and starts a per-tenant agent that advances against its own mark and persists its own `<proj>:All:<tenant>` progression row — polling the per-tenant high water right after start.
- `IEventStore.GroupAgentAssignmentsByDatabase` (default `false`): opt-in signal for **database-affine assignment** (marten#4806) — a distribution-aware host keeps all of a shard database's per-tenant agents together on one node, so connection pools scale with the number of shard databases instead of nodes × databases (which otherwise exhausts a shared server's `max_connections`).
- Defaults covered by `AgentDistributionDefaultTests` (same bare-store convention as `AllDatabasesDefaultTests`).

**Companion PRs (merge order):** this first → Marten #4799 (surfaces both signals + per-tenant high-water and bulk-import work) → Wolverine #3281 (per-tenant fan-out + affine distribution).