### PR TITLE
GH-505: Fix un-parenthesized GetUninitializedObject cast in sync null-snapshot Apply emission

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -1290,4 +1290,125 @@ public class Tally
 
         collisionErrors.ShouldBeEmpty();
     }
+
+    // Regression for https://github.com/JasperFx/jasperfx/issues/505 — an aggregate with no public
+    // parameterless ctor (record with a primary ctor) hits the GetUninitializedObject fallback in
+    // BuildAggregateConstructorExpression. The null-snapshot case for an instance Apply that
+    // *returns* the aggregate used that cast expression directly as the Apply receiver:
+    // `(Cart)RuntimeHelpers.GetUninitializedObject(typeof(Cart)).Apply(data)` — member access binds
+    // tighter than the cast, so Apply resolved against `object` and the user's build failed with
+    // CS1061. The fix emits the same two-statement local form the async twin uses.
+    [Fact]
+    public void apply_returning_aggregate_without_parameterless_ctor_compiles_null_snapshot_case()
+    {
+        var source = @"
+using System;
+using System.Collections.Generic;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public sealed record CartCreated(string Owner);
+public sealed record ItemAdded(string Name);
+
+// Self-aggregating record: primary constructor only (no public parameterless ctor),
+// instance Apply method that returns the aggregate.
+public sealed record Cart(Guid Id, string Owner, List<string> Items)
+{
+    public Cart Apply(ItemAdded e) => this with { Items = [.. Items, e.Name] };
+}
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+
+// Partial projection subclass declaring only Create(IEvent<CartCreated>), so the
+// ItemAdded null-snapshot case must construct the aggregate itself.
+public partial class CartProjection : SingleStreamProjection<Cart, Guid>
+{
+    public Cart Create(IEvent<CartCreated> e) => new Cart(e.StreamId, e.Data.Owner, new List<string>());
+}
+";
+        var diagnostics = CompileWithGenerator(source);
+
+        // CS1061 is the exact error shape the issue called out: 'object' does not contain
+        // a definition for 'Apply'.
+        var castBindingErrors = diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "CS1061")
+            .Select(d => d.GetMessage())
+            .ToArray();
+
+        castBindingErrors.ShouldBeEmpty();
+
+        // Spot-check the emitted form so a future regression that dodges CS1061 some other
+        // way still trips: the uninitialized instance lands in a local, and Apply is called
+        // on the local — never appended directly to the cast expression.
+        var (_, generatedSources) = RunGenerator(source);
+        var allGenerated = string.Join("\n", generatedSources);
+        allGenerated.ShouldContain(
+            "var s = (global::Test.Cart)global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(global::Test.Cart));");
+        allGenerated.ShouldContain("return s.Apply(data);");
+        allGenerated.ShouldNotContain("GetUninitializedObject(typeof(global::Test.Cart)).Apply(");
+    }
+
+    // Same defect through the other sync path (#505): the DI-activated partial-class override
+    // added for marten#4787 shares EmitNullSnapshotCases with the file-scoped evolver, so the
+    // Evolve override injected into the user's partial class emitted the identical broken cast.
+    [Fact]
+    public void di_activated_apply_returning_aggregate_without_parameterless_ctor_compiles_null_snapshot_case()
+    {
+        var source = @"
+using System;
+using System.Collections.Generic;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public sealed record CartCreated(string Owner);
+public sealed record ItemAdded(string Name);
+public interface ICartPricing { }
+
+public sealed record Cart(Guid Id, string Owner, List<string> Items)
+{
+    public Cart Apply(ItemAdded e) => this with { Items = [.. Items, e.Name] };
+}
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+
+// DI-only constructor forces the partial-class override path (marten#4787).
+public partial class CartProjection : SingleStreamProjection<Cart, Guid>
+{
+    private readonly ICartPricing _pricing;
+    public CartProjection(ICartPricing pricing) { _pricing = pricing; }
+
+    public Cart Create(IEvent<CartCreated> e) => new Cart(e.StreamId, e.Data.Owner, new List<string>());
+}
+";
+        var diagnostics = CompileWithGenerator(source);
+
+        var castBindingErrors = diagnostics
+            .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id == "CS1061")
+            .Select(d => d.GetMessage())
+            .ToArray();
+
+        castBindingErrors.ShouldBeEmpty();
+
+        var (_, generatedSources) = RunGenerator(source);
+        var allGenerated = string.Join("\n", generatedSources);
+        allGenerated.ShouldContain("public override global::Test.Cart? Evolve(");
+        allGenerated.ShouldContain(
+            "var s = (global::Test.Cart)global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(global::Test.Cart));");
+        allGenerated.ShouldContain("return s.Apply(data);");
+        allGenerated.ShouldNotContain("GetUninitializedObject(typeof(global::Test.Cart)).Apply(");
+    }
 }

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -1922,10 +1922,16 @@ internal static class EvolverCodeEmitter
             }
             else
             {
-                // Returns aggregate - pass new instance
+                // Returns aggregate - construct into a local first. Using the constructor
+                // expression directly as the Apply receiver breaks for the reflective
+                // `(T)GetUninitializedObject(...)` fallback: `.Apply(...)` binds tighter than
+                // the cast, so Apply resolves against `object` -> CS1061 (#505).
+                sb.AppendLine($"{indent}{{");
+                sb.AppendLine($"{indent}    var s = {ctorExpression};");
                 sb.Append($"{indent}    return ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, ctorExpression, dispatchOnThis);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s", dispatchOnThis);
                 sb.AppendLine(";");
+                sb.AppendLine($"{indent}}}");
             }
         }
     }


