### PR TITLE
fix(#524): HighWaterAgent survives a throwing wakeup; watchdog restarts a faulted loop

### DIFF
--- a/src/EventTests/Daemon/HighWater/HighWaterAgent_loop_robustness_Tests.cs
+++ b/src/EventTests/Daemon/HighWater/HighWaterAgent_loop_robustness_Tests.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// #524 (split from marten#4961): two robustness defects in the HighWaterAgent poll loop.
+//  * Defect A — an IDaemonWakeup that throws (e.g. Marten's LISTEN/NOTIFY wakeup reconnecting against a downed
+//    database) must not escape the loop and permanently stop high-water progress. The wakeup is now treated as
+//    untrusted: a throw is logged and the loop falls back to a delay and continues.
+//  * Defect C — Task.Factory.StartNew over the async loop delegate returned a Task<Task>, so the checkState
+//    watchdog inspected the always-successful outer task and never saw (or restarted) a faulted loop. The loop
+//    is now unwrapped, so a fault is observed and the loop restarts itself.
+public class HighWaterAgent_loop_robustness_Tests
+{
+    // Defect A: a wakeup that throws does not tear down the poll loop — the loop swallows it, waits, and keeps
+    // polling, so it reaches a *second* wakeup after at least one more Detect().
+    [Fact]
+    public async Task a_throwing_wakeup_does_not_kill_the_poll_loop()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new CountingDetector();
+        var wakeup = new ThrowOnceThenBlockWakeup();
+        var settings = new DaemonSettings { Wakeup = wakeup };
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+
+        var agent = new HighWaterAgent(new Meter("jasperfx.tests.highwater.defectA"), detector, tracker,
+            NullLogger.Instance, settings, cts.Token);
+
+        await agent.StartAsync();
+
+        // With the bug the first wakeup throw escapes detectChanges and the loop dies here; with the fix the
+        // loop recovers and reaches the (blocking) second wakeup.
+        (await wakeup.ReachedSecondWaitWithin(5.Seconds())).ShouldBeTrue();
+        detector.DetectCount.ShouldBeGreaterThanOrEqualTo(2);
+        agent.IsRunning.ShouldBeTrue();
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    // Defect C: a loop that faults (here through the unguarded DetectInSafeZone throw in the stale branch) is
+    // seen by the watchdog and restarted, so the recovered detector advances the mark on its own.
+    [Fact]
+    public async Task the_watchdog_restarts_a_faulted_loop()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new FaultThenRecoverDetector();
+        var settings = new DaemonSettings
+        {
+            // StaleThreshold=0 forces the stale branch straight into DetectInSafeZone; small poll/health
+            // intervals keep the fault-then-restart cycle quick and deterministic.
+            StaleSequenceThreshold = TimeSpan.Zero,
+            FastPollingTime = 25.Milliseconds(),
+            SlowPollingTime = 25.Milliseconds(),
+            HealthCheckPollingTime = 200.Milliseconds()
+        };
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+
+        var agent = new HighWaterAgent(new Meter("jasperfx.tests.highwater.defectC"), detector, tracker,
+            NullLogger.Instance, settings, cts.Token);
+
+        await agent.StartAsync();
+
+        // First pass faults the loop. With the unwrap fix the watchdog restarts it and the mark reaches 10;
+        // with the bug the outer Task<Task> never reports IsFaulted, so the loop is never restarted and the
+        // mark is stuck at 0.
+        (await waitForMark(tracker, 10, 5.Seconds())).ShouldBeTrue();
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    private static async Task<bool> waitForMark(ShardStateTracker tracker, long expected, TimeSpan timeout)
+    {
+        var elapsed = TimeSpan.Zero;
+        var step = 25.Milliseconds();
+        while (elapsed < timeout)
+        {
+            if (tracker.HighWaterMark >= expected)
+            {
+                return true;
+            }
+
+            await Task.Delay(step);
+            elapsed += step;
+        }
+
+        return tracker.HighWaterMark >= expected;
+    }
+
+    private sealed class CountingDetector: IHighWaterDetector
+    {
+        private int _detectCount;
+
+        public Uri DatabaseUri { get; } = new("fake://defect-a-db");
+        public bool SupportsTenantPartitioning => false;
+        public int DetectCount => Volatile.Read(ref _detectCount);
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+        {
+            Interlocked.Increment(ref _detectCount);
+            return Task.FromResult(new HighWaterStatistics { CurrentMark = 0, HighestSequence = 0 });
+        }
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+    }
+
+    // Throws on the first wakeup (as a reconnecting LISTEN/NOTIFY wakeup would against a downed DB), then signals
+    // and blocks forever so the loop parks deterministically at its second wakeup.
+    private sealed class ThrowOnceThenBlockWakeup: IDaemonWakeup
+    {
+        private int _calls;
+        private readonly TaskCompletionSource _secondWait = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitAsync(TimeSpan timeout, CancellationToken token)
+        {
+            if (Interlocked.Increment(ref _calls) == 1)
+            {
+                throw new InvalidOperationException("Simulated wakeup connection failure");
+            }
+
+            _secondWait.TrySetResult();
+            return Task.Delay(Timeout.Infinite, token);
+        }
+
+        public async Task<bool> ReachedSecondWaitWithin(TimeSpan timeout)
+        {
+            var winner = await Task.WhenAny(_secondWait.Task, Task.Delay(timeout));
+            return winner == _secondWait.Task;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    // Reports a stale sequence (CurrentMark behind HighestSequence) so the agent drops into the stale branch,
+    // where the first DetectInSafeZone throws and faults the loop. After the watchdog restarts the loop, the
+    // second DetectInSafeZone recovers and reports a caught-up mark of 10.
+    private sealed class FaultThenRecoverDetector: IHighWaterDetector
+    {
+        // A fixed, non-default timestamp shared by the seed and the stale reading so that, with
+        // StaleSequenceThreshold=0, safeHarborTime == the reading's timestamp and the branch proceeds to
+        // DetectInSafeZone instead of parking.
+        private static readonly DateTimeOffset Timestamp = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        private readonly object _lock = new();
+        private bool _safeZoneThrew;
+        private bool _recovered;
+
+        public Uri DatabaseUri { get; } = new("fake://faulting-db");
+        public bool SupportsTenantPartitioning => false;
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+        {
+            lock (_lock)
+            {
+                return Task.FromResult(_recovered
+                    ? new HighWaterStatistics { CurrentMark = 10, HighestSequence = 10, Timestamp = Timestamp }
+                    : new HighWaterStatistics { CurrentMark = 0, HighestSequence = 10, Timestamp = Timestamp });
+            }
+        }
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token)
+        {
+            lock (_lock)
+            {
+                if (!_safeZoneThrew)
+                {
+                    _safeZoneThrew = true;
+                    throw new InvalidOperationException("Simulated connection failure inside the high-water loop");
+                }
+
+                _recovered = true;
+                return Task.FromResult(new HighWaterStatistics
+                {
+                    CurrentMark = 10, HighestSequence = 10, Timestamp = Timestamp
+                });
+            }
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
@@ -19,7 +19,7 @@ public class HighWaterAgent: IDisposable
     private readonly IDaemonWakeup _daemonWakeup;
 
     private HighWaterStatistics? _current;
-    private Task<Task> _loop = null!;
+    private Task _loop = null!;
     private readonly CancellationToken _token;
     private readonly string _spanName;
     private readonly Counter<int> _skipping;
@@ -81,12 +81,48 @@ public class HighWaterAgent: IDisposable
             return;
         }
 
+        // #524 (defect C): StartNew over an async delegate hands back a Task<Task> that completes as soon as
+        // detectChanges hits its first await — the real poll loop is the inner task. Unwrap so _loop *is* that
+        // inner task; otherwise _loop.IsFaulted is always false and the checkState watchdog can never see the
+        // loop fault, let alone restart it.
         _loop = Task.Factory.StartNew(detectChanges, _token,
-            TaskCreationOptions.LongRunning | TaskCreationOptions.AttachedToParent, TaskScheduler.Default);
+            TaskCreationOptions.LongRunning | TaskCreationOptions.AttachedToParent, TaskScheduler.Default).Unwrap();
 
         _timer.Start();
 
         _logger.LogInformation("Started HighWaterAgent for database {Name}", _detector.DatabaseUri);
+    }
+
+    // #524 (defect A): the IDaemonWakeup implementation is untrusted. A custom wakeup — e.g. Marten's
+    // LISTEN/NOTIFY wakeup, which reconnects a dropped LISTEN connection — can throw a connection error when
+    // the database is down or failing over. Such a throw must never escape the poll loop and permanently kill
+    // high-water progress, so log it and fall back to a plain delay before the loop continues. Cancellation is
+    // the expected shutdown path and is swallowed quietly.
+    private async Task waitAsync(TimeSpan delayTime)
+    {
+        try
+        {
+            await _daemonWakeup.WaitAsync(delayTime, _token).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            if (_token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _logger.LogError(e,
+                "Error while waiting on the daemon wakeup for database {Name}; falling back to a delay",
+                _detector.DatabaseUri);
+
+            try
+            {
+                await Task.Delay(delayTime, _token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
     }
 
     private async Task detectChanges()
@@ -112,7 +148,7 @@ public class HighWaterAgent: IDisposable
             _logger.LogError(e, "Failed while making the initial determination of the high water mark for database {Name}", _detector.DatabaseUri);
         }
 
-        await _daemonWakeup.WaitAsync(_settings.FastPollingTime, _token).ConfigureAwait(false);
+        await waitAsync(_settings.FastPollingTime).ConfigureAwait(false);
 
         while (!_token.IsCancellationRequested)
         {
@@ -137,7 +173,7 @@ public class HighWaterAgent: IDisposable
                 }
 
                 _logger.LogError(ex, "Failed while trying to detect high water statistics for database {Name}", _detector.DatabaseUri);
-                await _daemonWakeup.WaitAsync(_settings.SlowPollingTime, _token).ConfigureAwait(false);
+                await waitAsync(_settings.SlowPollingTime).ConfigureAwait(false);
 
                 activity?.AddException(ex);
 
@@ -148,7 +184,7 @@ public class HighWaterAgent: IDisposable
             {
                 _logger.LogError(e, "Failed while trying to detect high water statistics for database {Name}", _detector.DatabaseUri);
                 activity?.AddException(e);
-                await _daemonWakeup.WaitAsync(_settings.SlowPollingTime, _token).ConfigureAwait(false);
+                await waitAsync(_settings.SlowPollingTime).ConfigureAwait(false);
                 continue;
             }
 
@@ -172,7 +208,7 @@ public class HighWaterAgent: IDisposable
                     var safeHarborTime = _current!.Timestamp.Add(_settings.StaleSequenceThreshold);
                     if (safeHarborTime > statistics.Timestamp)
                     {
-                        await _daemonWakeup.WaitAsync(_settings.SlowPollingTime, _token).ConfigureAwait(false);
+                        await waitAsync(_settings.SlowPollingTime).ConfigureAwait(false);
                         continue;
                     }
 
@@ -234,7 +270,7 @@ public class HighWaterAgent: IDisposable
                 _current = statistics;
             }
 
-            await _daemonWakeup.WaitAsync(delayTime, _token).ConfigureAwait(false);
+            await waitAsync(delayTime).ConfigureAwait(false);
             return;
         }
 
@@ -247,7 +283,7 @@ public class HighWaterAgent: IDisposable
 
         await _tracker.MarkHighWaterAsync(statistics.CurrentMark, lastAdvancedFrom(statistics));
 
-        await _daemonWakeup.WaitAsync(delayTime, _token).ConfigureAwait(false);
+        await waitAsync(delayTime).ConfigureAwait(false);
     }
 
     // Surface "when the current mark was observed" (jasperfx#449) so a monitor can compute
@@ -315,13 +351,18 @@ public class HighWaterAgent: IDisposable
         try
         {
             _timer?.Stop();
+
+            // #524 (defect C): now that _loop is the unwrapped inner poll task, awaiting it here genuinely
+            // blocks until the loop exits. The loop only breaks when it sees cancellation or IsRunning == false,
+            // so IsRunning must be cleared *before* the await — otherwise a loop parked in a wakeup wakes, never
+            // sees the stop signal, and StopAsync hangs forever on a stop that did not cancel the token.
+            IsRunning = false;
+
             if (_loop != null)
             {
                 await _loop.ConfigureAwait(false);
                 _loop?.Dispose();
             }
-
-            IsRunning = false;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Closes #524 (split from marten#4961).

Two `IDaemonWakeup`-agnostic, tenancy/mode-agnostic robustness defects in the `HighWaterAgent` poll loop. A routine, recoverable infra event (Postgres restart / managed-DB failover / maintenance window) could otherwise permanently stop all projection progress on a node, with the killing exception never surfaced and the watchdog never firing, until the process was restarted.

## Defect A — the poll loop awaited `IDaemonWakeup.WaitAsync` outside any try/catch

Every `await _daemonWakeup.WaitAsync(...)` in the loop (initial delay, both `Detect()` catch blocks, the stale branch, and both `markProgressAsync` calls) was unguarded. A wakeup that throws — Marten's `PostgresqlListenWakeup` reconnects a dropped LISTEN connection and can throw when the DB is down — propagated out of `detectChanges` and ended the loop task. The default `TaskDelayDaemonWakeup` can't throw a connection error, which is why this only surfaced with a custom wakeup.

**Fix:** treat the wakeup as untrusted. A new `waitAsync` helper wraps `WaitAsync`; a non-cancellation throw is logged and the loop falls back to a plain `Task.Delay` before continuing. Cancellation stays the quiet shutdown path.

## Defect C — the restart watchdog observed the wrong task

`Task.Factory.StartNew(detectChanges, …)` over an `async Task` returns a `Task<Task>` that completes **successfully** as soon as the method hits its first `await` — the real loop is the *inner* task. So `_loop.IsFaulted` was essentially always `false`, `checkState` never saw the inner loop fault, and `StartAsync()` was never called to restart it.

**Fix:** `.Unwrap()` the started task so `_loop` *is* the inner loop and `checkState`'s existing restart logic works. Awaiting the unwrapped loop in `StopAsync` now genuinely blocks until it exits, so `IsRunning` is cleared **before** that await — otherwise a loop parked in a wakeup would never see the stop signal and `StopAsync` would hang on a stop that didn't cancel the token.

## Tests

`HighWaterAgent_loop_robustness_Tests` — deterministic coverage for both:
- `a_throwing_wakeup_does_not_kill_the_poll_loop` — a wakeup that throws on its first call; the loop recovers and reaches a second wakeup after another `Detect()`.
- `the_watchdog_restarts_a_faulted_loop` — the loop faults via an unguarded `DetectInSafeZone` throw in the stale branch; the watchdog restarts it and the recovered detector advances the mark.

All 28 `Daemon.HighWater` tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)