### PR TITLE
Guarantee per-tenant high-water polling on the SlowPollingTime cadence (closes #492)

### DIFF
--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -152,6 +152,37 @@ public class PerTenantStartAgentAsyncTests
     }
 
     [Fact]
+    public async Task lagging_tenant_is_repolled_on_the_slow_polling_cadence_without_a_global_mark_change()
+    {
+        // jasperfx#492: OnNext(HighWaterMark) only fires when the STORE-GLOBAL mark changes. In this
+        // harness the store-global detector reading is pinned at 0 forever, so after the initial
+        // start-up publication no global tick will ever occur — exactly the quiet system where only a
+        // lagging tenant appends. Before the fix the per-tenant poll ran once at agent start and then
+        // never again; the daemon's SlowPollingTime timer must keep driving it.
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.SlowPollingTime = TimeSpan.FromMilliseconds(50),
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        var pollsAtStart = detector.TenantPollCount;
+
+        // The tenant appends below the (frozen) global max — its mark advances, the global one doesn't
+        detector.SetTenantMark("t1", 77);
+
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (detector.TenantPollCount < pollsAtStart + 3 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
+
+        detector.TenantPollCount.ShouldBeGreaterThanOrEqualTo(pollsAtStart + 3);
+    }
+
+    [Fact]
     public async Task second_start_of_the_same_tenant_identity_is_idempotent()
     {
         var detector = new StubPartitionedDetector();
@@ -174,6 +205,12 @@ public class PerTenantStartAgentAsyncTests
     private sealed class DaemonHarness : IAsyncDisposable
     {
         public DaemonHarness(IHighWaterDetector detector, params AsyncShard<FakeOperations, FakeSession>[] shards)
+            : this(detector, null, shards)
+        {
+        }
+
+        public DaemonHarness(IHighWaterDetector detector, Action<DaemonSettings>? configureSettings,
+            params AsyncShard<FakeOperations, FakeSession>[] shards)
         {
             Store = Substitute.For<IEventStore<FakeOperations, FakeSession>>();
             Store.Meter.Returns(new Meter("tests"));
@@ -206,8 +243,11 @@ public class PerTenantStartAgentAsyncTests
             Database.DatabaseUri.Returns(new Uri("fake://db1"));
             Database.Tracker.Returns(new ShardStateTracker(new NulloLogger()));
 
+            var projections = new FakeProjectionGraph();
+            configureSettings?.Invoke(projections);
+
             Daemon = new JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>(
-                Store, Database, new NulloLogger(), detector, new FakeProjectionGraph());
+                Store, Database, new NulloLogger(), detector, projections);
         }
 
         public IEventStore<FakeOperations, FakeSession> Store { get; }
@@ -258,6 +298,18 @@ public class PerTenantStartAgentAsyncTests
             lock (_tenantPolls)
             {
                 return _tenantPolls.SelectMany(x => x).Distinct().ToList();
+            }
+        }
+
+        // How many times the vectorized per-tenant poll has run
+        public int TenantPollCount
+        {
+            get
+            {
+                lock (_tenantPolls)
+                {
+                    return _tenantPolls.Count;
+                }
             }
         }
 

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -8,6 +8,7 @@ using JasperFx.Events.Daemon.HighWater;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Subscriptions;
 using Microsoft.Extensions.Logging;
+using Timer = System.Timers.Timer;
 
 namespace JasperFx.Events.Daemon;
 
@@ -32,6 +33,14 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // single store-global high-water mark (today's behavior, byte for byte). jasperfx#407 Phase 2b.
     private readonly TenantedHighWaterCoordinator? _tenantHighWater;
 
+    // jasperfx#492: OnNext(HighWaterMark) only fires when the STORE-GLOBAL mark changes, so a lagging
+    // tenant appending below the global max would never be re-polled in a quiet system. This timer
+    // guarantees a per-tenant poll at least every SlowPollingTime; _lastTenantHighWaterPoll dedups it
+    // against the OnNext-driven fast path so an active system still polls once per global tick.
+    private readonly Timer? _tenantHighWaterTimer;
+    private DateTimeOffset _lastTenantHighWaterPoll;
+    private int _tenantHighWaterPollInFlight;
+
     public JasperFxAsyncDaemon(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory, IHighWaterDetector detector, ProjectionGraph<TProjection, TOperations, TQuerySession> projections)
     {
         Database = database;
@@ -45,6 +54,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         if (detector.SupportsTenantPartitioning)
         {
             _tenantHighWater = new TenantedHighWaterCoordinator(detector, loggerFactory.CreateLogger<TenantedHighWaterCoordinator>());
+            _tenantHighWaterTimer = buildTenantHighWaterTimer();
         }
 
         _breakSubscription = database.Tracker.Subscribe(this);
@@ -65,6 +75,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         if (detector.SupportsTenantPartitioning)
         {
             _tenantHighWater = new TenantedHighWaterCoordinator(detector, logger);
+            _tenantHighWaterTimer = buildTenantHighWaterTimer();
         }
 
         _breakSubscription = database.Tracker.Subscribe(this);
@@ -91,6 +102,8 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     {
         _cancellation?.Dispose();
         _highWater?.Dispose();
+        _tenantHighWaterTimer?.Stop();
+        _tenantHighWaterTimer?.Dispose();
         _breakSubscription.Dispose();
         _deadLetterBlock.Dispose();
     }
@@ -655,6 +668,8 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             return;
         }
 
+        _lastTenantHighWaterPoll = DateTimeOffset.UtcNow;
+
         try
         {
             await _tenantHighWater.PollAndRouteAsync(CurrentAgents(), _cancellation.Token).ConfigureAwait(false);
@@ -662,6 +677,45 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         catch (Exception e)
         {
             Logger.LogError(e, "Error polling per-tenant high water for database {Name}", Database.Identifier);
+        }
+    }
+
+    // jasperfx#492: guarantee a per-tenant high-water poll on a reliable cadence, not solely on
+    // store-global mark publications. Runs for the daemon's lifetime; each tick is a no-op unless the
+    // high-water agent is running and no poll happened within the last SlowPollingTime window.
+    private Timer buildTenantHighWaterTimer()
+    {
+        var timer = new Timer(_projections.SlowPollingTime.TotalMilliseconds) { AutoReset = true };
+        timer.Elapsed += (_, _) => _ = pollTenantHighWaterOnCadenceAsync();
+        timer.Start();
+        return timer;
+    }
+
+    private async Task pollTenantHighWaterOnCadenceAsync()
+    {
+        if (!_highWater.IsRunning || _cancellation.IsCancellationRequested)
+        {
+            return;
+        }
+
+        // The OnNext(HighWaterMark) fast path already polled within this cadence window
+        if (DateTimeOffset.UtcNow - _lastTenantHighWaterPoll < _projections.SlowPollingTime)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _tenantHighWaterPollInFlight, 1, 0) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            await pollTenantHighWaterAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            Volatile.Write(ref _tenantHighWaterPollInFlight, 0);
         }
     }
 