### PR DESCRIPTION
Fixes #505

## Root cause

For an aggregate with no public parameterless constructor (e.g. a record with a primary constructor), `BuildAggregateConstructorExpression` falls back to the reflective form `(T)global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(T))`. The sync `EmitNullSnapshotCases` "returns aggregate" branch passed that expression directly as the receiver of the `Apply` call, producing:

```csharp
return (Cart)RuntimeHelpers.GetUninitializedObject(typeof(Cart)).Apply(data);
```

Member access binds tighter than a cast, so `Apply` resolves against `object` and every consumer with this (documented) aggregate/projection shape breaks with CS1061 on upgrade. Both sync emit paths are affected because they share `EmitNullSnapshotCases`: the file-scoped evolver (`EmitEvolveEvolverMethod`) and the partial-class DI override added for marten#4787 (`EmitEvolveAsOverride`). The async twin (`EmitNullSnapshotCasesAsync`) already emits a safe two-statement form.

## Fix

Emit the same two-statement form the async path uses — construct into a local, then call `Apply` on the local:

```csharp
case global::Test.ItemAdded data:
{
    var s = (global::Test.Cart)global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(global::Test.Cart));
    return s.Apply(data);
}
```

Semantics are identical to the previous intent; the defect was purely syntactic. The braces also keep the `var s` local scoped per `case`, matching the existing void-Apply branch.

## Tests

Two regression tests in `AggregateEvolverGeneratorTests` built from the issue's repro shape (record aggregate with primary ctor, instance `Apply` returning the aggregate, `partial SingleStreamProjection<T, TId>` declaring only `Create(...)`):

- `apply_returning_aggregate_without_parameterless_ctor_compiles_null_snapshot_case` — file-scoped evolver path
- `di_activated_apply_returning_aggregate_without_parameterless_ctor_compiles_null_snapshot_case` — DI partial-override path (marten#4787)

Both assert no CS1061 from the compiled generator output plus spot-check the emitted two-statement form. Verified both fail against the pre-fix emission with the exact CS1061 from the issue ("'object' does not contain a definition for 'Apply' ...") and pass with the fix. Full `JasperFx.Events.SourceGenerator.Tests` suite: 26/26 green; `EventTests` (net9.0, consumes the generator as an analyzer): 483/483 green; full solution builds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)