### PR TITLE
Preserve an inner exception on ConcurrencyException; make the daemon governors resizable

### DIFF
--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.Metrics;
+using System.Reflection;
 using EventTests.Projections;
 using JasperFx;
+using JasperFx.Core;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Daemon.HighWater;
@@ -9,6 +11,7 @@ using JasperFx.Events.Subscriptions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Shouldly;
+using Timer = System.Timers.Timer;
 
 namespace EventTests.Daemon;
 
@@ -258,6 +261,135 @@ public class PerTenantStartAgentAsyncTests
     }
 
     [Fact]
+    public async Task batch_write_governor_can_be_resized_at_runtime()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.MaxConcurrentBatchWritesPerDatabase = 4,
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        harness.Daemon.BatchWriteThrottle!.CurrentCount.ShouldBe(4);
+
+        harness.Daemon.MaxConcurrentBatchWritesPerDatabase = 2;
+
+        harness.Daemon.BatchWriteThrottle!.CurrentCount.ShouldBe(2);
+
+        // The agents read this through a live pass-through rather than capturing it, so an ALREADY
+        // running agent picks the new gate up - that is the half of the pacing story that has to work
+        // without restarting anything.
+        harness.Daemon.CurrentAgents()
+            .ShouldAllBe(x => ReferenceEquals(x.BatchWriteThrottle, harness.Daemon.BatchWriteThrottle));
+    }
+
+    [Fact]
+    public async Task batch_write_governor_can_be_disabled_at_runtime()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.MaxConcurrentBatchWritesPerDatabase = 4,
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        harness.Daemon.MaxConcurrentBatchWritesPerDatabase = 0;
+
+        harness.Daemon.BatchWriteThrottle.ShouldBeNull();
+        harness.Daemon.CurrentAgents().ShouldAllBe(x => x.BatchWriteThrottle == null);
+    }
+
+    [Fact]
+    public async Task resizing_the_load_governor_applies_to_agents_built_afterwards()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+        detector.SetTenantMark("t2", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.MaxConcurrentEventLoadsPerDatabase = 0,
+            shardFor(new ShardName("Trip")));
+
+        // Started while the governor was off, so this one's loader is unthrottled for its lifetime -
+        // the throttle is captured into the loader when the agent is built, not read per load.
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        harness.Daemon.MaxConcurrentEventLoadsPerDatabase = 3;
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t2", CancellationToken.None);
+
+        var agents = harness.Daemon.CurrentAgents().Cast<SubscriptionAgent>()
+            .ToDictionary(x => x.Name.Identity);
+
+        agents["Trip:All:t1"].Loader.ShouldNotBeOfType<ThrottledEventLoader>();
+        agents["Trip:All:t2"].Loader.ShouldBeOfType<ThrottledEventLoader>();
+    }
+
+    // The timer is deliberately private; there is no observable seam for "is it still waking up?"
+    // short of reaching for it, and the behavior below is worth pinning.
+    private static Timer TenantTimerOf(
+        JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>> daemon)
+    {
+        var field = daemon.GetType()
+            .GetField("_tenantHighWaterTimer", BindingFlags.Instance | BindingFlags.NonPublic);
+        return (Timer)field!.GetValue(daemon)!;
+    }
+
+    [Fact]
+    public async Task tenant_high_water_timer_idles_when_the_daemon_has_no_agents()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+        var timer = TenantTimerOf(harness.Daemon);
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        timer.Enabled.ShouldBeTrue();
+
+        await harness.Daemon.StopAllAsync();
+
+        // Used to run from construction until Dispose(), so a stopped daemon - or one whose database
+        // moved to another node - kept waking every SlowPollingTime forever to do nothing.
+        timer.Enabled.ShouldBeFalse();
+
+        // ...and comes back with the workload
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        timer.Enabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task tenant_high_water_timer_re_paces_when_slow_polling_time_changes()
+    {
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.SlowPollingTime = 100.Milliseconds(),
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        var timer = TenantTimerOf(harness.Daemon);
+        timer.Interval.ShouldBe(100);
+
+        // The interval used to be captured at construction, so this timer kept the original cadence for
+        // the daemon's whole life no matter what SlowPollingTime was re-paced to.
+        harness.Projections.SlowPollingTime = 400.Milliseconds();
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (Math.Abs(timer.Interval - 400) > 1 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+        }
+
+        timer.Interval.ShouldBe(400);
+    }
+
+    [Fact]
     public async Task second_start_of_the_same_tenant_identity_is_idempotent()
     {
         var detector = new StubPartitionedDetector();
@@ -318,15 +450,16 @@ public class PerTenantStartAgentAsyncTests
             Database.DatabaseUri.Returns(new Uri("fake://db1"));
             Database.Tracker.Returns(new ShardStateTracker(new NulloLogger()));
 
-            var projections = new FakeProjectionGraph();
-            configureSettings?.Invoke(projections);
+            Projections = new FakeProjectionGraph();
+            configureSettings?.Invoke(Projections);
 
             Daemon = new JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>(
-                Store, Database, new NulloLogger(), detector, projections);
+                Store, Database, new NulloLogger(), detector, Projections);
         }
 
         public IEventStore<FakeOperations, FakeSession> Store { get; }
         public IEventDatabase Database { get; }
