### PR TITLE
Per-tenant shard expansion at the distributor level + coordinator reconciliation (closes #489)

### DIFF
--- a/src/EventTests/Daemon/MultiTenantedProjectionDistributorTests.cs
+++ b/src/EventTests/Daemon/MultiTenantedProjectionDistributorTests.cs
@@ -34,6 +34,105 @@ public class MultiTenantedProjectionDistributorTests
         }
     }
 
+    // jasperfx#489: sharded databases + per-tenant event partitioning
+    // (DistributesAgentsPerTenant == true). Each database's set expands its
+    // store-global shard names into per-tenant names from THAT database's own tenant
+    // list. Set/lock granularity is unchanged — still one set per database — so a
+    // shard database's tenant agents all run together on the winning node.
+    [Fact]
+    public async Task expands_shards_per_database_using_each_databases_own_tenants()
+    {
+        var dbA = new FakeTenantSourceDatabase("a");
+        dbA.TenantsByProjection["Trip"] = ["a1"];
+        var dbB = new FakeTenantSourceDatabase("b");
+        dbB.TenantsByProjection["Trip"] = ["b1", "b2"];
+        // "Day" has no tenants on either database — zero-tenant fallback keeps the
+        // store-global name per database.
+
+        var shards = new[] { new ShardName("Trip", "All", 1), new ShardName("Day", "All", 1) };
+
+        var distributor = new MultiTenantedProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { dbA, dbB }),
+            allShards: () => shards,
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (db, names, lockId) => new FakeProjectionSet(db, names, lockId),
+            baseLockId: 7,
+            distributesAgentsPerTenant: true);
+
+        var sets = await distributor.BuildDistributionAsync();
+
+        // Still one set — and thus one lock — per database.
+        sets.Count.ShouldBe(2);
+
+        var setA = sets.Single(s => s.Database.Identifier == "a");
+        setA.Names.Select(x => x.Identity).ShouldBe(["Trip:All:a1", "Day:All"]);
+        setA.LockId.ShouldBe(7);
+
+        var setB = sets.Single(s => s.Database.Identifier == "b");
+        setB.Names.Select(x => x.Identity).ShouldBe(["Trip:All:b1", "Trip:All:b2", "Day:All"]);
+        setB.LockId.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task expansion_reenumerates_the_tenant_list_on_every_build()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1"];
+
+        var distributor = new MultiTenantedProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t1"]);
+
+        // A tenant added on another node shows up on the next distribution build.
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t1", "Trip:All:t2"]);
+    }
+
+    [Fact]
+    public async Task expansion_is_inert_when_the_store_does_not_distribute_per_tenant()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+
+        var distributor = new MultiTenantedProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:All");
+        db.Queried.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task expansion_is_inert_when_the_database_has_no_tenant_source()
+    {
+        var db = new FakeProjectionDatabase("only");
+
+        var distributor = new MultiTenantedProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:All");
+    }
+
     [Fact]
     public async Task try_attain_lock_caches_one_advisory_lock_per_database()
     {
@@ -179,6 +278,29 @@ public class MultiTenantedProjectionDistributorTests
 
         public string Identifier { get; }
         public Uri DatabaseUri { get; }
+    }
+
+    private sealed class FakeTenantSourceDatabase : IProjectionDatabase, ICrossTenantRebuildSource
+    {
+        public FakeTenantSourceDatabase(string identifier)
+        {
+            Identifier = identifier;
+            DatabaseUri = new Uri($"fake://{identifier}");
+        }
+
+        public string Identifier { get; }
+        public Uri DatabaseUri { get; }
+
+        public Dictionary<string, IReadOnlyList<string>> TenantsByProjection { get; } = new();
+        public List<string> Queried { get; } = [];
+
+        public Task<IReadOnlyList<string>> FindRebuildTenantsAsync(string projectionName, CancellationToken token)
+        {
+            Queried.Add(projectionName);
+            return Task.FromResult(TenantsByProjection.TryGetValue(projectionName, out var tenants)
+                ? tenants
+                : Array.Empty<string>());
+        }
     }
 
     private sealed class FakeProjectionSet : IProjectionSet

--- a/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
+++ b/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
@@ -3,6 +3,7 @@ using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Projections;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Polly;
 using Shouldly;
 
