### PR TITLE
fix(#513): box the subject of F# null guards so F# types need not be [<AllowNullLiteral>]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -58,6 +58,14 @@ jobs:
         run: ./build.sh test-codegen
         shell: bash
 
+      # Regenerates the F# fixture from the emitters and compiles it with the in-box F# compiler.
+      # The `compile` step above only builds the *committed* Generated.fs, so this is what catches
+      # the fixture drifting from the code generation that produces it (jasperfx#513).
+      - name: test-codegen-fsharp
+        if: ${{ success() || failure() }}
+        run: ./build.sh test-codegen-fsharp
+        shell: bash
+
       - name: test-command-line
         if: ${{ success() || failure() }}
         run: ./build.sh test-command-line

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -81,6 +81,18 @@ jobs:
         run: ./build.sh test-event-store
         shell: bash
 
+      # End-to-end CLI smoke tests, including `codegen preview --language fsharp`: proves the F# flag
+      # is wired through the CLI and the F# emit path runs without throwing. It does NOT prove the
+      # output compiles -- `preview` only prints, and GeneratorTarget feeds codegen a raw C# CodeFrame
+      # (a documented passthrough), so its F# preview is knowingly not valid F#. The compile proof is
+      # test-codegen-fsharp above. Also covers the C# `codegen preview` and the `describe` flag
+      # variants, none of which ran in CI before. These commands all exit 0 (unlike smoke-test-help
+      # below), so the Nuke target gates on the exit code directly.
+      - name: smoke-test-commands
+        if: ${{ success() || failure() }}
+        run: ./build.sh smoke-test-commands
+        shell: bash
+
       # Smoke test the usage/help renderer end-to-end. `help describe` renders a
       # NetCoreInput-derived command, which exercises the nullable-enum --log-level
       # flag that crashed usage rendering in jasperfx#441.

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -33,6 +33,7 @@
         "SmokeTestCommands",
         "Test",
         "TestCodegen",
+        "TestCodegenFSharp",
         "TestCommandLine",
         "TestCore",
         "TestEvents",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -50,7 +50,7 @@ partial class Build : NukeBuild
                 .EnableNoRestore());
         });
 
-    Target Test => _ => _.DependsOn(TestCore, TestCodegen, TestCommandLine, TestEvents, TestEventStore, SmokeTestAot);
+    Target Test => _ => _.DependsOn(TestCore, TestCodegen, TestCodegenFSharp, TestCommandLine, TestEvents, TestEventStore, SmokeTestAot);
     
     Target TestCore => _ => _
         .DependsOn(Compile)
@@ -74,6 +74,25 @@ partial class Build : NukeBuild
                 .EnableNoRestore());
         });
     
