### PR TITLE
Cap the intra-projection tenant/shard cross-product rebuild fan-out with one shared per-database budget (#497)

### DIFF
--- a/src/EventTests/Daemon/BatchWriteGovernorDefaultsTests.cs
+++ b/src/EventTests/Daemon/BatchWriteGovernorDefaultsTests.cs
@@ -13,12 +13,17 @@ public class BatchWriteGovernorDefaultsTests
     }
 
     [Fact]
-    public void rebuild_everywhere_default_parallelism_is_four()
+    public void rebuild_everywhere_default_parallelism_follows_the_daemon_budget_then_four()
     {
-        // An unbounded default let a 100-tenant store fan out 100 concurrent rebuilds against
-        // one database. Pin the new bounded default (0 still opts back into unbounded).
+        // #496: an unbounded default let a 100-tenant store fan out 100 concurrent rebuilds against
+        // one database, so the default became a bounded 4. jasperfx#497 refines it: the declared
+        // default is now null = "follow the daemon's shared per-database rebuild budget", and only
+        // when the daemon reports no budget does the resolution fall back to the #496 value of 4
+        // (0 still opts back into unbounded).
         var method = typeof(CrossTenantRebuild).GetMethod(nameof(CrossTenantRebuild.RebuildEverywhereAsync))!;
-        method.GetParameters().Single(x => x.Name == "maxParallelism").DefaultValue.ShouldBe(4);
+        method.GetParameters().Single(x => x.Name == "maxParallelism").DefaultValue.ShouldBeNull();
+
+        CrossTenantRebuild.ResolveLaunchWidth(null, null).ShouldBe(4);
     }
 
     [Fact]

