### PR TITLE
Stamp the owning database onto every published ShardState

### DIFF
--- a/src/EventTests/Daemon/ShardStateTrackerTests.cs
+++ b/src/EventTests/Daemon/ShardStateTrackerTests.cs
@@ -183,4 +183,60 @@ public class ShardStateTrackerTests : IDisposable
 
         state.SkippedEventsCount.ShouldBe(42L);
     }
+
+    // CritterWatch#678 — a store backed by more than one database runs one daemon (and one tracker) per
+    // database, and every one of them publishes the same shard names. Stamping the tracker's database onto
+    // each state is what lets a consumer tell them apart.
+
+    [Fact]
+    public void shard_state_database_identifier_defaults_to_null()
+    {
+        new ShardState("foo", 100).DatabaseIdentifier.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task publish_stamps_the_trackers_database_onto_every_state()
+    {
+        theTracker.DatabaseIdentifier = "tenant-a";
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        await theTracker.PublishAsync(new ShardState("foo", 35));
+        // The high water agent's marks go through the same door.
+        await theTracker.MarkHighWaterAsync(100);
+
+        await theTracker.Complete();
+
+        observer.States.Count.ShouldBe(2);
+        observer.States.ShouldAllBe(x => x.DatabaseIdentifier == "tenant-a");
+    }
+
+    [Fact]
+    public async Task publish_leaves_a_state_that_already_names_its_database_alone()
+    {
+        theTracker.DatabaseIdentifier = "tenant-a";
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        await theTracker.PublishAsync(new ShardState("foo", 35) { DatabaseIdentifier = "tenant-b" });
+        await theTracker.PublishAsync(new ShardState("bar", 36));
+
+        await theTracker.Complete();
+
+        observer.States.Single(x => x.ShardName == "foo").DatabaseIdentifier.ShouldBe("tenant-b");
+        observer.States.Single(x => x.ShardName == "bar").DatabaseIdentifier.ShouldBe("tenant-a");
+    }
+
+    [Fact]
+    public async Task publish_leaves_the_database_null_when_the_tracker_has_none()
+    {
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        await theTracker.PublishAsync(new ShardState("foo", 35));
+
+        await theTracker.Complete();
+
+        observer.States.ShouldAllBe(x => x.DatabaseIdentifier == null);
+    }
 }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -83,6 +83,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _projections = projections;
         Logger = loggerFactory.CreateLogger(GetType());
         Tracker = Database.Tracker;
+        // A multi-database store runs one of these per database, all publishing the same shard names.
+        // Stamping the tracker is what lets a consumer tell them apart. See CritterWatch#678.
+        Tracker.DatabaseIdentifier ??= Database.Identifier;
         _highWater = new HighWaterAgent(store.Meter, detector, Tracker, loggerFactory.CreateLogger<HighWaterAgent>(), projections, _cancellation.Token);
 
         if (detector.SupportsTenantPartitioning)
@@ -118,6 +121,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _loggerFactory = null;
         Logger = logger;
         Tracker = Database.Tracker;
+        Tracker.DatabaseIdentifier ??= Database.Identifier;
         _highWater = new HighWaterAgent(store.Meter, detector, Tracker, logger, _projections, _cancellation.Token);
 
         if (detector.SupportsTenantPartitioning)

--- a/src/JasperFx.Events/Daemon/ShardStateTracker.cs
+++ b/src/JasperFx.Events/Daemon/ShardStateTracker.cs
@@ -32,6 +32,15 @@ public class ShardStateTracker: IObservable<ShardState>, IObserver<ShardState>, 
     /// </summary>
     public long HighWaterMark { get; private set; }
 
+    /// <summary>
+    ///     <see cref="IEventDatabase.Identifier" /> of the database this tracker belongs to. Stamped onto every
+    ///     published <see cref="ShardState" /> that doesn't already carry one, so a consumer of a multi-database
+    ///     store (database-per-tenant, sharded tenancy) can tell one database's <c>Trip:All</c> from another's.
+    ///     Set by <see cref="JasperFxAsyncDaemon{TOperations,TQuerySession,TProjection}" /> at construction. See
+    ///     JasperFx/CritterWatch#678.
+    /// </summary>
+    public string? DatabaseIdentifier { get; set; }
+
     void IDisposable.Dispose()
     {
         _subscription.Dispose();
@@ -73,6 +82,11 @@ public class ShardStateTracker: IObservable<ShardState>, IObserver<ShardState>, 
         {
             HighWaterMark = state.Sequence;
         }
+
+        // One stamp point for every state this database's daemon publishes — the subscription agents'
+        // progress and the high water agent's marks alike. A state that already names a database (a
+        // republish, or a publisher that knows better) keeps its own.
+        state.DatabaseIdentifier ??= DatabaseIdentifier;
 
         return _block.PostAsync(state);
     }

