### PR TITLE
fix(daemon): emit ProjectionDeleted for DeleteEvent-driven deletions in composite projections (#483)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.18.1</JasperFxVersion>
+        <JasperFxVersion>2.19.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/Daemon/AggregationRunnerDeleteEventTests.cs
+++ b/src/EventTests/Daemon/AggregationRunnerDeleteEventTests.cs
@@ -1,0 +1,97 @@
+using EventTests.Projections;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// Regression coverage for JasperFx/jasperfx#483: a DeleteEvent<T>-driven deletion short-circuits
+// ApplyChangesAsync before DetermineActionAsync, so it must record ActionType.Delete and clear the
+// slice snapshot itself. Otherwise MarkSliceAction never fans the synthetic ProjectionDeleted<TDoc,TId>
+// to downstream composite stages.
+public class AggregationRunnerDeleteEventTests
+{
+    private readonly IAggregationProjection<User, Guid, FakeOperations, FakeSession> theProjection =
+        Substitute.For<IAggregationProjection<User, Guid, FakeOperations, FakeSession>>();
+
+    private readonly IProjectionStorage<User, Guid> theStorage = Substitute.For<IProjectionStorage<User, Guid>>();
+    private readonly IAggregateCache<Guid, User> theCache = Substitute.For<IAggregateCache<Guid, User>>();
+    private readonly IProjectionBatch theBatch = Substitute.For<IProjectionBatch>();
+
+    private AggregationRunner<User, Guid, FakeOperations, FakeSession> theRunner;
+
+    public AggregationRunnerDeleteEventTests()
+    {
+        // Force the DeleteEvent<T> short-circuit, and stay MultiStream so maybeArchiveStream is a no-op.
+        theProjection.MatchesAnyDeleteType(Arg.Any<IReadOnlyList<IEvent>>()).Returns(true);
+        theProjection.Scope.Returns(AggregationScope.MultiStream);
+
+        theStorage.TenantId.Returns("foo");
+
+        theRunner = new AggregationRunner<User, Guid, FakeOperations, FakeSession>(
+            Substitute.For<IEventStore<FakeOperations, FakeSession>>(),
+            Substitute.For<IEventDatabase>(),
+            theProjection,
+            SliceBehavior.None,
+            Substitute.For<IEventSlicer>(),
+            NullLogger.Instance);
+    }
+
+    private async Task<EventSlice<User, Guid>> applyDeleteAsync(User? preExisting)
+    {
+        var slice = new EventSlice<User, Guid>(Guid.NewGuid(), "foo",
+            new IEvent[] { new Event<AEvent>(new AEvent()) })
+        {
+            Snapshot = preExisting
+        };
+
+        await theRunner.ApplyChangesAsync(ShardExecutionMode.Rebuild, theBatch, new FakeOperations(), slice,
+            theStorage, theCache, CancellationToken.None);
+
+        return slice;
+    }
+
+    [Fact]
+    public async Task delete_event_with_pre_existing_snapshot_records_delete_and_clears_snapshot()
+    {
+        var slice = await applyDeleteAsync(new User("Beast", "Hank McCoy"));
+
+        slice.ResultingAction.ShouldBe(ActionType.Delete);
+        slice.Snapshot.ShouldBeNull();
+        theStorage.Received().Delete(slice.Id);
+    }
+
+    [Fact]
+    public async Task delete_event_with_pre_existing_snapshot_fans_projection_deleted_downstream()
+    {
+        var slice = await applyDeleteAsync(new User("Beast", "Hank McCoy"));
+
+        var range = new EventRange(new ShardName("name"), 0, 100, Substitute.For<ISubscriptionAgent>());
+        range.MarkSliceAction("foo", slice);
+
+        var deleted = range.AllRecordedActions().OfType<ProjectionDeleted<User, Guid>>().Single();
+        deleted.Identity.ShouldBe(slice.Id);
+        deleted.TenantId.ShouldBe("foo");
+    }
+
+    [Fact]
+    public async Task delete_event_with_no_pre_existing_snapshot_is_a_no_op()
+    {
+        var slice = await applyDeleteAsync(null);
+
+        // Mirrors buildActionAsync: no prior snapshot means there is nothing to delete, so no
+        // synthetic ProjectionDeleted should be fanned to downstream stages.
+        slice.ResultingAction.ShouldBe(ActionType.Nothing);
+        slice.Snapshot.ShouldBeNull();
+
+        var range = new EventRange(new ShardName("name"), 0, 100, Substitute.For<ISubscriptionAgent>());
+        range.MarkSliceAction("foo", slice);
+
+        range.AllRecordedActions().OfType<ProjectionDeleted<User, Guid>>().ShouldBeEmpty();
+    }
+}

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -272,11 +272,27 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
                 await processPossibleSideEffects(batch, operations, slice).ConfigureAwait(false);
             }
 