+        public ProjectionGraph<IJasperFxProjection<FakeOperations>, FakeOperations, FakeSession> Projections { get; }
         public JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>> Daemon { get; }
 
         public async ValueTask DisposeAsync()

--- a/src/EventTests/SharedExceptionTests.cs
+++ b/src/EventTests/SharedExceptionTests.cs
@@ -10,6 +10,20 @@ namespace EventTests;
 public class SharedExceptionTests
 {
     [Fact]
+    public void concurrency_exception_preserves_an_inner_exception()
+    {
+        // Stores that detect the violation through their own exception (a CosmosDB 412 Precondition
+        // Failed, say) need to keep it attached, so error handling policies and logs can still see what
+        // the database actually said. Without a base ctor taking one, a derived exception cannot set
+        // InnerException at all - it is only settable through Exception(string, Exception).
+        var inner = new InvalidOperationException("412 Precondition Failed");
+        var ex = new ConcurrencyException("Saga was modified concurrently", inner);
+
+        ex.InnerException.ShouldBeSameAs(inner);
+        ex.Message.ShouldBe("Saga was modified concurrently");
+    }
+
+    [Fact]
     public void dcb_concurrency_exception_carries_query_and_sequence_and_is_a_concurrency_exception()
     {
         var query = new EventTagQuery().Or<Guid>(Guid.NewGuid());

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -43,11 +43,49 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
     // jasperfx#494 (epic #486 WS2): shared by every agent loader this daemon builds so the
     // database's connection footprint stays O(databases), not O(agents). Null = unthrottled.
-    private readonly SemaphoreSlim? _loadThrottle;
+    private SemaphoreSlim? _loadThrottle;
+    private int _maxConcurrentEventLoads;
 
     // Epic #486 WS3: bounds concurrent projection batch execute/commit sessions. Reaches the
     // executions through IDaemonRuntime -> SubscriptionAgent -> EventRange.Agent. Null = unbounded.
-    public SemaphoreSlim? BatchWriteThrottle { get; }
+    private SemaphoreSlim? _batchWriteThrottle;
+    private int _maxConcurrentBatchWrites;
+
+    public SemaphoreSlim? BatchWriteThrottle => _batchWriteThrottle;
+
+    /// <summary>
+    /// The per-database cap on concurrent event loads. Setting it replaces the throttle for agent
+    /// loaders built AFTER the change — a running agent captured its loader's throttle when it was
+    /// built (see ThrottledEventLoader), so resizing does not retroactively narrow an in-flight load.
+    /// Null or a non-positive value is unthrottled. Mirrors <see cref="MaxConcurrentRebuildsPerDatabase"/>:
+    /// the previous semaphore is deliberately not disposed, since callers may still be waiting on it.
+    /// </summary>
+    public int MaxConcurrentEventLoadsPerDatabase
+    {
+        get => _maxConcurrentEventLoads;
+        set
+        {
+            _maxConcurrentEventLoads = value;
+            _loadThrottle = value > 0 ? new SemaphoreSlim(value) : null;
+        }
+    }
+
+    /// <summary>
+    /// The per-database cap on concurrent projection batch execute/commit sessions. Unlike
+    /// <see cref="MaxConcurrentEventLoadsPerDatabase"/> this one reaches running agents immediately,
+    /// because they read it through a live pass-through (SubscriptionAgent.BatchWriteThrottle) rather
+    /// than capturing it. Null or a non-positive value is unbounded. The previous semaphore is
+    /// deliberately not disposed, since callers may still be waiting on it.
+    /// </summary>
+    public int MaxConcurrentBatchWritesPerDatabase
+    {
+        get => _maxConcurrentBatchWrites;
+        set
+        {
+            _maxConcurrentBatchWrites = value;
+            _batchWriteThrottle = value > 0 ? new SemaphoreSlim(value) : null;
+        }
+    }
 
     // jasperfx#497 (the #420 leftover): ONE shared budget per daemon (= per database) for rebuild
     // cells, spanning both fan-out layers — the CLI's projection-level fan-out AND the
@@ -98,13 +136,8 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _deadLetterBlock = buildDeadLetterBlock();
 
-        _loadThrottle = _projections.MaxConcurrentEventLoadsPerDatabase > 0
-            ? new SemaphoreSlim(_projections.MaxConcurrentEventLoadsPerDatabase)
-            : null;
-
-        BatchWriteThrottle = _projections.MaxConcurrentBatchWritesPerDatabase > 0
-            ? new SemaphoreSlim(_projections.MaxConcurrentBatchWritesPerDatabase)
-            : null;
+        MaxConcurrentEventLoadsPerDatabase = _projections.MaxConcurrentEventLoadsPerDatabase;
+        MaxConcurrentBatchWritesPerDatabase = _projections.MaxConcurrentBatchWritesPerDatabase;
 
         // jasperfx#497: explicit DaemonSettings knob wins, then the store-derived default. Concrete
         // stores typically fold the settings knob into their override already; the double-consult is
@@ -134,13 +167,8 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _deadLetterBlock = buildDeadLetterBlock();
 
-        _loadThrottle = _projections.MaxConcurrentEventLoadsPerDatabase > 0
-            ? new SemaphoreSlim(_projections.MaxConcurrentEventLoadsPerDatabase)
-            : null;
-
-        BatchWriteThrottle = _projections.MaxConcurrentBatchWritesPerDatabase > 0
-            ? new SemaphoreSlim(_projections.MaxConcurrentBatchWritesPerDatabase)
-            : null;
+        MaxConcurrentEventLoadsPerDatabase = _projections.MaxConcurrentEventLoadsPerDatabase;
+        MaxConcurrentBatchWritesPerDatabase = _projections.MaxConcurrentBatchWritesPerDatabase;
 
         // jasperfx#497: see the ILoggerFactory constructor overload for the resolution rationale
         MaxConcurrentRebuildsPerDatabase =
@@ -171,7 +199,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _breakSubscription.Dispose();
         _deadLetterBlock.Dispose();
         _loadThrottle?.Dispose();
-        BatchWriteThrottle?.Dispose();
+        _batchWriteThrottle?.Dispose();
         _rebuildBudget?.Dispose();
     }
 
@@ -790,9 +818,33 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     private Timer buildTenantHighWaterTimer()
     {
         var timer = new Timer(_projections.SlowPollingTime.TotalMilliseconds) { AutoReset = true };
-        timer.Elapsed += (_, _) => _ = pollTenantHighWaterOnCadenceAsync();
+        timer.Elapsed += (_, _) =>
+        {
+            syncTenantHighWaterInterval();
+            _ = pollTenantHighWaterOnCadenceAsync();
+        };
         timer.Start();
         return timer;
+    }
+
+    /// <summary>
+    /// Re-read SlowPollingTime every tick so a caller that re-paces the daemon at runtime is honored.
+    /// The interval used to be captured at construction, which left this timer polling at the original
+    /// cadence for the life of the daemon no matter what SlowPollingTime was changed to — the high-water
+    /// loop itself re-reads its polling times every wait, so this was the odd one out.
+    /// </summary>
+    private void syncTenantHighWaterInterval()
+    {
+        if (_tenantHighWaterTimer == null) return;
+
+        var desired = _projections.SlowPollingTime.TotalMilliseconds;
+        if (desired <= 0) return;
+
+        // Assigning Interval restarts the timer, so only touch it on a real change
+        if (Math.Abs(_tenantHighWaterTimer.Interval - desired) > 1)
+        {
+            _tenantHighWaterTimer.Interval = desired;
+        }
     }
 
     private async Task pollTenantHighWaterOnCadenceAsync()
@@ -827,7 +879,25 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // node. No-op for non-partitioned stores. jasperfx#407 Phase 2b.
     private void syncTenantPolling()
     {
-        _tenantHighWater?.SyncAssignedTenants(CurrentAgents().Select(x => x.Name));
+        var assigned = CurrentAgents().Select(x => x.Name).ToArray();
+        _tenantHighWater?.SyncAssignedTenants(assigned);
+
+        // Idle the cadence timer along with the daemon's actual workload. It used to run from
+        // construction until Dispose(), so a daemon that had been stopped — or one whose database was
+        // handed to another node — kept waking every SlowPollingTime forever to do nothing. The poll
+        // itself already no-ops via the _highWater.IsRunning guard, so this is housekeeping rather
+        // than a correctness fix, and StartAgentAsync's syncTenantPolling call starts it again.
+        if (_tenantHighWaterTimer == null) return;
+
+        if (assigned.Length == 0)
+        {
+            _tenantHighWaterTimer.Stop();
+        }
+        else if (!_tenantHighWaterTimer.Enabled)
+        {
+            syncTenantHighWaterInterval();
+            _tenantHighWaterTimer.Start();
+        }
     }
 
     public Task RecordDeadLetterEventAsync(DeadLetterEvent @event)

--- a/src/JasperFx/ConcurrencyException.cs
+++ b/src/JasperFx/ConcurrencyException.cs
@@ -40,6 +40,15 @@ public class ConcurrencyException: Exception
     {
     }
 
+    /// <summary>
+    /// Use when a store detects the concurrency violation through its own exception (say, a CosmosDB 412
+    /// Precondition Failed) and needs to keep that exception attached, so error handling policies and logs
+    /// can still see what the database actually said.
+    /// </summary>
+    public ConcurrencyException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
     public string DocType { get; set; }
     public object Id { get; set; }
 }