--- a/src/JasperFx.Events/Projections/ShardState.cs
+++ b/src/JasperFx.Events/Projections/ShardState.cs
@@ -144,6 +144,22 @@ public class ShardState
     /// </summary>
     public string? StoreUri { get; set; }
 
+    /// <summary>
+    /// <see cref="IEventDatabase.Identifier"/> of the database this shard state came from. An event store
+    /// backed by more than one database — database-per-tenant, sharded tenancy — runs one daemon per
+    /// database, and every one of them publishes the same shard names (<c>Trip:All</c>) and the same
+    /// <c>HighWaterMark</c>. Without this, a consumer keying on shard name alone collapses all of them into
+    /// one entry and reports whichever database published last.
+    ///
+    /// Stamped by <see cref="Daemon.ShardStateTracker.DatabaseIdentifier"/> when the daemon is constructed,
+    /// so it rides both the subscription agents' states and the high-water agent's marks. Null only when
+    /// the publisher predates this field.
+    ///
+    /// Surfaces JasperFx/CritterWatch#678: a database-per-tenant service reported a high-water mark of 0 and
+    /// every projection as "awaiting its first event" while its per-tenant daemons were actively running.
+    /// </summary>
+    public string? DatabaseIdentifier { get; set; }
+
     public override string ToString()
     {
         return $"{nameof(ShardName)}: {ShardName}, {nameof(Sequence)}: {Sequence}, {nameof(Action)}: {Action}";


### PR DESCRIPTION
## Problem

An event store backed by more than one database — database-per-tenant, sharded tenancy — runs one daemon, and one `ShardStateTracker`, per database. Every one of them publishes the same shard names (`Trip:All`) and the same `HighWaterMark`.

`ShardState` carries no database identity, so a consumer keying on shard name alone collapses all of them into a single entry and reports whichever database published last.

This surfaced as [JasperFx/CritterWatch#678](https://github.com/JasperFx/CritterWatch/issues/678): a database-per-tenant service showed a high water mark of **0** and every projection as *"awaiting its first event"*, while its per-tenant daemons were actively running and advancing. Wolverine's `EventStoreAgents` subscribes the same observer to each database's daemon, so the monitoring side had no way to tell one tenant database's `Trip:All` from another's.

## Change

Three additions, all in `JasperFx.Events`:

- `ShardState.DatabaseIdentifier` — the `IEventDatabase.Identifier` of the database the state came from.
- `ShardStateTracker.DatabaseIdentifier` — `PublishAsync` stamps it onto any state that doesn't already carry one.
- `JasperFxAsyncDaemon` sets `Tracker.DatabaseIdentifier ??= Database.Identifier` in both constructors.

`JasperFxAsyncDaemon` already holds the `IEventDatabase` and takes its `Tracker` from it, so the stamp lands in exactly one place and rides **both** the subscription agents' progress and the high water agent's marks. Marten and Polecat inherit it with no change of their own.

## Compatibility

Additive and binary-safe: two nullable properties on classes, no positional-record parameters touched. A publisher that predates this leaves the field null, and a state that already names its database is left alone (`??=`), so a republishing consumer can't have its attribution overwritten.

## Verification

- 4 new unit tests in `ShardStateTrackerTests` (default null, stamped on both shard states and high-water marks, pre-set value preserved, null tracker leaves null).
- Full `EventTests` suite green: **481/481 on net9.0 and net10.0**.
- Verified end-to-end from CritterWatch against a locally-packed `2.18.2-cw678`, driving a real two-tenant-database Marten store (`MultiTenantedDatabasesWithMasterDatabaseTable`): the observed shard states now report `tenant-a` / `tenant-b` with correctly attributed high-water marks, where previously they collapsed to a single mark of 0.