### PR TITLE
fix: SubscriptionDescriptor NRE on null ImplementationType + run EventTests in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,6 +63,11 @@ jobs:
         run: ./build.sh test-command-line
         shell: bash
 
+      - name: test-events
+        if: ${{ success() || failure() }}
+        run: ./build.sh test-events
+        shell: bash
+
       - name: test-event-store
         if: ${{ success() || failure() }}
         run: ./build.sh test-event-store

--- a/src/EventTests/Descriptors/SubscriptionDescriptorTests.cs
+++ b/src/EventTests/Descriptors/SubscriptionDescriptorTests.cs
@@ -26,6 +26,7 @@ public class SubscriptionDescriptorTests
         source.Version.Returns(2U);
         source.ShardNames().Returns([new ShardName("Foo", "One", 2U), new ShardName("Foo", "Two", 2U)]);
         source.Lifecycle.Returns(ProjectionLifecycle.Async);
+        source.ImplementationType.Returns(typeof(FakeSubscription));
 
         var store = new FakeEventStore();
 
@@ -34,9 +35,12 @@ public class SubscriptionDescriptorTests
         descriptor.Name.ShouldBe("Foo");
         descriptor.Version.ShouldBe(2U);
         descriptor.Lifecycle.ShouldBe(ProjectionLifecycle.Async);
-        
+
+        descriptor.ImplementationType.ShouldBe(TypeDescriptor.For(typeof(FakeSubscription)));
+        descriptor.AggregateType.ShouldBeNull();
+
         descriptor.ShardNames.ShouldBe([new ShardName("Foo", "One", 2U), new ShardName("Foo", "Two", 2U)]);
-        
+
         descriptor.Metrics.Select(x => x.Name).ShouldBe(["fake.foo.one.gap", "fake.foo.two.gap"]);
         descriptor.Metrics.Select(x => x.Type).Distinct().Single().ShouldBe(MetricsType.Histogram);
         
@@ -52,12 +56,33 @@ public class SubscriptionDescriptorTests
         source.Version.Returns(2U);
         source.ShardNames().Returns([new ShardName("Foo", "One", 2U), new ShardName("Foo", "Two", 2U)]);
         source.Lifecycle.Returns(ProjectionLifecycle.Async);
+        source.ImplementationType.Returns(typeof(FakeSubscription));
 
         var store = new FakeEventStore();
 
         var descriptor = new SubscriptionDescriptor(source, store);
-        
+
         descriptor.ShouldBeSerializable();
+    }
+
+    [Fact]
+    public void tolerates_a_source_with_no_implementation_type()
+    {
+        // ISubscriptionSource.ImplementationType is declared non-nullable, but the
+        // descriptor is diagnostics-only metadata — a source that returns null (as an
+        // unconfigured mock does) should yield a null ImplementationType, not an NRE
+        // out of the whole Describe() pipeline. Pins the jasperfx#465 regression.
+        var source = Substitute.For<ISubscriptionSource>();
+        source.Type.Returns(SubscriptionType.Subscription);
+        source.Name.Returns("Foo");
+        source.Version.Returns(2U);
+        source.ShardNames().Returns([new ShardName("Foo", "One", 2U)]);
+        source.Lifecycle.Returns(ProjectionLifecycle.Async);
+
+        var descriptor = new SubscriptionDescriptor(source, new FakeEventStore());
+
+        descriptor.ImplementationType.ShouldBeNull();
+        descriptor.AggregateType.ShouldBeNull();
     }
 
     [Fact]
@@ -83,6 +108,10 @@ public class SubscriptionDescriptorTests
         descriptor.Metrics.Any().ShouldBeFalse();
         descriptor.ActivitySpans.Any().ShouldBeFalse();
     }
+}
+
+public class FakeSubscription
+{
 }
 
 public class FakeEventStore : IEventStore

