### PR TITLE
Per-database projection batch-write governor + bounded cross-tenant rebuild default (epic #486 WS3)

### DIFF
--- a/src/EventTests/Daemon/BatchWriteGovernorDefaultsTests.cs
+++ b/src/EventTests/Daemon/BatchWriteGovernorDefaultsTests.cs
@@ -1,0 +1,31 @@
+using JasperFx.Events.Daemon;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// Epic #486 WS3: write-side throttling defaults.
+public class BatchWriteGovernorDefaultsTests
+{
+    [Fact]
+    public void daemon_settings_default_is_four()
+    {
+        new DaemonSettings().MaxConcurrentBatchWritesPerDatabase.ShouldBe(4);
+    }
+
+    [Fact]
+    public void rebuild_everywhere_default_parallelism_is_four()
+    {
+        // An unbounded default let a 100-tenant store fan out 100 concurrent rebuilds against
+        // one database. Pin the new bounded default (0 still opts back into unbounded).
+        var method = typeof(CrossTenantRebuild).GetMethod(nameof(CrossTenantRebuild.RebuildEverywhereAsync))!;
+        method.GetParameters().Single(x => x.Name == "maxParallelism").DefaultValue.ShouldBe(4);
+    }
+
+    [Fact]
+    public void agents_and_runtimes_default_to_no_governor()
+    {
+        // The default interface members keep every existing ISubscriptionAgent /
+        // IDaemonRuntime implementation (including the Nullo) on unbounded behavior.
+        (new NulloDaemonRuntime() as IDaemonRuntime).BatchWriteThrottle.ShouldBeNull();
+    }
+}

--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -205,6 +205,43 @@ public class PerTenantStartAgentAsyncTests
     }
 
     [Fact]
+    public async Task started_agents_surface_the_daemon_batch_write_governor()
+    {
+        // Epic #486 WS3: the governor flows daemon (IDaemonRuntime) -> agent -> execution via
+        // EventRange.Agent. The agent only learns its runtime at StartAsync, so assert on a
+        // STARTED agent.
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+        detector.SetTenantMark("t2", 42);
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        await harness.Daemon.StartAgentAsync("Trip:All:t2", CancellationToken.None);
+
+        var agents = harness.Daemon.CurrentAgents();
+        agents.ShouldAllBe(x => ReferenceEquals(x.BatchWriteThrottle, harness.Daemon.BatchWriteThrottle));
+        harness.Daemon.BatchWriteThrottle.ShouldNotBeNull();
+        harness.Daemon.BatchWriteThrottle!.CurrentCount.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task batch_write_governor_is_disabled_by_a_nonpositive_setting()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.MaxConcurrentBatchWritesPerDatabase = 0,
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        harness.Daemon.BatchWriteThrottle.ShouldBeNull();
+        harness.Daemon.CurrentAgents().ShouldAllBe(x => x.BatchWriteThrottle == null);
+    }
+
+    [Fact]
     public async Task load_throttle_is_disabled_by_a_nonpositive_setting()
     {
         var detector = new StubPartitionedDetector();

--- a/src/JasperFx.Events/Daemon/CrossTenantRebuild.cs
+++ b/src/JasperFx.Events/Daemon/CrossTenantRebuild.cs
@@ -41,9 +41,11 @@ public class CrossTenantRebuild
     /// <param name="projectionName">Projection to rebuild for every tenant.</param>
     /// <param name="shardTimeout">Per-shard rebuild timeout.</param>
     /// <param name="token"></param>
-    /// <param name="maxParallelism">Maximum simultaneous per-tenant rebuilds. 0 (default) means unbounded.</param>
+    /// <param name="maxParallelism">Maximum simultaneous per-tenant rebuilds. Defaults to 4
+    /// (epic #486 WS3 — an unbounded default let a 100-tenant store fan out 100 concurrent
+    /// rebuilds against one database); pass 0 for the old unbounded behavior.</param>
     public async Task<IReadOnlyList<string>> RebuildEverywhereAsync(IProjectionDaemon daemon, string projectionName,
-        TimeSpan shardTimeout, CancellationToken token, int maxParallelism = 0)
+        TimeSpan shardTimeout, CancellationToken token, int maxParallelism = 4)
     {
         var tenants = await _source.FindRebuildTenantsAsync(projectionName, token).ConfigureAwait(false);
         if (tenants.Count == 0)

--- a/src/JasperFx.Events/Daemon/DaemonSettings.cs
+++ b/src/JasperFx.Events/Daemon/DaemonSettings.cs
@@ -118,4 +118,16 @@ public class DaemonSettings: IReadOnlyDaemonSettings
     /// disables the throttle.
     /// </summary>
     public int MaxConcurrentEventLoadsPerDatabase { get; set; } = 4;
+
+    /// <summary>
+    /// Epic #486 WS3: cap on how many projection batches may execute their SQL (the
+    /// commit round-trip) concurrently against one database. Each agent's batch opens its
+    /// own session to write documents + progression, so without a bound a burst of active
+    /// agents — e.g. every (projection × tenant) agent committing its first batch right
+    /// after daemon start — drives the connection pool's high-water mark toward the agent
+    /// count. Measurement (jasperfx#494) attributed ~29 of ~35 steady-state daemon
+    /// connections to these commit sessions. Applies per daemon instance (one daemon per
+    /// store × database). Zero or negative disables the governor.
+    /// </summary>
+    public int MaxConcurrentBatchWritesPerDatabase { get; set; } = 4;
 }