### PR DESCRIPTION
Closes #492. Part of the #486 epic (WS1 residue).

## Problem

`JasperFxAsyncDaemon.pollTenantHighWaterAsync()` was driven solely by `OnNext(ShardState.HighWaterMark)`, which `HighWaterAgent` publishes **only when the store-global mark changes**. Under per-tenant partitioning the global mark is the max across all tenants' independent sequences, so a lagging tenant appending below the global max never produces a global tick. In a quiet system where only the lagging tenant appends, its projections stall until unrelated tenant activity occurs (or restart). marten#4869 fixed what the *detector* returns when polled; this fixes **when polling happens**.

## Fix

The daemon owns a modest `System.Timers.Timer` (the same pattern `HighWaterAgent` already uses internally), created only when the store partitions per tenant, driving the same vectorized single-round-trip poll every `SlowPollingTime`:

- A last-poll timestamp dedups it against the `OnNext` fast path — an active system still polls exactly once per global tick, no extra DB chatter.
- An in-flight guard prevents overlapping polls if a poll outlives the cadence.
- Ticks are no-ops while the high-water agent is stopped, preserving the "nothing happening, stop hammering the database" behavior.

## Test

`lagging_tenant_is_repolled_on_the_slow_polling_cadence_without_a_global_mark_change` pins the quiet-system shape: the harness's store-global mark is frozen at 0 forever, so only the timer can drive further per-tenant polls. Verified the test fails without the daemon change and passes with it. Full EventTests suite green (438 tests, net9.0); full solution builds clean.

## Follow-up unblocked

With a reliable poll cadence, the seed-above-global-mark workarounds (loudly commented) in marten `TenantPartitionedEventsTests` dynamic-lifecycle tests — and possibly the Wolverine failover e2e — can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)