-            // Only archive from the perspective of a projection that actually owns the stream.
-            // The delete-type branch only fires when a pre-existing snapshot is present
-            // (otherwise buildActionAsync returns Nothing), so slice.Snapshot signals ownership.
+            // A DeleteEvent<T> registration deletes through this short-circuit rather than
+            // through DetermineActionAsync/buildActionAsync. A pre-existing snapshot is what
+            // makes this a real deletion and signals stream ownership; with no prior snapshot
+            // buildActionAsync maps to ActionType.Nothing, so this stays a no-op.
             // See issue JasperFx/marten#4093.
-            maybeArchiveStream(storage, slice, ownsStream: slice.Snapshot != null);
+            var ownsStream = slice.Snapshot != null;
+
+            maybeArchiveStream(storage, slice, ownsStream);
+
+            if (ownsStream)
+            {
+                // Record the delete and clear the snapshot so MarkSliceAction fans the synthetic
+                // ProjectionDeleted<TDoc,TId> event to downstream composite stages. Without this,
+                // ResultingAction stayed at Nothing (and slice.Snapshot non-null), so later stages
+                // saw a stale Updated<TDoc> instead of the deletion — or nothing at all. This
+                // mirrors the DetermineActionAsync delete path below. See issue JasperFx/jasperfx#483.
+                slice.RecordAction(ActionType.Delete);
+                slice.Snapshot = default;
+                removeFromCache(cache, slice.Id);
+            }
+
             storage.Delete(slice.Id);
             return;
         }


### PR DESCRIPTION
Fixes #483.

## Problem

In a composite projection, a downstream stage never received the synthetic `ProjectionDeleted<TDoc, TId>` event when an upstream stage deleted its document through a `DeleteEvent<T>()` registration. Deletions performed via `Evolve`/`DetermineActionAsync` returning `null` worked correctly.

## Root cause

`AggregationRunner.ApplyChangesAsync` short-circuits the delete-type branch **before** the slice action is recorded. `slice.RecordAction(...)` was only reached on the non-`DeleteEvent` path, so `ResultingAction` stayed at its default (`Nothing`) and `slice.Snapshot` kept the pre-existing document. `EventRange.MarkSliceAction` only emits `ProjectionDeleted` when the recorded action is `Delete`/`HardDelete` **and** the snapshot is null — so downstream stages saw a stale `Updated<TDoc>` (or nothing) instead of the deletion.

## Fix

Mirror the canonical `DetermineActionAsync` delete path inside the short-circuit:

- When a pre-existing snapshot is present (a real deletion / stream ownership), `RecordAction(ActionType.Delete)`, clear `slice.Snapshot`, and remove the cache entry so `MarkSliceAction` fans the synthetic `ProjectionDeleted<TDoc,TId>` downstream.
- With no prior snapshot, stay a no-op — matching `buildActionAsync`'s `ActionType.Nothing` mapping so downstream stages don't see phantom deletions for documents that never existed.

## Tests

Adds `AggregationRunnerDeleteEventTests` covering the delete short-circuit:
- pre-existing snapshot → records `Delete`, clears snapshot, deletes storage, and fans `ProjectionDeleted` through `MarkSliceAction`;
- no pre-existing snapshot → no-op, no synthetic deletion.

## Release

Bumps the package minor version `2.18.1` → `2.19.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)