--- a/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
+++ b/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
@@ -220,6 +220,25 @@ public class GroupedProjectionExecution : ISubscriptionExecution
 
     private async Task applyBatchOperationsToDatabaseAsync(EventRange range, IProjectionBatch batch)
     {
+        // Epic #486 WS3: bound concurrent batch execute/commit sessions per database. Only
+        // BatchBehavior.Individual ranges reach this method (composite members ride the parent's
+        // batch and never execute), so the slot economy cannot deadlock on nested batches.
+        var writeThrottle = range.Agent.BatchWriteThrottle;
+        if (writeThrottle != null)
+        {
+            try
+            {
+                await writeThrottle.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                // Shard is being torn down while queued for a write slot — nothing was executed,
+                // so don't mark success and don't treat the teardown as a failure
+                await batch.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+        }
+
         try
         {
             // Polly is already around the basic retry here, so anything that gets past this
@@ -252,6 +271,7 @@ public class GroupedProjectionExecution : ISubscriptionExecution
         }
         finally
         {
+            writeThrottle?.Release();
             await batch.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/src/JasperFx.Events/Daemon/IDeadLetterQueue.cs
+++ b/src/JasperFx.Events/Daemon/IDeadLetterQueue.cs
@@ -7,4 +7,11 @@ public interface IDaemonRuntime
     Task RecordDeadLetterEventAsync(DeadLetterEvent @event);
     ILogger Logger { get; }
     long HighWaterMark();
+
+    /// <summary>
+    /// Epic #486 WS3: the daemon-owned governor bounding concurrent projection batch
+    /// execute/commit sessions against this daemon's database. Null = unbounded. See
+    /// <see cref="DaemonSettings.MaxConcurrentBatchWritesPerDatabase"/>.
+    /// </summary>
+    SemaphoreSlim? BatchWriteThrottle => null;
 }

--- a/src/JasperFx.Events/Daemon/ISubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/ISubscriptionAgent.cs
@@ -34,4 +34,12 @@ public interface ISubscriptionAgent : ISubscriptionController
     /// </summary>
     /// <param name="sequence"></param>
     void MarkSkipped(long sequence);
+
+    /// <summary>
+    /// Epic #486 WS3: the daemon-owned governor bounding concurrent projection batch
+    /// execute/commit sessions against this agent's database. Null = unbounded. Surfaced
+    /// here so the projection executions (which only see the agent via EventRange) can
+    /// share the daemon-wide bound.
+    /// </summary>
+    SemaphoreSlim? BatchWriteThrottle => null;
 }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -45,6 +45,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // database's connection footprint stays O(databases), not O(agents). Null = unthrottled.
     private readonly SemaphoreSlim? _loadThrottle;
 
+    // Epic #486 WS3: bounds concurrent projection batch execute/commit sessions. Reaches the
+    // executions through IDaemonRuntime -> SubscriptionAgent -> EventRange.Agent. Null = unbounded.
+    public SemaphoreSlim? BatchWriteThrottle { get; }
+
     public JasperFxAsyncDaemon(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory, IHighWaterDetector detector, ProjectionGraph<TProjection, TOperations, TQuerySession> projections)
     {
         Database = database;
@@ -67,6 +71,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _loadThrottle = _projections.MaxConcurrentEventLoadsPerDatabase > 0
             ? new SemaphoreSlim(_projections.MaxConcurrentEventLoadsPerDatabase)
+            : null;
+
+        BatchWriteThrottle = _projections.MaxConcurrentBatchWritesPerDatabase > 0
+            ? new SemaphoreSlim(_projections.MaxConcurrentBatchWritesPerDatabase)
             : null;
     }
 
@@ -92,6 +100,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _loadThrottle = _projections.MaxConcurrentEventLoadsPerDatabase > 0
             ? new SemaphoreSlim(_projections.MaxConcurrentEventLoadsPerDatabase)
+            : null;
+
+        BatchWriteThrottle = _projections.MaxConcurrentBatchWritesPerDatabase > 0
+            ? new SemaphoreSlim(_projections.MaxConcurrentBatchWritesPerDatabase)
             : null;
     }
 