--- a/src/JasperFx.Events/Descriptors/SubscriptionDescriptor.cs
+++ b/src/JasperFx.Events/Descriptors/SubscriptionDescriptor.cs
@@ -32,11 +32,17 @@ public class SubscriptionDescriptor : OptionsDescription
 
         // The CLR type that implements this projection/subscription, plus — for self-aggregating
         // projections (Snapshot<T> / SingleStreamProjection<T>) — the aggregate/document type, so
-        // consumers can display "what .NET type implements this projection".
-        ImplementationType = TypeDescriptor.For(subject.ImplementationType);
-        if (subject is IAggregateProjection aggregate)
+        // consumers can display "what .NET type implements this projection". This is diagnostics-only
+        // metadata, so a source that fails to supply a type leaves the property null rather than
+        // blowing up the whole Describe() pipeline.
+        if (subject.ImplementationType is { } implementationType)
         {
-            AggregateType = TypeDescriptor.For(aggregate.AggregateType);
+            ImplementationType = TypeDescriptor.For(implementationType);
+        }
+
+        if (subject is IAggregateProjection { AggregateType: { } aggregateType })
+        {
+            AggregateType = TypeDescriptor.For(aggregateType);
         }
 
         if (Lifecycle == ProjectionLifecycle.Async)

--- a/src/JasperFx/Descriptors/TypeDescriptor.cs
+++ b/src/JasperFx/Descriptors/TypeDescriptor.cs
@@ -8,8 +8,10 @@ namespace JasperFx.Descriptors;
 /// <param name="AssemblyName"></param>
 public record TypeDescriptor(string Name, string FullName, string AssemblyName)
 {
+    // FullName is null for open generics' type parameters; fall back to Name
+    // rather than poisoning a diagnostics DTO with a null FullName
     public static TypeDescriptor For(Type type) =>
-        new TypeDescriptor(type.Name, type.FullName!, type.Assembly.GetName().Name!);
+        new TypeDescriptor(type.Name, type.FullName ?? type.Name, type.Assembly.GetName().Name ?? string.Empty);
 
     public override string ToString()
     {


### PR DESCRIPTION
## What happened

Seven `EventTests.Descriptors` tests (`SubscriptionDescriptorTests` + the agent-URI tests in `EventStoreUsageTests`) fail on clean `main` with a `NullReferenceException` in `TypeDescriptor.For` — but only when run locally, because **CI never runs the EventTests suite at all**: the workflow has `test-core`, `test-codegen`, and `test-command-line` steps, but no `test-events`.

## Root cause

#465 added `ImplementationType = TypeDescriptor.For(subject.ImplementationType)` to the `SubscriptionDescriptor(ISubscriptionSource, IEventStore)` ctor without touching any tests. The affected tests build their source with `Substitute.For<ISubscriptionSource>()` and never stub `ImplementationType`; NSubstitute auto-substitutes interfaces but not `System.Type`, so the unstubbed property returns null and `TypeDescriptor.For` dereferences it. With no CI coverage, the break shipped silently.

## Changes

- **`SubscriptionDescriptor`** — null-guard `ImplementationType`/`AggregateType` in the ctor. Descriptors are diagnostics-only metadata; a source that fails to supply a type now yields a null property instead of crashing the whole `Describe()` pipeline.
- **`TypeDescriptor.For`** — drop the `FullName!` bang (legitimately null for open generics' type parameters) and fall back to `Name`.
- **`SubscriptionDescriptorTests`** — stub `ImplementationType` and assert on the #465 properties (they previously had zero coverage), plus a new `tolerates_a_source_with_no_implementation_type` test pinning the null-tolerance.
- **CI workflow** — add the missing `test-events` step so this suite actually runs from now on.

## Verification

- EventTests: 7 failed → **411/411 passing** on both net9.0 and net10.0
- CoreTests: 453/453 passing on both frameworks (covers the `TypeDescriptor` change)

Follow-up (separate session in flight): `src/EventStoreTests` (72 tests) is also orphaned — absent from both `jasperfx.sln` and `Build.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)