### PR TITLE
fix(#4913): skip the store-global high water polling loop under per-tenant partitioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.25.0</JasperFxVersion>
+        <JasperFxVersion>2.26.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/Daemon/HighWater/HighWaterAgent_partitioning_skips_global_poll_Tests.cs
+++ b/src/EventTests/Daemon/HighWater/HighWaterAgent_partitioning_skips_global_poll_Tests.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// #4913: under per-tenant event partitioning the store-global HighWaterAgent must NOT run its recurring
+// Detect() loop (Marten emits that as `max(seq_id)` fanned out across every tenant partition). Tenant high
+// water is driven per-tenant by the daemon's TenantedHighWaterCoordinator, so the store-global mark is only
+// seeded once at startup. When partitioning is off, the recurring loop must still run exactly as before.
+public class HighWaterAgent_partitioning_skips_global_poll
+{
+    private static HighWaterAgent buildAgent(CountingDetector detector, BlockingWakeup wakeup, CancellationToken token)
+    {
+        var settings = new DaemonSettings { Wakeup = wakeup };
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+        return new HighWaterAgent(new Meter("jasperfx.tests.highwater"), detector, tracker,
+            NullLogger.Instance, settings, token);
+    }
+
+    [Fact]
+    public async Task partitioned_store_seeds_once_and_does_not_start_the_recurring_loop()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new CountingDetector(supportsTenantPartitioning: true);
+        var wakeup = new BlockingWakeup();
+
+        var agent = buildAgent(detector, wakeup, cts.Token);
+        await agent.StartAsync();
+
+        // The mark is seeded exactly once; the recurring loop (which would call the wakeup) never starts.
+        detector.DetectCount.ShouldBe(1);
+        (await wakeup.EnteredWithin(500.Milliseconds())).ShouldBeFalse();
+        detector.DetectCount.ShouldBe(1);
+
+        // Still "running" so the daemon's per-tenant high-water timer stays enabled.
+        agent.IsRunning.ShouldBeTrue();
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    [Fact]
+    public async Task non_partitioned_store_starts_the_recurring_loop()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new CountingDetector(supportsTenantPartitioning: false);
+        var wakeup = new BlockingWakeup();
+
+        var agent = buildAgent(detector, wakeup, cts.Token);
+        await agent.StartAsync();
+
+        // The loop ran an in-loop Detect() beyond the initial seed and then parked in the wakeup.
+        (await wakeup.EnteredWithin(2.Seconds())).ShouldBeTrue();
+        detector.DetectCount.ShouldBeGreaterThanOrEqualTo(2);
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    private sealed class CountingDetector: IHighWaterDetector
+    {
+        private int _detectCount;
+
+        public CountingDetector(bool supportsTenantPartitioning) =>
+            SupportsTenantPartitioning = supportsTenantPartitioning;
+
+        public Uri DatabaseUri { get; } = new("fake://db");
+        public bool SupportsTenantPartitioning { get; }
+        public int DetectCount => Volatile.Read(ref _detectCount);
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+        {
+            Interlocked.Increment(ref _detectCount);
+            return Task.FromResult(new HighWaterStatistics { CurrentMark = 0, HighestSequence = 0 });
+        }
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+    }
+
+    // Signals the first time the agent's loop reaches its inter-poll wait, then blocks forever so the loop
+    // parks after a single in-loop Detect() — making DetectCount deterministic rather than time-dependent.
+    private sealed class BlockingWakeup: IDaemonWakeup
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitAsync(TimeSpan timeout, CancellationToken token)
+        {
+            _entered.TrySetResult();
+            return Task.Delay(Timeout.Infinite, token);
+        }
+
+        public async Task<bool> EnteredWithin(TimeSpan timeout)
+        {
+            var winner = await Task.WhenAny(_entered.Task, Task.Delay(timeout));
+            return winner == _entered.Task;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
@@ -65,6 +65,22 @@ public class HighWaterAgent: IDisposable
                 Action = ShardAction.Started, LastAdvanced = lastAdvancedFrom(_current)
             });
 
+        // #4913: under per-tenant event partitioning the store-global high-water mark is not used to
+        // advance any projection — tenant agents advance from the per-tenant vectorized poll driven by
+        // the daemon's TenantedHighWaterCoordinator. The store-global Detect() is `max(seq_id)` fanned
+        // out across every tenant partition, so polling it on the recurring loop is pure overhead whose
+        // cost scales with the partition count. The mark is seeded once above (so the fallback ceiling and
+        // Tracker stay meaningful) and CheckNowAsync still runs an on-demand scan for rebuild/catch-up,
+        // but the continuous scan loop is skipped. Per-tenant polling cadence is carried by the daemon's
+        // tenant high-water timer instead.
+        if (_detector.SupportsTenantPartitioning)
+        {
+            _logger.LogInformation(
+                "Skipping the recurring store-global high water polling loop for database {Name} because per-tenant event partitioning drives high water per tenant",
+                _detector.DatabaseUri);
+            return;
+        }
+
         _loop = Task.Factory.StartNew(detectChanges, _token,
             TaskCreationOptions.LongRunning | TaskCreationOptions.AttachedToParent, TaskScheduler.Default);
 


### PR DESCRIPTION
Addresses JasperFx/marten#4913.

### Problem
Under `UseTenantPartitionedEvents`, the store-global `HighWaterAgent` keeps polling `IHighWaterDetector.Detect()` on its recurring loop (250ms when advancing, 1s idle) — and Marten emits that under partitioning as `select coalesce(max(seq_id),0) from mt_events`, an **unfiltered scan that fans out across every tenant partition**, on every tick, per database. On a sharded deployment (hundreds of partitions per DB, hundreds of DBs) it's a continuous heavy query whose cost grows with tenant count.

### Why it's safe to skip under partitioning
The store-global mark is **not consumed to advance any projection** when partitioning is on — tenant agents advance from the per-tenant vectorized poll driven by `TenantedHighWaterCoordinator`, and the per-tenant poll timer (jasperfx#492) already guarantees that cadence independently of the store-global mark.

### Change
`HighWaterAgent.StartAsync` still **seeds the mark once** (so the fallback ceiling and `Tracker` stay meaningful, and `CheckNowAsync` still runs an on-demand scan for rebuild/catch-up) but does **not launch the recurring scan loop** when `detector.SupportsTenantPartitioning` is true. `IsRunning` stays `true`, so the daemon's per-tenant high-water timer remains enabled.

Non-partitioned stores are completely unchanged — `SupportsTenantPartitioning` defaults to `false` on `IHighWaterDetector`.

**Tradeoff:** under partitioning the per-tenant poll cadence falls back from the global agent's fast 250ms clock to the 1s `SlowPollingTime` timer — worst-case tenant projection latency rises from ~250ms toward ~1s in exchange for eliminating the continuous full-partition scan.

### Tests
`HighWaterAgent_partitioning_skips_global_poll` — a counting detector plus a blocking wakeup deterministically prove a partitioned store seeds `Detect` exactly once and never enters the loop, while a non-partitioned store runs the recurring loop as before. All 178 existing high-water/daemon tests still pass (net9 + net10).

Also bumps `JasperFxVersion` 2.25.0 → 2.26.0 for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)