@@ -12,12 +13,13 @@ public class ProjectionCoordinatorBaseTests
 {
     private static readonly ShardName TheShard = new("Trip", "All", 1);
 
-    private static TestCoordinator BuildCoordinator(FakeDistributor distributor, FakeDaemon daemon)
+    private static TestCoordinator BuildCoordinator(FakeDistributor distributor, FakeDaemon daemon,
+        TimeSpan? leadershipPollingTime = null)
     {
         return new TestCoordinator(
             distributor,
             daemon,
-            leadershipPollingTime: TimeSpan.FromSeconds(30),
+            leadershipPollingTime: leadershipPollingTime ?? TimeSpan.FromSeconds(30),
             agentPauseTime: TimeSpan.FromSeconds(30),
             healthCheckPollingTime: TimeSpan.FromSeconds(30));
     }
@@ -77,6 +79,132 @@ public class ProjectionCoordinatorBaseTests
         await coordinator.StopAsync(CancellationToken.None);
 
         daemon.Stopped.ShouldContain(TheShard.Identity);
+    }
+
+    // ---- jasperfx#489: per-tenant reconciliation in the start-agents pass ----
+    //
+    // Under per-tenant agent distribution the distributor re-expands each set's Names
+    // from the current tenant list on every leadership cycle. The coordinator's owned
+    // pass must converge the running agents onto those Names: tenants added on another
+    // node get agents started (through the existing #487 tenant-bearing StartAgentAsync
+    // branch), removed tenants get their agents reaped, and the store-global agent left
+    // over from a pre-expansion cycle is retired once per-tenant names appear (same
+    // shape as Wolverine's #3328 stale-agent retirement).
+
+    [Fact]
+    public async Task starts_an_agent_for_a_tenant_added_between_leadership_cycles()
+    {
+        var t1 = TheShard.ForTenant("t1");
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([new FakeProjectionSet("db1", [t1], 100)]) { LockHeld = true };
+
+        var coordinator = BuildCoordinator(distributor, daemon, TimeSpan.FromMilliseconds(25));
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => daemon.Started.Contains("Trip:All:t1"));
+
+        // A tenant registered on another node shows up in the next cycle's expansion.
+        distributor.Sets = [new FakeProjectionSet("db1", [t1, TheShard.ForTenant("t2")], 100)];
+        await WaitFor(() => daemon.Started.Contains("Trip:All:t2"));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Started.ShouldContain("Trip:All:t2");
+        // The tenant that was already running is untouched.
+        daemon.Stopped.ShouldNotContain("Trip:All:t1");
+    }
+
+    [Fact]
+    public async Task reaps_the_agent_for_a_tenant_removed_between_leadership_cycles()
+    {
+        var t1 = TheShard.ForTenant("t1");
+        var t2 = TheShard.ForTenant("t2");
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([new FakeProjectionSet("db1", [t1, t2], 100)]) { LockHeld = true };
+
+        var coordinator = BuildCoordinator(distributor, daemon, TimeSpan.FromMilliseconds(25));
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => daemon.Started.Contains("Trip:All:t1") && daemon.Started.Contains("Trip:All:t2"));
+
+        // Tenant t2 was removed — the next expansion no longer carries its name.
+        distributor.Sets = [new FakeProjectionSet("db1", [t1], 100)];
+        await WaitFor(() => daemon.Stopped.Contains("Trip:All:t2"));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Stopped.ShouldContain("Trip:All:t2");
+        daemon.Stopped.ShouldNotContain("Trip:All:t1");
+        daemon.CurrentAgents().Select(x => x.Name.Identity).ShouldBe(["Trip:All:t1"]);
+    }
+
+    [Fact]
+    public async Task retires_a_store_global_agent_when_per_tenant_names_first_appear()
+    {
+        var daemon = new FakeDaemon();
+        // Store-global agent left over from a cycle before the store's tenant list
+        // could be enumerated (the transition edge).
+        daemon.SeedRunningAgent(TheShard);
+
+        var distributor = new FakeDistributor([new FakeProjectionSet("db1", [TheShard.ForTenant("t1")], 100)])
+        {
+            LockHeld = true
+        };
+
+        var coordinator = BuildCoordinator(distributor, daemon);
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => daemon.Started.Contains("Trip:All:t1"));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Stopped.ShouldContain("Trip:All");
+        // The stale store-global agent stops BEFORE its per-tenant replacement starts,
+        // so the two never process the same events concurrently.
+        daemon.Log.IndexOf("stop:Trip:All").ShouldBeLessThan(daemon.Log.IndexOf("start:Trip:All:t1"));
+    }
+
+    [Fact]
+    public async Task reaping_matches_on_the_tenant_neutral_base_and_never_touches_other_projections()
+    {
+        var daemon = new FakeDaemon();
+        // Agents for a DIFFERENT projection on the same daemon — one store-global, one
+        // tenant-bearing — must never be reaped by the Trip set's reconciliation.
+        var day = new ShardName("Day", "All", 1);
+        daemon.SeedRunningAgent(day);
+        daemon.SeedRunningAgent(day.ForTenant("t9"));
+
+        var distributor = new FakeDistributor([new FakeProjectionSet("db1", [TheShard.ForTenant("t1")], 100)])
+        {
+            LockHeld = true
+        };
+
+        var coordinator = BuildCoordinator(distributor, daemon);
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => daemon.Started.Contains("Trip:All:t1"));
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Stopped.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task reconciliation_is_inert_for_a_non_partitioned_set()
+    {
+        // A store that does not distribute agents per tenant keeps store-global Names,
+        // so the reconciliation pass finds nothing to reap across leadership cycles.
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([new FakeProjectionSet("db1", [TheShard], 100)]) { LockHeld = true };
+
+        var coordinator = BuildCoordinator(distributor, daemon, TimeSpan.FromMilliseconds(25));
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => daemon.Started.Contains(TheShard.Identity));
+
+        // Let several more leadership cycles run.
+        await Task.Delay(250);
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        daemon.Stopped.ShouldBeEmpty();
+        // And the running agent was never churned — exactly one start.
+        daemon.Started.Count(x => x == TheShard.Identity).ShouldBe(1);
     }
 
     [Fact]
