### PR TITLE
feat(#503): tenant-scoped overloads for the IEventStore explorer read surface

### DIFF
--- a/src/EventTests/TenantScopedExplorerReadDefaultsTests.cs
+++ b/src/EventTests/TenantScopedExplorerReadDefaultsTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests;
+
+/// <summary>
+/// jasperfx#503 — the tenant-scoped explorer read overloads ship as default interface
+/// implementations so out-of-tree stores keep compiling. These pin the two halves of the
+/// graceful-degradation contract: a null tenant is store-global and delegates to the
+/// tenant-less member, and a non-null tenant throws rather than silently serving a read
+/// from whichever tenant the store's default session happened to resolve.
+/// </summary>
+public class TenantScopedExplorerReadDefaultsTests
+{
+    // Overrides only the tenant-LESS explorer reads, recording that they were reached. That is
+    // what lets these tests prove the null-tenant overload actually delegates, rather than merely
+    // failing to throw. The tenant-scoped overloads are deliberately left un-overridden — they are
+    // the defaults under test.
+    private sealed class ExplorerEventStore : IEventStore
+    {
+        public List<string> Calls { get; } = [];
+
+        public Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(int count, CancellationToken ct)
+        {
+            Calls.Add($"GetRecentStreamsAsync({count})");
+            return Task.FromResult<IReadOnlyList<StreamSummary>>([]);
+        }
+
+        public async IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, CancellationToken ct)
+        {
+            Calls.Add($"ReadStreamAsync({streamId})");
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, CancellationToken ct)
+        {
+            Calls.Add($"GetStreamMetadataAsync({streamId})");
+            return Task.FromResult<StreamMetadata?>(null);
+        }
+
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private readonly ExplorerEventStore theRecorder = new();
+
+    // The tenant overloads are default interface members, so they are only reachable through the
+    // interface — not off the concrete type. That is exactly how CritterWatch consumes them.
+    private IEventStore theStore => theRecorder;
+
+    [Fact]
+    public async Task get_recent_streams_for_null_tenant_delegates_to_store_global()
+    {
+        await theStore.GetRecentStreamsAsync(5, tenantId: null, CancellationToken.None);
+        theRecorder.Calls.ShouldBe(["GetRecentStreamsAsync(5)"]);
+    }
+
+    [Fact]
+    public async Task get_recent_streams_for_a_tenant_throws_when_not_multi_tenanted()
+    {
+        await Should.ThrowAsync<NotSupportedException>(
+            () => theStore.GetRecentStreamsAsync(5, "tenant-1", CancellationToken.None));
+        theRecorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task read_stream_for_null_tenant_delegates_to_store_global()
+    {
+        await foreach (var _ in theStore.ReadStreamAsync("stream-1", tenantId: null, CancellationToken.None))
+        {
+        }
+
+        theRecorder.Calls.ShouldBe(["ReadStreamAsync(stream-1)"]);
+    }
+
+    [Fact]
+    public void read_stream_for_a_tenant_throws_when_not_multi_tenanted()
+    {
+        // The default is an expression-bodied member rather than an async iterator, so it throws on
+        // the call itself instead of deferring to the first MoveNextAsync. Asserted that way on
+        // purpose: a caller that never enumerates still gets told the tenant scope was ignored.
+        Should.Throw<NotSupportedException>(
+            () => theStore.ReadStreamAsync("stream-1", "tenant-1", CancellationToken.None));
+        theRecorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task get_stream_metadata_for_null_tenant_delegates_to_store_global()
+    {
+        await theStore.GetStreamMetadataAsync("stream-1", tenantId: null, CancellationToken.None);
+        theRecorder.Calls.ShouldBe(["GetStreamMetadataAsync(stream-1)"]);
+    }
+
+    [Fact]
+    public async Task get_stream_metadata_for_a_tenant_throws_when_not_multi_tenanted()
+    {
+        await Should.ThrowAsync<NotSupportedException>(
+            () => theStore.GetStreamMetadataAsync("stream-1", "tenant-1", CancellationToken.None));
+        theRecorder.Calls.ShouldBeEmpty();
+    }
+
+    // A bare IEventDatabase whose only real member is the tenant-less head sequence, so the tenant
+    // overload's delegation is observable through the returned value.
+    private sealed class HeadSequenceEventDatabase : IEventDatabase
+    {
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token) => Task.FromResult(42L);
+
+        public string Identifier => throw new NotImplementedException();
+        public Uri DatabaseUri => throw new NotImplementedException();
+        public ShardStateTracker Tracker => throw new NotImplementedException();
+        public string StorageIdentifier => throw new NotImplementedException();
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
+            => throw new NotImplementedException();
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private readonly IEventDatabase theDatabase = new HeadSequenceEventDatabase();
+
+    [Fact]
+    public async Task fetch_highest_event_sequence_for_null_tenant_delegates_to_store_global()
+    {
+        var sequence = await theDatabase.FetchHighestEventSequenceNumber(tenantId: null, CancellationToken.None);
+        sequence.ShouldBe(42L);
+    }
+
+    [Fact]
+    public async Task fetch_highest_event_sequence_for_a_tenant_throws_when_not_partitioned()
+    {
+        // Under UseTenantPartitionedEvents each tenant draws its own sequence, so quietly handing back
+        // the store-global head would render a plausible-looking but wrong lag number.
+        await Should.ThrowAsync<NotSupportedException>(
+            () => theDatabase.FetchHighestEventSequenceNumber("tenant-1", CancellationToken.None));
+    }
+}

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -67,7 +67,24 @@ public interface IEventDatabase
 
     string StorageIdentifier { get; }
     Task<long> FetchHighestEventSequenceNumber(CancellationToken token);
-    
+
+    /// <summary>
+    ///     Fetch the highest assigned event sequence number for a single tenant partition — the "head"
+    ///     an explorer subtracts projection progress from to render lag. A null <paramref name="tenantId" />
+    ///     is store-global and delegates to the tenant-less overload (today's behavior). Under
+    ///     <c>UseTenantPartitionedEvents</c> each tenant draws its own sequence, so the store-global head
+    ///     is not a meaningful lag baseline for any single tenant; event stores that implement per-tenant
+    ///     partitioning override this. The default throws for a non-null tenant. See jasperfx#503.
+    /// </summary>
+    /// <param name="tenantId">Tenant partition to scope the head sequence to. Null means store-global.</param>
+    /// <param name="token"></param>
+    Task<long> FetchHighestEventSequenceNumber(string? tenantId, CancellationToken token)
+        => tenantId == null
+            ? FetchHighestEventSequenceNumber(token)
+            : throw new NotSupportedException(
+                "Per-tenant FetchHighestEventSequenceNumber is not implemented on this IEventDatabase. Use an event store that implements per-tenant partitioning.");
+
+
     /// <summary>
     ///     Check the current progress of all asynchronous projections
     /// </summary>

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -108,6 +108,21 @@ public interface IEventStore
             "GetRecentStreamsAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for the event store explorer.");
 
     /// <summary>
+    /// Return the most recently updated streams within a single tenant partition. A null
+    /// <paramref name="tenantId"/> is store-global and delegates to the tenant-less overload
+    /// (today's behavior). Event stores that implement multi-tenancy override this to open a
+    /// tenant-scoped session; the default throws for a non-null tenant. See jasperfx#503.
+    /// </summary>
+    /// <param name="count">Maximum number of streams to return.</param>
+    /// <param name="tenantId">Tenant partition to scope the listing to. Null means store-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(int count, string? tenantId, CancellationToken ct)
+        => tenantId == null
+            ? GetRecentStreamsAsync(count, ct)
+            : throw new NotSupportedException(
+                "Per-tenant GetRecentStreamsAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
+
+    /// <summary>
     /// Stream the events of a single stream from oldest to newest. Powers
     /// the explorer's stream-detail timeline. The default implementation
     /// throws <see cref="NotImplementedException"/>.
@@ -117,6 +132,24 @@ public interface IEventStore
     IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, CancellationToken ct)
         => throw new NotImplementedException(
             "ReadStreamAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for the event store explorer.");
+
+    /// <summary>
+    /// Stream the events of a single stream within a single tenant partition. A null
+    /// <paramref name="tenantId"/> is store-global and delegates to the tenant-less overload
+    /// (today's behavior). This overload exists because on a conjoined multi-tenant store the same
+    /// stream id can exist under two tenants, so the tenant-less read resolves whichever tenant the
+    /// default session happens to carry. Event stores that implement multi-tenancy override this to
+    /// open a tenant-scoped session; the default throws for a non-null tenant rather than silently
+    /// returning another tenant's events. See jasperfx#503.
+    /// </summary>
+    /// <param name="streamId">String form of the stream identifier.</param>
+    /// <param name="tenantId">Tenant partition to read the stream from. Null means store-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, string? tenantId, CancellationToken ct)
+        => tenantId == null
+            ? ReadStreamAsync(streamId, ct)
+            : throw new NotSupportedException(
+                "Per-tenant ReadStreamAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
 
     /// <summary>
     /// Return full diagnostic metadata for a single stream — version,
@@ -129,6 +162,22 @@ public interface IEventStore
     Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, CancellationToken ct)
         => throw new NotImplementedException(
             "GetStreamMetadataAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for the event store explorer.");
+
+    /// <summary>
+    /// Return full diagnostic metadata for a single stream within a single tenant partition. A null
+    /// <paramref name="tenantId"/> is store-global and delegates to the tenant-less overload
+    /// (today's behavior). Event stores that implement multi-tenancy override this to open a
+    /// tenant-scoped session; the default throws for a non-null tenant. See jasperfx#503.
+    /// </summary>
+    /// <param name="streamId">String form of the stream identifier.</param>
+    /// <param name="tenantId">Tenant partition to resolve the stream in. Null means store-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Stream metadata, or <see langword="null"/> when no stream exists with that id in that tenant.</returns>
+    Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, string? tenantId, CancellationToken ct)
+        => tenantId == null
+            ? GetStreamMetadataAsync(streamId, ct)
+            : throw new NotSupportedException(
+                "Per-tenant GetStreamMetadataAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
 
     /// <summary>
     /// Stream events that match all of the supplied DCB tag values.


### PR DESCRIPTION
Closes #503.

## Problem

The `IEventStore` explorer read surface is tenant-blind. On a conjoined multi-tenant store (`TenancyStyle.Conjoined`, with or without `UseTenantPartitionedEvents`) the same stream id can exist under two tenants, so a monitoring tool reading through the abstraction gets whichever tenant the default session resolves — an ambiguous, potentially **cross-tenant read**. CritterWatch consumes these strictly through the abstraction (its client package stays store-agnostic across Marten and Polecat), so it cannot work around this by opening a tenant-scoped Marten session.

## What this adds

Tenant-scoped overloads as **default interface implementations**, so out-of-tree stores and older implementations keep compiling unchanged:

| Member | Type |
|---|---|
| `GetRecentStreamsAsync(count, tenantId, ct)` | `IEventStore` |
| `ReadStreamAsync(streamId, tenantId, ct)` | `IEventStore` |
| `GetStreamMetadataAsync(streamId, tenantId, ct)` | `IEventStore` |
| `FetchHighestEventSequenceNumber(tenantId, ct)` | `IEventDatabase` |

`StreamSummary`, `StreamMetadata`, and `EventRecord` already carry `TenantId`, so no DTO shape changes were needed.

## Two decisions worth a reviewer's attention

**1. Non-null tenant throws rather than delegating.** The issue's snippet proposed `=> ReadStreamAsync(streamId, ct)` — i.e. ignore `tenantId`. That would make a store which hasn't implemented the override *silently serve the exact cross-tenant read this issue exists to prevent*, and it would do so invisibly: the caller asked for tenant A and gets whatever the default session resolves. This follows the established graceful-degradation pattern instead (jasperfx#407 / #450 — `FindEventStoreFloorAtTimeAsync`, `AllProjectionProgress`, `FetchDeadLetterCountsAsync`, `GetProjectionStatusesAsync`): **null tenant delegates to today's behavior, non-null throws `NotSupportedException`** until a store overrides it. Loud beats wrong for a tenant-isolation boundary.

**2. Head sequence named as an overload.** The issue floated `FetchMaxEventSequenceAsync(tenantId)` as one option. Added it as an overload of the existing `IEventDatabase.FetchHighestEventSequenceNumber` instead, matching the adjacent tenant-overload pattern rather than introducing a second name for the same concept.

Both are reversible if you'd rather match the issue text literally.

## Test coverage

`src/EventTests/TenantScopedExplorerReadDefaultsTests.cs` — 8 tests pinning both halves of the contract for all four members: a null tenant **delegates** (the stub records the tenant-less calls, so this proves delegation actually lands rather than merely not throwing), and a non-null tenant throws without reaching the store-global read.

Verified by mutation: reverting the `ReadStreamAsync` guard to the issue's literal snippet fails `read_stream_for_a_tenant_throws_when_not_multi_tenanted` and leaves the other 7 green.

Note that `ReadStreamAsync`'s default throws on the *call* rather than deferring to the first `MoveNextAsync` (it's an expression-bodied member, not an async iterator) — a caller that never enumerates still learns the tenant scope was ignored. That's asserted deliberately.

## Verification

- `dotnet build jasperfx.sln` — clean, 0 errors
- `src/EventTests` — 506/506 pass on net9.0 and net10.0

## Follow-on

The Marten/Polecat overrides that open the tenant-scoped session are downstream work; this PR is the abstraction plus its degradation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)