### PR TITLE
DaemonMode.ExternallyManaged — external hosts (Wolverine) run the projections; store stays quiet without warning (wolverine#3290)

### DIFF
--- a/src/JasperFx.Events/Daemon/DaemonMode.cs
+++ b/src/JasperFx.Events/Daemon/DaemonMode.cs
@@ -19,5 +19,17 @@ public enum DaemonMode
     ///     Marten will ensure that the full async projection daemon will only execute on
     ///     one node at a time, with fail over to other nodes.
     /// </summary>
-    HotCold
+    HotCold,
+
+    /// <summary>
+    ///     Async projections and subscriptions are executed by an external system
+    ///     (e.g. Wolverine's managed event-subscription distribution) rather than by the
+    ///     event store's own hosted daemon coordination. The store itself hosts no
+    ///     coordinator and starts no agents — the same runtime posture as <see cref="Disabled" /> —
+    ///     but, unlike Disabled, the store must NOT warn that async projections will never
+    ///     run: the external host is responsible for executing them. Set by integrations
+    ///     (never overriding an explicit user choice), not by application code directly.
+    ///     See wolverine#3290.
+    /// </summary>
+    ExternallyManaged
 }


### PR DESCRIPTION
Adds a fourth `DaemonMode` value, **`ExternallyManaged`**: async projections/subscriptions are executed by an external system (Wolverine's managed event-subscription distribution) rather than the store's own hosted daemon coordination. Runtime posture of `Disabled` (no coordinator, no agents started by the store) — but stores must not emit the "async daemon is disabled / projections will not run" warning, because the external host runs them.

Replaces the closed wolverine#3329 approach (setting `HotCold` from the integration would activate the store's own coordination in parallel — wrong). Downstream legs: Marten honors it in `warnIfAsyncDaemonIsDisabledWithAsyncProjections` + coordinator registration; Wolverine's `MartenIntegration` sets it (never overriding an explicit user `AddAsyncDaemon` choice); Polecat parity to follow.

No behavior change in this repo — nothing in JasperFx.Events branches on the value; `DaemonSettings.AsyncMode` default stays `Disabled`.

Part of the per-tenant event partitioning epic #486 (WS1 polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)