@@ -191,12 +319,22 @@ public class ProjectionCoordinatorBaseTests
 
     private sealed class FakeDistributor(IReadOnlyList<IProjectionSet> sets) : IProjectionDistributor
     {
+        // Mutable so jasperfx#489 reconciliation tests can change the distribution
+        // between leadership cycles, the way a real distributor re-expands tenant
+        // lists on every BuildDistributionAsync call.
+        private volatile IReadOnlyList<IProjectionSet> _sets = sets;
+
+        public IReadOnlyList<IProjectionSet> Sets
+        {
+            set => _sets = value;
+        }
+
         public bool LockHeld { get; init; }
         public bool CanAttain { get; init; } = true;
         public List<IProjectionSet> ReleasedLocks { get; } = [];
         public int ReleaseAllLocksCount { get; private set; }
 
-        public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync() => new(sets);
+        public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync() => new(_sets);
         public Task RandomWait(CancellationToken token) => Task.CompletedTask;
         public bool HasLock(IProjectionSet set) => LockHeld;
         public Task<bool> TryAttainLockAsync(IProjectionSet set, CancellationToken token) => Task.FromResult(CanAttain);
@@ -227,10 +365,33 @@ public class ProjectionCoordinatorBaseTests
         public List<string> Started { get; } = [];
         public List<string> Stopped { get; } = [];
         public List<string> Ejected { get; } = [];
+
+        // Interleaved start:/stop: record so tests can assert ordering — e.g. the
+        // jasperfx#489 transition edge where the stale store-global agent must stop
+        // BEFORE its per-tenant replacements start.
+        public List<string> Log { get; } = [];
+
         public int DisposeCount { get; private set; }
         public int StopAllCount { get; private set; }
 
+        private readonly List<ISubscriptionAgent> _agents = [];
         private bool _failed;
+
+        // Pre-load a running agent, e.g. a store-global agent left over from a
+        // pre-expansion leadership cycle.
+        public void SeedRunningAgent(ShardName name) => addAgent(name);
+
+        private void addAgent(ShardName name)
+        {
+            lock (_agents)
+            {
+                _agents.RemoveAll(x => x.Name.Identity == name.Identity);
+                var agent = Substitute.For<ISubscriptionAgent>();
+                agent.Name.Returns(name);
+                agent.Status.Returns(AgentStatus.Running);
+                _agents.Add(agent);
+            }
+        }
 
         public Task StartAgentAsync(string shardName, CancellationToken token)
         {
@@ -240,13 +401,30 @@ public class ProjectionCoordinatorBaseTests
                 throw new InvalidOperationException("boom");
             }
 
-            Started.Add(shardName);
+            lock (Log)
+            {
+                Started.Add(shardName);
+                Log.Add($"start:{shardName}");
+            }
+
+            ShardName.TryParse(shardName, out var parsed);
+            addAgent(parsed ?? new ShardName(shardName));
             return Task.CompletedTask;
         }
 
         public Task StopAgentAsync(string shardName, Exception? ex = null)
         {
-            Stopped.Add(shardName);
+            lock (Log)
+            {
+                Stopped.Add(shardName);
+                Log.Add($"stop:{shardName}");
+            }
+
+            lock (_agents)
+            {
+                _agents.RemoveAll(x => x.Name.Identity == shardName);
+            }
+
             return Task.CompletedTask;
         }
 
@@ -256,7 +434,14 @@ public class ProjectionCoordinatorBaseTests
             return Status;
         }
 
-        public IReadOnlyList<ISubscriptionAgent> CurrentAgents() => [];
+        public IReadOnlyList<ISubscriptionAgent> CurrentAgents()
+        {
+            lock (_agents)
+            {
+                return _agents.ToArray();
+            }
+        }
+
         public bool HasAnyPaused() => false;
 
         public void EjectPausedShard(string shardName) => Ejected.Add(shardName);

--- a/src/EventTests/Daemon/SingleTenantProjectionDistributorTests.cs
+++ b/src/EventTests/Daemon/SingleTenantProjectionDistributorTests.cs
@@ -69,6 +69,145 @@ public class SingleTenantProjectionDistributorTests
         }
     }
 
