### PR TITLE
feat(#480): opt-in blue/green side-effect gate — bounded rebuild to the prior version's mark, then Continuous

### DIFF
--- a/src/EventTests/Daemon/BlueGreenSideEffectGateTests.cs
+++ b/src/EventTests/Daemon/BlueGreenSideEffectGateTests.cs
@@ -1,0 +1,441 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using System.Threading.Channels;
+using EventTests.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Subscriptions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#480 acceptance: the opt-in blue/green side-effect gate. When a NEW version of a
+// projection (ShardName.Version > 1) starts continuous execution behind the highest PRIOR version's
+// persisted progression mark N, the daemon first replays to N in Rebuild mode (side effects
+// suppressed) and only then starts Continuous from N — so RaiseSideEffects only fires for events the
+// previous version never processed. These tests drive the REAL JasperFxAsyncDaemon (real
+// SubscriptionAgents, substituted store/database) with a recording execution: every page the daemon
+// enqueues is captured with the execution mode it ran under, so the [0..N] = Rebuild / (N..HWM] =
+// Continuous boundary is asserted directly.
+public class BlueGreenSideEffectGateTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    private const long HighWater = 1500;
+
+    [Fact]
+    public async Task fresh_deploy_replays_to_the_prior_version_mark_without_side_effects_then_continues()
+    {
+        // The issue's headline scenario: V3 is freshly deployed (no progression of its own), V2 left
+        // off at 1,000. Phase 1 must be a Rebuild-mode replay of [0..1000]; phase 2 Continuous from
+        // 1,000 to the high-water.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+        harness.SetProgress("Trips:V2:All", 1000);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1000L));
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
+
+        harness.Daemon.StatusFor("Trips:V3:All").ShouldBe(AgentStatus.Running);
+        harness.ProgressFor("Trips:V3:All").ShouldBe(HighWater);
+    }
+
+    [Fact]
+    public async Task the_gate_applies_when_starting_a_single_agent_by_identity()
+    {
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+        harness.SetProgress("Trips:V2:All", 1000);
+
+        await harness.Daemon.StartAgentAsync("Trips:V3:All", CancellationToken.None).WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1000L));
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
+
+        harness.Daemon.StatusFor("Trips:V3:All").ShouldBe(AgentStatus.Running);
+    }
+
+    [Fact]
+    public async Task an_interrupted_warm_up_resumes_the_suppressed_replay_from_its_own_progress()
+    {
+        // A crash mid-warm-up leaves the new version's progression at 400 < N (1,000). The gate
+        // triggers on "behind the prior mark", not only on zero progress, so the restart suppresses
+        // side effects for the remaining (400..1000] instead of re-emitting them.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+        harness.SetProgress("Trips:V2:All", 1000);
+        harness.SetProgress("Trips:V3:All", 400);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 400L, 1000L));
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
+    }
+
+    [Fact]
+    public async Task no_gate_without_the_opt_in()
+    {
+        // Same fresh-deploy state, but the projection did not opt in: today's behavior, one
+        // continuous catch-up over the whole history (side effects firing throughout).
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3));
+        harness.SetProgress("Trips:V2:All", 1000);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 0L, HighWater));
+    }
+
+    [Fact]
+    public async Task no_gate_for_version_1()
+    {
+        await using var harness = new GateHarness(ShardName.Compose("Trips"),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 0L, HighWater));
+    }
+
+    [Fact]
+    public async Task no_gate_when_the_new_version_is_already_past_the_prior_mark()
+    {
+        // Not a fresh deploy — V3 has its own progression ahead of V2's final mark, so this is a
+        // plain resume and the gate must not add a rebuild phase.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+        harness.SetProgress("Trips:V2:All", 1000);
+        harness.SetProgress("Trips:V3:All", 1200);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1200L, HighWater));
+    }
+
+    [Fact]
+    public async Task no_gate_when_no_prior_version_progression_exists()
+    {
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 0L, HighWater));
+    }
+
+    [Fact]
+    public async Task the_gate_resolves_the_highest_prior_version_and_ignores_other_shards()
+    {
+        // V5 must warm up to V4's mark (the highest prior), not V2's — and rows for other tenants
+        // or other projections must not leak into the resolution.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 5),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+        harness.SetProgress("Trips:V2:All", 800);
+        harness.SetProgress("Trips:V4:All", 1200);
+        harness.SetProgress("Trips:V4:All:tenant1", 5000);
+        harness.SetProgress("Others:V4:All", 999);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1200L));
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1200L, HighWater));
+    }
+
+    [Fact]
+    public async Task the_gate_is_skipped_for_from_present_subscriptions()
+    {
+        // FromPresent ignores persisted progression entirely and jumps to the live high-water, which
+        // is incompatible with replaying to a persisted mark — the daemon skips the gate (warning)
+        // and the shard starts exactly as it does today.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options =>
+            {
+                options.GateSideEffectsBehindPriorVersion = true;
+                options.SubscribeFromPresent();
+            });
+        harness.SetProgress("Trips:V2:All", 1000);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        harness.Daemon.StatusFor("Trips:V3:All").ShouldBe(AgentStatus.Running);
+
+        // Give the command loop a beat: a wrongly-triggered warm-up would surface as a Rebuild page.
+        await Task.Delay(100);
+        harness.Execution.RecordedPages.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_warm_up_never_routes_through_the_optimized_replay_executor()
+    {
+        // Store-implemented replay executors (Marten/Polecat) are not guaranteed to honor a custom
+        // ceiling — they replay to their own detected high-water, which would overshoot N and skip
+        // the (N..HWM] side effects. The warm-up must use the plain loader path even when an
+        // optimized executor is available.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true, withReplayExecutor: true);
+        harness.SetProgress("Trips:V2:All", 1000);
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1000L));
+        (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
+
+        harness.Execution.ReplayExecutorInvocations.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_failed_warm_up_leaves_the_shard_stopped_instead_of_emitting_side_effects()
+    {
+        // If the suppressed warm-up fails, starting Continuous anyway would fire side effects over
+        // history the prior version already covered — the exact bug the opt-in exists to prevent.
+        // The shard stays paused (carrying the failure for observers); its partial progress makes
+        // the next start resume the warm-up.
+        await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
+            options => options.GateSideEffectsBehindPriorVersion = true);
+        harness.SetProgress("Trips:V2:All", 1000);
+        harness.Loader.ThrowOnLoad = true;
+
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+
+        harness.Daemon.StatusFor("Trips:V3:All").ShouldBe(AgentStatus.Paused);
+        harness.Execution.RecordedPages.ShouldBeEmpty();
+        harness.ProgressFor("Trips:V3:All").ShouldBe(0);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Harness: a REAL JasperFxAsyncDaemon over a substituted store + database with a single
+    // registered shard. Progression is a mutable dictionary — the recording execution writes each
+    // acknowledged page's ceiling back to it, so the continuous hand-off reads the mark the warm-up
+    // replay just persisted, exactly as a real store would behave.
+    // ---------------------------------------------------------------------------------------------
+
+    private sealed class GateHarness : IAsyncDisposable
+    {
+        private readonly ConcurrentDictionary<string, long> _progress = new();
+
+        public GateHarness(ShardName shardName, Action<AsyncOptions>? configureOptions = null,
+            bool withReplayExecutor = false)
+        {
+            Loader = new StubPageLoader();
+
+            var detector = new StubDetector { Mark = HighWater };
+
+            var store = Substitute.For<IEventStore<FakeOperations, FakeSession>>();
+            store.Meter.Returns(new Meter("tests"));
+            store.TimeProvider.Returns(TimeProvider.System);
+            store.AutoCreateSchemaObjects.Returns(AutoCreate.None);
+            store.ContinuousErrors.Returns(new ErrorHandlingOptions());
+            store.RebuildErrors.Returns(new ErrorHandlingOptions());
+            store.BuildEventLoader(Arg.Any<IEventDatabase>(), Arg.Any<ILogger>(), Arg.Any<EventFilterable>(),
+                Arg.Any<AsyncOptions>(), Arg.Any<ShardName>()).Returns(Loader);
+
+            var options = new AsyncOptions { BatchSize = 10_000 };
+            configureOptions?.Invoke(options);
+
+            Execution = new RecordingExecution(this, shardName, withReplayExecutor);
+            var shard = new AsyncShard<FakeOperations, FakeSession>(options, ShardRole.Projection, shardName,
+                new SingleExecutionFactory(Execution), new EventFilterable());
+            store.AllShards().Returns([shard]);
+
+            var database = Substitute.For<IEventDatabase>();
+            database.Identifier.Returns("db1");
+            database.DatabaseUri.Returns(new Uri("fake://db1"));
+            database.Tracker.Returns(new ShardStateTracker(new NulloLogger()));
+            database.ProjectionProgressFor(Arg.Any<ShardName>(), Arg.Any<CancellationToken>())
+                .Returns(info => Task.FromResult(_progress.GetValueOrDefault(info.Arg<ShardName>().Identity)));
+            database.AllProjectionProgress(Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult<IReadOnlyList<ShardState>>(
+                    _progress.Select(pair => new ShardState(pair.Key, pair.Value)).ToList()));
+
+            var projections = new FakeProjectionGraph { MaxConcurrentEventLoadsPerDatabase = 0 };
+
+            Daemon = new JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>(
+                store, database, new NulloLogger(), detector, projections);
+        }
+
+        public StubPageLoader Loader { get; }
+        public RecordingExecution Execution { get; }
+        public JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>> Daemon { get; }
+
+        public void SetProgress(string shardIdentity, long sequence) => _progress[shardIdentity] = sequence;
+
+        public long ProgressFor(string shardIdentity) => _progress.GetValueOrDefault(shardIdentity);
+
+        public async ValueTask DisposeAsync()
+        {
+            await Daemon.StopAllAsync();
+            Daemon.Dispose();
+        }
+    }
+
+    private sealed class FakeProjectionGraph :
+        ProjectionGraph<IJasperFxProjection<FakeOperations>, FakeOperations, FakeSession>
+    {
+        public FakeProjectionGraph() : base(Substitute.For<IEventRegistry>(), "tests")
+        {
+        }
+
+        protected override void onAddProjection(object projection)
+        {
+            // Nothing
+        }
+    }
+
+    // Serves empty, already-caught-up pages spanning (request.Floor, request.HighWater] so a single
+    // load completes each phase; the recorded page boundaries ARE the assertion surface.
+    private sealed class StubPageLoader : IEventLoader
+    {
+        public bool ThrowOnLoad { get; set; }
+
+        public Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+        {
+            if (ThrowOnLoad)
+            {
+                throw new DivideByZeroException("Configured loader failure");
+            }
+
+            var page = new EventPage(request.Floor);
+            page.CalculateCeiling(request.BatchSize, request.HighWater);
+            return Task.FromResult(page);
+        }
+    }
+
+    // Hands the SAME execution to every agent the daemon builds for the shard (warm-up + continuous
+    // run sequentially, never concurrently), so one recorder observes the full phase sequence.
+    private sealed class SingleExecutionFactory : ISubscriptionFactory<FakeOperations, FakeSession>
+    {
+        private readonly RecordingExecution _execution;
+
+        public SingleExecutionFactory(RecordingExecution execution)
+        {
+            _execution = execution;
+        }
+
+        public ISubscriptionExecution BuildExecution(IEventStore<FakeOperations, FakeSession> store,
+            IEventDatabase database, ILoggerFactory loggerFactory, ShardName shardName) => _execution;
+
+        public ISubscriptionExecution BuildExecution(IEventStore<FakeOperations, FakeSession> store,
+            IEventDatabase database, ILogger logger, ShardName shardName) => _execution;
+    }
+
+    // Acknowledges every page immediately (posting RangeCompleted back to the agent), records the
+    // (mode, floor, ceiling) it ran under, and persists the ceiling as the shard's progression —
+    // the store-side behavior the continuous hand-off depends on.
+    private sealed class RecordingExecution : ISubscriptionExecution
+    {
+        private readonly GateHarness _harness;
+        private readonly bool _withReplayExecutor;
+        private readonly Channel<(ShardExecutionMode, long, long)> _pages =
+            Channel.CreateUnbounded<(ShardExecutionMode, long, long)>();
+        private int _replayExecutorInvocations;
+
+        public RecordingExecution(GateHarness harness, ShardName shardName, bool withReplayExecutor)
+        {
+            _harness = harness;
+            ShardName = shardName;
+            _withReplayExecutor = withReplayExecutor;
+        }
+
+        public ShardName ShardName { get; }
+
+        public ShardExecutionMode Mode { get; set; } = ShardExecutionMode.Continuous;
+
+        public ConcurrentBag<(ShardExecutionMode, long, long)> RecordedPages { get; } = new();
+
+        public int ReplayExecutorInvocations => Volatile.Read(ref _replayExecutorInvocations);
+
+        public async Task<(ShardExecutionMode, long, long)> NextPageAsync()
+        {
+            using var timeout = new CancellationTokenSource(TestTimeout);
+            return await _pages.Reader.ReadAsync(timeout.Token);
+        }
+
+        public ValueTask EnqueueAsync(EventPage page, ISubscriptionAgent subscriptionAgent)
+        {
+            var entry = (Mode, page.Floor, page.Ceiling);
+            RecordedPages.Add(entry);
+            _pages.Writer.TryWrite(entry);
+            _harness.SetProgress(subscriptionAgent.Name.Identity, page.Ceiling);
+            return subscriptionAgent.MarkSuccessAsync(page.Ceiling);
+        }
+
+        public Task StopAndDrainAsync(CancellationToken token) => Task.CompletedTask;
+
+        public Task HardStopAsync() => Task.CompletedTask;
+
+        public bool TryBuildReplayExecutor([NotNullWhen(true)] out IReplayExecutor? executor)
+        {
+            if (!_withReplayExecutor)
+            {
+                executor = null;
+                return false;
+            }
+
+            executor = new CountingReplayExecutor(this);
+            return true;
+        }
+
+        public Task ProcessImmediatelyAsync(SubscriptionAgent subscriptionAgent, EventPage events,
+            CancellationToken cancellation) => Task.CompletedTask;
+
+        public Task ProcessRangeAsync(EventRange range) => Task.CompletedTask;
+
+        public bool TryGetAggregateCache<TId, TDoc>([NotNullWhen(true)] out IAggregateCaching<TId, TDoc>? caching)
+        {
+            caching = null;
+            return false;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private sealed class CountingReplayExecutor : IReplayExecutor
+        {
+            private readonly RecordingExecution _parent;
+
+            public CountingReplayExecutor(RecordingExecution parent)
+            {
+                _parent = parent;
+            }
+
+            public Task StartAsync(SubscriptionExecutionRequest request, ISubscriptionController controller,
+                CancellationToken cancellation)
+            {
+                Interlocked.Increment(ref _parent._replayExecutorInvocations);
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    // A plain, non-partitioned detector pinned at Mark: the initial StartAsync detection publishes
+    // it, deterministically seeding Tracker.HighWaterMark before any agent starts.
+    private sealed class StubDetector : IHighWaterDetector
+    {
+        public long Mark { get; set; }
+
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        public bool SupportsTenantPartitioning => false;
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics
+            {
+                CurrentMark = Mark, LastMark = Mark, HighestSequence = Mark
+            });
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+
+        public Task<HighWaterVector> DetectForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token) => throw new NotSupportedException();
+
+        public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token) => throw new NotSupportedException();
+    }
+}

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -269,7 +269,11 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // (_semaphore) is now held only around the registry mutations, NOT across the replay itself —
     // holding it across the replay (the pre-#497 shape) serialized every rebuild cell in the daemon at
     // an effective concurrency of one, making any cap > 1 unreachable.
-    private async Task rebuildAgent(ISubscriptionAgent agent, long highWaterMark, TimeSpan shardTimeout)
+    // The optional floor/disableOptimizedReplay parameters exist for the jasperfx#480 side-effect
+    // version gate: its bounded replay resumes from the new version's own persisted progress (not 0)
+    // and must not route through a store replay executor that ignores the custom ceiling.
+    private async Task rebuildAgent(ISubscriptionAgent agent, long highWaterMark, TimeSpan shardTimeout,
+        long floor = 0, bool disableOptimizedReplay = false)
     {
         var budget = _rebuildBudget;
         if (budget != null)
@@ -293,7 +297,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
             var errorOptions = _store.RebuildErrors;
 
-            var request = new SubscriptionExecutionRequest(0, ShardExecutionMode.Rebuild, errorOptions, this);
+            var request = new SubscriptionExecutionRequest(floor, ShardExecutionMode.Rebuild, errorOptions, this)
+            {
+                DisableOptimizedReplay = disableOptimizedReplay
+            };
             await agent.ReplayAsync(request, highWaterMark, shardTimeout).ConfigureAwait(false);
 
             await _semaphore.WaitAsync(_cancellation.Token).ConfigureAwait(false);
@@ -312,8 +319,154 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             budget?.Release();
         }
     }