@@ -119,6 +131,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _breakSubscription.Dispose();
         _deadLetterBlock.Dispose();
         _loadThrottle?.Dispose();
+        BatchWriteThrottle?.Dispose();
     }
 
     public ShardStateTracker Tracker { get; }

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -47,6 +47,11 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     // Exposed so tests can assert how the daemon composed this agent's loader (jasperfx#494)
     internal IEventLoader Loader => _loader;
 
+    // Epic #486 WS3: surface the owning daemon's batch-write governor to the projection
+    // executions (they only see this agent via EventRange.Agent). The runtime is the daemon
+    // once StartAsync/ReplayAsync has run; the Nullo default yields null = unbounded.
+    public SemaphoreSlim? BatchWriteThrottle => _runtime.BatchWriteThrottle;
+
     public string ProjectionShardIdentity { get; }
 
     public CancellationToken CancellationToken => _cancellation.Token;

--- a/src/JasperFx.Events/Projections/ProjectionExecution.cs
+++ b/src/JasperFx.Events/Projections/ProjectionExecution.cs
@@ -154,6 +154,25 @@ public class ProjectionExecution<TOperations, TQuerySession> : ISubscriptionExec
 
     private async Task applyBatchOperationsToDatabaseAsync(EventRange range, IProjectionBatch batch)
     {
+        // Epic #486 WS3: bound concurrent batch execute/commit sessions per database. Only
+        // BatchBehavior.Individual ranges reach this method (composite members ride the parent's
+        // batch and never execute), so the slot economy cannot deadlock on nested batches.
+        var writeThrottle = range.Agent.BatchWriteThrottle;
+        if (writeThrottle != null)
+        {
+            try
+            {
+                await writeThrottle.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (_cancellation.IsCancellationRequested)
+            {
+                // Shard is being torn down while queued for a write slot — nothing was executed,
+                // so don't mark success and don't treat the teardown as a failure
+                await batch.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+        }
+
         try
         {
             // Polly is already around the basic retry here, so anything that gets past this
@@ -181,6 +200,7 @@ public class ProjectionExecution<TOperations, TQuerySession> : ISubscriptionExec
         }
         finally
         {
+            writeThrottle?.Release();
             await batch.DisposeAsync().ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
The write-side half of the connection-conservation work (#494 landed the read side as #495). Epic #486 WS3.

## Why

Measurement on #494 attributed **~29 of ~35 steady-state daemon connections to per-agent projection-batch COMMIT sessions**, with the racy cold-start burst (every (projection × tenant) agent committing its first batch near-simultaneously) freezing the Npgsql pool anywhere between ~35 and ~99 connections across identical 200-agent runs.

## What

- Both projection execution flavors acquire a daemon-owned write slot around the batch execute/commit round-trip (`applyBatchOperationsToDatabaseAsync`), sized by `DaemonSettings.MaxConcurrentBatchWritesPerDatabase` (default 4; ≤0 disables).
- The governor reaches the executions through **default interface members** — `IDaemonRuntime.BatchWriteThrottle` → `SubscriptionAgent` → `EventRange.Agent` — so no implementation of either interface breaks.
- Only `BatchBehavior.Individual` ranges execute batches (composite members ride the parent's batch and never reach the seam), so the slot economy cannot deadlock on nested batches. A shard torn down while queued for a slot disposes its batch and exits without marking success or reporting a spurious failure.
- `CrossTenantRebuild.RebuildEverywhereAsync` gets a real `maxParallelism` default (4, was unbounded — a 100-tenant store fanned out 100 concurrent rebuilds against one database); passing 0 opts back into unbounded.

## Measurement (daemonload, 100 tenants × 2 projections = 200 agents, 120s @ ~190 ev/s)

| | Peak conns | Peak busy | Caught up | Throughput |
|---|---|---|---|---|
| Unthrottled (2.21.1) | 79 | 5 | 100/100 | ~191/s |
| Load throttle only (#495) | 35–99 (racy burst) | 5–6 | 100/100 | ~191/s |
| **+ write governor (this PR)** | **12** | 5 | 100/100 | ~189/s |

12 ≈ 4 load slots + 4 write slots + 4 appender writers + high-water — **the WS2/WS3 O(databases) gate, met**. EventTests 449/449 green on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)