+    // The F# acceptance gate: regenerates the fixture's Generated.fs from the emitters and compiles it
+    // with the in-box F# compiler. Compile alone only proves the *committed* Generated.fs builds, so
+    // without this target the fixture can silently drift from the emitters that produce it.
+    //
+    // Pinned to a single framework on purpose: the gate writes Generated.fs and builds the fixture, so
+    // running both target frameworks would have two test runs racing on the same file. (CI's
+    // DISABLE_TEST_PARALLELIZATION only serializes *within* an assembly, not across frameworks.)
+    Target TestCodegenFSharp => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile(Solution.src.CodegenTests_FSharp)
+                .SetFramework("net9.0")
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore());
+        });
+
     Target TestCommandLine => _ => _
         .DependsOn(Compile)
         .Executes(() =>

--- a/src/CodegenTests.FSharp/CodegenTests.FSharp.csproj
+++ b/src/CodegenTests.FSharp/CodegenTests.FSharp.csproj
@@ -3,16 +3,23 @@
     <!--
       F# code-generation integration tests (jasperfx#383).
 
-      This project is intentionally NOT wired into any ./build.sh / Nuke test target:
-      its single test shells out to `dotnet build` against the checked-in F# fixture,
-      which is too slow/heavy for the fast unit run. It is still part of jasperfx.sln so
-      it compiles with the rest of the solution. Run it explicitly with:
-          dotnet test src/CodegenTests.FSharp
+      Run by the `test-codegen-fsharp` target (./build.sh test-codegen-fsharp), separate from
+      test-codegen because the single test here shells out to `dotnet build` against the checked-in
+      F# fixture rather than being a fast in-process unit test. Measured cost is ~10s in CI, which
+      buys the only proof that the emitted F# actually compiles (jasperfx#513).
     -->
 
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <!--
+          The gate locates the checked-in fixture via [CallerFilePath]. ContinuousIntegrationBuild
+          (which the SDK turns on automatically under GITHUB_ACTIONS) enables DeterministicSourcePaths,
+          rewriting those baked-in paths to '/_/...' and making the lookup fail with
+          DirectoryNotFoundException. This project needs real source paths, and it is a test assembly
+          that is never packaged, so opt out (jasperfx#513).
+        -->
+        <DeterministicSourcePaths>false</DeterministicSourcePaths>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/CodegenTests.FSharp/FSharpCodegenSample.cs
+++ b/src/CodegenTests.FSharp/FSharpCodegenSample.cs
@@ -55,6 +55,7 @@ public static class FSharpCodegenSample
         AddDirectAsyncType(assembly);
         AddAccumulatorType(assembly);
         AddConditionalType(assembly);
+        AddFSharpSagaGuardType(assembly);
         AddToggleType(assembly);
         AddResourceType(assembly);
         AddOrderHandlerType(assembly);
@@ -318,6 +319,34 @@ public static class FSharpCodegenSample
         echo.Arguments[0] = input;
 
         method.Frames.Add(new IfElseNullGuardFrame(input, new Frame[] { fallback }, new Frame[] { echo }));
+    }
+
+    /// <summary>
+    ///     The same null-guard over an F# class type that is not <c>[&lt;AllowNullLiteral&gt;]</c> — the
+    ///     regression for jasperfx#513. <see cref="AddConditionalType" /> guards a <c>string</c>, which is
+    ///     null-permitting in F# and so compiles with a bare <c>isNull</c>; only a genuine F# class type
+    ///     trips the <c>'T : null</c> constraint. If the guard ever stops boxing its subject, the compile
+    ///     gate fails here.
+    /// </summary>
+    private static void AddFSharpSagaGuardType(GeneratedAssembly assembly)
+    {
+        var type = assembly.AddType("GeneratedFSharpSagaGuard", typeof(IFSharpSagaGuard));
+        var method = type.MethodFor(nameof(IFSharpSagaGuard.Describe));
+        var saga = method.Arguments[0];
+
+        var service = new InjectedField(typeof(SagaService), "sagaService");
+
+        var fallback = new MethodCall(typeof(SagaService), nameof(SagaService.Fallback))
+        {
+            Target = service, ReturnAction = ReturnAction.Return
+        };
+        var echo = new MethodCall(typeof(SagaService), nameof(SagaService.Echo))
+        {
+            Target = service, ReturnAction = ReturnAction.Return
+        };
+        echo.Arguments[0] = saga;
+
+        method.Frames.Add(new IfElseNullGuardFrame(saga, new Frame[] { fallback }, new Frame[] { echo }));
     }
 
     /// <summary>

--- a/src/CodegenTests.FSharpFixture/Generated.fs
+++ b/src/CodegenTests.FSharpFixture/Generated.fs
@@ -3,6 +3,7 @@
 namespace FSharpCodegenTarget.Generated
 
 open FSharpCodegenTarget
+open FSharpTypes
 open Microsoft.Extensions.DependencyInjection
 open System
 open System.Threading.Tasks
@@ -53,10 +54,20 @@ type GeneratedConditionalGreeter(controlFlowService: FSharpCodegenTarget.Control
 
     interface FSharpCodegenTarget.IConditionalGreeter with
         member this.Describe(input: string) : string =
-            if isNull input then
+            if isNull (box input) then
                 _controlFlowService.Fallback()
             else
                 _controlFlowService.Echo(input)
+
+type GeneratedFSharpSagaGuard(sagaService: FSharpCodegenTarget.SagaService) =
+    let _sagaService = sagaService
+
+    interface FSharpCodegenTarget.IFSharpSagaGuard with
+        member this.Describe(saga: FSharpTypes.FSharpSaga) : string =
+            if isNull (box saga) then
+                _sagaService.Fallback()
+            else
+                _sagaService.Echo(saga)
 
 type GeneratedToggle(controlFlowService: FSharpCodegenTarget.ControlFlowService) =
     let _controlFlowService = controlFlowService

--- a/src/CodegenTests/FSharpControlFlowTests.cs
+++ b/src/CodegenTests/FSharpControlFlowTests.cs
@@ -80,7 +80,8 @@ public class FSharpControlFlowTests
         var code = assembly.GenerateFSharpCode();
         _output.WriteLine(code);
 
-        code.ShouldContain("if isNull input then");
+        // Boxed so the guard does not require the subject type to be [<AllowNullLiteral>] (jasperfx#513)
+        code.ShouldContain("if isNull (box input) then");
         code.ShouldContain("_service.Fallback()");
         code.ShouldContain("else");
         code.ShouldContain("_service.Echo(input)");

--- a/src/FSharpCodegenTarget/Contracts.cs
+++ b/src/FSharpCodegenTarget/Contracts.cs
@@ -57,6 +57,31 @@ public interface IConditionalGreeter
     string Describe(string input);
 }
 
+/// <summary>
+///     The same null-guard, but over an F# class type that is not <c>[&lt;AllowNullLiteral&gt;]</c> —
+///     the shape of an F# Wolverine saga. F#'s <c>isNull</c> carries a <c>'T : null</c> constraint that
+///     such a type does not satisfy, so the guard must box its subject to compile (jasperfx#513).
+///     <see cref="IConditionalGreeter" /> cannot cover this: its subject is a <c>string</c>, which is
+///     null-permitting in F# and so compiles either way.
+/// </summary>
+public interface IFSharpSagaGuard
+{
+    string Describe(FSharpTypes.FSharpSaga saga);
+}
+
+public class SagaService
+{
+    public string Fallback()
+    {
+        return "no saga";
+    }
+
+    public string Echo(FSharpTypes.FSharpSaga saga)
+    {
+        return saga.Name;
+    }
+}
+
 public interface IToggle
 {
     void Toggle(bool flag);

--- a/src/FSharpCodegenTarget/FSharpCodegenTarget.csproj
+++ b/src/FSharpCodegenTarget/FSharpCodegenTarget.csproj
@@ -12,4 +12,9 @@
       compiles) and the F# codegen integration test (so it can reflect over the Types).
     -->
 
+    <ItemGroup>
+        <!-- FSharpSaga: a real F# class type for the null-guard fixture (jasperfx#513). -->
+        <ProjectReference Include="..\FSharpTypes\FSharpTypes.fsproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/FSharpTypes/Types.fs
+++ b/src/FSharpTypes/Types.fs
@@ -7,3 +7,9 @@ type FSharpGuidId = FSharpGuidId of Guid
 type FSharpStringId = FSharpStringId of string
 
 type FSharpIntId = FSharpIntId of int
+
+/// An ordinary F# class type — deliberately NOT [<AllowNullLiteral>], mirroring how a user
+/// would actually write an F# Wolverine saga. Generated null guards over this type must
+/// compile without the attribute (jasperfx#513).
+type FSharpSaga() =
+    member val Name = "" with get, set

--- a/src/JasperFx/CodeGeneration/Frames/IfElseNullGuardFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/IfElseNullGuardFrame.cs
@@ -45,7 +45,9 @@ public class IfElseNullGuardFrame : Frame
         // F# if/then/else is an expression: when it is the trailing position both branches yield
         // the method's return value; otherwise both branches must be unit. `else` dedents back to
         // align with `if` (no braces).
-        writer.Write($"BLOCK:if isNull {_subject.FSharpUsage} then");
+        // `isNull` carries a 'T : null constraint that F# class types do not satisfy unless they are
+        // [<AllowNullLiteral>], so box the subject first to erase the constraint (jasperfx#513).
+        writer.Write($"BLOCK:if isNull (box {_subject.FSharpUsage}) then");
         foreach (var frame in _nullPath) frame.GenerateFSharpCode(method, writer);
         writer.FinishBlock();
 
@@ -113,7 +115,8 @@ public class IfElseNullGuardFrame : Frame
 
         protected override void generateFSharpCode(GeneratedMethod method, ISourceWriter writer, Frame inner)
         {
-            writer.Write($"BLOCK:if not (isNull {_variable.FSharpUsage}) then");
+            // Boxed for the same 'T : null reason as IfElseNullGuardFrame above (jasperfx#513).
+            writer.Write($"BLOCK:if not (isNull (box {_variable.FSharpUsage})) then");
             inner.GenerateFSharpCode(method, writer);
             writer.FinishBlock();
         }

--- a/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
+++ b/src/JasperFx/CodeGeneration/Services/ArrayPlan.cs
@@ -142,7 +142,7 @@ public class CreateArrayFrame : SyncFrame
             {
                 var message = EnumerableSingletons.MissingMirrorMessage(_elementType, descriptor.ServiceKey);
                 writer.WriteLine(
-                    $"if isNull {element.FSharpUsage} then raise({typeof(InvalidOperationException).FSharpName()}({CodeFormatter.Write(message)}))");
+                    $"if isNull (box {element.FSharpUsage}) then raise({typeof(InvalidOperationException).FSharpName()}({CodeFormatter.Write(message)}))");
             }
         }
 


