### PR TITLE
feat(CritterWatch#675): standalone display-only high-water monitor hook

### DIFF
--- a/src/EventTests/Daemon/HighWater/HighWaterMonitorTests.cs
+++ b/src/EventTests/Daemon/HighWater/HighWaterMonitorTests.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// CritterWatch#675: the standalone, display-only high-water monitor — just the high-water agent for a single
+// database, with no projection shards attached — so a monitoring tool can show a live event-store ceiling for a
+// store whose projections are all Inline/Live and therefore run no async daemon.
+public class HighWaterMonitorTests
+{
+    private static HighWaterMonitor buildMonitor(SeedingDetector detector)
+    {
+        var settings = new DaemonSettings { Wakeup = new BlockingWakeup() };
+        return new HighWaterMonitor(new Meter("jasperfx.tests.highwatermonitor"), detector, settings,
+            NullLogger.Instance);
+    }
+
+    [Fact]
+    public async Task starting_seeds_the_current_mark_onto_the_tracker()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SeedingDetector(seedMark: 100);
+        var monitor = buildMonitor(detector);
+
+        monitor.IsRunning.ShouldBeFalse();
+        monitor.CurrentMark.ShouldBe(0);
+
+        await monitor.StartAsync(cts.Token);
+
+        monitor.IsRunning.ShouldBeTrue();
+        monitor.CurrentMark.ShouldBe(100);
+        monitor.Tracker.HighWaterMark.ShouldBe(100);
+        monitor.DatabaseUri.ShouldBe(detector.DatabaseUri);
+
+        await monitor.StopAsync();
+    }
+
+    [Fact]
+    public async Task can_be_stopped_and_restarted()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SeedingDetector(seedMark: 42);
+        var monitor = buildMonitor(detector);
+
+        await monitor.StartAsync(cts.Token);
+        monitor.IsRunning.ShouldBeTrue();
+
+        await monitor.StopAsync();
+        monitor.IsRunning.ShouldBeFalse();
+
+        await monitor.StartAsync(cts.Token);
+        monitor.IsRunning.ShouldBeTrue();
+
+        await monitor.StopAsync();
+    }
+
+    [Fact]
+    public async Task detect_is_an_on_demand_read_that_does_not_require_starting()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SeedingDetector(seedMark: 7);
+        var monitor = buildMonitor(detector);
+
+        var stats = await monitor.DetectAsync(cts.Token);
+
+        stats.CurrentMark.ShouldBe(7);
+        monitor.IsRunning.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task dispose_stops_the_monitor()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SeedingDetector(seedMark: 5);
+        var monitor = buildMonitor(detector);
+
+        await monitor.StartAsync(cts.Token);
+        monitor.IsRunning.ShouldBeTrue();
+
+        await monitor.DisposeAsync();
+        monitor.IsRunning.ShouldBeFalse();
+    }
+
+    // A partitioning detector seeds the mark once at StartAsync and never runs the recurring loop, which keeps the
+    // seed deterministic while still exercising the publish-to-tracker path.
+    private sealed class SeedingDetector: IHighWaterDetector
+    {
+        private readonly long _seedMark;
+
+        public SeedingDetector(long seedMark) => _seedMark = seedMark;
+
+        public Uri DatabaseUri { get; } = new("fake://display-only-db");
+
+        // Skips the recurring loop so the seed value is the only mark published — makes the assertions deterministic.
+        public bool SupportsTenantPartitioning => true;
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token) =>
+            Task.FromResult(new HighWaterStatistics { CurrentMark = _seedMark, HighestSequence = _seedMark });
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+    }
+
+    private sealed class BlockingWakeup: IDaemonWakeup
+    {
+        public Task WaitAsync(TimeSpan timeout, CancellationToken token) => Task.Delay(Timeout.Infinite, token);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterMonitor.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterMonitor.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Core;
+using Microsoft.Extensions.Logging;
+
+namespace JasperFx.Events.Daemon.HighWater;
+
+/// <summary>
+///     Reusable, store-agnostic implementation of <see cref="IHighWaterMonitor" /> that wraps a single
+///     <see cref="HighWaterAgent" /> — the same high-water polling loop a full daemon runs — without any projection
+///     shards. Concrete event stores (Marten, Polecat) construct one of these from their own
+///     <see cref="IHighWaterDetector" /> + <see cref="DaemonSettings" /> to satisfy
+///     <see cref="IEventStore.BuildHighWaterMonitorAsync" />, so the standalone-detector contract lives here rather
+///     than being re-implemented per store. See <see href="https://github.com/JasperFx/CritterWatch/issues/675" />.
+/// </summary>
+public class HighWaterMonitor : IHighWaterMonitor
+{
+    private readonly Meter _meter;
+    private readonly IHighWaterDetector _detector;
+    private readonly DaemonSettings _settings;
+    private readonly ILogger _logger;
+    private readonly bool _ownsTracker;
+
+    private HighWaterAgent? _agent;
+    private CancellationTokenSource? _cancellation;
+
+    /// <param name="meter">The event store's <see cref="IEventStore.Meter" />, so the standalone loop emits the same skip metric a full daemon does.</param>
+    /// <param name="detector">The store's high-water detector for the target database.</param>
+    /// <param name="settings">Daemon settings governing polling cadence and stale-gap handling.</param>
+    /// <param name="logger">Logger for the agent's diagnostic output.</param>
+    /// <param name="tracker">
+    ///     Optional tracker to publish high-water progression to. When null the monitor creates and owns its own,
+    ///     which is the display-only default: the monitor runs independently of any projection daemon, so it does
+    ///     not borrow a daemon's tracker.
+    /// </param>
+    public HighWaterMonitor(Meter meter, IHighWaterDetector detector, DaemonSettings settings, ILogger logger,
+        ShardStateTracker? tracker = null)
+    {
+        _meter = meter;
+        _detector = detector;
+        _settings = settings;
+        _logger = logger;
+
+        _ownsTracker = tracker == null;
+        Tracker = tracker ?? new ShardStateTracker(logger);
+    }
+
+    public Uri DatabaseUri => _detector.DatabaseUri;
+
+    public ShardStateTracker Tracker { get; }
+
+    public long CurrentMark => Tracker.HighWaterMark;
+
+    public bool IsRunning => _agent is { IsRunning: true };
+
+    public async Task StartAsync(CancellationToken token)
+    {
+        if (IsRunning)
+        {
+            return;
+        }
+
+        // Fresh linked source per start so the monitor can be stopped and restarted (e.g. as single-node
+        // election moves the detector between nodes).
+        _cancellation = CancellationTokenSource.CreateLinkedTokenSource(token);
+        _agent = new HighWaterAgent(_meter, _detector, Tracker, _logger, _settings, _cancellation.Token);
+        await _agent.StartAsync().ConfigureAwait(false);
+    }
+
+    public async Task StopAsync()
+    {
+        if (_agent != null)
+        {
+            await _agent.StopAsync().ConfigureAwait(false);
+            _agent.SafeDispose();
+            _agent = null;
+        }
+
+        if (_cancellation != null)
+        {
+            await _cancellation.CancelAsync().ConfigureAwait(false);
+            _cancellation.SafeDispose();
+            _cancellation = null;
+        }
+    }
+
+    public Task<HighWaterStatistics> DetectAsync(CancellationToken token)
+    {
+        return _detector.Detect(token);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+        if (_ownsTracker)
+        {
+            (Tracker as IDisposable)?.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/JasperFx.Events/Daemon/HighWater/IHighWaterMonitor.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/IHighWaterMonitor.cs
@@ -1,0 +1,57 @@
+namespace JasperFx.Events.Daemon.HighWater;
+
+/// <summary>
+///     A standalone, display-only high-water detector: just the high-water agent for a single
+///     <see cref="IEventDatabase" />, running on one node, with no projection shards attached. It exists so a
+///     monitoring tool (CritterWatch) can show a live event-store "ceiling" for stores whose projections are all
+///     Inline/Live and therefore run no async daemon — there is otherwise no high-water progression to display.
+///     See <see href="https://github.com/JasperFx/CritterWatch/issues/675" />.
+///     <para>
+///     This is deliberately narrower than <see cref="IProjectionDaemon" />: it neither starts nor tracks any
+///     projection, so standing one up does not require registering a projection. The caller owns the lifecycle —
+///     start it on exactly one node (reuse the host's leader/agent election rather than a bespoke one) and stop it
+///     when the node stands down. Observe progression via <see cref="Tracker" />; the running loop publishes a
+///     <see cref="Projections.ShardState.HighWaterMark" /> state whenever the mark advances, exactly as a full
+///     daemon's high-water agent does.
+///     </para>
+/// </summary>
+public interface IHighWaterMonitor : IAsyncDisposable
+{
+    /// <summary>
+    ///     Subject URI of the <see cref="IEventDatabase" /> this monitor polls, matching
+    ///     <see cref="IHighWaterDetector.DatabaseUri" />.
+    /// </summary>
+    Uri DatabaseUri { get; }
+
+    /// <summary>
+    ///     Observable the monitor publishes high-water progression to. A consumer subscribes here for the same
+    ///     <see cref="Projections.ShardState.HighWaterMark" /> states a full daemon would emit.
+    /// </summary>
+    ShardStateTracker Tracker { get; }
+
+    /// <summary>
+    ///     The most recently observed high-water mark, or 0 before the first successful detection.
+    /// </summary>
+    long CurrentMark { get; }
+
+    /// <summary>
+    ///     Is the recurring polling loop currently running?
+    /// </summary>
+    bool IsRunning { get; }
+
+    /// <summary>
+    ///     Start the recurring high-water polling loop. Call on exactly one node.
+    /// </summary>
+    Task StartAsync(CancellationToken token);
+
+    /// <summary>
+    ///     Stop the recurring polling loop. The monitor may be restarted with <see cref="StartAsync" />.
+    /// </summary>
+    Task StopAsync();
+
+    /// <summary>
+    ///     Perform a single on-demand high-water detection without relying on the recurring loop — useful for a
+    ///     one-shot "where is the ceiling right now?" read.
+    /// </summary>
+    Task<HighWaterStatistics> DetectAsync(CancellationToken token);
+}

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Metrics;
 using System.Text.Json;
 using JasperFx.Descriptors;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
 using JasperFx.Events.Descriptors;
 using JasperFx.Events.Projections;
 using Microsoft.Extensions.Logging;
@@ -72,6 +73,29 @@ public interface IEventStore
     /// </summary>
     ValueTask<IReadOnlyList<IEventDatabase>> AllDatabases()
         => ValueTask.FromResult<IReadOnlyList<IEventDatabase>>([]);
+
+    /// <summary>
+    ///     Build a standalone, display-only high-water monitor for a single database — just the high-water agent,
+    ///     with no projection shards attached, so a monitoring tool can show a live event-store "ceiling" for a
+    ///     store whose projections are all Inline/Live and therefore run no async daemon. This is the abstraction
+    ///     CritterWatch reaches for instead of <see cref="BuildProjectionDaemonAsync(string?, ILogger?)" /> when it
+    ///     only wants the store's head sequence to progress, not any projection to run. The caller owns the
+    ///     lifecycle: start the returned monitor on exactly one node (reuse the host's leader/agent election) and
+    ///     stop it when the node stands down. The default implementation throws <see cref="NotSupportedException" />;
+    ///     event stores (Marten, Polecat) override this to construct a <see cref="HighWaterMonitor" /> from their own
+    ///     <see cref="IHighWaterDetector" /> and <see cref="DaemonSettings" />.
+    ///     See <see href="https://github.com/JasperFx/CritterWatch/issues/675" />.
+    /// </summary>
+    /// <param name="tenantIdOrDatabaseIdentifier">
+    ///     Resolves which database to monitor, matching <see cref="BuildProjectionDaemonAsync(string?, ILogger?)" />.
+    ///     Null selects the default/main database.
+    /// </param>
+    /// <param name="logger">Optional logger for the monitor's diagnostic output.</param>
+    ValueTask<IHighWaterMonitor> BuildHighWaterMonitorAsync(
+        string? tenantIdOrDatabaseIdentifier = null,
+        ILogger? logger = null)
+        => throw new NotSupportedException(
+            "BuildHighWaterMonitorAsync is not implemented on this IEventStore. Use an event store (Marten or Polecat) that supports standing up a standalone display-only high-water detector.");
 
     /// <summary>
     /// Identifies the event store within an application


### PR DESCRIPTION
## What

Adds interface hooks so a monitoring tool (CritterWatch) can stand up a **standalone, display-only high-water detector** — just the high-water agent for a single database, with no projection shards attached — without registering a full projection daemon.

Supports [CritterWatch#675](https://github.com/JasperFx/CritterWatch/issues/675): when every projection on a store is Inline/Live there is no async daemon running, so there is no live high-water progression to display. This lets operators opt in to a display-only detector that surfaces the event-store "ceiling."

## Changes

- **`IHighWaterMonitor`** — display-only monitor abstraction: `StartAsync`/`StopAsync`/`DetectAsync`, current mark, and progression observable via `ShardStateTracker`. The caller owns the single-node lifecycle (reuse the host's leader/agent election, per the issue's design notes).
- **`HighWaterMonitor`** — reusable, store-agnostic implementation wrapping the existing `HighWaterAgent`, so concrete stores (Marten/Polecat) don't re-implement the standalone-detector contract. Supports stop/restart and owns its own tracker by default.
- **`IEventStore.BuildHighWaterMonitorAsync`** — factory hook mirroring `BuildProjectionDaemonAsync`, defaulting to `NotSupportedException` so downstream stores keep compiling until they opt in.

## Downstream safety

All new surface is a default-implemented interface method plus additive types — no existing implementation breaks. Concrete stores override `BuildHighWaterMonitorAsync` to construct a `HighWaterMonitor` from their own `IHighWaterDetector` + `DaemonSettings`.

## Tests

`HighWaterMonitorTests` covers seeding the current mark onto the tracker, stop/restart, on-demand `DetectAsync` without starting, and dispose-stops-the-monitor. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)