+    // jasperfx#489: when the store distributes agents per tenant, each store-global
+    // shard's set expands into per-tenant shard names at distribution-build time so
+    // the coordinator loop starts tenant-bearing identities through the daemon's
+    // per-tenant StartAgentAsync branch (#487). Lock granularity is unchanged — one
+    // set (and thus one advisory lock) per STORE-GLOBAL shard; the tenant names ride
+    // inside that same set.
+    [Fact]
+    public async Task expands_each_shard_into_per_tenant_names_keeping_one_lock_per_store_global_shard()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+        // "Day" has no registered tenants yet — the zero-tenant fallback keeps its
+        // store-global name, mirroring buildPerTenantContinuousAgents.
+
+        var trip = new ShardName("Trip", "All", 1);
+        var day = new ShardName("Day", "All", 1);
+
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { trip, day },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 100,
+            distributesAgentsPerTenant: true);
+
+        var sets = await distributor.BuildDistributionAsync();
+
+        // One set per store-global shard — NOT per tenant. No per-tenant lock explosion.
+        sets.Count.ShouldBe(2);
+
+        var tripSet = sets.Single(s => s.Names[0].Name == "Trip");
+        tripSet.Names.Select(x => x.Identity).ShouldBe(["Trip:All:t1", "Trip:All:t2"]);
+        // The lock id stays keyed off the store-global shard identity.
+        tripSet.LockId.ShouldBe(ProjectionLockIds.Compute("public", trip, 100));
+
+        var daySet = sets.Single(s => s.Names[0].Name == "Day");
+        daySet.Names.ShouldHaveSingleItem().Identity.ShouldBe("Day:All");
+        daySet.LockId.ShouldBe(ProjectionLockIds.Compute("public", day, 100));
+
+        // The tenant source is consulted with the projection name — the same lookup
+        // grammar buildPerTenantContinuousAgents uses.
+        db.Queried.OrderBy(x => x).ShouldBe(["Day", "Trip"]);
+    }
+
+    [Fact]
+    public async Task expansion_preserves_the_version_segment_of_the_shard_grammar()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1"];
+        var shard = new ShardName("Trip", "All", 2);
+
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { shard },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:V2:All:t1");
+        set.LockId.ShouldBe(ProjectionLockIds.Compute("public", shard, 0));
+    }
+
+    [Fact]
+    public async Task expansion_reenumerates_the_tenant_list_on_every_build()
+    {
+        // Tenant add/remove on another node must converge on the next leadership
+        // polling cycle without a restart — the tenant list is read fresh per build.
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1"];
+
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t1"]);
+
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t1", "Trip:All:t2"]);
+
+        db.TenantsByProjection["Trip"] = ["t2"];
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t2"]);
+    }
+
+    [Fact]
+    public async Task expansion_is_inert_when_the_store_does_not_distribute_per_tenant()
+    {
+        // DistributesAgentsPerTenant false → byte-for-byte the pre-#489 behavior,
+        // even against a database that could enumerate tenants.
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:All");
+        db.Queried.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task expansion_is_inert_when_the_database_has_no_tenant_source()
+    {
+        // Flag on, but the database is not an ICrossTenantRebuildSource — the
+        // store-global names pass through untouched.
+        var db = new FakeProjectionDatabase("only");
+
+        var distributor = new SingleTenantProjectionDistributor(
+            databaseAccessor: () => db,
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            lockFactory: _ => new FakeAdvisoryLock(),
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            schemaQualifier: "public",
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:All");
+    }
+
     [Fact]
     public async Task try_attain_lock_caches_one_advisory_lock_per_database()
     {
@@ -161,6 +300,29 @@ public class SingleTenantProjectionDistributorTests
 
         public string Identifier { get; }
         public Uri DatabaseUri { get; }
+    }
+
+    private sealed class FakeTenantSourceDatabase : IProjectionDatabase, ICrossTenantRebuildSource
+    {
+        public FakeTenantSourceDatabase(string identifier)
+        {
+            Identifier = identifier;
+            DatabaseUri = new Uri($"fake://{identifier}");
+        }
+
+        public string Identifier { get; }
+        public Uri DatabaseUri { get; }
+
+        public Dictionary<string, IReadOnlyList<string>> TenantsByProjection { get; } = new();
+        public List<string> Queried { get; } = [];
+
+        public Task<IReadOnlyList<string>> FindRebuildTenantsAsync(string projectionName, CancellationToken token)
+        {
+            Queried.Add(projectionName);
+            return Task.FromResult(TenantsByProjection.TryGetValue(projectionName, out var tenants)
+                ? tenants
+                : Array.Empty<string>());
+        }
     }
 
     private sealed class FakeProjectionSet : IProjectionSet

--- a/src/EventTests/Daemon/SoloProjectionDistributorTests.cs
+++ b/src/EventTests/Daemon/SoloProjectionDistributorTests.cs
@@ -53,6 +53,86 @@ public class SoloProjectionDistributorTests
         (await distributor.BuildDistributionAsync())[0].Names.Count.ShouldBe(2);
     }
 
+    // jasperfx#489: the Solo hosted path starts agents per identity through the same
+    // coordinator loop as HotCold, so a tenant-partitioned store needs the same
+    // per-tenant expansion here — one agent per (shard, tenant), zero-tenant shards
+    // keep their store-global name.
+    [Fact]
+    public async Task expands_shards_into_per_tenant_names_when_the_store_distributes_per_tenant()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+
+        var shards = new[] { new ShardName("Trip", "All", 1), new ShardName("Day", "All", 1) };
+
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => shards,
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.Select(x => x.Identity).ShouldBe(["Trip:All:t1", "Trip:All:t2", "Day:All"]);
+    }
+
+    [Fact]
+    public async Task expansion_reenumerates_the_tenant_list_on_every_build()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1"];
+
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t1"]);
+
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+        (await distributor.BuildDistributionAsync())[0].Names.Select(x => x.Identity)
+            .ShouldBe(["Trip:All:t1", "Trip:All:t2"]);
+    }
+
+    [Fact]
+    public async Task expansion_is_inert_when_the_store_does_not_distribute_per_tenant()
+    {
+        var db = new FakeTenantSourceDatabase("only");
+        db.TenantsByProjection["Trip"] = ["t1", "t2"];
+
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:All");
+        db.Queried.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task expansion_is_inert_when_the_database_has_no_tenant_source()
+    {
+        var db = new FakeProjectionDatabase("only", new Uri("fake://only"));
+
+        var distributor = new SoloProjectionDistributor(
+            databaseSource: () => new ValueTask<IReadOnlyList<IProjectionDatabase>>(new IProjectionDatabase[] { db }),
+            allShards: () => new[] { new ShardName("Trip", "All", 1) },
+            setFactory: (database, names, lockId) => new FakeProjectionSet(database, names, lockId),
+            baseLockId: 0,
+            distributesAgentsPerTenant: true);
+
+        var set = (await distributor.BuildDistributionAsync()).ShouldHaveSingleItem();
+
+        set.Names.ShouldHaveSingleItem().Identity.ShouldBe("Trip:All");
+    }
+
     [Fact]
     public async Task no_locks_in_solo_mode()
     {
@@ -103,6 +183,29 @@ public class SoloProjectionDistributorTests
 
         public string Identifier { get; }
         public Uri DatabaseUri { get; }
+    }
+
+    private sealed class FakeTenantSourceDatabase : IProjectionDatabase, ICrossTenantRebuildSource
+    {
+        public FakeTenantSourceDatabase(string identifier)
+        {
+            Identifier = identifier;
+            DatabaseUri = new Uri($"fake://{identifier}");
+        }
+
+        public string Identifier { get; }
+        public Uri DatabaseUri { get; }
+
+        public Dictionary<string, IReadOnlyList<string>> TenantsByProjection { get; } = new();
+        public List<string> Queried { get; } = [];
+
+        public Task<IReadOnlyList<string>> FindRebuildTenantsAsync(string projectionName, CancellationToken token)
+        {
+            Queried.Add(projectionName);
+            return Task.FromResult(TenantsByProjection.TryGetValue(projectionName, out var tenants)
+                ? tenants
+                : Array.Empty<string>());
+        }
     }
 
     private sealed class FakeProjectionSet : IProjectionSet

--- a/src/JasperFx.Events/Daemon/MultiTenantedProjectionDistributor.cs
+++ b/src/JasperFx.Events/Daemon/MultiTenantedProjectionDistributor.cs
@@ -31,6 +31,7 @@ public class MultiTenantedProjectionDistributor : IProjectionDistributor
     private readonly Func<IProjectionDatabase, IAdvisoryLock> _lockFactory;
     private readonly Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> _setFactory;
     private readonly int _baseLockId;
+    private readonly bool _distributesAgentsPerTenant;
     private readonly Dictionary<string, IAdvisoryLock> _locks = new();
 
     /// <summary>
@@ -67,12 +68,38 @@ public class MultiTenantedProjectionDistributor : IProjectionDistributor
         Func<IProjectionDatabase, IAdvisoryLock> lockFactory,
         Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
         int baseLockId)
