### PR TITLE
Per-database event-load throttle (#494 Phase A, epic #486 WS2)

### DIFF
--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -183,6 +183,44 @@ public class PerTenantStartAgentAsyncTests
     }
 
     [Fact]
+    public async Task agents_share_the_daemon_load_throttle_by_default()
+    {
+        // jasperfx#494: every agent loader the daemon builds is wrapped in the shared
+        // ThrottledEventLoader so concurrent LoadAsync executions per database stay bounded.
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+        detector.SetTenantMark("t2", 42);
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        await harness.Daemon.StartAgentAsync("Trip:All:t2", CancellationToken.None);
+
+        var loaders = harness.Daemon.CurrentAgents()
+            .Cast<SubscriptionAgent>()
+            .Select(x => x.Loader)
+            .ToArray();
+
+        loaders.ShouldAllBe(x => x is ThrottledEventLoader);
+    }
+
+    [Fact]
+    public async Task load_throttle_is_disabled_by_a_nonpositive_setting()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.MaxConcurrentEventLoadsPerDatabase = 0,
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        var agent = harness.Daemon.CurrentAgents().Cast<SubscriptionAgent>().ShouldHaveSingleItem();
+        agent.Loader.ShouldNotBeOfType<ThrottledEventLoader>();
+    }
+
+    [Fact]
     public async Task second_start_of_the_same_tenant_identity_is_idempotent()
     {
         var detector = new StubPartitionedDetector();

--- a/src/EventTests/Daemon/ThrottledEventLoaderTests.cs
+++ b/src/EventTests/Daemon/ThrottledEventLoaderTests.cs
@@ -1,0 +1,188 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#494 (epic #486 WS2): ThrottledEventLoader bounds concurrent LoadAsync executions
+// against one database. These tests are fully gate-driven (TaskCompletionSource), never
+// timing-driven — a load only completes when the test releases it, so the observed concurrency
+// numbers are exact, not racy.
+public class ThrottledEventLoaderTests
+{
+    [Fact]
+    public async Task bounds_concurrent_loads_to_the_semaphore_size()
+    {
+        var inner = new GatedLoader();
+        using var throttle = new SemaphoreSlim(2);
+        var loader = new ThrottledEventLoader(inner, throttle);
+
+        var loads = Enumerable.Range(0, 5)
+            .Select(_ => loader.LoadAsync(request(), CancellationToken.None))
+            .ToArray();
+
+        // Exactly the semaphore size may start; the other three queue on the throttle.
+        await inner.WaitForStartsAsync(2);
+        inner.Started.ShouldBe(2);
+        inner.Active.ShouldBe(2);
+
+        // Each completion admits exactly one queued load. Sequenced start-by-start so the
+        // test never races the admissions.
+        inner.ReleaseOne();
+        await inner.WaitForStartsAsync(3);
+        inner.Started.ShouldBe(3);
+
+        inner.ReleaseOne();
+        await inner.WaitForStartsAsync(4);
+        inner.ReleaseOne();
+        await inner.WaitForStartsAsync(5);
+
+        // Drain the final two in-flight loads
+        inner.ReleaseOne();
+        inner.ReleaseOne();
+        await Task.WhenAll(loads);
+
+        inner.Started.ShouldBe(5);
+        inner.MaxActive.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task releases_the_slot_when_the_inner_loader_throws()
+    {
+        var inner = new GatedLoader();
+        using var throttle = new SemaphoreSlim(1);
+        var loader = new ThrottledEventLoader(inner, throttle);
+
+        var failing = loader.LoadAsync(request(), CancellationToken.None);
+        await inner.WaitForStartsAsync(1);
+        inner.FailOne(new InvalidOperationException("boom"));
+        await Should.ThrowAsync<InvalidOperationException>(() => failing);
+
+        // The slot must have been released — a subsequent load starts immediately.
+        var next = loader.LoadAsync(request(), CancellationToken.None);
+        await inner.WaitForStartsAsync(2);
+        inner.ReleaseOne();
+        (await next).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_queued_load_can_be_cancelled_without_consuming_a_slot()
+    {
+        var inner = new GatedLoader();
+        using var throttle = new SemaphoreSlim(1);
+        var loader = new ThrottledEventLoader(inner, throttle);
+
+        var running = loader.LoadAsync(request(), CancellationToken.None);
+        await inner.WaitForStartsAsync(1);
+
+        using var cts = new CancellationTokenSource();
+        var queued = loader.LoadAsync(request(), cts.Token);
+        cts.Cancel();
+        await Should.ThrowAsync<OperationCanceledException>(() => queued);
+
+        // The cancelled waiter never reached the inner loader...
+        inner.Started.ShouldBe(1);
+
+        // ...and the slot economy is intact: finishing the first load lets a new one start.
+        inner.ReleaseOne();
+        await running;
+        var next = loader.LoadAsync(request(), CancellationToken.None);
+        await inner.WaitForStartsAsync(2);
+        inner.ReleaseOne();
+        await next;
+    }
+
+    [Fact]
+    public void daemon_settings_default_is_four()
+    {
+        new DaemonSettings().MaxConcurrentEventLoadsPerDatabase.ShouldBe(4);
+    }
+
+    private static EventRequest request() => new()
+    {
+        Floor = 0, HighWater = 10, BatchSize = 100,
+        ErrorOptions = new ErrorHandlingOptions(),
+        Runtime = new NulloDaemonRuntime(),
+        Name = new ShardName("Throttled")
+    };
+
+    // A loader whose loads only complete when the test says so. Start notifications are
+    // TCS-armed (WaitForStartsAsync), so assertions never race the loads.
+    private sealed class GatedLoader: IEventLoader
+    {
+        private readonly object _lock = new();
+        private readonly Queue<TaskCompletionSource<EventPage>> _inFlight = new();
+        private readonly List<(int Threshold, TaskCompletionSource Signal)> _startWaiters = new();
+
+        public int Started { get; private set; }
+        public int Active { get; private set; }
+        public int MaxActive { get; private set; }
+
+        public Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+        {
+            var gate = new TaskCompletionSource<EventPage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            lock (_lock)
+            {
+                Started++;
+                Active++;
+                MaxActive = Math.Max(MaxActive, Active);
+                _inFlight.Enqueue(gate);
+
+                foreach (var waiter in _startWaiters.Where(w => Started >= w.Threshold).ToArray())
+                {
+                    waiter.Signal.TrySetResult();
+                    _startWaiters.Remove(waiter);
+                }
+            }
+
+            return gate.Task.ContinueWith(t =>
+            {
+                lock (_lock)
+                {
+                    Active--;
+                }
+
+                return t.GetAwaiter().GetResult();
+            }, TaskScheduler.Default);
+        }
+
+        public Task WaitForStartsAsync(int threshold)
+        {
+            lock (_lock)
+            {
+                if (Started >= threshold)
+                {
+                    return Task.CompletedTask;
+                }
+
+                var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _startWaiters.Add((threshold, signal));
+                return signal.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            }
+        }
+
+        public void ReleaseOne()
+        {
+            TaskCompletionSource<EventPage> gate;
+            lock (_lock)
+            {
+                gate = _inFlight.Dequeue();
+            }
+
+            gate.SetResult(new EventPage(0));
+        }
+
+        public void FailOne(Exception ex)
+        {
+            TaskCompletionSource<EventPage> gate;
+            lock (_lock)
+            {
+                gate = _inFlight.Dequeue();
+            }
+
+            gate.SetException(ex);
+        }
+
+    }
+}

--- a/src/JasperFx.Events/Daemon/DaemonSettings.cs
+++ b/src/JasperFx.Events/Daemon/DaemonSettings.cs
@@ -107,4 +107,15 @@ public class DaemonSettings: IReadOnlyDaemonSettings
     /// and <see cref="SlowPollingTime"/>.
     /// </summary>
     public IDaemonWakeup? Wakeup { get; set; }
+
+    /// <summary>
+    /// jasperfx#494 (epic #486 WS2): cap on how many subscription agents may execute
+    /// IEventLoader.LoadAsync concurrently against one database. Every load opens its own
+    /// store session, so without a bound the connection pool's high-water mark trends toward
+    /// the number of running agents — under per-tenant event partitioning that is
+    /// (projections × tenants) even though only a handful of loads are ever active at once.
+    /// Applies per daemon instance (one daemon per store × database). Zero or negative
+    /// disables the throttle.
+    /// </summary>
+    public int MaxConcurrentEventLoadsPerDatabase { get; set; } = 4;
 }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -41,6 +41,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     private DateTimeOffset _lastTenantHighWaterPoll;
     private int _tenantHighWaterPollInFlight;
 
+    // jasperfx#494 (epic #486 WS2): shared by every agent loader this daemon builds so the
+    // database's connection footprint stays O(databases), not O(agents). Null = unthrottled.
+    private readonly SemaphoreSlim? _loadThrottle;
+
     public JasperFxAsyncDaemon(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory, IHighWaterDetector detector, ProjectionGraph<TProjection, TOperations, TQuerySession> projections)
     {
         Database = database;
@@ -60,6 +64,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _breakSubscription = database.Tracker.Subscribe(this);
 
         _deadLetterBlock = buildDeadLetterBlock();
+
+        _loadThrottle = _projections.MaxConcurrentEventLoadsPerDatabase > 0
+            ? new SemaphoreSlim(_projections.MaxConcurrentEventLoadsPerDatabase)
+            : null;
     }
 
     public JasperFxAsyncDaemon(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILogger logger, IHighWaterDetector detector, ProjectionGraph<TProjection, TOperations, TQuerySession> projections)
@@ -81,6 +89,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _breakSubscription = database.Tracker.Subscribe(this);
 
         _deadLetterBlock = buildDeadLetterBlock();
+
+        _loadThrottle = _projections.MaxConcurrentEventLoadsPerDatabase > 0
+            ? new SemaphoreSlim(_projections.MaxConcurrentEventLoadsPerDatabase)
+            : null;
     }
 
     private RetryBlock<DeadLetterEvent> buildDeadLetterBlock()
@@ -106,6 +118,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _tenantHighWaterTimer?.Dispose();
         _breakSubscription.Dispose();
         _deadLetterBlock.Dispose();
+        _loadThrottle?.Dispose();
     }
 
     public ShardStateTracker Tracker { get; }