-    
-    
+
+    // jasperfx#480: the bounded warm-up replay is capped like any other rebuild; a timeout leaves the
+    // shard stopped with its partial progress persisted, and the next start resumes the warm-up from
+    // that floor (the gate triggers on progress < prior mark, not only on zero progress).
+    private static readonly TimeSpan SideEffectGateTimeout = 5.Minutes();
+
+    // jasperfx#480: single entry point for starting a shard in Continuous mode so every start path
+    // (StartAllAsync, StartAgentAsync by name, the per-tenant fan-outs) runs the opt-in blue/green
+    // side-effect gate first. Returns true when the continuous agent was actually started.
+    private async Task<bool> startContinuousShardAsync(AsyncShard<TOperations, TQuerySession> shard)
+    {
+        if (!await tryApplySideEffectVersionGateAsync(shard).ConfigureAwait(false))
+        {
+            // The warm-up replay failed; leave the shard stopped rather than starting continuous
+            // execution that would emit side effects over history the prior version already covered.
+            return false;
+        }
+
+        var agent = buildAgentForShard(shard);
+        var started = await tryStartAgentAsync(agent, ShardExecutionMode.Continuous).ConfigureAwait(false);
+
+        if (!started && agent is IAsyncDisposable d)
+        {
+            await d.DisposeAsync().ConfigureAwait(false);
+        }
+
+        return started;
+    }
+
+    // jasperfx#480: opt-in blue/green side-effect gate. When a projection opts in and a NEW version of
+    // it starts behind the highest PRIOR version's persisted progression mark N, first run a bounded
+    // replay to N in Rebuild mode (side effects suppressed, aggregate state correct), then let the
+    // caller hand off to Continuous — DetermineStartingPositionAsync reads the persisted progress (now
+    // N) so side effects only fire for events the previous version never processed. Returns false ONLY
+    // when the warm-up replay was attempted and failed; every not-triggered case returns true.
+    private async Task<bool> tryApplySideEffectVersionGateAsync(AsyncShard<TOperations, TQuerySession> shard)
+    {
+        var name = shard.Name;
+        if (!shard.Options.GateSideEffectsBehindPriorVersion || name.Version <= 1)
+        {
+            return true;
+        }
+
+        if (shard.Options.UsesFromPresent(Database))
+        {
+            Logger.LogWarning(
+                "Projection shard {Name} opts into GateSideEffectsBehindPriorVersion but subscribes from 'present', which ignores persisted progression. The side-effect gate is skipped",
+                name.Identity);
+            return true;
+        }
+
+        try
+        {
+            var current = await Database.ProjectionProgressFor(name, _cancellation.Token).ConfigureAwait(false);
+            var prior = await resolvePriorVersionProgressAsync(name, _cancellation.Token).ConfigureAwait(false);
+
+            // Triggering on current < prior (rather than only current == 0) makes an interrupted
+            // warm-up resumable: a crash mid-replay leaves progress at M < N, and the next start
+            // suppresses side effects for the remaining (M, N] instead of re-emitting them.
+            if (prior <= current)
+            {
+                return true;
+            }
+
+            Logger.LogInformation(
+                "Projection shard {Name} v{Version} is behind the prior version's progression ({Current} < {Prior}); replaying to {Prior} with side effects suppressed before continuous execution starts (blue/green side-effect gate)",
+                name.Identity, name.Version, current, prior, prior);
+
+            var warmup = buildAgentForShard(shard);
+            Tracker.MarkAsRestarted(warmup.Name);
+            await rebuildAgent(warmup, prior, SideEffectGateTimeout, floor: current, disableOptimizedReplay: true)
+                .ConfigureAwait(false);
+
+            // A failed replay does NOT propagate out of ReplayAsync — the agent pauses itself via
+            // ReportCriticalFailureAsync and the completion await swallows the fault — so judge the
+            // warm-up by the agent's own state: it must still be Running and have committed the
+            // target mark. On failure, leave the paused agent registered (it carries the exception
+            // for observers) and do not start continuous execution.
+            if (warmup.Status != AgentStatus.Running || warmup.LastCommitted < prior)
+            {
+                Logger.LogError(
+                    "The blue/green side-effect gate warm-up for projection shard {Name} stopped at {Position} in status {Status} before reaching {Prior}. The shard is left in that state; restarting it will resume the suppressed warm-up from its persisted progress",
+                    name.Identity, warmup.LastCommitted, warmup.Status, prior);
+                return false;
+            }
+
+            using var cancellation = new CancellationTokenSource(5.Seconds());
+            try
+            {
+                // Marks the warm-up agent Stopped so the continuous start below is not mistaken
+                // for a duplicate of a running agent (mirrors the rebuildProjection sequence).
+                await warmup.StopAndDrainAsync(cancellation.Token).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Error trying to stop and drain the side-effect gate warm-up agent {Name}",
+                    warmup.Name.Identity);
+            }
+
+            Logger.LogInformation(
+                "Projection shard {Name} v{Version} finished its side-effect-suppressed warm-up at {Prior}; side effects are enabled from here on",
+                name.Identity, name.Version, prior);
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e,
+                "Error running the blue/green side-effect gate for projection shard {Name}. The shard is left stopped; restarting it will resume the suppressed warm-up from its persisted progress",
+                name.Identity);
+            return false;
+        }
+    }
+
+    // jasperfx#480: the one genuinely new read — resolve the HIGHEST prior version's persisted
+    // progression mark for the same (projection, shard key, tenant). The version is baked into the
+    // progression-row identity (Trips:V2:All vs Trips:V3:All are distinct rows), so the prior mark
+    // survives the version bump and parses back out of AllProjectionProgress here.
+    private async Task<long> resolvePriorVersionProgressAsync(ShardName name, CancellationToken token)
+    {
+        var progress = await Database.AllProjectionProgress(token).ConfigureAwait(false);
+
+        long mark = 0;
+        uint priorVersion = 0;
+        foreach (var state in progress)
+        {
+            if (!ShardName.TryParse(state.ShardName, out var parsed) || parsed == null)
+            {
+                continue;
+            }
+
+            if (parsed.Version >= name.Version || parsed.Version < priorVersion)
+            {
+                continue;
+            }
+
+            if (!parsed.Name.EqualsIgnoreCase(name.Name)) continue;
+            if (!parsed.ShardKey.EqualsIgnoreCase(name.ShardKey)) continue;
+            if (!string.Equals(parsed.TenantId, name.TenantId)) continue;
+
+            priorVersion = parsed.Version;
+            mark = state.Sequence;
+        }
+
+        return mark;
+    }
+
+
     public async Task StartAgentAsync(string shardName, CancellationToken token)
     {
         if (!_highWater.IsRunning)
@@ -342,16 +495,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         var shard = _store.AllShards().FirstOrDefault(x => x.Name.Identity == shardName);
         if (shard != null)
         {
-            var agent = buildAgentForShard(shard);
-
-            var didStart = await tryStartAgentAsync(agent, ShardExecutionMode.Continuous).ConfigureAwait(false);
-
-            if (!didStart && agent is IAsyncDisposable d)
-            {
-                // Could not be started
-                await d.DisposeAsync().ConfigureAwait(false);
-            }
-
+            await startContinuousShardAsync(shard).ConfigureAwait(false);
             return;
         }
 
@@ -391,12 +535,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             await pollTenantHighWaterAsync().ConfigureAwait(false);
 
             var tenantShard = baseShard with { Name = baseShard.Name.ForTenant(requested.TenantId) };
-            var tenantAgent = buildAgentForShard(tenantShard);
-            var tenantStarted = await tryStartAgentAsync(tenantAgent, ShardExecutionMode.Continuous).ConfigureAwait(false);
-            if (!tenantStarted && tenantAgent is IAsyncDisposable td)
+            var tenantStarted = await startContinuousShardAsync(tenantShard).ConfigureAwait(false);
+            if (!tenantStarted)
             {
-                await td.DisposeAsync().ConfigureAwait(false);
-
                 // Reconcile the polled-tenant set so a failed start doesn't leave the coordinator
                 // polling (and persisting high-water rows for) a tenant with no agent on this node.
                 syncTenantPolling();
@@ -514,7 +655,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             await StartHighWaterDetectionAsync().ConfigureAwait(false);
         }
 
-        var agents = new List<ISubscriptionAgent>();
+        var shards = new List<AsyncShard<TOperations, TQuerySession>>();
 
         if (_tenantHighWater != null && Database is ICrossTenantRebuildSource crossTenantSource)
         {
@@ -525,7 +666,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             // tenant's projection advances against its own high-water and persists its own
             // <Projection>:All:<tenant> progression row. OnNext + pollTenantHighWaterAsync already route
             // each tenant's mark to its TenantId-bearing agents.
-            await buildPerTenantContinuousAgents(crossTenantSource, agents).ConfigureAwait(false);
+            await buildPerTenantContinuousShards(crossTenantSource, shards).ConfigureAwait(false);
 
             // Prime the per-tenant ceilings BEFORE starting the agents so each tenant agent seeds from
             // its own high-water (tryStartAgentAsync reads CeilingFor) rather than the store-global mark.
@@ -535,23 +676,20 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
         else
         {
-            foreach (var shard in _store.AllShards())
-            {
-                agents.Add(buildAgentForShard(shard));
-            }
+            shards.AddRange(_store.AllShards());
         }
 
-        foreach (var agent in agents)
+        foreach (var shard in shards)
         {
-            await tryStartAgentAsync(agent, ShardExecutionMode.Continuous).ConfigureAwait(false);
+            await startContinuousShardAsync(shard).ConfigureAwait(false);
         }
     }
 
-    // marten#4717: build one continuous agent per (shard, tenant), enumerating tenants from the store's
+    // marten#4717: build one continuous shard per (shard, tenant), enumerating tenants from the store's
     // ICrossTenantRebuildSource (mt_tenant_partitions). A projection with no registered tenants yet keeps
-    // its store-global agent so it still runs (there are no events to process until a tenant exists).
-    private async Task buildPerTenantContinuousAgents(
-        ICrossTenantRebuildSource crossTenantSource, List<ISubscriptionAgent> agents)
+    // its store-global shard so it still runs (there are no events to process until a tenant exists).
+    private async Task buildPerTenantContinuousShards(
+        ICrossTenantRebuildSource crossTenantSource, List<AsyncShard<TOperations, TQuerySession>> shards)
     {
         foreach (var shard in _store.AllShards())
         {
@@ -560,15 +698,14 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
             if (tenants.Count == 0)
             {
-                agents.Add(buildAgentForShard(shard));
+                shards.Add(shard);
                 continue;
             }
 
             foreach (var tenantId in tenants)
             {
                 _tenantHighWater!.PolledTenants.Activate(tenantId);
-                var tenantShard = shard with { Name = shard.Name.ForTenant(tenantId) };
-                agents.Add(buildAgentForShard(tenantShard));
+                shards.Add(shard with { Name = shard.Name.ForTenant(tenantId) });
             }
         }
     }

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -244,7 +244,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
         try
         {
-            if (_execution.TryBuildReplayExecutor(out var executor))
+            if (!request.DisableOptimizedReplay && _execution.TryBuildReplayExecutor(out var executor))
             {
                 _logger.LogInformation("Starting optimized rebuild for projection/subscription {ShardName}",
                     Name.Identity);
@@ -342,7 +342,13 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
                 HighWaterMark = command.HighWaterMark;
                 LastCommitted = LastEnqueued = command.LastCommitted;
 
-                if (LastCommitted == 0 && HighWaterMark > 0 && _execution.TryBuildReplayExecutor(out var executor))
+                // The Mode guard matters for jasperfx#480: a bounded rebuild that disabled the
+                // optimized replay (ReplayAsync above) posts Start in Rebuild mode with a replay
+                // executor available — kicking off the executor here would overshoot the custom
+                // ceiling. Unreachable in Rebuild mode before #480 (ReplayAsync would have taken
+                // the optimized branch), so this is behavior-preserving for every other path.
+                if (Mode != ShardExecutionMode.Rebuild && LastCommitted == 0 && HighWaterMark > 0 &&
+                    _execution.TryBuildReplayExecutor(out var executor))
                 {
                     _logger.LogInformation("Starting optimized rebuild for projection/subscription {ShardName}",
                         Name.Identity);

--- a/src/JasperFx.Events/Daemon/SubscriptionExecutionRequest.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionExecutionRequest.cs
@@ -14,4 +14,13 @@ public record SubscriptionExecutionRequest(
     /// at start is essential.
     /// </summary>
     public long? StartingHighWater { get; init; }
+
+    /// <summary>
+    /// jasperfx#480: force the plain event-loader replay path even when the store's execution can
+    /// build an optimized IReplayExecutor. The blue/green side-effect gate replays to a CUSTOM
+    /// ceiling (the prior version's mark) that store-implemented replay executors are not guaranteed
+    /// to honor — they typically replay to their own detected high-water. Default false keeps
+    /// today's behavior everywhere else.
+    /// </summary>
+    public bool DisableOptimizedReplay { get; init; }
 }

--- a/src/JasperFx.Events/Projections/AsyncOptions.cs
+++ b/src/JasperFx.Events/Projections/AsyncOptions.cs
@@ -48,6 +48,17 @@ public class AsyncOptions
     public bool TeardownDataOnRebuild { get; set; } = true;
 
     /// <summary>
+    /// jasperfx#480, opt-in for blue/green projection deploys. When a NEW version of this projection
+    /// (ShardName.Version > 1) starts continuous execution and a PRIOR version's progression row is
+    /// ahead of this version's own progress, the daemon first replays up to the prior version's mark
+    /// with side effects suppressed (rebuild semantics), then hands off to continuous execution — so
+    /// RaiseSideEffects (raised events / published messages) only fires for events the previous
+    /// version never processed. Default is false, i.e. the new version emits side effects over the
+    /// whole replay exactly as before.
+    /// </summary>
+    public bool GateSideEffectsBehindPriorVersion { get; set; }
+
+    /// <summary>
     /// The maximum number of aggregates that will be cached per tenant in a 2nd level,
     /// most recently used cache during async projection. Defaults to 0 (the aggregate cache
     /// is disabled) so async projection behavior matches re-fetching committed state from the
@@ -96,6 +107,11 @@ public class AsyncOptions
         var strategy = matchStrategy(database);
         return strategy.DetermineStartingPositionAsync(highWaterMark, name, mode, database, token);
     }
+
+    // jasperfx#480: the side-effect version gate replays to the PERSISTED prior-version mark, but a
+    // FromPresent subscription ignores persisted rows entirely and jumps to the live high-water —
+    // the two are incompatible, so the daemon skips the gate (with a warning) for these databases.
+    internal bool UsesFromPresent(IEventDatabase database) => matchStrategy(database) is FromPresent;
 
     private IPositionStrategy matchStrategy(IEventDatabase database)
     {

--- a/src/JasperFx.Events/Projections/ProjectionBase.cs
+++ b/src/JasperFx.Events/Projections/ProjectionBase.cs
@@ -48,6 +48,18 @@ public abstract class ProjectionBase : EventFilterable, IHasLogger
     /// </summary>
     public uint Version { get; set; } = 1;
 
+    /// <summary>
+    /// jasperfx#480, opt-in for blue/green projection deploys. When a new version of this projection
+    /// (Version > 1) starts up behind a prior version's persisted progression, the async daemon first
+    /// replays up to the prior version's mark with side effects suppressed, and only emits side
+    /// effects (raised events / published messages) for events past that mark. Default is false.
+    /// </summary>
+    public bool GateSideEffectsBehindPriorVersion
+    {
+        get => Options.GateSideEffectsBehindPriorVersion;
+        set => Options.GateSideEffectsBehindPriorVersion = value;
+    }
+
     public void OverwriteVersion(uint version)
     {
         Version = version;


### PR DESCRIPTION
Closes #480.

## What this does

Adds the opt-in behavior from #480 for blue/green projection-version deploys: when a new version of an existing projection is deployed, it does **not** fire side-effects (`RaiseSideEffects` → raised events / published messages) while replaying history the previous version already processed, and only begins emitting them once it advances past where the previous version left off.

Mechanism, exactly as sketched in the issue: detect the fresh-deploy case, resolve the prior version's progression `N` from the versioned progression rows, run a **bounded Rebuild to `N`** (Rebuild mode already suppresses side effects), then hand off to **Continuous from `N`** (the default `CatchUp` position strategy reads the just-persisted progress).

## API surface

- `AsyncOptions.GateSideEffectsBehindPriorVersion` (bool, default `false`) — the flag rides on the shard's options so the daemon can see it; `ProjectionBase.GateSideEffectsBehindPriorVersion` is a pass-through, keeping the issue's working name. Rename away if you want something else.
- `SubscriptionExecutionRequest.DisableOptimizedReplay` (default `false`) — the warm-up forces the plain loader replay because store-implemented `IReplayExecutor`s are not guaranteed to honor a custom ceiling (they'd overshoot `N` and swallow the `(N, HWM]` side effects). Downstream issues cover teaching Marten/Polecat executors the ceiling so the optimized path can be re-enabled later.

## Deliberate deviations from the issue sketch

1. **Trigger condition 4 is generalized**: the gate triggers on *own progress `<` prior version's mark*, not only on "no progression of its own yet". This makes an interrupted warm-up resumable — a crash at `M < N` re-triggers the gate on restart and suppresses the remaining `(M, N]` instead of re-emitting it (with the literal fresh-deploy-only trigger, a mid-warm-up crash would permanently defeat the gate). A months-old stale prior row is naturally inert because the new version's progress is already past it.
2. **A failed warm-up refuses to start Continuous** and leaves the shard paused with the failure attached. `ReplayAsync` swallows rebuild faults (`ReportCriticalFailureAsync` pauses the shard; the completion await drops the exception), so the gate judges the warm-up by the agent's own status/position.
3. **`FromPresent` subscriptions skip the gate with a warning** — that strategy ignores persisted progression entirely, per the issue's caveat.

## Structure

- Every continuous start path (`StartAllAsync` incl. the per-tenant fan-out, `StartAgentAsync` by identity incl. the tenant branch) now routes through a single `startContinuousShardAsync` entry point that runs the gate first, so Wolverine-distributed per-shard starts get the same behavior.
- `rebuildAgent` grew optional `floor` / `disableOptimizedReplay` parameters (defaults preserve every existing call byte-for-byte).
- The `SubscriptionAgent` continuous-startup optimized-replay branch is now guarded with `Mode != Rebuild` — unreachable in Rebuild mode before this change, required once a rebuild can decline the optimized path.

## Tests

New `BlueGreenSideEffectGateTests` drive the real `JasperFxAsyncDaemon` (real `SubscriptionAgent`s, substituted store/database, recording execution) and assert the `[floor..N] = Rebuild / (N..HWM] = Continuous` page boundaries directly: fresh deploy, single-agent-by-identity start, interrupted-warm-up resume, all four skip conditions, highest-prior-version + tenant/projection row filtering, optimized-executor bypass, and the failed-warm-up pause. Full `EventTests` (523) and `EventStoreTests` (72) pass; solution builds clean.

## Downstream

Follow-up implementation + testing-plan issues are being filed on Marten and Polecat (optimized replay executor ceiling honoring, end-to-end blue/green integration coverage, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)