+        : this(databaseSource, allShards, lockFactory, setFactory, baseLockId,
+            distributesAgentsPerTenant: false)
+    {
+    }
+
+    /// <summary>
+    /// jasperfx#489 overload — the original constructor is kept intact for binary
+    /// compatibility with consumers compiled against earlier releases.
+    /// </summary>
+    /// <param name="distributesAgentsPerTenant">
+    /// Pass the store's <see cref="IEventStore.DistributesAgentsPerTenant"/> here.
+    /// When true, each database's set expands its store-global shard names into
+    /// per-tenant shard names using that database's own tenant list
+    /// (<see cref="ICrossTenantRebuildSource"/>) — see <see cref="PerTenantShardExpansion"/>.
+    /// Lock granularity is unchanged: still one set/lock per database, so a shard
+    /// database's tenant agents all run together on the winning node. False keeps
+    /// the pre-#489 behavior byte-for-byte.
+    /// </param>
+    public MultiTenantedProjectionDistributor(
+        Func<ValueTask<IReadOnlyList<IProjectionDatabase>>> databaseSource,
+        Func<IEnumerable<ShardName>> allShards,
+        Func<IProjectionDatabase, IAdvisoryLock> lockFactory,
+        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
+        int baseLockId,
+        bool distributesAgentsPerTenant)
     {
         _databaseSource = databaseSource ?? throw new ArgumentNullException(nameof(databaseSource));
         _allShards = allShards ?? throw new ArgumentNullException(nameof(allShards));
         _lockFactory = lockFactory ?? throw new ArgumentNullException(nameof(lockFactory));
         _setFactory = setFactory ?? throw new ArgumentNullException(nameof(setFactory));
         _baseLockId = baseLockId;
+        _distributesAgentsPerTenant = distributesAgentsPerTenant;
     }
 
     /// <inheritdoc />
@@ -81,13 +108,27 @@ public class MultiTenantedProjectionDistributor : IProjectionDistributor
         var databases = await _databaseSource().ConfigureAwait(false);
         var shards = _allShards().ToList();
 
+        // jasperfx#489: when the store distributes agents per tenant, expand each
+        // database's store-global shard names into per-tenant names from that
+        // database's own tenant list. The set/lock granularity is unchanged — one
+        // set per database — so the winning node runs every tenant agent for that
+        // shard database.
+        var sets = new List<IProjectionSet>(databases.Count);
+        foreach (var db in databases)
+        {
+            IReadOnlyList<ShardName> names = shards;
+            if (_distributesAgentsPerTenant)
+            {
+                names = await PerTenantShardExpansion.ExpandAsync(db, names).ConfigureAwait(false);
+            }
+
+            sets.Add(_setFactory(db, names, _baseLockId));
+        }
+
         // Shuffle databases so multiple nodes coming up at the same time don't
         // collide acquiring locks in the same order — same trick both Marten and
         // Polecat already used.
-        return databases
-            .Select(db => _setFactory(db, shards, _baseLockId))
-            .OrderBy(_ => Random.Shared.NextDouble())
-            .ToList();
+        return sets.OrderBy(_ => Random.Shared.NextDouble()).ToList();
     }
 
     /// <summary>