### PR DESCRIPTION
Three small additive changes. The first unblocks a Wolverine fix; the other two are what Wolverine's adaptive connection-budget work (wolverine#3397 Phase 2) needs from this side.

## 1. `ConcurrencyException(string, Exception)`

A derived exception **cannot** set `InnerException` unless a base constructor takes one — it's only settable through `Exception(string, Exception)`. Today `ConcurrencyException` offers `(Type, object)`, `(string, Type?, object)`, and `(string)`, so a store that detects the violation through its *own* exception has to choose between inheriting from `ConcurrencyException` and keeping the exception the database actually threw.

Wolverine's `SagaConcurrencyException` is exactly that case. It carries a CosmosDB 412 Precondition Failed as its inner exception, so it stays outside this hierarchy — which means an `OnException<ConcurrencyException>()` retry policy **silently never fires** for an EF Core or lightweight saga, even though Wolverine's own docs tell users to write one. With this ctor, Wolverine can inherit and keep the 412.

## 2. Resizable daemon governors

`MaxConcurrentEventLoadsPerDatabase` and `MaxConcurrentBatchWritesPerDatabase` become settable on `JasperFxAsyncDaemon`, mirroring the swap-on-set pattern `MaxConcurrentRebuildsPerDatabase` already uses. A host can then pace a database that's under connection pressure without rebuilding the daemon.