@@ -330,6 +343,13 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     {
         var execution = _loggerFactory == null ? shard.Factory.BuildExecution(_store, Database, Logger, shard.Name) : shard.Factory.BuildExecution(_store, Database, _loggerFactory, shard.Name);
         var loader = _store.BuildEventLoader(Database, Logger, shard.Filters, shard.Options, shard.Name);
+
+        if (_loadThrottle != null)
+        {
+            // jasperfx#494: all of this daemon's agents share one load throttle so the pool's
+            // high-water mark stays bounded no matter how many (projection × tenant) agents run
+            loader = new ThrottledEventLoader(loader, _loadThrottle);
+        }
 
         var metrics = new SubscriptionMetrics(_store, shard.Name, Database);
         

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -44,6 +44,9 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
         ProjectionShardIdentity = name.Identity;
     }
 
+    // Exposed so tests can assert how the daemon composed this agent's loader (jasperfx#494)
+    internal IEventLoader Loader => _loader;
+
     public string ProjectionShardIdentity { get; }
 
     public CancellationToken CancellationToken => _cancellation.Token;

--- a/src/JasperFx.Events/Daemon/ThrottledEventLoader.cs
+++ b/src/JasperFx.Events/Daemon/ThrottledEventLoader.cs
@@ -1,0 +1,39 @@
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// jasperfx#494 (epic #486 WS2): bounds how many subscription agents load events concurrently
+/// against one database. Each IEventLoader.LoadAsync opens its own store session, so N running
+/// agents drive the connection pool's high-water mark toward N — under per-tenant event
+/// partitioning that is (projections × tenants) — even though measurement shows only a handful
+/// of loads are ever active at an instant. All of a daemon's agent loaders share one semaphore
+/// sized by <see cref="DaemonSettings.MaxConcurrentEventLoadsPerDatabase"/>, collapsing the
+/// steady-state connection footprint to O(databases) with no measured throughput cost.
+/// </summary>
+internal class ThrottledEventLoader: IEventLoader
+{
+    private readonly SemaphoreSlim _throttle;
+
+    public ThrottledEventLoader(IEventLoader inner, SemaphoreSlim throttle)
+    {
+        Inner = inner;
+        _throttle = throttle;
+    }
+
+    // Exposed for wiring assertions in tests
+    internal IEventLoader Inner { get; }
+
+    public async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+    {
+        await _throttle.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            return await Inner.LoadAsync(request, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            _throttle.Release();
+        }
+    }
+}