--- a/src/JasperFx.Events/Daemon/PerTenantShardExpansion.cs
+++ b/src/JasperFx.Events/Daemon/PerTenantShardExpansion.cs
@@ -1,0 +1,69 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// jasperfx#489: distribution-build-time expansion of store-global shard names into
+/// per-tenant shard names for stores that distribute agents per tenant
+/// (<see cref="IEventStore.DistributesAgentsPerTenant"/>). Shared by the Solo /
+/// SingleTenant / MultiTenanted <see cref="IProjectionDistributor"/> concretes so the
+/// native HotCold coordination loop starts tenant-bearing identities through
+/// <c>JasperFxAsyncDaemon.StartAgentAsync</c>'s per-tenant branch (#487) instead of a
+/// single store-global agent per shard.
+/// </summary>
+/// <remarks>
+/// The tenant source is the same one <c>JasperFxAsyncDaemon.StartAllAsync</c> /
+/// <c>buildPerTenantContinuousAgents</c> uses: the database's
+/// <see cref="ICrossTenantRebuildSource"/> implementation (Marten: the registered
+/// partitions in <c>mt_tenant_partitions</c>). A database with no tenant source, or a
+/// projection whose tenant list is empty, keeps its store-global shard name — the
+/// zero-tenant fallback mirrors <c>buildPerTenantContinuousAgents</c> so the shard
+/// still runs (there are no events to process until a tenant exists).
+///
+/// Expansion is re-evaluated on every <c>BuildDistributionAsync</c> call, so tenants
+/// added or removed at runtime (Marten's <c>AddMartenManagedTenantsAsync</c> /
+/// <c>AddTenantToShardAsync</c>, possibly from another node) converge on the next
+/// leadership polling cycle without a restart.
+/// </remarks>
+public static class PerTenantShardExpansion
+{
+    /// <summary>
+    /// Expand each store-global shard name into per-tenant shard names when
+    /// <paramref name="database"/> can enumerate tenants. Returns
+    /// <paramref name="shards"/> untouched when the database is not an
+    /// <see cref="ICrossTenantRebuildSource"/>; a shard whose tenant list is empty
+    /// keeps its store-global name.
+    /// </summary>
+    public static async ValueTask<IReadOnlyList<ShardName>> ExpandAsync(
+        IProjectionDatabase database,
+        IReadOnlyList<ShardName> shards,
+        CancellationToken token = default)
+    {
+        if (database is not ICrossTenantRebuildSource tenantSource)
+        {
+            return shards;
+        }
+
+        var expanded = new List<ShardName>(shards.Count);
+        foreach (var shard in shards)
+        {
+            // Same lookup key buildPerTenantContinuousAgents uses — the projection
+            // name, not the shard identity.
+            var tenants = await tenantSource
+                .FindRebuildTenantsAsync(shard.Name, token).ConfigureAwait(false);
+
+            if (tenants.Count == 0)
+            {
+                expanded.Add(shard);
+                continue;
+            }
+
+            foreach (var tenantId in tenants)
+            {
+                expanded.Add(shard.ForTenant(tenantId));
+            }
+        }
+
+        return expanded;
+    }
+}

--- a/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
+++ b/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
@@ -292,6 +292,17 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
     private async Task startAgentsIfNecessaryAsync(IProjectionDistributor distributor, IProjectionSet set,
         IProjectionDaemon daemon, CancellationToken stoppingToken)
     {
+        // jasperfx#489: reconcile before starting. Under per-tenant agent distribution the
+        // set's Names are re-expanded from the current tenant list on every leadership
+        // cycle, so an agent whose identity no longer appears in Names is stale — a
+        // removed tenant's agent, or the store-global agent left over from a
+        // pre-expansion cycle (the transition edge; same shape as Wolverine's #3328
+        // stale-agent retirement). Reap it FIRST so a store-global agent never runs
+        // concurrently with the per-tenant agents that replace it. For sets whose Names
+        // match the running agents exactly (every non-partitioned store), this finds
+        // nothing and the pass is inert.
+        await reapOrphanedAgentsAsync(set, daemon).ConfigureAwait(false);
+
         foreach (var name in set.Names)
         {
             var agent = daemon.CurrentAgents().FirstOrDefault(x => x.Name.Equals(name));
@@ -307,7 +318,7 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
         }
     }
 
-    private static async Task stopAgentsIfNecessaryAsync(IProjectionSet set, IProjectionDaemon daemon)
+    private async Task stopAgentsIfNecessaryAsync(IProjectionSet set, IProjectionDaemon daemon)
     {
         foreach (var shardName in set.Names)
         {
@@ -317,6 +328,53 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
                 await daemon.StopAgentAsync(shardName.Identity).ConfigureAwait(false);
             }
         }