### PR DESCRIPTION
Closes #513.

## The problem

F#'s `isNull` carries a `'T : null` constraint. F# class types are not null-permitting by default, so `IfElseNullGuardFrame` emitting `if isNull x then` produced F# that **does not compile** unless the user's saga type was decorated:

```fsharp
[<AllowNullLiteral>]
type ThingSaga() =
    inherit Saga()
```

That forced the attribute onto every F# Wolverine saga, documented nowhere, with a compile error in *generated* code as the failure mode. Surfaced by JasperFx/wolverine#3410.

## The fix

Emit `isNull (box x)`. Boxing to `obj` erases the `'T : null` constraint, so the guard compiles for any F# type and the `[<AllowNullLiteral>]` requirement disappears. Semantics are unchanged — a null reference boxes to null.

Beyond the method named in the issue, two more sites had the identical pattern over user-controlled types and would fail the same way:

| Site | Emits |
|---|---|
| `IfElseNullGuardFrame.GenerateFSharpCode` | `if isNull (box saga) then` |
| `IfElseNullGuardFrame.IfNullGuardFrame` | `if not (isNull (box x)) then` |
| `CreateArrayFrame` keyed-singleton guard | `if isNull (box element) then raise(...)` |

`AppendActivityEventFrame` is deliberately left alone — its subject is `Activity.Current`, a BCL type that is always null-permitting in F#.

