### PR TITLE
Do not restart an already-started host in RunCommand. Closes #510

### DIFF
--- a/src/CommandLineTests/run_command_compliance.cs
+++ b/src/CommandLineTests/run_command_compliance.cs
@@ -1,4 +1,7 @@
+using JasperFx;
+using JasperFx.CommandLine;
 using JasperFx.CommandLine.Commands;
+using JasperFx.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
@@ -7,6 +10,62 @@ namespace CommandLineTests;
 
 public class run_command_compliance
 {
+    [Fact]
+    public async Task does_not_restart_a_host_already_started_by_auto_start()
+    {
+        // JasperFxEnvironment.AutoStartHost (WebApplicationFactory testing) makes the command
+        // executor eager-start the pre-built host before the run command executes. The run
+        // command must not start it a second time — IHost.StartAsync is not re-entrant and would
+        // re-run every IHostedService.StartAsync.
+        JasperFxEnvironment.AutoStartHost = true;
+        try
+        {
+            // Signalled by the counter's second StartAsync — i.e. the redundant start we guard
+            // against. It fires promptly when the bug is present and never when it is fixed.
+            var redundantStart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var counter = new StartCounter(onSecondStart: () => redundantStart.TrySetResult());
+
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services => services.AddSingleton<IHostedService>(counter))
+                .Build();
+
+            // Run on a background thread: with the guard in place the run command skips its only
+            // await, so its shutdown Wait() blocks synchronously — a direct call would deadlock.
+            var runTask = Task.Run(() => host.RunJasperFxCommands([]));
+
+            // Do not shut down until any redundant start has happened, or a stopping host would
+            // mask it. A correct run never signals, so bound the wait to prove the negative.
+            await Task.WhenAny(redundantStart.Task, Task.Delay(2.Seconds()));
+
+            host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+            await runTask.TimeoutAfterAsync(5000);
+
+            counter.Starts.ShouldBe(1);
+        }
+        finally
+        {
+            JasperFxEnvironment.AutoStartHost = false;
+        }
+    }
+
+    public class StartCounter(Action? onSecondStart = null) : IHostedService
+    {
+        private int _starts;
+        public int Starts => _starts;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _starts) == 2)
+            {
+                onSecondStart?.Invoke();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/src/JasperFx/CommandLine/Commands/RunCommand.cs
+++ b/src/JasperFx/CommandLine/Commands/RunCommand.cs
@@ -39,7 +39,14 @@ public class RunCommand : JasperFxAsyncCommand<RunInput>
         var lifetime = host.Services.GetService<IHostApplicationLifetime>();
         lifetime?.ApplicationStopping.Register(() => reset.Set());
 
-        await host.StartAsync();
+        // A host started under JasperFxEnvironment.AutoStartHost (WebApplicationFactory testing)
+        // has already run every IHostedService.StartAsync. IHost.StartAsync is not re-entrant, so
+        // starting it again re-runs them all — skip the redundant start.
+        if (lifetime is null || !lifetime.ApplicationStarted.IsCancellationRequested)
+        {
+            await host.StartAsync();
+        }
+
         reset.Wait();
         await host.StopAsync();
         return true;


### PR DESCRIPTION
Fixes #510: under `JasperFxEnvironment.AutoStartHost` (WebApplicationFactory testing), `buildExecutor` eager-starts the pre-built host and `RunCommand.Execute` then calls `StartAsync` on the same instance. `IHost.StartAsync` is not re-entrant, so every `IHostedService.StartAsync` runs a second time after `ApplicationStarted` has fired.

## The change

One guard in `RunCommand.Execute` — skip the start when the host already started:

```csharp
if (lifetime is null || !lifetime.ApplicationStarted.IsCancellationRequested)
{
    await host.StartAsync();
}
```

**Why read `ApplicationStarted` and not the `AutoStartHost` flag?** `buildExecutor` only eager-starts when `AutoStartHost && source is PreBuiltHostBuilder`. A caller that set the flag but ran through the plain `IHostBuilder` overload is *not* eager-started, and `RunCommand` should start it. Reading the lifetime asks the actual host instance, so it is correct on every path; the flag is not.

- Preserves the normal CLI path: without an eager start, `ApplicationStarted` is not yet signalled, so the guard starts the host exactly as before.
- Leaves `buildExecutor`'s eager start untouched — other commands (describe, resources) rely on a live host, and command resolution happens after `buildExecutor`, so the guard belongs at the redundant start in `RunCommand`.

## Testing

New `run_command_compliance` regression test drives the real `RunJasperFxCommands` path under `AutoStartHost` and asserts a single start. It gates on the redundant second start (a `TaskCompletionSource` signalled by the counter's second `StartAsync`), so it fails fast when the bug is present and a bounded wait proves the negative when it is fixed — no stopping the host early, which would mask the redundant start. Fails without the guard (`Starts == 2`), passes with it; full `CommandLineTests` suite green (295).