### PR DESCRIPTION
Phase A of #494 (epic #486 WS2 — connection conservation).

## What

Every subscription agent's `IEventLoader.LoadAsync` opens its own store session, so a daemon running (projections × tenants) agents under per-tenant partitioning drives the pool's high-water mark toward the agent count. All agent loaders a daemon builds now share one `SemaphoreSlim` sized by `DaemonSettings.MaxConcurrentEventLoadsPerDatabase` (default 4; ≤0 disables), applied as a `ThrottledEventLoader` decorator in `buildAgentForShard`. The composite replay loader path is deliberately NOT throttled — one serial loader per rebuild, already bounded by the per-database rebuild cap.

## Verification

- Deterministic TCS-gated concurrency tests (bound honored, slot released on failure, cancelled waiter consumes no slot) + daemon wiring tests. Full EventTests 444/444 green on net9.0 + net10.0.
- `daemonload` (marten ScaleTesting; 100 tenants × 2 projections = 200 agents, continuous append): event-loader sessions observed ≤ 4 via `pg_stat_activity` last-query attribution; **100/100 tenants caught up, throughput unchanged**.

## Honest finding → WS3

The throttle alone does **not** collapse total pool size in an all-tenants-active steady state: live sampling shows **29 of ~35 open sessions last executed `COMMIT`** — they're per-agent projection-batch write sessions, which are unbounded (the racy cold-start burst of 200 first-batch commits explains run-to-run peaks of ~35 vs ~99). That's the WS3 write governor's territory, now with hard evidence; measurement details on #494. Where Phase A matters most on its own: cold-start/catch-up storms, which would otherwise be 200 concurrent loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)