## Test coverage

The repo's F# compile gate regenerates `Generated.fs` and runs the real F# compiler against it, but **it could not have caught this**: the existing null-guard sample guards a `string`, which is null-permitting in F# and compiles either way.

So this adds an `FSharpSaga` F# class type — deliberately **not** `[<AllowNullLiteral>]`, mirroring how a user would actually write an F# saga — and runs it through the guard in the fixture. Reverting the box makes the gate fail with the exact error from wolverine#3410:

```
Generated.fs(67,23): error FS0001: The type 'FSharpSaga' does not have 'null' as a proper value
```

## Follow-up commits: run the F# codegen coverage in CI

While confirming the fix was actually protected, I found that **neither** piece of F# codegen coverage ran in CI.

**1. The compile gate never ran** (`ci: run the F# codegen acceptance gate`). `CodegenTests.FSharp` was referenced by no Nuke target — `TestCodegen` runs only `Solution.CodegenTests`. To be precise about the gap:

- ✅ The **committed** `Generated.fs` *is* compiled by CI, since the fixture is in the solution and `compile` builds it. A bad committed file gets caught.
- ❌ The **linkage between the emitters and the fixture** was unguarded. Change an F# emit path, forget to regenerate, and CI compiles the stale file and goes green while the fixture silently drifts from the code it exists to test.

Verified that gap is real: reverting the box in the emitter while leaving the committed `Generated.fs` correct, `compile` still reports **`Build succeeded`** while the new `TestCodegenFSharp` target **fails** with FS0001. Without this target, that regression ships green.

Pinned to a single framework: the gate writes `Generated.fs` and builds the fixture, so running both TFMs has two test runs racing on the same file. CI's `DISABLE_TEST_PARALLELIZATION` only serializes *within* an assembly, not across frameworks.

**2. The CLI smoke tests never ran** (`ci: run the CLI smoke tests…`). `SmokeTestCommands` had no CI step, so `codegen preview --language fsharp` never ran there — nor did the C# `codegen preview` or the `describe` variants. The F# smoke test lives in that target and `Main` already treats it as a default, so this runs the target rather than carving out a fragment and leaving a half-used target behind.

Its scope is deliberately narrow, and worth stating plainly: it proves the `--language fsharp` flag is wired through the CLI and the F# emit path runs without throwing. It does **not** prove the output compiles. `preview` only prints, and `GeneratorTarget` feeds codegen a raw C# `CodeFrame` — a documented passthrough where supplying F#-valid text is the caller's responsibility — so that harness's F# preview is knowingly *not* valid F#. The compile proof is `test-codegen-fsharp`.

Verified this step has teeth too: making `CodeFrame.GenerateFSharpCode` throw fails the target rather than passing quietly.

## Verification

F# compile gate passes on net9.0 + net10.0, CodegenTests 408/408, CoreTests 462/462, full solution builds, and both new CI steps (`./build.sh test-codegen-fsharp`, `./build.sh smoke-test-commands`) pass as CI will invoke them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)