The two are **not** equivalent, and each property documents which it is:

- **`BatchWriteThrottle` reaches running agents immediately** — they read it through a live pass-through (`SubscriptionAgent.BatchWriteThrottle => _runtime.BatchWriteThrottle`).
- **The load throttle only applies to agents built afterwards** — it's captured into a `ThrottledEventLoader` when the agent is built, so resizing can't retroactively narrow an in-flight load.

Neither setter disposes the semaphore it replaces, since callers may still be waiting on it — same as `MaxConcurrentRebuildsPerDatabase`.

## 3. Tenant high-water timer: re-pace + idle

- **Re-pace:** the interval was captured at construction, so the timer kept the original cadence for the daemon's whole life regardless of what `SlowPollingTime` was later set to. The high-water loop already re-reads its polling times every wait — this timer was the odd one out. It now re-reads on each tick.
- **Idle:** the timer ran from construction until `Dispose()`, so a stopped daemon — or one whose database moved to another node — kept waking every `SlowPollingTime` to do nothing. It now stops when the daemon has no agents and starts again with the workload. The poll already no-opped via the `_highWater.IsRunning` guard, so this is housekeeping rather than a correctness fix.

## Note on what's *not* here

This started as a "add a `StopAndReleaseAsync()` for the 1→0 agent transition" item. On reading the code that turned out to be mostly unnecessary: `StopAllAsync()` **already** stops high-water, stops and drains the agents, drains the dead-letter block, rebuilds it, and resets the cancellation source — it's already a restartable quiesce. The only genuine leftover was the tenant timer, which item 3 covers.

A release method that disposed the throttles and the tracker subscription would also make the daemon single-use, which conflicts with callers that cache and reuse a daemon across reassignment (`IProjectionCoordinator` hands the same instance out, and rebuilds hold it across a replay). So the daemon stays reusable and this PR sticks to the parts that are real.

## Verification

EventTests (518) and CoreTests (462) pass. The new tests were each confirmed to fail without their fix — I neutered the re-pace and the idle-stop and watched both timer tests go red. The governor tests cover resize, disable, and the built-afterwards caveat; the ctor test pins that `InnerException` round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)