### PR TITLE
Per-tenant agent distribution: IEventStore.DistributesAgentsPerTenant + hardened per-tenant StartAgentAsync (supersedes #482)

### DIFF
--- a/src/EventTests/AgentDistributionDefaultTests.cs
+++ b/src/EventTests/AgentDistributionDefaultTests.cs
@@ -16,10 +16,9 @@ public class AgentDistributionDefaultTests
 {
     // A bare IEventStore that overrides none of the agent-distribution members, so the assertions below
     // exercise the default interface implementations. A store that does not opt in must behave exactly as
-    // before: one agent per shard×database (DistributesAgentsPerTenant false), even per-agent spreading
-    // (GroupAgentAssignmentsByDatabase false), and no fan-out bound (MaxNodesPerDatabaseForAgents 1).
-    // See jasperfx/wolverine#3280 and JasperFx/marten#4806. Everything else throws — those members are
-    // never invoked here.
+    // before: one agent per shard×database (DistributesAgentsPerTenant false) and even per-agent spreading
+    // (GroupAgentAssignmentsByDatabase false). See jasperfx/wolverine#3280 and JasperFx/marten#4806.
+    // Everything else throws — those members are never invoked here.
     private sealed class BareEventStore : IEventStore
     {
         public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
@@ -59,11 +58,5 @@ public class AgentDistributionDefaultTests
     public void group_agent_assignments_by_database_defaults_to_false()
     {
         theStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void max_nodes_per_database_for_agents_defaults_to_one()
-    {
-        theStore.MaxNodesPerDatabaseForAgents.ShouldBe(1);
     }
 }

--- a/src/EventTests/AgentDistributionDefaultTests.cs
+++ b/src/EventTests/AgentDistributionDefaultTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests;
+
+public class AgentDistributionDefaultTests
+{
+    // A bare IEventStore that overrides none of the agent-distribution members, so the assertions below
+    // exercise the default interface implementations. A store that does not opt in must behave exactly as
+    // before: one agent per shard×database (DistributesAgentsPerTenant false), even per-agent spreading
+    // (GroupAgentAssignmentsByDatabase false), and no fan-out bound (MaxNodesPerDatabaseForAgents 1).
+    // See jasperfx/wolverine#3280 and JasperFx/marten#4806. Everything else throws — those members are
+    // never invoked here.
+    private sealed class BareEventStore : IEventStore
+    {
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private readonly IEventStore theStore = new BareEventStore();
+
+    [Fact]
+    public void distributes_agents_per_tenant_defaults_to_false()
+    {
+        theStore.DistributesAgentsPerTenant.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void group_agent_assignments_by_database_defaults_to_false()
+    {
+        theStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void max_nodes_per_database_for_agents_defaults_to_one()
+    {
+        theStore.MaxNodesPerDatabaseForAgents.ShouldBe(1);
+    }
+}

--- a/src/EventTests/AgentDistributionDefaultTests.cs
+++ b/src/EventTests/AgentDistributionDefaultTests.cs
@@ -16,8 +16,7 @@ public class AgentDistributionDefaultTests
 {
     // A bare IEventStore that overrides none of the agent-distribution members, so the assertions below
     // exercise the default interface implementations. A store that does not opt in must behave exactly as
-    // before: one agent per shard×database (DistributesAgentsPerTenant false) and even per-agent spreading
-    // (GroupAgentAssignmentsByDatabase false). See jasperfx/wolverine#3280 and JasperFx/marten#4806.
+    // before: one agent per shard×database (DistributesAgentsPerTenant false). See jasperfx/wolverine#3280.
     // Everything else throws — those members are never invoked here.
     private sealed class BareEventStore : IEventStore
     {
@@ -52,11 +51,5 @@ public class AgentDistributionDefaultTests
     public void distributes_agents_per_tenant_defaults_to_false()
     {
         theStore.DistributesAgentsPerTenant.ShouldBeFalse();
-    }
-
-    [Fact]
-    public void group_agent_assignments_by_database_defaults_to_false()
-    {
-        theStore.GroupAgentAssignmentsByDatabase.ShouldBeFalse();
     }
 }

--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -1,0 +1,305 @@
+using System.Diagnostics.Metrics;
+using EventTests.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Subscriptions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// wolverine#3280: under node-distributed daemons (Wolverine-managed event-subscription distribution
+// against a store that partitions events per tenant), a single tenant-bearing shard identity like
+// "Trip:All:t1" is requested individually via StartAgentAsync(string, ...). AllShards() only carries the
+// store-global identities, so the daemon must resolve the BASE shard, prime that tenant's high-water
+// ceiling in the TenantedHighWaterCoordinator BEFORE starting, and then fan out a tenant-scoped agent —
+// otherwise a SubscribeFromPresent subscription resolves "present" against high-water 0 and rewinds its
+// progression row to the beginning, replaying the tenant's entire history. These tests pin the behavior
+// of that per-tenant branch in isolation with a substituted store/database and a stub detector.
+public class PerTenantStartAgentAsyncTests
+{
+    private static AsyncShard<FakeOperations, FakeSession> shardFor(ShardName name, AsyncOptions? options = null)
+    {
+        // The factory's BuildExecution auto-returns a substituted ISubscriptionExecution whose
+        // TryBuildReplayExecutor is false, so a started agent runs the plain continuous path.
+        var factory = Substitute.For<ISubscriptionFactory<FakeOperations, FakeSession>>();
+
+        return new AsyncShard<FakeOperations, FakeSession>(options ?? new AsyncOptions(), ShardRole.Projection,
+            name, factory, new EventFilterable());
+    }
+
+    [Fact]
+    public async Task starts_a_per_tenant_agent_for_a_tenant_bearing_identity()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        var agent = harness.Daemon.CurrentAgents().ShouldHaveSingleItem();
+        agent.Name.Identity.ShouldBe("Trip:All:t1");
+        agent.Name.TenantId.ShouldBe("t1");
+        agent.Status.ShouldBe(AgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task primes_the_tenant_ceiling_before_determining_the_starting_position()
+    {
+        // THE wolverine#3280 / SubscribeFromPresent regression pin. The FromPresent strategy resolves
+        // "present" to the high-water mark it is handed. The store-global mark in this harness is pinned
+        // at 0, so the ONLY way the rewind floor can be 42 is if the tenant's ceiling was polled and
+        // primed in the coordinator BEFORE tryStartAgentAsync determined the starting position. Starting
+        // first and polling after would compute "present" as sequence 0 and rewind the progression row
+        // to the beginning, replaying the tenant's entire history.
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        var shard = shardFor(new ShardName("Sub"), new AsyncOptions().SubscribeFromPresent());
+        await using var harness = new DaemonHarness(detector, shard);
+
+        await harness.Daemon.StartAgentAsync("Sub:All:t1", CancellationToken.None);
+
+        // FromPresent says ShouldUpdateProgressFirst, so the progress row is rewound to the PRIMED
+        // per-tenant ceiling of 42...
+        await harness.Store.Received(1).RewindSubscriptionProgressAsync(
+            Arg.Any<IEventDatabase>(), "Sub:All:t1", Arg.Any<CancellationToken>(), 42L);
+
+        // ... and never to the un-primed store-global mark of 0.
+        await harness.Store.DidNotReceive().RewindSubscriptionProgressAsync(
+            Arg.Any<IEventDatabase>(), "Sub:All:t1", Arg.Any<CancellationToken>(), 0L);
+    }
+
+    [Fact]
+    public async Task throws_for_a_tenant_identity_when_the_store_has_no_tenant_partitioning()
+    {
+        // Without per-tenant high-water tracking a tenant agent would seed from the store-global mark
+        // and double-process events already covered by the store-global agent — fail loudly instead.
+        await using var harness = new DaemonHarness(new GlobalOnlyStubDetector(), shardFor(new ShardName("Trip")));
+
+        var ex = await Should.ThrowAsync<ArgumentOutOfRangeException>(
+            () => harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None));
+
+        ex.Message.ShouldContain("does not use per-tenant event partitioning");
+
+        harness.Daemon.CurrentAgents().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task throws_for_an_unknown_base_shard()
+    {
+        // Tenant-bearing identity on a partitioned store, but no registered shard matches the base
+        // identity "Nope:All" — the error lists the valid registered options.
+        await using var harness = new DaemonHarness(new StubPartitionedDetector(), shardFor(new ShardName("Trip")));
+
+        var ex = await Should.ThrowAsync<ArgumentOutOfRangeException>(
+            () => harness.Daemon.StartAgentAsync("Nope:All:t1", CancellationToken.None));
+
+        ex.Message.ShouldContain("Unknown shard name 'Nope:All:t1'");
+        ex.Message.ShouldContain("Trip:All");
+
+        harness.Daemon.CurrentAgents().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task an_exactly_registered_identity_wins_over_tenant_parsing()
+    {
+        // A registered store-global shard whose identity happens to carry enough segments to parse as
+        // tenant-bearing must be started as-is, never hijacked by the per-tenant branch.
+        var registered = new ShardName("Fancy:Weird"); // Identity "Fancy:Weird:All"
+
+        // Sanity check the trap actually exists: this identity genuinely parses as tenant-bearing,
+        // with the trailing "All" segment landing in the tenant slot.
+        ShardName.TryParse(registered.Identity, out var parsed).ShouldBeTrue();
+        parsed!.TenantId.ShouldBe("All");
+
+        var detector = new StubPartitionedDetector();
+        await using var harness = new DaemonHarness(detector, shardFor(registered));
+
+        await harness.Daemon.StartAgentAsync("Fancy:Weird:All", CancellationToken.None);
+
+        var agent = harness.Daemon.CurrentAgents().ShouldHaveSingleItem();
+        agent.Name.Identity.ShouldBe("Fancy:Weird:All");
+        agent.Name.TenantId.ShouldBeNull();
+        agent.Status.ShouldBe(AgentStatus.Running);
+
+        // The pseudo-tenant "All" was never activated in the coordinator's polled set.
+        detector.PolledTenants().ShouldNotContain("All");
+    }
+
+    [Fact]
+    public async Task resolves_versioned_tenant_identities()
+    {
+        // Versioned grammar: base shard "Trip:V2:All" + tenant slot -> "Trip:V2:All:t1".
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 7);
+
+        await using var harness =
+            new DaemonHarness(detector, shardFor(ShardName.Compose("Trip", "All", null, 2)));
+
+        await harness.Daemon.StartAgentAsync("Trip:V2:All:t1", CancellationToken.None);
+
+        var agent = harness.Daemon.CurrentAgents().ShouldHaveSingleItem();
+        agent.Name.Identity.ShouldBe("Trip:V2:All:t1");
+        agent.Name.TenantId.ShouldBe("t1");
+        agent.Name.Version.ShouldBe(2u);
+        agent.Status.ShouldBe(AgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task second_start_of_the_same_tenant_identity_is_idempotent()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        // Still exactly one running agent for the identity; the duplicate was quietly disposed.
+        var agent = harness.Daemon.CurrentAgents().ShouldHaveSingleItem();
+        agent.Name.Identity.ShouldBe("Trip:All:t1");
+        agent.Status.ShouldBe(AgentStatus.Running);
+    }
+
+    // Real daemon + real SubscriptionAgents over a substituted store/database. The store-global
+    // high-water detector reading is pinned at mark 0, so any nonzero seed/floor a test observes can
+    // only have come from the per-tenant coordinator.
+    private sealed class DaemonHarness : IAsyncDisposable
+    {
+        public DaemonHarness(IHighWaterDetector detector, params AsyncShard<FakeOperations, FakeSession>[] shards)
+        {
+            Store = Substitute.For<IEventStore<FakeOperations, FakeSession>>();
+            Store.Meter.Returns(new Meter("tests"));
+            Store.TimeProvider.Returns(TimeProvider.System);
+            // Keep StartHighWaterDetectionAsync away from EnsureStorageExistsAsync
+            Store.AutoCreateSchemaObjects.Returns(AutoCreate.None);
+            Store.ContinuousErrors.Returns(new ErrorHandlingOptions());
+            Store.RebuildErrors.Returns(new ErrorHandlingOptions());
+            Store.AllShards().Returns(shards);
+
+            // The loader hands back an empty, already-caught-up page so a started agent stays healthy
+            // (Status == Running) without any real event storage behind it.
+            var loader = Substitute.For<IEventLoader>();
+            loader.LoadAsync(Arg.Any<EventRequest>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var request = callInfo.Arg<EventRequest>();
+                    var page = new EventPage(request.Floor);
+                    page.CalculateCeiling(request.BatchSize, request.HighWater);
+                    return Task.FromResult(page);
+                });
+
+            Store.BuildEventLoader(Arg.Any<IEventDatabase>(), Arg.Any<ILogger>(), Arg.Any<EventFilterable>(),
+                Arg.Any<AsyncOptions>()).Returns(loader);
+            Store.BuildEventLoader(Arg.Any<IEventDatabase>(), Arg.Any<ILogger>(), Arg.Any<EventFilterable>(),
+                Arg.Any<AsyncOptions>(), Arg.Any<ShardName>()).Returns(loader);
+
+            Database = Substitute.For<IEventDatabase>();
+            Database.Identifier.Returns("db1");
+            Database.DatabaseUri.Returns(new Uri("fake://db1"));
+            Database.Tracker.Returns(new ShardStateTracker(new NulloLogger()));
+
+            Daemon = new JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>(
+                Store, Database, new NulloLogger(), detector, new FakeProjectionGraph());
+        }
+
+        public IEventStore<FakeOperations, FakeSession> Store { get; }
+        public IEventDatabase Database { get; }
+        public JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>> Daemon { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Daemon.StopAllAsync();
+            Daemon.Dispose();
+        }
+    }
+
+    // Minimal concrete ProjectionGraph — the daemon only consumes it as DaemonSettings on these code
+    // paths (shard resolution goes through the substituted store's AllShards()).
+    private sealed class FakeProjectionGraph :
+        ProjectionGraph<IJasperFxProjection<FakeOperations>, FakeOperations, FakeSession>
+    {
+        public FakeProjectionGraph() : base(Substitute.For<IEventRegistry>(), "tests")
+        {
+        }
+
+        protected override void onAddProjection(object projection)
+        {
+            // Nothing
+        }
+    }
+
+    // A detector for a store WITH per-tenant event partitioning. The store-global Detect() stays pinned
+    // at mark 0; per-tenant marks are whatever the test seeded via SetTenantMark.
+    private sealed class StubPartitionedDetector : IHighWaterDetector
+    {
+        private readonly Dictionary<string, long> _marks = new();
+        private readonly List<string[]> _tenantPolls = new();
+
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        public bool SupportsTenantPartitioning => true;
+
+        public void SetTenantMark(string tenantId, long mark)
+        {
+            _marks[tenantId] = mark;
+        }
+
+        // Every tenant id the vectorized poll was ever asked about
+        public IReadOnlyList<string> PolledTenants()
+        {
+            lock (_tenantPolls)
+            {
+                return _tenantPolls.SelectMany(x => x).Distinct().ToList();
+            }
+        }
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics());
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+
+        public Task<HighWaterVector> DetectForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+        {
+            lock (_tenantPolls)
+            {
+                _tenantPolls.Add(tenantIds.ToArray());
+            }
+
+            var statistics = tenantIds.Select(tenantId =>
+            {
+                var mark = _marks.GetValueOrDefault(tenantId);
+                return new HighWaterStatistics
+                {
+                    TenantId = tenantId, CurrentMark = mark, LastMark = mark, HighestSequence = mark
+                };
+            }).ToArray();
+
+            return Task.FromResult(new HighWaterVector(statistics));
+        }
+
+        public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => DetectForTenantsAsync(tenantIds, token);
+    }
+
+    // A detector for a store WITHOUT per-tenant event partitioning — SupportsTenantPartitioning stays on
+    // its interface default of false, so the daemon never builds a TenantedHighWaterCoordinator.
+    private sealed class GlobalOnlyStubDetector : IHighWaterDetector
+    {
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics());
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+    }
+}

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -227,6 +227,24 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
 
 
+        // Exact registered identities always win — a shard identity that happens to contain enough
+        // segments to parse as tenant-bearing must not be hijacked by the per-tenant branch below.
+        var shard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == shardName);
+        if (shard != null)
+        {
+            var agent = buildAgentForShard(shard);
+
+            var didStart = await tryStartAgentAsync(agent, ShardExecutionMode.Continuous).ConfigureAwait(false);
+
+            if (!didStart && agent is IAsyncDisposable d)
+            {
+                // Could not be started
+                await d.DisposeAsync().ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         // wolverine#3280: a per-tenant identity ("<proj>:All:<tenant>", or versioned
         // "<proj>:V{n}:All:<tenant>") is requested individually under node-distributed daemons
         // (Wolverine-managed distribution). AllShards() only carries the store-global identities, so
@@ -235,6 +253,16 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         // advances against its own mark and persists its own <proj>:All:<tenant> progression row.
         if (ShardName.TryParse(shardName, out var requested) && requested?.TenantId != null)
         {
+            if (_tenantHighWater == null)
+            {
+                // Without per-tenant high-water tracking a tenant agent would seed from the store-global
+                // mark and double-process events already covered by the store-global agent. A tenant-bearing
+                // identity arriving here means the host (e.g. Wolverine) fanned out per-tenant agents
+                // against a store that does not distribute per tenant — fail loudly instead.
+                throw new ArgumentOutOfRangeException(nameof(shardName),
+                    $"Shard name '{shardName}' addresses tenant '{requested.TenantId}', but this event store does not use per-tenant event partitioning. Value options are {_store.AllShards().Select(x => x.Name.Identity).Join(", ")}");
+            }
+
             var baseIdentity = ShardName.Compose(requested.Name, requested.ShardKey, null, requested.Version).Identity;
             var baseShard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == baseIdentity);
             if (baseShard == null)
@@ -243,46 +271,32 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
                     $"Unknown shard name '{shardName}'. Value options are {_store.AllShards().Select(x => x.Name.Identity).Join(", ")}");
             }
 
-            _tenantHighWater?.PolledTenants.Activate(requested.TenantId);
+            // Prime the tenant's ceiling BEFORE starting the agent, mirroring StartAllAsync's
+            // prime-then-start order. tryStartAgentAsync seeds the agent from CeilingFor(tenant) and the
+            // starting position strategy runs against that ceiling — starting first and polling after
+            // would run DetermineStartingPositionAsync against high-water 0, which for a
+            // SubscribeFromPresent subscription resolves "present" to sequence 0 and rewinds its
+            // progression row, replaying the tenant's entire history.
+            _tenantHighWater.PolledTenants.Activate(requested.TenantId);
+            await pollTenantHighWaterAsync().ConfigureAwait(false);
+
             var tenantShard = baseShard with { Name = baseShard.Name.ForTenant(requested.TenantId) };
             var tenantAgent = buildAgentForShard(tenantShard);
             var tenantStarted = await tryStartAgentAsync(tenantAgent, ShardExecutionMode.Continuous).ConfigureAwait(false);
             if (!tenantStarted && tenantAgent is IAsyncDisposable td)
             {
                 await td.DisposeAsync().ConfigureAwait(false);
-            }
-            else if (tenantStarted)
-            {
-                // wolverine#3280: unlike StartAllAsync (which primes every tenant's ceiling before
-                // starting its agents), Wolverine-managed distribution starts each tenant agent
-                // individually here — so its ceiling is not yet known and tryStartAgentAsync seeds it at
-                // high-water 0. The per-tenant poll only re-runs on a *global* high-water tick, which the
-                // store broadcasts only when the store-global mark CHANGES (HighWaterAgent publishes only on
-                // change); once it is stable (e.g. a node that starts after catch-up), no tick follows and
-                // the freshly-started agent would sit idle at 0 forever. Drive one poll now so it is routed
-                // its own tenant's mark and advances.
-                await pollTenantHighWaterAsync().ConfigureAwait(false);
+
+                // Reconcile the polled-tenant set so a failed start doesn't leave the coordinator
+                // polling (and persisting high-water rows for) a tenant with no agent on this node.
+                syncTenantPolling();
             }
 
             return;
         }
 
-        var shard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == shardName);
-        if (shard == null)
-        {
-            throw new ArgumentOutOfRangeException(nameof(shardName),
-                $"Unknown shard name '{shardName}'. Value options are {_store.AllShards().Select(x => x.Name.Identity).Join(", ")}");
-        }
-
-        var agent = buildAgentForShard(shard);
-
-        var didStart = await tryStartAgentAsync(agent, ShardExecutionMode.Continuous).ConfigureAwait(false);
-
-        if (!didStart && agent is IAsyncDisposable d)
-        {
-            // Could not be started
-            await d.DisposeAsync().ConfigureAwait(false);
-        }
+        throw new ArgumentOutOfRangeException(nameof(shardName),
+            $"Unknown shard name '{shardName}'. Value options are {_store.AllShards().Select(x => x.Name.Identity).Join(", ")}");
     }
     
     public async Task<ISubscriptionAgent> StartAgentAsync(ShardName name, CancellationToken token)

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -251,6 +251,18 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             {
                 await td.DisposeAsync().ConfigureAwait(false);
             }
+            else if (tenantStarted)
+            {
+                // wolverine#3280: unlike StartAllAsync (which primes every tenant's ceiling before
+                // starting its agents), Wolverine-managed distribution starts each tenant agent
+                // individually here — so its ceiling is not yet known and tryStartAgentAsync seeds it at
+                // high-water 0. The per-tenant poll only re-runs on a *global* high-water tick, which the
+                // store broadcasts only when the store-global mark CHANGES (HighWaterAgent publishes only on
+                // change); once it is stable (e.g. a node that starts after catch-up), no tick follows and
+                // the freshly-started agent would sit idle at 0 forever. Drive one poll now so it is routed
+                // its own tenant's mark and advances.
+                await pollTenantHighWaterAsync().ConfigureAwait(false);
+            }
 
             return;
         }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -227,6 +227,34 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
 
 
+        // wolverine#3280: a per-tenant identity ("<proj>:All:<tenant>", or versioned
+        // "<proj>:V{n}:All:<tenant>") is requested individually under node-distributed daemons
+        // (Wolverine-managed distribution). AllShards() only carries the store-global identities, so
+        // resolve the BASE shard and fan out a per-tenant agent — the same shape
+        // buildPerTenantContinuousAgents uses — activating the tenant in the high-water coordinator so it
+        // advances against its own mark and persists its own <proj>:All:<tenant> progression row.
+        if (ShardName.TryParse(shardName, out var requested) && requested?.TenantId != null)
+        {
+            var baseIdentity = ShardName.Compose(requested.Name, requested.ShardKey, null, requested.Version).Identity;
+            var baseShard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == baseIdentity);
+            if (baseShard == null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(shardName),
+                    $"Unknown shard name '{shardName}'. Value options are {_store.AllShards().Select(x => x.Name.Identity).Join(", ")}");
+            }
+
+            _tenantHighWater?.PolledTenants.Activate(requested.TenantId);
+            var tenantShard = baseShard with { Name = baseShard.Name.ForTenant(requested.TenantId) };
+            var tenantAgent = buildAgentForShard(tenantShard);
+            var tenantStarted = await tryStartAgentAsync(tenantAgent, ShardExecutionMode.Continuous).ConfigureAwait(false);
+            if (!tenantStarted && tenantAgent is IAsyncDisposable td)
+            {
+                await td.DisposeAsync().ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         var shard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == shardName);
         if (shard == null)
         {

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -50,20 +50,6 @@ public interface IEventStore
     bool DistributesAgentsPerTenant => false;
 
     /// <summary>
-    ///     When true, a node-distributed async daemon should assign the per-(shard, tenant) agents with
-    ///     <b>database affinity</b> — every agent for the same shard database is placed on the same node —
-    ///     rather than spreading individual agents evenly by count. This complements
-    ///     <see cref="DistributesAgentsPerTenant" /> (which fans agents out per tenant): with many tenants
-    ///     scattered across many shard databases, an even per-agent spread makes every node open a
-    ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
-    ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
-    ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
-    ///     false (even per-agent distribution). Only meaningful for sharded-database stores.
-    ///     See JasperFx/marten#4806.
-    /// </summary>
-    bool GroupAgentAssignmentsByDatabase => false;
-
-    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -58,10 +58,22 @@ public interface IEventStore
     ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
     ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
     ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
-    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. See
-    ///     JasperFx/marten#4806.
+    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. The fan-out is
+    ///     bounded by <see cref="MaxNodesPerDatabaseForAgents" />. See JasperFx/marten#4806.
     /// </summary>
     bool GroupAgentAssignmentsByDatabase => false;
+
+    /// <summary>
+    ///     Upper bound, when <see cref="GroupAgentAssignmentsByDatabase" /> is on, on how many nodes a single
+    ///     shard database's agents may be spread across. This is the "mix" between strict affinity and even
+    ///     spreading: <c>1</c> pins every database to one node (fewest connections, but a heavy database is
+    ///     serialized on a single node's pool); a higher value lets a database's per-tenant agents fan out
+    ///     across up to N least-loaded nodes for more parallelism, at the cost of that database being reached
+    ///     by up to N nodes (so its server-side connection ceiling becomes N × per-node pool). A database with
+    ///     fewer tenants than N naturally uses fewer nodes. Choose N so <c>databases × N × pool</c> stays
+    ///     under the server's max_connections. Default 1 (strict affinity). See JasperFx/marten#4806.
+    /// </summary>
+    int MaxNodesPerDatabaseForAgents => 1;
 
     /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -50,6 +50,20 @@ public interface IEventStore
     bool DistributesAgentsPerTenant => false;
 
     /// <summary>
+    ///     When true, a node-distributed async daemon should assign the per-(shard, tenant) agents with
+    ///     <b>database affinity</b> — every agent for the same shard database is placed on the same node —
+    ///     rather than spreading individual agents evenly by count. This complements
+    ///     <see cref="DistributesAgentsPerTenant" /> (which fans agents out per tenant): with many tenants
+    ///     scattered across many shard databases, an even per-agent spread makes every node open a
+    ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
+    ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
+    ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
+    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. See
+    ///     JasperFx/marten#4806.
+    /// </summary>
+    bool GroupAgentAssignmentsByDatabase => false;
+
+    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -58,22 +58,10 @@ public interface IEventStore
     ///     connection pool to (nearly) every shard database, so the pool count grows as nodes×databases and
     ///     exhausts a shared server's max_connections. Grouping a database's agents onto one node bounds
     ///     each node to the databases it owns, so pools scale with databases, not nodes×databases. Default
-    ///     false (even per-agent distribution). Only meaningful for sharded-database stores. The fan-out is
-    ///     bounded by <see cref="MaxNodesPerDatabaseForAgents" />. See JasperFx/marten#4806.
+    ///     false (even per-agent distribution). Only meaningful for sharded-database stores.
+    ///     See JasperFx/marten#4806.
     /// </summary>
     bool GroupAgentAssignmentsByDatabase => false;
-
-    /// <summary>
-    ///     Upper bound, when <see cref="GroupAgentAssignmentsByDatabase" /> is on, on how many nodes a single
-    ///     shard database's agents may be spread across. This is the "mix" between strict affinity and even
-    ///     spreading: <c>1</c> pins every database to one node (fewest connections, but a heavy database is
-    ///     serialized on a single node's pool); a higher value lets a database's per-tenant agents fan out
-    ///     across up to N least-loaded nodes for more parallelism, at the cost of that database being reached
-    ///     by up to N nodes (so its server-side connection ceiling becomes N × per-node pool). A database with
-    ///     fewer tenants than N naturally uses fewer nodes. Choose N so <c>databases × N × pool</c> stays
-    ///     under the server's max_connections. Default 1 (strict affinity). See JasperFx/marten#4806.
-    /// </summary>
-    int MaxNodesPerDatabaseForAgents => 1;
 
     /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -38,6 +38,18 @@ public interface IEventStore
     bool HasMultipleTenants { get; }
 
     /// <summary>
+    ///     When true, a node-distributed async daemon (e.g. Wolverine-managed event-subscription
+    ///     distribution) must fan out one subscription agent per (shard, tenant) rather than a single
+    ///     store-global agent per (shard, database). Required for stores where multiple tenants are
+    ///     co-located in one database and each tenant draws its own event sequence (sharded databases +
+    ///     per-tenant event partitioning): a single store-global high-water cannot track tenants whose
+    ///     independent sequences overlap, so a lagging tenant's later appends would fall below it and be
+    ///     skipped. Default false (one agent per shard×database) — correct for store-global, single-database
+    ///     per-tenant partitioning, and database-per-tenant stores. See jasperfx/wolverine#3280.
+    /// </summary>
+    bool DistributesAgentsPerTenant => false;
+
+    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read


### PR DESCRIPTION
Supersedes #482 — carries all of @erdtsieck's commits with authorship intact, plus three review-driven revisions on top. Part of the per-tenant event partitioning epic #486; first in the merge order (→ Marten → Wolverine).

## What this adds (from #482)

- `IEventStore.DistributesAgentsPerTenant` (default-`false` DIM): signals that a node-distributed daemon host (Wolverine-managed distribution) must fan out one subscription agent per (shard × tenant) instead of one per (shard × database). Needed where co-located tenants draw independent event sequences (sharded databases + per-tenant event partitioning) — a single store-global high water skips a lagging tenant's appends (wolverine#3280).
- `JasperFxAsyncDaemon.StartAgentAsync(string, ...)` resolves tenant-bearing shard identities (`<proj>:All:<tenant>`, versioned forms included) to the base shard and starts a per-tenant agent — the same shape `StartAllAsync`'s per-tenant fan-out builds.

## Revisions vs. #482

1. **`GroupAgentAssignmentsByDatabase` is gone.** Database-affine agent grouping will not be a per-store opt-in contract: Wolverine will always group a store's agents by database when the store reports a multi-database `DatabaseCardinality` (`StaticMultiple`/`DynamicMultiple`) — existing surface, no new flag, nothing for users to configure.
2. **Prime-then-start (blocking fix).** The tenant branch primed the tenant's high water *after* starting the agent, so `DetermineStartingPositionAsync` ran against ceiling 0 — a `SubscribeFromPresent` subscription resolved "present" as sequence 0, rewound its progression row, and replayed the tenant's entire history with side effects. The branch now activates + polls the tenant ceiling *before* `tryStartAgentAsync` (mirroring `StartAllAsync`), which also makes the post-start poll redundant.
3. **Hardenings.** Exact `AllShards()` identity matches take precedence over tenant parsing (colon-bearing registered identities can't be hijacked); a tenant identity against a non-partitioned store throws a descriptive `ArgumentOutOfRangeException` instead of silently starting a phantom agent seeded from the store-global mark; a failed tenant start resyncs the polled-tenant set.

## Tests

`PerTenantStartAgentAsyncTests` — 7 daemon-level behavioral tests against a real `JasperFxAsyncDaemon` (stubbed store/detector/loader), green on net9.0 + net10.0, including the regression pin that the from-present floor derives from the primed per-tenant ceiling and floor 0 is never written. Plus the retained `AgentDistributionDefaultTests` default-value fact.

Note: 7 pre-existing `EventTests.Descriptors` failures reproduce locally on clean `main` (NRE in `TypeDescriptor.For`; CI is green) — unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