+
+        // jasperfx#489: also stop stale agents that belong to this set's store-global
+        // shards but whose identity fell out of the freshly expanded Names (a tenant
+        // that was removed since this node last held the lock). The identity loop
+        // above can't see them because they're no longer in Names.
+        await reapOrphanedAgentsAsync(set, daemon).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// jasperfx#489: stop agents currently running for this set's store-global shards
+    /// whose identity is NOT in the set's current Names. Identities are matched on the
+    /// tenant-neutral base (same store-global shard) so agents belonging to other
+    /// projections — or other sets on the same daemon — are never touched.
+    /// </summary>
+    private async Task reapOrphanedAgentsAsync(IProjectionSet set, IProjectionDaemon daemon)
+    {
+        var currentIdentities = set.Names.Select(x => x.Identity).ToHashSet();
+        var baseIdentities = set.Names.Select(tenantNeutralIdentity).ToHashSet();
+
+        foreach (var agent in daemon.CurrentAgents().ToArray())
+        {
+            var identity = agent.Name.Identity;
+            if (currentIdentities.Contains(identity)) continue;
+            if (!baseIdentities.Contains(tenantNeutralIdentity(agent.Name))) continue;
+
+            try
+            {
+                await daemon.StopAgentAsync(identity).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e,
+                    "Error trying to stop orphaned subscription agent {Name} on database {Database}",
+                    identity, set.Database.Identifier);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The store-global (tenant-neutral) identity for a shard name — the identity with
+    /// the trailing tenant slot removed. A store-global name is its own base.
+    /// </summary>
+    private static string tenantNeutralIdentity(ShardName name)
+    {
+        return name.TenantId == null
+            ? name.Identity
+            : ShardName.Compose(name.Name, name.ShardKey, null, name.Version).Identity;
     }
 
     private async Task tryStartAgent(IProjectionDistributor distributor, CancellationToken stoppingToken,

--- a/src/JasperFx.Events/Daemon/SingleTenantProjectionDistributor.cs
+++ b/src/JasperFx.Events/Daemon/SingleTenantProjectionDistributor.cs
@@ -33,6 +33,7 @@ public class SingleTenantProjectionDistributor : IProjectionDistributor
     private readonly Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> _setFactory;
     private readonly string _schemaQualifier;
     private readonly int _baseLockId;
+    private readonly bool _distributesAgentsPerTenant;
     private readonly Dictionary<string, IAdvisoryLock> _locks = new();
 
     /// <summary>
@@ -75,6 +76,32 @@ public class SingleTenantProjectionDistributor : IProjectionDistributor
         Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
         string schemaQualifier,
         int baseLockId)
+        : this(databaseAccessor, allShards, lockFactory, setFactory, schemaQualifier, baseLockId,
+            distributesAgentsPerTenant: false)
+    {
+    }
+
+    /// <summary>
+    /// jasperfx#489 overload — the original constructor is kept intact for binary
+    /// compatibility with consumers compiled against earlier releases.
+    /// </summary>
+    /// <param name="distributesAgentsPerTenant">
+    /// Pass the store's <see cref="IEventStore.DistributesAgentsPerTenant"/> here.
+    /// When true and the database can enumerate tenants
+    /// (<see cref="ICrossTenantRebuildSource"/>), each store-global shard's set carries
+    /// per-tenant shard names instead — see <see cref="PerTenantShardExpansion"/>.
+    /// Lock granularity is unchanged: still one advisory lock per store-global shard,
+    /// with the winning node running all of that shard's tenant agents. False keeps
+    /// the pre-#489 behavior byte-for-byte.
+    /// </param>
+    public SingleTenantProjectionDistributor(
+        Func<IProjectionDatabase> databaseAccessor,
+        Func<IEnumerable<ShardName>> allShards,
+        Func<IProjectionDatabase, IAdvisoryLock> lockFactory,
+        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
+        string schemaQualifier,
+        int baseLockId,
+        bool distributesAgentsPerTenant)
     {
         _databaseAccessor = databaseAccessor ?? throw new ArgumentNullException(nameof(databaseAccessor));
         _allShards = allShards ?? throw new ArgumentNullException(nameof(allShards));
@@ -82,26 +109,39 @@ public class SingleTenantProjectionDistributor : IProjectionDistributor
         _setFactory = setFactory ?? throw new ArgumentNullException(nameof(setFactory));
         _schemaQualifier = schemaQualifier ?? throw new ArgumentNullException(nameof(schemaQualifier));
         _baseLockId = baseLockId;
+        _distributesAgentsPerTenant = distributesAgentsPerTenant;
     }
 
     /// <inheritdoc />
-    public ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync()
+    public async ValueTask<IReadOnlyList<IProjectionSet>> BuildDistributionAsync()
     {
         var database = _databaseAccessor();
 
-        // One IProjectionSet per shard — per-shard lock granularity. Shuffle the
-        // result so multiple nodes coming up at the same time don't race for locks
-        // in identical order (same trick MultiTenanted uses, same trick both
-        // Marten and Polecat already shipped).
-        IReadOnlyList<IProjectionSet> sets = _allShards()
-            .Select(shard => _setFactory(
-                database,
-                [shard],
-                ProjectionLockIds.Compute(_schemaQualifier, shard, _baseLockId)))
-            .OrderBy(_ => Random.Shared.NextDouble())
-            .ToList();
+        // One IProjectionSet per store-global shard — per-shard lock granularity.
+        // jasperfx#489: when the store distributes agents per tenant, the set's Names
+        // expand to per-tenant shard names, but the lock id stays keyed off the
+        // store-global shard — one advisory lock per store-global shard, no
+        // per-tenant lock explosion; the winning node runs all of that shard's
+        // tenant agents.
+        var sets = new List<IProjectionSet>();
+        foreach (var shard in _allShards())
+        {
+            IReadOnlyList<ShardName> names = [shard];
+            if (_distributesAgentsPerTenant)
+            {
+                names = await PerTenantShardExpansion.ExpandAsync(database, names).ConfigureAwait(false);
+            }
 
-        return ValueTask.FromResult(sets);
+            sets.Add(_setFactory(
+                database,
+                names,
+                ProjectionLockIds.Compute(_schemaQualifier, shard, _baseLockId)));
+        }
+
+        // Shuffle the result so multiple nodes coming up at the same time don't race
+        // for locks in identical order (same trick MultiTenanted uses, same trick
+        // both Marten and Polecat already shipped).
+        return sets.OrderBy(_ => Random.Shared.NextDouble()).ToList();
     }
 
     /// <summary>

--- a/src/JasperFx.Events/Daemon/SoloProjectionDistributor.cs
+++ b/src/JasperFx.Events/Daemon/SoloProjectionDistributor.cs
@@ -27,6 +27,7 @@ public sealed class SoloProjectionDistributor : IProjectionDistributor
     private readonly Func<IEnumerable<ShardName>> _allShards;
     private readonly Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> _setFactory;
     private readonly int _baseLockId;
+    private readonly bool _distributesAgentsPerTenant;
 
     /// <summary>
     /// Construct a Solo distributor with store-supplied closures.
@@ -57,11 +58,35 @@ public sealed class SoloProjectionDistributor : IProjectionDistributor
         Func<IEnumerable<ShardName>> allShards,
         Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
         int baseLockId)
+        : this(databaseSource, allShards, setFactory, baseLockId, distributesAgentsPerTenant: false)
+    {
+    }
+
+    /// <summary>
+    /// jasperfx#489 overload — the original constructor is kept intact for binary
+    /// compatibility with consumers compiled against earlier releases.
+    /// </summary>
+    /// <param name="distributesAgentsPerTenant">
+    /// Pass the store's <see cref="IEventStore.DistributesAgentsPerTenant"/> here.
+    /// When true, each database's set expands its store-global shard names into
+    /// per-tenant shard names using that database's own tenant list
+    /// (<see cref="ICrossTenantRebuildSource"/>) — see <see cref="PerTenantShardExpansion"/>.
+    /// The Solo hosted path drives agents through the same coordinator per-identity
+    /// starts as HotCold, so it needs the same expansion. False keeps the pre-#489
+    /// behavior byte-for-byte.
+    /// </param>
+    public SoloProjectionDistributor(
+        Func<ValueTask<IReadOnlyList<IProjectionDatabase>>> databaseSource,
+        Func<IEnumerable<ShardName>> allShards,
+        Func<IProjectionDatabase, IReadOnlyList<ShardName>, int, IProjectionSet> setFactory,
+        int baseLockId,
+        bool distributesAgentsPerTenant)
     {
         _databaseSource = databaseSource ?? throw new ArgumentNullException(nameof(databaseSource));
         _allShards = allShards ?? throw new ArgumentNullException(nameof(allShards));
         _setFactory = setFactory ?? throw new ArgumentNullException(nameof(setFactory));
         _baseLockId = baseLockId;
+        _distributesAgentsPerTenant = distributesAgentsPerTenant;
     }
 
     /// <inheritdoc />
@@ -69,7 +94,24 @@ public sealed class SoloProjectionDistributor : IProjectionDistributor
     {
         var databases = await _databaseSource().ConfigureAwait(false);
         var shards = _allShards().ToList();
-        return databases.Select(db => _setFactory(db, shards, _baseLockId)).ToList();
+
+        // jasperfx#489: same per-tenant expansion as the multi-node distributors —
+        // the Solo hosted path also starts agents per identity through the
+        // coordinator loop, so a tenant-partitioned store needs per-tenant names here
+        // too. Inert when the flag is false or the database has no tenant source.
+        var sets = new List<IProjectionSet>(databases.Count);
+        foreach (var db in databases)
+        {
+            IReadOnlyList<ShardName> names = shards;
+            if (_distributesAgentsPerTenant)
+            {
+                names = await PerTenantShardExpansion.ExpandAsync(db, names).ConfigureAwait(false);
+            }
+
+            sets.Add(_setFactory(db, names, _baseLockId));
+        }
+
+        return sets;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Closes #489. Part of the per-tenant event partitioning epic #486 (WS1) — the native-coordination sibling of marten#4862.

## What it does

**Distributor-level per-tenant expansion** (new `PerTenantShardExpansion` helper): when a store distributes agents per tenant and the target `IProjectionDatabase` implements `ICrossTenantRebuildSource`, each store-global shard name inside an `IProjectionSet` expands into per-tenant `ShardName`s — same identity grammar `StartAllAsync`'s internal fan-out uses; an empty tenant list keeps the store-global name. Applied to all three distributors:

- `SingleTenantProjectionDistributor`: still **one advisory lock per store-global shard** — the per-tenant names ride inside that set (the winning node runs all of that shard's tenant agents; no lock explosion)
- `MultiTenantedProjectionDistributor`: one set/lock per database unchanged, Names expanded from that database's own tenant list
- `SoloProjectionDistributor`: same — and yes, **Solo was broken identically** (Marten's Solo mode registers the standard coordinator driving per-identity `StartAgentAsync`; only `ExplicitProjectionCoordinator` used `StartAllAsync`)

Tenant lists are re-read every leadership polling cycle (`BuildDistributionAsync` is called fresh each cycle, no caching), so tenants added on other nodes converge without restart.

**Coordinator reconciliation** (`ProjectionCoordinatorBase`): before starting a set's agents, any running agent whose tenant-neutral base identity matches the set but whose full identity is no longer in the set's Names gets stopped — tenant-removed reaping AND the transition edge (a leftover store-global agent is retired before its per-tenant replacements start; ordering pinned by test). The lock-lost path gets the same orphan sweep. Base-identity matching guarantees other projections' agents are never touched. Tenant-added starts flow through the existing per-identity path, which primes per-tenant ceilings (#487).

Non-partitioned stores: byte-for-byte unchanged; original distributor constructors kept and chained (binary-compatible with consumers compiled against 2.20.0, including Polecat).

## Tests

437/437 on net9.0 and net10.0 — 419 existing + expansion suites for all three distributors (lock-count assertions included) + coordinator reconciliation tests (tenant add between cycles, tenant removal, store-global retirement ordering, non-partitioned inertness), run 5× with no flakes.

## Marten consumption notes

`ProjectionCoordinator.BuildDistributor` must thread `IEventStore.DistributesAgentsPerTenant` into the new overloads for all three modes; the single-DB gate widening is marten#4864 (in review). Expansion costs one `mt_tenant_partitions` query per shard per polling cycle per database on partitioned stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)