--- a/src/EventTests/Daemon/CrossProductRebuildCapTests.cs
+++ b/src/EventTests/Daemon/CrossProductRebuildCapTests.cs
@@ -1,0 +1,530 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using System.Threading.Channels;
+using EventTests.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Subscriptions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#497 (the #420 leftover) acceptance: ONE shared per-database budget bounds the rebuild
+// cell fan-out across BOTH layers — concurrent projection-level rebuilds AND each projection's
+// per-(tenant, shard) cross product — so `projections rebuild --max-concurrent N` on a
+// tenant-partitioned store really means "at most N concurrently replaying cells per database",
+// never N x tenants. These tests drive the REAL JasperFxAsyncDaemon (real SubscriptionAgents,
+// substituted store/database) with an instrumented, TCS-gated event loader: every rebuild cell
+// blocks inside its LoadAsync until the test releases it, so an over-admitted cell is caught
+// deterministically (it would show up as an extra concurrent load while the gates are closed)
+// rather than by timing.
+public class CrossProductRebuildCapTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    private static string[] tenantsNamed(int count)
+        => Enumerable.Range(1, count).Select(i => $"t{i}").ToArray();
+
+    private static string[] expectedCells(string[] projections, string[] tenants)
+        => projections.SelectMany(p => tenants.Select(t => $"{p}:All:{t}")).OrderBy(x => x).ToArray();
+
+    [Fact]
+    public async Task cells_across_projections_and_tenants_never_exceed_and_actually_reach_the_cap()
+    {
+        // The issue's scenario shrunk to test size: 2 projections x 6 tenants = 12 rebuild cells,
+        // budget 3, both projections rebuilding concurrently (the CLI's projection-level layer).
+        // Without a SHARED budget, layer multiplication would admit up to 6 concurrent cells
+        // (projection-level 2 x per-projection 3); without any cap, all 12.
+        var tenants = tenantsNamed(6);
+        await using var harness = new RebuildHarness(tenants, ["ProjA", "ProjB"],
+            settings => settings.MaxConcurrentRebuildsPerDatabase = 3);
+
+        var rebuilds = Task.WhenAll(
+            harness.Daemon.RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, CancellationToken.None),
+            harness.Daemon.RebuildProjectionAsync("ProjB", tenantId: null, TestTimeout, CancellationToken.None));
+
+        // Hold the first 3 gates until all 3 cells are simultaneously blocked inside LoadAsync —
+        // that forces the observed peak to actually REACH the cap instead of passing vacuously.
+        var held = new List<TaskCompletionSource>();
+        for (var i = 0; i < 3; i++)
+        {
+            held.Add(await harness.Loader.NextEntryAsync());
+        }
+
+        harness.Loader.CurrentlyLoading.ShouldBe(3);
+
+        foreach (var gate in held)
+        {
+            gate.SetResult();
+        }
+
+        // Release the remaining cells as they arrive.
+        for (var i = 0; i < 9; i++)
+        {
+            (await harness.Loader.NextEntryAsync()).SetResult();
+        }
+
+        await rebuilds.WaitAsync(TestTimeout);
+
+        harness.Loader.PeakConcurrency.ShouldBe(3);
+        harness.Loader.CellsLoaded.OrderBy(x => x)
+            .ShouldBe(expectedCells(["ProjA", "ProjB"], tenants));
+    }
+
+    [Fact]
+    public async Task the_cli_override_path_replaces_the_budget()
+    {
+        // No DaemonSettings knob and no store default -> the daemon starts with no budget. The
+        // ProjectionHost --max-concurrent path assigns the resolved cap straight onto the daemon;
+        // subsequent rebuilds must honor the NEW budget.
+        var tenants = tenantsNamed(5);
+        await using var harness = new RebuildHarness(tenants, ["ProjA"]);
+
+        harness.Daemon.MaxConcurrentRebuildsPerDatabase.ShouldBeNull();
+        harness.Daemon.MaxConcurrentRebuildsPerDatabase = 2;
+        harness.Daemon.MaxConcurrentRebuildsPerDatabase.ShouldBe(2);
+
+        var rebuild = harness.Daemon
+            .RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, CancellationToken.None);
+
+        var held = new List<TaskCompletionSource>
+        {
+            await harness.Loader.NextEntryAsync(),
+            await harness.Loader.NextEntryAsync()
+        };
+
+        harness.Loader.CurrentlyLoading.ShouldBe(2);
+
+        foreach (var gate in held)
+        {
+            gate.SetResult();
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            (await harness.Loader.NextEntryAsync()).SetResult();
+        }
+
+        await rebuild.WaitAsync(TestTimeout);
+
+        harness.Loader.PeakConcurrency.ShouldBe(2);
+        harness.Loader.CellsLoaded.OrderBy(x => x).ShouldBe(expectedCells(["ProjA"], tenants));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task a_non_positive_cap_is_unbounded_and_still_runs_every_cell_exactly_once(int cap)
+    {
+        // ParallelOptions.MaxDegreeOfParallelism = 0 throws — a non-positive budget must never
+        // reach it. Unbounded keeps the historical sequential per-tenant walk, so the loader runs
+        // ungated here (a held gate would deadlock a serialized walk, by design of the gating).
+        var tenants = tenantsNamed(4);
+        await using var harness = new RebuildHarness(tenants, ["ProjA", "ProjB"], gated: false);
+
+        harness.Daemon.MaxConcurrentRebuildsPerDatabase = cap;
+
+        await Task.WhenAll(
+                harness.Daemon.RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, CancellationToken.None),
+                harness.Daemon.RebuildProjectionAsync("ProjB", tenantId: null, TestTimeout, CancellationToken.None))
+            .WaitAsync(TestTimeout);
+
+        harness.Loader.CellsLoaded.OrderBy(x => x)
+            .ShouldBe(expectedCells(["ProjA", "ProjB"], tenants));
+    }
+
+    [Fact]
+    public async Task an_unset_cap_keeps_the_historical_behavior_and_runs_every_cell_exactly_once()
+    {
+        var tenants = tenantsNamed(3);
+        await using var harness = new RebuildHarness(tenants, ["ProjA"], gated: false);
+
+        await harness.Daemon
+            .RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        harness.Loader.CellsLoaded.OrderBy(x => x).ShouldBe(expectedCells(["ProjA"], tenants));
+    }
+
+    [Theory]
+    [InlineData(2, 8, 2)] // explicit maxParallelism always wins over the daemon budget
+    [InlineData(0, 8, 0)] // explicit non-positive = unbounded, even with a budget configured
+    [InlineData(-1, null, -1)]
+    [InlineData(null, 8, 8)] // jasperfx#497: default follows the daemon's shared budget
+    [InlineData(null, -1, -1)] // a daemon explicitly set unbounded stays unbounded
+    [InlineData(null, null, 4)] // no signal anywhere -> the #496 default of 4
+    public void rebuild_everywhere_launch_width_resolution(int? maxParallelism, int? daemonBudget, int expected)
+    {
+        CrossTenantRebuild.ResolveLaunchWidth(maxParallelism, daemonBudget).ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task rebuild_everywhere_defaults_its_fan_out_to_the_daemon_budget()
+    {
+        // jasperfx#496 gave RebuildEverywhereAsync a fixed default of 4; #497 keeps it consistent
+        // with the shared per-database budget instead whenever one is configured.
+        var daemon = new GatedRecordingDaemon { MaxConcurrentRebuildsPerDatabase = 2 };
+
+        var source = Substitute.For<ICrossTenantRebuildSource>();
+        var tenants = tenantsNamed(5);
+        source.FindRebuildTenantsAsync("Orders", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<string>>(tenants));
+
+        var rebuild = new CrossTenantRebuild(source)
+            .RebuildEverywhereAsync(daemon, "Orders", TestTimeout, CancellationToken.None);
+
+        var held = new List<TaskCompletionSource>
+        {
+            await daemon.NextEntryAsync(),
+            await daemon.NextEntryAsync()
+        };
+
+        daemon.CurrentlyRebuilding.ShouldBe(2);
+
+        foreach (var gate in held)
+        {
+            gate.SetResult();
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            (await daemon.NextEntryAsync()).SetResult();
+        }
+
+        var rebuilt = await rebuild.WaitAsync(TestTimeout);
+
+        rebuilt.OrderBy(x => x).ShouldBe(tenants.OrderBy(x => x));
+        daemon.PeakConcurrency.ShouldBe(2);
+        daemon.RebuiltTenants.OrderBy(x => x).ShouldBe(tenants.OrderBy(x => x));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Harness: a REAL JasperFxAsyncDaemon over a substituted store + database. The database also
+    // implements ICrossTenantRebuildSource and the detector supports tenant partitioning, so a
+    // store-global RebuildProjectionAsync fans out the per-(tenant, shard) cross product exactly the
+    // way Marten/Polecat do under per-tenant event partitioning.
+    // ---------------------------------------------------------------------------------------------
+
+    private sealed class RebuildHarness : IAsyncDisposable
+    {
+        public RebuildHarness(string[] tenants, string[] projectionNames,
+            Action<DaemonSettings>? configureSettings = null, bool gated = true)
+        {
+            Loader = new GatedInstrumentedLoader(gated);
+
+            var detector = new StubPartitionedDetector();
+            foreach (var tenantId in tenants)
+            {
+                detector.SetTenantMark(tenantId, 42);
+            }
+
+            Store = Substitute.For<IEventStore<FakeOperations, FakeSession>>();
+            Store.Meter.Returns(new Meter("tests"));
+            Store.TimeProvider.Returns(TimeProvider.System);
+            Store.AutoCreateSchemaObjects.Returns(AutoCreate.None);
+            Store.ContinuousErrors.Returns(new ErrorHandlingOptions());
+            Store.RebuildErrors.Returns(new ErrorHandlingOptions());
+            Store.BuildEventLoader(Arg.Any<IEventDatabase>(), Arg.Any<ILogger>(), Arg.Any<EventFilterable>(),
+                Arg.Any<AsyncOptions>()).Returns(Loader);
+            Store.BuildEventLoader(Arg.Any<IEventDatabase>(), Arg.Any<ILogger>(), Arg.Any<EventFilterable>(),
+                Arg.Any<AsyncOptions>(), Arg.Any<ShardName>()).Returns(Loader);
+
+            // The database doubles as the cross-tenant rebuild source, like Marten's
+            // MartenDatabase under per-tenant partitioning.
+            Database = Substitute.For<IEventDatabase, ICrossTenantRebuildSource>();
+            Database.Identifier.Returns("db1");
+            Database.DatabaseUri.Returns(new Uri("fake://db1"));
+            Database.Tracker.Returns(new ShardStateTracker(new NulloLogger()));
+            ((ICrossTenantRebuildSource)Database)
+                .FindRebuildTenantsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<IReadOnlyList<string>>(tenants));
+
+            var projections = new FakeProjectionGraph
+            {
+                // Keep the jasperfx#494 load throttle out of the way — the loader IS the
+                // instrumentation point and must observe only the rebuild budget.
+                MaxConcurrentEventLoadsPerDatabase = 0
+            };
+            configureSettings?.Invoke(projections);
+
+            foreach (var name in projectionNames)
+            {
+                var factory = new CompletingSubscriptionFactory();
+                var shard = new AsyncShard<FakeOperations, FakeSession>(new AsyncOptions(), ShardRole.Projection,
+                    new ShardName(name), factory, new EventFilterable());
+
+                var source = Substitute.For<IProjectionSource<FakeOperations, FakeSession>>();
+                source.Name.Returns(name);
+                source.Shards().Returns([shard]);
+
+                projections.All.Add(source);
+            }
+
+            Daemon = new JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>(
+                Store, Database, new NulloLogger(), detector, projections);
+        }
+
+        public IEventStore<FakeOperations, FakeSession> Store { get; }
+        public IEventDatabase Database { get; }
+        public GatedInstrumentedLoader Loader { get; }
+        public JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>> Daemon { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Daemon.StopAllAsync();
+            Daemon.Dispose();
+        }
+    }
+
+    // Minimal concrete ProjectionGraph — the daemon consumes it as DaemonSettings plus the
+    // registered projection sources in All.
+    private sealed class FakeProjectionGraph :
+        ProjectionGraph<IJasperFxProjection<FakeOperations>, FakeOperations, FakeSession>
+    {
+        public FakeProjectionGraph() : base(Substitute.For<IEventRegistry>(), "tests")
+        {
+        }
+
+        protected override void onAddProjection(object projection)
+        {
+            // Nothing
+        }
+    }
+
+    // The instrumentation heart: every rebuild cell's single LoadAsync increments a live counter
+    // (tracking the peak), parks on a TCS gate the test hands out through an unbounded channel, and
+    // only then returns an already-caught-up page. Cells therefore stay INSIDE the instrumented
+    // region until the test releases them — an over-admitted cell deterministically raises the
+    // observed concurrency while the gates are closed, no timing required.
+    private sealed class GatedInstrumentedLoader : IEventLoader
+    {
+        private readonly bool _gated;
+        private readonly Channel<TaskCompletionSource> _entries = Channel.CreateUnbounded<TaskCompletionSource>();
+        private int _current;
+        private int _peak;
+
+        public GatedInstrumentedLoader(bool gated)
+        {
+            _gated = gated;
+        }
+
+        public ConcurrentBag<string> CellsLoaded { get; } = new();
+
+        public int PeakConcurrency => Volatile.Read(ref _peak);
+
+        public int CurrentlyLoading => Volatile.Read(ref _current);
+
+        public async Task<TaskCompletionSource> NextEntryAsync()
+        {
+            using var timeout = new CancellationTokenSource(TestTimeout);
+            return await _entries.Reader.ReadAsync(timeout.Token);
+        }
+
+        public async Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+        {
+            var now = Interlocked.Increment(ref _current);
+            int snapshot;
+            while (now > (snapshot = Volatile.Read(ref _peak)))
+            {
+                Interlocked.CompareExchange(ref _peak, now, snapshot);
+            }
+
+            CellsLoaded.Add(request.Name.Identity);
+
+            if (_gated)
+            {
+                var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _entries.Writer.TryWrite(gate);
+                await gate.Task.WaitAsync(TestTimeout, token);
+            }
+
+            Interlocked.Decrement(ref _current);
+
+            // An already-caught-up page: ceiling == the request's high water, zero events. The
+            // completing execution below acknowledges it, which finishes the cell's replay.
+            var page = new EventPage(request.Floor);
+            page.CalculateCeiling(request.BatchSize, request.HighWater);
+            return page;
+        }
+    }
+
+    private sealed class CompletingSubscriptionFactory : ISubscriptionFactory<FakeOperations, FakeSession>
+    {
+        public ISubscriptionExecution BuildExecution(IEventStore<FakeOperations, FakeSession> store,
+            IEventDatabase database, ILoggerFactory loggerFactory, ShardName shardName)
+            => new CompletingExecution(shardName);
+
+        public ISubscriptionExecution BuildExecution(IEventStore<FakeOperations, FakeSession> store,
+            IEventDatabase database, ILogger logger, ShardName shardName)
+            => new CompletingExecution(shardName);
+    }
+
+    // Acknowledges every enqueued page immediately, which posts RangeCompleted back to the agent and
+    // completes the rebuild replay once the page ceiling reaches the cell's high-water ceiling.
+    private sealed class CompletingExecution : ISubscriptionExecution
+    {
+        public CompletingExecution(ShardName shardName)
+        {
+            ShardName = shardName;
+        }
+
+        public ShardName ShardName { get; }
+
+        public ShardExecutionMode Mode { get; set; } = ShardExecutionMode.Rebuild;
+
+        public ValueTask EnqueueAsync(EventPage page, ISubscriptionAgent subscriptionAgent)
+            => subscriptionAgent.MarkSuccessAsync(page.Ceiling);
+
+        public Task StopAndDrainAsync(CancellationToken token) => Task.CompletedTask;
+
+        public Task HardStopAsync() => Task.CompletedTask;
+
+        public bool TryBuildReplayExecutor([NotNullWhen(true)] out IReplayExecutor? executor)
+        {
+            executor = null;
+            return false;
+        }
+
+        public Task ProcessImmediatelyAsync(SubscriptionAgent subscriptionAgent, EventPage events,
+            CancellationToken cancellation) => Task.CompletedTask;
+
+        public Task ProcessRangeAsync(EventRange range) => Task.CompletedTask;
+
+        public bool TryGetAggregateCache<TId, TDoc>([NotNullWhen(true)] out IAggregateCaching<TId, TDoc>? caching)
+        {
+            caching = null;
+            return false;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    // A hand-rolled IProjectionDaemon for the RebuildEverywhereAsync consistency test: per-tenant
+    // rebuild calls park on TCS gates handed to the test (same protocol as the loader above) while
+    // an Interlocked pair tracks live/peak concurrency. Only the members the cross-tenant fan-out
+    // touches are implemented; the rest throw so an accidental new dependency surfaces loudly.
+    private sealed class GatedRecordingDaemon : IProjectionDaemon
+    {
+        private readonly Channel<TaskCompletionSource> _entries = Channel.CreateUnbounded<TaskCompletionSource>();
+        private int _current;
+        private int _peak;
+
+        public int? MaxConcurrentRebuildsPerDatabase { get; set; }
+
+        public ConcurrentBag<string> RebuiltTenants { get; } = new();
+
+        public int PeakConcurrency => Volatile.Read(ref _peak);
+
+        public int CurrentlyRebuilding => Volatile.Read(ref _current);
+
+        public async Task<TaskCompletionSource> NextEntryAsync()
+        {
+            using var timeout = new CancellationTokenSource(TestTimeout);
+            return await _entries.Reader.ReadAsync(timeout.Token);
+        }
+
+        public async Task RebuildProjectionAsync(string projectionName, string? tenantId, TimeSpan shardTimeout,
+            CancellationToken token)
+        {
+            var now = Interlocked.Increment(ref _current);
+            int snapshot;
+            while (now > (snapshot = Volatile.Read(ref _peak)))
+            {
+                Interlocked.CompareExchange(ref _peak, now, snapshot);
+            }
+
+            RebuiltTenants.Add(tenantId!);
+
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _entries.Writer.TryWrite(gate);
+            await gate.Task.WaitAsync(TestTimeout, token);
+
+            Interlocked.Decrement(ref _current);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        // ---- Unused by the cross-tenant fan-out ----
+        public Task PrepareForRebuildsAsync() => throw new NotSupportedException();
+        public ShardStateTracker Tracker => throw new NotSupportedException();
+        public bool IsRunning => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(string projectionName, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync<TView>(CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(Type projectionType, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(Type projectionType, TimeSpan shardTimeout, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync(string projectionName, TimeSpan shardTimeout, CancellationToken token) => throw new NotSupportedException();
+        public Task RebuildProjectionAsync<TView>(TimeSpan shardTimeout, CancellationToken token) => throw new NotSupportedException();
+        public Task StartAgentAsync(string shardName, CancellationToken token) => throw new NotSupportedException();
+        public Task<ISubscriptionAgent> StartAgentAsync(ShardName name, CancellationToken token) => throw new NotSupportedException();
+        public Task StopAgentAsync(string shardName, Exception? ex = null) => throw new NotSupportedException();
+        public Task StopAgentAsync(ShardName shardName, Exception? ex = null) => throw new NotSupportedException();
+        public Task StartAllAsync() => throw new NotSupportedException();
+        public Task StopAllAsync() => throw new NotSupportedException();
+        public Task CatchUpAsync(CancellationToken cancellation) => throw new NotSupportedException();
+        public Task CatchUpAsync(TimeSpan timeout, CancellationToken cancellation) => throw new NotSupportedException();
+        public Task WaitForNonStaleData(TimeSpan timeout) => throw new NotSupportedException();
+        public long HighWaterMark() => throw new NotSupportedException();
+        public Task WaitForShardToBeRunning(string shardName, TimeSpan timeout) => throw new NotSupportedException();
+        public Task RewindSubscriptionAsync(string subscriptionName, CancellationToken token, long? sequenceFloor = 0, DateTimeOffset? timestamp = null) => throw new NotSupportedException();
+        public IReadOnlyList<ISubscriptionAgent> CurrentAgents() => throw new NotSupportedException();
+        public bool HasAnyPaused() => throw new NotSupportedException();
+        public void EjectPausedShard(string shardName) => throw new NotSupportedException();
+        public AgentStatus StatusFor(string shardName) => throw new NotSupportedException();
+    }
+
+    // A detector for a store WITH per-tenant event partitioning — the store-global Detect() stays
+    // pinned at mark 0 so any nonzero rebuild ceiling can only come from the per-tenant coordinator.
+    // (Same stub shape as PerTenantStartAgentAsyncTests.)
+    private sealed class StubPartitionedDetector : IHighWaterDetector
+    {
+        private readonly Dictionary<string, long> _marks = new();
+
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        public bool SupportsTenantPartitioning => true;
+
+        public void SetTenantMark(string tenantId, long mark)
+        {
+            lock (_marks)
+            {
+                _marks[tenantId] = mark;
+            }
+        }
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics());
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+
+        public Task<HighWaterVector> DetectForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+        {
+            lock (_marks)
+            {
+                var statistics = tenantIds.Select(tenantId =>
+                {
+                    var mark = _marks.GetValueOrDefault(tenantId);
+                    return new HighWaterStatistics
+                    {
+                        TenantId = tenantId, CurrentMark = mark, LastMark = mark, HighestSequence = mark
+                    };
+                }).ToArray();
+
+                return Task.FromResult(new HighWaterVector(statistics));
+            }
+        }
+
+        public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => DetectForTenantsAsync(tenantIds, token);
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionHost.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionHost.cs
@@ -101,6 +101,12 @@ internal class ProjectionHost: IProjectionHost
         // the previous unbounded behavior. A non-positive value stays unbounded.
         var maxConcurrent = input.ResolveMaxDegreeOfParallelism(store.MaxConcurrentRebuildsPerDatabase);
 
+        // jasperfx#497: thread the SAME resolved cap into the daemon so the intra-projection
+        // per-(tenant, shard) rebuild cells draw from one shared per-database budget. The
+        // projection-level fan-out below and each projection's tenant cross-product therefore
+        // never multiply — total concurrent rebuild cells per database stay <= maxConcurrent.
+        daemon.MaxConcurrentRebuildsPerDatabase = maxConcurrent;
+
         AnsiConsole.MarkupLine(maxConcurrent > 0
             ? $"[grey]Rebuilding with a maximum of {maxConcurrent} concurrent projection(s) per database[/]"
             : "[grey]Rebuilding with unbounded concurrency per database[/]");

--- a/src/JasperFx.Events/Daemon/CrossTenantRebuild.cs
+++ b/src/JasperFx.Events/Daemon/CrossTenantRebuild.cs
@@ -41,19 +41,26 @@ public class CrossTenantRebuild
     /// <param name="projectionName">Projection to rebuild for every tenant.</param>
     /// <param name="shardTimeout">Per-shard rebuild timeout.</param>
     /// <param name="token"></param>
-    /// <param name="maxParallelism">Maximum simultaneous per-tenant rebuilds. Defaults to 4
-    /// (epic #486 WS3 — an unbounded default let a 100-tenant store fan out 100 concurrent
-    /// rebuilds against one database); pass 0 for the old unbounded behavior.</param>
+    /// <param name="maxParallelism">Maximum simultaneous per-tenant rebuild launches. When null
+    /// (the default), follows the daemon's shared per-database rebuild budget
+    /// (<see cref="IProjectionDaemon.MaxConcurrentRebuildsPerDatabase" />, jasperfx#497) so this
+    /// fan-out stays consistent with the cap the rebuild cells draw from; falls back to 4 when the
+    /// daemon reports no budget (epic #486 WS3 — an unbounded default let a 100-tenant store fan out
+    /// 100 concurrent rebuilds against one database). Pass 0 or a negative value for the old
+    /// unbounded behavior. Whatever the launch width, the per-tenant replays themselves also draw
+    /// from the daemon's shared budget, so cells never exceed it.</param>
     public async Task<IReadOnlyList<string>> RebuildEverywhereAsync(IProjectionDaemon daemon, string projectionName,
-        TimeSpan shardTimeout, CancellationToken token, int maxParallelism = 4)
+        TimeSpan shardTimeout, CancellationToken token, int? maxParallelism = null)
     {
+        var launchWidth = ResolveLaunchWidth(maxParallelism, daemon.MaxConcurrentRebuildsPerDatabase);
+
         var tenants = await _source.FindRebuildTenantsAsync(projectionName, token).ConfigureAwait(false);
         if (tenants.Count == 0)
         {
             return tenants;
         }
 
-        if (maxParallelism <= 0)
+        if (launchWidth <= 0)
         {
             await Task.WhenAll(tenants.Select(tenantId =>
                 daemon.RebuildProjectionAsync(projectionName, tenantId, shardTimeout, token))).ConfigureAwait(false);
@@ -61,7 +68,7 @@ public class CrossTenantRebuild
             return tenants;
         }
 
-        using var gate = new SemaphoreSlim(maxParallelism);
+        using var gate = new SemaphoreSlim(launchWidth);
         await Task.WhenAll(tenants.Select(async tenantId =>
         {
             await gate.WaitAsync(token).ConfigureAwait(false);
@@ -76,5 +83,18 @@ public class CrossTenantRebuild
         })).ConfigureAwait(false);
 
         return tenants;
+    }
+
+    /// <summary>
+    /// jasperfx#497: resolve the effective launch width for the cross-tenant fan-out. An explicit
+    /// <paramref name="maxParallelism" /> always wins (non-positive = unbounded); otherwise follow the
+    /// daemon's shared per-database rebuild budget so this layer stays consistent with the cap the
+    /// rebuild cells draw from; otherwise the #496 default of 4.
+    /// </summary>
+    internal static int ResolveLaunchWidth(int? maxParallelism, int? daemonBudget)
+    {
+        if (maxParallelism.HasValue) return maxParallelism.Value;
+        if (daemonBudget.HasValue) return daemonBudget.Value;
+        return 4;
     }
 }

--- a/src/JasperFx.Events/Daemon/HighWater/VectorizedHighWaterMonitor.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/VectorizedHighWaterMonitor.cs
@@ -20,7 +20,12 @@ public class VectorizedHighWaterMonitor
 
     // The last-known reading per tenant. Each tenant's gap detection reads ONLY its own entry, which is
     // what keeps tenants independent of one another.
+    // jasperfx#497: guarded by _lock — parallel per-tenant rebuild cells now drive concurrent polls
+    // (on top of the pre-existing OnNext-driven and timer-driven poll paths), and an unguarded
+    // Dictionary corrupts under concurrent writes. The detector round-trip stays outside the lock;
+    // only the interpretation/bookkeeping section is serialized.
     private readonly Dictionary<string, HighWaterStatistics> _current = new();
+    private readonly object _lock = new();
 
     public VectorizedHighWaterMonitor(IHighWaterDetector detector, ILogger? logger = null)
     {
@@ -62,28 +67,31 @@ public class VectorizedHighWaterMonitor
         var vector = await detect(tenants, token).ConfigureAwait(false);
 
         var readings = new List<TenantHighWaterReading>(tenants.Count);
-        foreach (var tenantId in tenants)
+        lock (_lock)
         {
-            if (!vector.TryGetStatistics(tenantId, out var statistics))
+            foreach (var tenantId in tenants)
             {
-                // The detector returned nothing for an assigned tenant (e.g. it has no events yet). Skip
-                // it for this round without disturbing any other tenant's state.
-                continue;
+                if (!vector.TryGetStatistics(tenantId, out var statistics))
+                {
+                    // The detector returned nothing for an assigned tenant (e.g. it has no events yet). Skip
+                    // it for this round without disturbing any other tenant's state.
+                    continue;
+                }
+
+                // Independent gap detection: interpret against THIS tenant's previous reading only. On the
+                // first sighting we compare the reading against itself, which yields CaughtUp/Changed but
+                // never a spurious Stale driven by another tenant.
+                var previous = _current.TryGetValue(tenantId, out var prior) ? prior : statistics;
+                var status = statistics.InterpretStatus(previous);
+
+                // Advance the stored mark monotonically; a stale tenant keeps its last good mark.
+                if (!_current.TryGetValue(tenantId, out var existing) || statistics.CurrentMark >= existing.CurrentMark)
+                {
+                    _current[tenantId] = statistics;
+                }
+
+                readings.Add(new TenantHighWaterReading(tenantId, statistics, status));
             }
-
-            // Independent gap detection: interpret against THIS tenant's previous reading only. On the
-            // first sighting we compare the reading against itself, which yields CaughtUp/Changed but
-            // never a spurious Stale driven by another tenant.
-            var previous = _current.TryGetValue(tenantId, out var prior) ? prior : statistics;
-            var status = statistics.InterpretStatus(previous);
-
-            // Advance the stored mark monotonically; a stale tenant keeps its last good mark.
-            if (!_current.TryGetValue(tenantId, out var existing) || statistics.CurrentMark >= existing.CurrentMark)
-            {
-                _current[tenantId] = statistics;
-            }
-
-            readings.Add(new TenantHighWaterReading(tenantId, statistics, status));
         }
 
         return readings;
@@ -95,11 +103,21 @@ public class VectorizedHighWaterMonitor
     /// null when the tenant has not yet been polled.
     /// </summary>
     public long? CeilingFor(string tenantId)
-        => _current.TryGetValue(tenantId, out var statistics) ? statistics.CurrentMark : null;
+    {
+        lock (_lock)
+        {
+            return _current.TryGetValue(tenantId, out var statistics) ? statistics.CurrentMark : null;
+        }
+    }
 
     /// <summary>
     /// The most recent reading observed for a tenant, if any.
     /// </summary>
     public bool TryGetCurrent(string tenantId, out HighWaterStatistics statistics)
-        => _current.TryGetValue(tenantId, out statistics!);
+    {
+        lock (_lock)
+        {
+            return _current.TryGetValue(tenantId, out statistics!);
+        }
+    }
 }

--- a/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
@@ -42,6 +42,24 @@ public interface IProjectionDaemon: IDisposable
     bool IsRunning { get; }
 
     /// <summary>
+    ///     jasperfx#497 (the #420 leftover): the shared per-database budget on how many projection
+    ///     rebuild cells — the (projection × tenant/shard) cross product — may replay concurrently
+    ///     within this daemon's database. One budget spans BOTH fan-out layers, so a projection-level
+    ///     rebuild slot and its per-tenant cells never multiply the bound. Null means "derive from
+    ///     <see cref="DaemonSettings.MaxConcurrentRebuildsPerDatabase" /> /
+    ///     <see cref="IEventStore.MaxConcurrentRebuildsPerDatabase" />"; a non-positive value is
+    ///     unbounded. Setting it (e.g. the <c>projections rebuild --max-concurrent</c> CLI flag via
+    ///     <see cref="CommandLine.ProjectionInput.ResolveMaxDegreeOfParallelism" />) replaces the
+    ///     budget for subsequent rebuild operations. The default implementation ignores writes and
+    ///     reports no budget, so daemons without cross-product rebuild fan-out are unaffected.
+    /// </summary>
+    int? MaxConcurrentRebuildsPerDatabase
+    {
+        get => null;
+        set { }
+    }
+
+    /// <summary>
     ///     Rebuilds a single projection by projection name inline.
     ///     Will timeout if a shard takes longer than 5 minutes.
     /// </summary>

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -49,6 +49,32 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // executions through IDaemonRuntime -> SubscriptionAgent -> EventRange.Agent. Null = unbounded.
     public SemaphoreSlim? BatchWriteThrottle { get; }
 
+    // jasperfx#497 (the #420 leftover): ONE shared budget per daemon (= per database) for rebuild
+    // cells, spanning both fan-out layers — the CLI's projection-level fan-out AND the
+    // intra-projection per-(tenant, shard) fan-out — so a projection-level slot and its tenant
+    // cells never multiply the bound. Each cell holds a slot only for the duration of its replay
+    // (rebuildAgent). Null = unbounded.
+    private SemaphoreSlim? _rebuildBudget;
+    private int? _maxConcurrentRebuilds;
+
+    /// <summary>
+    /// jasperfx#497: the shared per-database rebuild cell budget. Resolved at construction from
+    /// <see cref="DaemonSettings.MaxConcurrentRebuildsPerDatabase"/> (explicit knob) falling back to
+    /// <see cref="IEventStore.MaxConcurrentRebuildsPerDatabase"/> (store-derived default, e.g.
+    /// Marten/Polecat's pool-size / 8). Setting it — the <c>projections rebuild --max-concurrent</c>
+    /// CLI override path — replaces the budget for subsequent rebuild operations. Null or a
+    /// non-positive value is unbounded.
+    /// </summary>
+    public int? MaxConcurrentRebuildsPerDatabase
+    {
+        get => _maxConcurrentRebuilds;
+        set
+        {
+            _maxConcurrentRebuilds = value;
+            _rebuildBudget = value is > 0 ? new SemaphoreSlim(value.Value) : null;
+        }
+    }
+
     public JasperFxAsyncDaemon(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILoggerFactory loggerFactory, IHighWaterDetector detector, ProjectionGraph<TProjection, TOperations, TQuerySession> projections)
     {
         Database = database;
@@ -76,6 +102,12 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         BatchWriteThrottle = _projections.MaxConcurrentBatchWritesPerDatabase > 0
             ? new SemaphoreSlim(_projections.MaxConcurrentBatchWritesPerDatabase)
             : null;
+
+        // jasperfx#497: explicit DaemonSettings knob wins, then the store-derived default. Concrete
+        // stores typically fold the settings knob into their override already; the double-consult is
+        // idempotent. Null resolves to null = unbounded (JasperFx.Events has no pool signal).
+        MaxConcurrentRebuildsPerDatabase =
+            _projections.MaxConcurrentRebuildsPerDatabase ?? store.MaxConcurrentRebuildsPerDatabase;
     }
 
     public JasperFxAsyncDaemon(IEventStore<TOperations, TQuerySession> store, IEventDatabase database, ILogger logger, IHighWaterDetector detector, ProjectionGraph<TProjection, TOperations, TQuerySession> projections)
@@ -105,6 +137,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         BatchWriteThrottle = _projections.MaxConcurrentBatchWritesPerDatabase > 0
             ? new SemaphoreSlim(_projections.MaxConcurrentBatchWritesPerDatabase)
             : null;
+
+        // jasperfx#497: see the ILoggerFactory constructor overload for the resolution rationale
+        MaxConcurrentRebuildsPerDatabase =
+            _projections.MaxConcurrentRebuildsPerDatabase ?? store.MaxConcurrentRebuildsPerDatabase;
     }
 
     private RetryBlock<DeadLetterEvent> buildDeadLetterBlock()
@@ -132,6 +168,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _deadLetterBlock.Dispose();
         _loadThrottle?.Dispose();
         BatchWriteThrottle?.Dispose();
+        _rebuildBudget?.Dispose();
     }
 
     public ShardStateTracker Tracker { get; }
@@ -220,25 +257,55 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         return true;
     }
 
+    // jasperfx#497: one rebuild "cell" — a single (projection, tenant/shard) replay. The cell draws a
+    // slot from the shared per-database rebuild budget for the duration of its replay, so no matter how
+    // wide the caller's fan-out is (the CLI's projection-level Parallel.ForEachAsync, the per-tenant
+    // cross-product loop, CrossTenantRebuild.RebuildEverywhereAsync), the number of concurrently
+    // replaying cells per database never exceeds the budget. The daemon's agent-registry lock
+    // (_semaphore) is now held only around the registry mutations, NOT across the replay itself —
+    // holding it across the replay (the pre-#497 shape) serialized every rebuild cell in the daemon at
+    // an effective concurrency of one, making any cap > 1 unreachable.
     private async Task rebuildAgent(ISubscriptionAgent agent, long highWaterMark, TimeSpan shardTimeout)
     {
-        await _semaphore.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+        var budget = _rebuildBudget;
+        if (budget != null)
+        {
+            await budget.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+        }
 
         try
         {
-            // Ensure that the agent is stopped if it is already running
-            await stopIfRunningAsync(agent.Name.Identity).ConfigureAwait(false);
+            await _semaphore.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+
+            try
+            {
+                // Ensure that the agent is stopped if it is already running
+                await stopIfRunningAsync(agent.Name.Identity).ConfigureAwait(false);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
 
             var errorOptions = _store.RebuildErrors;
 
             var request = new SubscriptionExecutionRequest(0, ShardExecutionMode.Rebuild, errorOptions, this);
             await agent.ReplayAsync(request, highWaterMark, shardTimeout).ConfigureAwait(false);
 
-            _agents = _agents.AddOrUpdate(agent.Name.Identity, agent);
+            await _semaphore.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+
+            try
+            {
+                _agents = _agents.AddOrUpdate(agent.Name.Identity, agent);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
         }
         finally
         {
-            _semaphore.Release();
+            budget?.Release();
         }
     }
     
@@ -861,6 +928,12 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // partitioning, reusing the per-tenant rebuild that scopes teardown + ceiling to (shard, tenant).
     // Tenant enumeration mirrors catchUpPerTenantAsync. With no tenants registered yet, fall back to the
     // store-global rebuild (a no-op when the high-water is 0).
+    //
+    // jasperfx#497: when a rebuild budget is configured, the per-tenant fan-out runs in parallel with a
+    // launch width of the budget size — the actual replay concurrency is bounded by the SHARED
+    // per-database budget inside rebuildAgent, so overlapping projection-level rebuilds (the CLI's
+    // --max-concurrent layer) and their tenant cells never multiply the bound. With no budget
+    // (null/non-positive = unbounded core-side), the historical sequential tenant walk is preserved.
     private async Task rebuildProjectionAllTenants(
         ICrossTenantRebuildSource crossTenantSource,
         IProjectionSource<TOperations, TQuerySession> source,
@@ -873,6 +946,19 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         if (tenants.Count == 0)
         {
             await RebuildProjectionAsync(source.Name, shardTimeout, token).ConfigureAwait(false);
+            return;
+        }
+
+        // ParallelOptions.MaxDegreeOfParallelism throws on 0 — only a positive budget may pass through.
+        var maxConcurrent = MaxConcurrentRebuildsPerDatabase;
+        if (maxConcurrent is > 0)
+        {
+            await Parallel.ForEachAsync(tenants,
+                    new ParallelOptions { CancellationToken = token, MaxDegreeOfParallelism = maxConcurrent.Value },
+                    async (tenantId, ct) =>
+                        await rebuildProjectionForTenant(source, tenantId, shardTimeout, ct).ConfigureAwait(false))
+                .ConfigureAwait(false);
+
             return;
         }
 


### PR DESCRIPTION
Closes #497 (the #420 leftover, epic #486 WS3). Follows #463/#496.

## Problem

`MaxConcurrentRebuildsPerDatabase` was only enforced at the **projection level** in the CLI path (`ProjectionHost.RebuildProjectionsWithCapAsync`). A single projection on a tenant-partitioned store still fanned out its per-(tenant, shard) rebuild cells inside `JasperFxAsyncDaemon` without consulting the cap — `projections rebuild --max-concurrent 2` on a 100-tenant store bounded concurrent *projections* at 2 while each tenant cross-product ran unchecked.

Worse, the intra-daemon replay concurrency was accidentally **serialized at one**: `rebuildAgent` held the daemon's single-slot agent-registry `_semaphore` across the entire `ReplayAsync`, so the existing `Parallel.ForEachAsync` fan-outs launched wide but replayed one cell at a time — any cap > 1 was unreachable inside a database.

## Budget design

**One shared `SemaphoreSlim` budget per daemon (= per database), acquired per rebuild *cell*.**

- A cell = a single (projection, tenant/shard) replay = one `rebuildAgent` call. Each cell holds exactly one budget slot for the duration of its replay, regardless of which layer launched it (the CLI's projection-level `Parallel.ForEachAsync`, the intra-projection tenant cross-product, or `CrossTenantRebuild.RebuildEverywhereAsync`). Outer layers hold **no** slots, so the two layers share the bound instead of multiplying it (projection slots × tenant cells ≤ cap, never cap²) and nesting cannot deadlock.
- **Resolution**: `DaemonSettings.MaxConcurrentRebuildsPerDatabase` ?? `IEventStore.MaxConcurrentRebuildsPerDatabase` (store-derived, e.g. Marten/Polecat pool-size/8) at daemon construction; the `--max-concurrent` CLI flag overrides per operation via a new `IProjectionDaemon.MaxConcurrentRebuildsPerDatabase` DIM (no-op default) that `ProjectionHost` assigns with the SAME resolved value it uses for the projection-level layer.
- **Non-positive = unbounded**, and a non-positive value never reaches `ParallelOptions.MaxDegreeOfParallelism` (0 throws). With no budget, `rebuildProjectionAllTenants` keeps its historical sequential tenant walk.
- `rebuildAgent` now takes the agent-registry `_semaphore` only around the registry mutations (stop-if-running, `_agents` update), not across the replay — that is what makes a cap > 1 actually reachable.
- `CrossTenantRebuild.RebuildEverywhereAsync`'s `maxParallelism` becomes `int?` defaulting to the daemon's budget when configured, falling back to the #496 default of 4; explicit values (including non-positive = unbounded) still win. Its per-tenant rebuilds draw from the same cell budget either way.
- Hardening: `VectorizedHighWaterMonitor`'s per-tenant readings dictionary is now lock-guarded — parallel tenant rebuild cells poll concurrently on top of the pre-existing OnNext/timer poll paths.

## Regression tests

`CrossProductRebuildCapTests` drives the **real** `JasperFxAsyncDaemon` (real `SubscriptionAgent`s, substituted store/database implementing `ICrossTenantRebuildSource`, tenant-partitioned detector) with a TCS-gated instrumented loader — cells park inside their `LoadAsync` until released, so over-admission is caught deterministically, no timing:

- 2 projections × 6 tenants rebuilt concurrently under cap 3: `Interlocked` peak concurrency **never exceeds 3 and actually reaches 3**; all 12 cells run exactly once
- the CLI-override path (`daemon.MaxConcurrentRebuildsPerDatabase = n`) replaces the budget
- non-positive/unset caps stay unbounded, complete without deadlock, and run every cell exactly once
- `RebuildEverywhereAsync` launch-width resolution matrix + a gated test that its default fan-out follows the daemon budget
- updated the #496 pin in `BatchWriteGovernorDefaultsTests` to the refined default contract

## Test results

- `dotnet test src/EventTests/EventTests.csproj --framework net9.0` → 475 passed / 0 failed
- `dotnet test src/EventTests/EventTests.csproj --framework net10.0` → 475 passed / 0 failed
- full solution `dotnet build` clean

Cross-refs: marten#4884 (rebuild load tests validating tuned defaults), JasperFx/CritterWatch#309 (orchestration consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNfeNz73Q3EdiTgSeDbo96