### PR TITLE
feat(#525): deferred single-flush rebuild writes (flag-gated, default off)

### DIFF
--- a/src/EventTests/Daemon/AggregationRunnerDeferredRebuildTests.cs
+++ b/src/EventTests/Daemon/AggregationRunnerDeferredRebuildTests.cs
@@ -1,0 +1,311 @@
+using EventTests.Projections;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#525: the deferred single-flush rebuild accumulator. During a rebuild with RebuildFlushThreshold > 0,
+// AggregationRunner buffers the latest snapshot (or tombstone) per aggregate id instead of writing per page, and
+// emits exactly one operation per aggregate when it flushes at the threshold or the rebuild ceiling. These tests
+// drive ApplyChangesAsync + the flush directly (the pattern AggregationRunnerDeleteEventTests established). The
+// multi-page read-through invariant is covered end-to-end by Marten's integration harness.
+public class AggregationRunnerDeferredRebuildTests
+{
+    private readonly IAggregationProjection<User, Guid, FakeOperations, FakeSession> theProjection =
+        Substitute.For<IAggregationProjection<User, Guid, FakeOperations, FakeSession>>();
+
+    private readonly IProjectionStorage<User, Guid> theStorage = Substitute.For<IProjectionStorage<User, Guid>>();
+    private readonly IAggregateCache<Guid, User> theCache = Substitute.For<IAggregateCache<Guid, User>>();
+    private readonly IProjectionBatch theBatch = Substitute.For<IProjectionBatch>();
+    private readonly IEventStore<FakeOperations, FakeSession> theStore =
+        Substitute.For<IEventStore<FakeOperations, FakeSession>>();
+
+    private readonly AsyncOptions theOptions = new() { RebuildFlushThreshold = 100 };
+    private readonly AggregationRunner<User, Guid, FakeOperations, FakeSession> theRunner;
+
+    public AggregationRunnerDeferredRebuildTests()
+    {
+        theProjection.Options.Returns(theOptions);
+        theProjection.Scope.Returns(AggregationScope.MultiStream);
+        theStorage.TenantId.Returns("foo");
+
+        theRunner = new AggregationRunner<User, Guid, FakeOperations, FakeSession>(
+            theStore,
+            Substitute.For<IEventDatabase>(),
+            theProjection,
+            SliceBehavior.None,
+            Substitute.For<IEventSlicer>(),
+            NullLogger.Instance);
+    }
+
+    // Configure the projection so a slice resolves to ActionType.Store yielding the given snapshot.
+    private void storeYields(User snapshot)
+    {
+        theProjection.MatchesAnyDeleteType(Arg.Any<IReadOnlyList<IEvent>>()).Returns(false);
+        theProjection
+            .DetermineActionAsync(Arg.Any<FakeSession>(), Arg.Any<User?>(), Arg.Any<Guid>(),
+                Arg.Any<IProjectionStorage<User, Guid>>(), Arg.Any<IReadOnlyList<IEvent>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<(User?, ActionType)>((snapshot, ActionType.Store)));
+        theProjection
+            .TryApplyMetadata(Arg.Any<IReadOnlyList<IEvent>>(), Arg.Any<User?>(), Arg.Any<Guid>(),
+                Arg.Any<IProjectionStorage<User, Guid>>())
+            .Returns(((IEvent?)null, snapshot));
+    }
+
+    private async Task applyStoreAsync(Guid id, User snapshot)
+    {
+        storeYields(snapshot);
+        var slice = new EventSlice<User, Guid>(id, "foo", new IEvent[] { new Event<AEvent>(new AEvent()) });
+        await theRunner.ApplyChangesAsync(ShardExecutionMode.Rebuild, theBatch, new FakeOperations(), slice,
+            theStorage, theCache, CancellationToken.None);
+    }
+
+    // Drive the DeleteEvent<T> short-circuit: a matching delete event plus a pre-existing snapshot (stream
+    // ownership) records a delete tombstone into the accumulator.
+    private async Task applyDeleteAsync(Guid id, User preExisting)
+    {
+        theProjection.MatchesAnyDeleteType(Arg.Any<IReadOnlyList<IEvent>>()).Returns(true);
+        var slice = new EventSlice<User, Guid>(id, "foo", new IEvent[] { new Event<AEvent>(new AEvent()) })
+        {
+            Snapshot = preExisting
+        };
+        await theRunner.ApplyChangesAsync(ShardExecutionMode.Rebuild, theBatch, new FakeOperations(), slice,
+            theStorage, theCache, CancellationToken.None);
+    }
+
+    private EventRange flushRange(long ceiling, long highWaterMark = 0)
+    {
+        var agent = Substitute.For<ISubscriptionAgent>();
+        agent.HighWaterMark.Returns(highWaterMark);
+        agent.Metrics.Returns(Substitute.For<ISubscriptionMetrics>());
+        return new EventRange(agent, 0, ceiling);
+    }
+
+    // Wire theStore.StartProjectionBatchAsync -> a substitute batch whose per-tenant session hands back theStorage,
+    // so the flush's writes land on the storage substitute we assert against.
+    private IProjectionBatch<FakeOperations, FakeSession> wireFlushBatch()
+    {
+        var batch = Substitute.For<IProjectionBatch<FakeOperations, FakeSession>>();
+        var operations = new FakeOperations { ProjectionStorage = theStorage };
+        batch.SessionForTenant("foo").Returns(operations);
+        theStore
+            .StartProjectionBatchAsync(Arg.Any<EventRange>(), Arg.Any<IEventDatabase>(),
+                ShardExecutionMode.Rebuild, Arg.Any<AsyncOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IProjectionBatch<FakeOperations, FakeSession>>(batch));
+        return batch;
+    }
+
+    [Fact]
+    public void defers_only_for_rebuild_individual_batches_with_a_positive_threshold()
+    {
+        var individual = new EventRange(Substitute.For<ISubscriptionAgent>(), 0, 10)
+            { BatchBehavior = BatchBehavior.Individual };
+        var composite = new EventRange(Substitute.For<ISubscriptionAgent>(), 0, 10)
+            { BatchBehavior = BatchBehavior.Composite };
+
+        theRunner.DefersRebuildWrites(ShardExecutionMode.Rebuild, individual).ShouldBeTrue();
+
+        // Off in every other mode, for composite batches, and when the threshold is 0.
+        theRunner.DefersRebuildWrites(ShardExecutionMode.Continuous, individual).ShouldBeFalse();
+        theRunner.DefersRebuildWrites(ShardExecutionMode.CatchUp, individual).ShouldBeFalse();
+        theRunner.DefersRebuildWrites(ShardExecutionMode.Rebuild, composite).ShouldBeFalse();
+
+        theOptions.RebuildFlushThreshold = 0;
+        theRunner.DefersRebuildWrites(ShardExecutionMode.Rebuild, individual).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task accumulates_without_writing_until_flush()
+    {
+        theRunner.BeginDeferredRebuildWindowForTesting();
+
+        var id = Guid.NewGuid();
+        await applyStoreAsync(id, new User("Beast", "Hank"));
+        await applyStoreAsync(id, new User("Beast", "Hank McCoy")); // same id, later page
+
+        // Nothing hit the database during accumulation, and the two writes for one id collapse to one dirty entry.
+        theStorage.DidNotReceive().StoreProjection(Arg.Any<User>(), Arg.Any<IEvent?>(), Arg.Any<AggregationScope>());
+        theStorage.DidNotReceiveWithAnyArgs()
+            .StoreProjectionForRebuildFlush(default!, default, default, default);
+        theRunner.DeferredWriteCount.ShouldBe(1);
+
+        wireFlushBatch();
+        var range = flushRange(50);
+        await theRunner.FlushDeferredRebuildWritesAsync(range, 50, CancellationToken.None);
+
+        // Exactly one op per aggregate per flush window, routed as a first-time (not previously flushed) write,
+        // carrying the LATEST snapshot; progress advances to the flush ceiling.
+        theStorage.Received(1).StoreProjectionForRebuildFlush(
+            Arg.Is<User>(u => u.RealName == "Hank McCoy"), Arg.Any<IEvent?>(), AggregationScope.MultiStream, false);
+        await range.Agent.Received().MarkSuccessAsync(50);
+        theRunner.DeferredWriteCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task one_op_per_distinct_aggregate()
+    {
+        theRunner.BeginDeferredRebuildWindowForTesting();
+
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        await applyStoreAsync(a, new User("A", "A"));
+        await applyStoreAsync(b, new User("B", "B"));
+        await applyStoreAsync(a, new User("A", "A2")); // a touched again
+
+        theRunner.DeferredWriteCount.ShouldBe(2);
+
+        wireFlushBatch();
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(99), 99, CancellationToken.None);
+
+        theStorage.Received(1).StoreProjectionForRebuildFlush(
+            Arg.Is<User>(u => u.RealName == "A2"), Arg.Any<IEvent?>(), Arg.Any<AggregationScope>(), false);
+        theStorage.Received(1).StoreProjectionForRebuildFlush(
+            Arg.Is<User>(u => u.RealName == "B"), Arg.Any<IEvent?>(), Arg.Any<AggregationScope>(), false);
+    }
+
+    [Fact]
+    public async Task overflow_reflush_routes_previously_flushed_ids_as_upserts()
+    {
+        theRunner.BeginDeferredRebuildWindowForTesting();
+        wireFlushBatch();
+
+        var id = Guid.NewGuid();
+
+        // Window 1: first flush -> first-time write (previouslyFlushed == false).
+        await applyStoreAsync(id, new User("v", "1"));
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(10), 10, CancellationToken.None);
+
+        // Window 2: same id reappears (overflow) -> must be routed as an UPSERT (previouslyFlushed == true).
+        await applyStoreAsync(id, new User("v", "2"));
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(20), 20, CancellationToken.None);
+
+        theStorage.Received(1).StoreProjectionForRebuildFlush(
+            Arg.Is<User>(u => u.RealName == "1"), Arg.Any<IEvent?>(), Arg.Any<AggregationScope>(), false);
+        theStorage.Received(1).StoreProjectionForRebuildFlush(
+            Arg.Is<User>(u => u.RealName == "2"), Arg.Any<IEvent?>(), Arg.Any<AggregationScope>(), true);
+    }
+
+    [Fact]
+    public async Task empty_final_flush_still_advances_progress()
+    {
+        wireFlushBatch();
+        theRunner.BeginDeferredRebuildWindowForTesting();
+
+        // No pending writes, but the flush must still run a batch (to advance the DB progression to the ceiling)
+        // and mark success so the rebuild completes. No document writes should be emitted.
+        var range = flushRange(200);
+        await theRunner.FlushDeferredRebuildWritesAsync(range, 200, CancellationToken.None);
+
+        await range.Agent.Received().MarkSuccessAsync(200);
+        theStorage.DidNotReceiveWithAnyArgs()
+            .StoreProjectionForRebuildFlush(default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task deferred_delete_is_buffered_then_emitted_once_at_flush()
+    {
+        theProjection.MatchesAnyDeleteType(Arg.Any<IReadOnlyList<IEvent>>()).Returns(true);
+        theRunner.BeginDeferredRebuildWindowForTesting();
+
+        var id = Guid.NewGuid();
+        var slice = new EventSlice<User, Guid>(id, "foo", new IEvent[] { new Event<AEvent>(new AEvent()) })
+        {
+            Snapshot = new User("Beast", "Hank") // pre-existing => owns stream => a real delete
+        };
+        await theRunner.ApplyChangesAsync(ShardExecutionMode.Rebuild, theBatch, new FakeOperations(), slice,
+            theStorage, theCache, CancellationToken.None);
+
+        theStorage.DidNotReceive().Delete(Arg.Any<Guid>());
+        theRunner.DeferredWriteCount.ShouldBe(1);
+
+        wireFlushBatch();
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(30), 30, CancellationToken.None);
+
+        theStorage.Received(1).Delete(id);
+    }
+
+    [Fact]
+    public async Task delete_overwrites_a_pending_store_in_the_same_window_and_flushes_as_a_delete()
+    {
+        theRunner.BeginDeferredRebuildWindowForTesting();
+
+        var id = Guid.NewGuid();
+        await applyStoreAsync(id, new User("Beast", "Hank"));   // pending store
+        await applyDeleteAsync(id, new User("Beast", "Hank"));  // ...superseded by a delete in the same window
+
+        theRunner.DeferredWriteCount.ShouldBe(1); // one entry for the id, now a tombstone
+
+        wireFlushBatch();
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(40), 40, CancellationToken.None);
+
+        // The delete wins: a Delete is emitted, and NO store op for that id.
+        theStorage.Received(1).Delete(id);
+        theStorage.DidNotReceiveWithAnyArgs()
+            .StoreProjectionForRebuildFlush(default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task deleting_a_flushed_id_lets_a_later_recreate_be_a_fresh_insert()
+    {
+        wireFlushBatch();
+        theRunner.BeginDeferredRebuildWindowForTesting();
+        var id = Guid.NewGuid();
+
+        // Window 1: create + flush -> first-time INSERT.
+        await applyStoreAsync(id, new User("v", "1"));
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(10), 10, CancellationToken.None);
+
+        // Window 2: delete + flush -> row removed, id dropped from the flushed set.
+        await applyDeleteAsync(id, new User("v", "1"));
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(20), 20, CancellationToken.None);
+
+        // Window 3: recreate + flush -> because the row was deleted, this must be a FRESH insert, not an UPSERT.
+        await applyStoreAsync(id, new User("v", "3"));
+        await theRunner.FlushDeferredRebuildWritesAsync(flushRange(30), 30, CancellationToken.None);
+
+        theStorage.Received(1).Delete(id);
+        theStorage.Received(1).StoreProjectionForRebuildFlush(
+            Arg.Is<User>(u => u.RealName == "3"), Arg.Any<IEvent?>(), Arg.Any<AggregationScope>(), false);
+    }
+
+    [Fact]
+    public async Task discard_drops_the_accumulator_without_writing()
+    {
+        theRunner.BeginDeferredRebuildWindowForTesting();
+        await applyStoreAsync(Guid.NewGuid(), new User("A", "A"));
+        theRunner.DeferredWriteCount.ShouldBe(1);
+
+        theRunner.DiscardDeferredRebuildWrites();
+
+        theRunner.DeferredWriteCount.ShouldBe(0);
+        theStorage.DidNotReceiveWithAnyArgs()
+            .StoreProjectionForRebuildFlush(default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task flush_due_at_threshold_or_ceiling()
+    {
+        theOptions.RebuildFlushThreshold = 2;
+        theRunner.BeginDeferredRebuildWindowForTesting();
+
+        // One dirty aggregate, ceiling not yet reached => not due.
+        await applyStoreAsync(Guid.NewGuid(), new User("A", "A"));
+        theRunner.DeferredFlushDue(flushRange(10, highWaterMark: 100)).ShouldBeFalse();
+
+        // Threshold reached => due.
+        await applyStoreAsync(Guid.NewGuid(), new User("B", "B"));
+        theRunner.DeferredFlushDue(flushRange(10, highWaterMark: 100)).ShouldBeTrue();
+
+        // Final range (ceiling reaches the high-water target) is always due, even below threshold.
+        theRunner.DiscardDeferredRebuildWrites();
+        theRunner.BeginDeferredRebuildWindowForTesting();
+        theRunner.DeferredFlushDue(flushRange(100, highWaterMark: 100)).ShouldBeTrue();
+    }
+}

--- a/src/EventTests/Projections/FakeOperations.cs
+++ b/src/EventTests/Projections/FakeOperations.cs
@@ -10,9 +10,18 @@ public class FakeOperations : FakeSession, IStorageOperations
         throw new NotImplementedException();
     }
 
+    // jasperfx#525: set this to have FetchProjectionStorageAsync hand back a stubbed storage (used by the
+    // deferred-rebuild flush tests); left null it preserves the original throwing behavior.
+    public object? ProjectionStorage { get; set; }
+
     public Task<IProjectionStorage<TDoc, TId>> FetchProjectionStorageAsync<TDoc, TId>(string tenantId,
         CancellationToken cancellationToken)
     {
+        if (ProjectionStorage is IProjectionStorage<TDoc, TId> storage)
+        {
+            return Task.FromResult(storage);
+        }
+
         throw new NotImplementedException();
     }
 

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -27,6 +27,17 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
     private ConcurrentQueue<(IAggregateCache<TId, TDoc> Cache, TId Id, TDoc? Snapshot, bool Remove)> _pendingCacheUpdates = new();
     private bool _populateCacheImmediately;
 
+    // jasperfx#525: the deferred-rebuild write accumulator. Unlike _pendingCacheUpdates (reset per batch),
+    // this persists across ranges for the whole rebuild until a flush commits or a stop discards it, so a
+    // stream spanning several pages is written exactly once per flush window instead of once per page. Guarded
+    // by _bufferLock because slices within a range are applied on a parallel Block. Non-null only while a
+    // deferred rebuild is active (RebuildFlushThreshold > 0, Rebuild mode, Individual batch).
+    private readonly object _bufferLock = new();
+    private RebuildFlushWindow? _flush;
+    private bool _deferWrites;
+
+    private int rebuildFlushThreshold => Projection.Options.RebuildFlushThreshold;
+
     public AggregationRunner(IEventStore<TOperations, TQuerySession> store, IEventDatabase database,
         IAggregationProjection<TDoc, TId, TOperations, TQuerySession> projection,
         SliceBehavior sliceBehavior, IEventSlicer slicer, ILogger logger)
@@ -63,6 +74,21 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         // read an upstream stage's in-flight aggregate (marten#4329). Standalone (Individual)
         // batches defer cache population until the batch commits.
         _populateCacheImmediately = range.BatchBehavior == BatchBehavior.Composite;
+
+        // jasperfx#525: for a threshold-enabled Individual rebuild batch, the per-slice writes below are
+        // buffered instead of executed, and the (empty) batch built here is used only to load prior snapshots.
+        // Open the accumulator once and keep it across ranges until a flush or discard.
+        _deferWrites = DefersRebuildWrites(mode, range);
+        if (_deferWrites)
+        {
+            lock (_bufferLock)
+            {
+                _flush ??= new RebuildFlushWindow();
+                // Seed the flush window's floor from the first range so the flush's progression update keys off
+                // the projection's current committed progression.
+                _flush.EnsureFloor(range.SequenceFloor);
+            }
+        }
 
         var batch = range.ActiveBatch as IProjectionBatch<TOperations, TQuerySession> ?? await _store.StartProjectionBatchAsync(range, _database, mode, Projection.Options, cancellation);
 
@@ -210,8 +236,18 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
 
         foreach (var slice in group.Slices)
         {
+            // jasperfx#525: during a deferred rebuild the authoritative in-flight aggregate lives in the flush
+            // accumulator (its write was buffered, never sent to the database), so a later range for the same
+            // stream must read it back from there — otherwise it would reload null and lose the earlier pages.
+            // Ids already flushed in an earlier window are absent here and fall through to the database load
+            // below, which is correct because they were written there.
+            if (_deferWrites && tryFindPendingSnapshot(group.TenantId, slice.Id, out var pending))
+            {
+                slice.Snapshot = pending;
+                await builder.PostAsync(new EventSliceExecution(slice, operations, storage, cache));
+            }
             // If you can find the snapshot in the cache, use that
-            if (cache.TryFind(slice.Id, out var snapshot))
+            else if (cache.TryFind(slice.Id, out var snapshot))
             {
                 slice.Snapshot = snapshot;
 
@@ -279,6 +315,22 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             // See issue JasperFx/marten#4093.
             var ownsStream = slice.Snapshot != null;
 
+            // jasperfx#525: buffer the delete tombstone (idempotent when replayed at flush) instead of writing
+            // it now; the stream-archive rides the flush batch too. Cache is untouched because the accumulator
+            // is the authoritative in-flight source during a deferred rebuild.
+            if (_deferWrites)
+            {
+                if (ownsStream)
+                {
+                    slice.RecordAction(ActionType.Delete);
+                    slice.Snapshot = default;
+                }
+
+                recordDeferredWrite(storage.TenantId, slice.Id, ActionType.Delete, default, null,
+                    wouldArchiveStream(slice, ownsStream));
+                return;
+            }
+
             maybeArchiveStream(storage, slice, ownsStream);
 
             if (ownsStream)
@@ -312,7 +364,7 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         // Ownership: either there was a pre-loaded snapshot or the slice's events
         // materialized one. Siblings that did neither skip the archive.
         // See issue JasperFx/marten#4093.
-        maybeArchiveStream(storage, slice, ownsStream: slice.Snapshot != null || snapshot != null);
+        var ownsResultingStream = slice.Snapshot != null || snapshot != null;
 
         // Set the resulting aggregate on the slice in EVERY mode. A composite stage fans an
         // Updated<TDoc> event to its downstream stages via MarkSliceAction, which only emits when
@@ -322,6 +374,19 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         // themselves (RaiseSideEffects -> raised events / published messages) stay Continuous-only
         // so a rebuild does not re-emit them. See marten#4729.
         slice.Snapshot = snapshot;
+
+        // jasperfx#525: buffer the resulting write keyed by aggregate id (a later range overwrites this entry,
+        // which is the dedup) rather than sending it to the database now. Side effects never run in a rebuild,
+        // so nothing else here needs the batch. The buffered snapshot becomes the in-flight read for later
+        // ranges (see processBatchAsync) and is materialized into a single op at flush.
+        if (_deferWrites)
+        {
+            recordDeferredWrite(storage.TenantId, slice.Id, action, snapshot, lastEvent,
+                wouldArchiveStream(slice, ownsResultingStream));
+            return;
+        }
+
+        maybeArchiveStream(storage, slice, ownsStream: ownsResultingStream);
 
         if (mode == ShardExecutionMode.Continuous)
         {
@@ -395,6 +460,307 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         if (slice.Events().OfType<IEvent<Archived>>().Any())
         {
             storage.ArchiveStream(slice.Id, slice.TenantId);
+        }
+    }
+
+    // jasperfx#525: would maybeArchiveStream have archived this stream? Used to record the archive intent onto
+    // a buffered write so the archive rides the flush batch instead of being emitted per range.
+    private bool wouldArchiveStream(EventSlice<TDoc, TId> slice, bool ownsStream)
+        => Projection.Scope == AggregationScope.SingleStream
+           && ownsStream
+           && slice.Events().OfType<IEvent<Archived>>().Any();
+
+    // jasperfx#525
+    public bool DefersRebuildWrites(ShardExecutionMode mode, EventRange range)
+        => mode == ShardExecutionMode.Rebuild
+           && range.BatchBehavior == BatchBehavior.Individual
+           && rebuildFlushThreshold > 0;
+
+    // jasperfx#525
+    public int DeferredWriteCount
+    {
+        get
+        {
+            lock (_bufferLock)
+            {
+                return _flush?.DirtyCount ?? 0;
+            }
+        }
+    }
+
+    // jasperfx#525: flush at the threshold, and always at the rebuild's target ceiling (the final range) so
+    // progress reaches the ceiling and the rebuild completes even when the last window is already empty.
+    public bool DeferredFlushDue(EventRange range)
+    {
+        if (!_deferWrites)
+        {
+            return false;
+        }
+
+        var reachedCeiling = range.Agent.HighWaterMark > 0 && range.SequenceCeiling >= range.Agent.HighWaterMark;
+
+        lock (_bufferLock)
+        {
+            return reachedCeiling || (_flush?.DirtyCount ?? 0) >= rebuildFlushThreshold;
+        }
+    }
+
+    private void recordDeferredWrite(string tenantId, TId id, ActionType action, TDoc? snapshot, IEvent? lastEvent,
+        bool archiveStream)
+    {
+        lock (_bufferLock)
+        {
+            _flush!.Record(tenantId, id, new PendingWrite(action, snapshot, lastEvent, archiveStream));
+        }
+    }
+
+    private bool tryFindPendingSnapshot(string tenantId, TId id, out TDoc? snapshot)
+    {
+        lock (_bufferLock)
+        {
+            if (_flush != null && _flush.TryGetPending(tenantId, id, out var write))
+            {
+                // #525: a buffered delete is a tombstone — a later range for the same stream must see the
+                // aggregate as gone (null) rather than resurrecting the pre-delete snapshot from the buffer.
+                snapshot = isRemoval(write.Action) ? default : write.Snapshot;
+                return true;
+            }
+        }
+
+        snapshot = default;
+        return false;
+    }
+
+    // #525: actions that leave no live row behind, so the aggregate is "gone" for read-through and must be
+    // dropped from the flushed-id set (a later re-create is then a fresh INSERT, not a reflush/UPSERT).
+    private static bool isRemoval(ActionType action)
+        => action is ActionType.Delete or ActionType.HardDelete;
+
+    // jasperfx#525: emit exactly one operation per pending aggregate into a fresh batch, execute it, and only
+    // then advance progress to the ceiling and promote this window's ids to the flushed set. If the flush
+    // itself fails the accumulator is left intact, so a retry (or a fresh rebuild) rewrites the same state.
+    public async Task FlushDeferredRebuildWritesAsync(EventRange range, long ceiling, CancellationToken cancellation)
+    {
+        List<(string TenantId, TId Id, PendingWrite Write, bool PreviouslyFlushed)> entries;
+        long windowFloor;
+        lock (_bufferLock)
+        {
+            entries = _flush?.Drain().ToList() ?? new();
+            windowFloor = _flush?.WindowFloor ?? range.SequenceFloor;
+        }
+
+        // Always build and execute a batch — even when there are no pending writes (e.g. the final range after a
+        // threshold flush drained the window) — because the batch is what advances the projection's *committed*
+        // progression in the database. MarkSuccessAsync only advances the agent's in-memory mark.
+        //
+        // The flush batch carries no events of its own — it only re-emits the accumulated snapshots — but a
+        // store's StartProjectionBatchAsync may enumerate range.Events (e.g. Marten's natural-key hook), so give
+        // it an empty (non-null) list. Its floor is the window floor (the current committed progression) so the
+        // store's optimistic progression update `set last_seq_id = ceiling where last_seq_id = floor` matches.
+        var flushRange = new EventRange(range.Agent, windowFloor, ceiling)
+        {
+            Events = new List<IEvent>()
+        };
+        var batch = await _store
+            .StartProjectionBatchAsync(flushRange, _database, ShardExecutionMode.Rebuild, Projection.Options,
+                cancellation).ConfigureAwait(false);
+
+        var writeThrottle = range.Agent.BatchWriteThrottle;
+        if (writeThrottle != null)
+        {
+            await writeThrottle.WaitAsync(cancellation).ConfigureAwait(false);
+        }
+
+        try
+        {
+            foreach (var group in entries.GroupBy(x => x.TenantId))
+            {
+                var operations = batch.SessionForTenant(group.Key);
+                var storage = await operations.FetchProjectionStorageAsync<TDoc, TId>(group.Key, cancellation)
+                    .ConfigureAwait(false);
+
+                foreach (var entry in group)
+                {
+                    applyPendingWrite(storage, entry.Id, entry.Write, entry.PreviouslyFlushed);
+                }
+            }
+
+            await batch.ExecuteAsync(cancellation).ConfigureAwait(false);
+            await range.Agent.MarkSuccessAsync(ceiling).ConfigureAwait(false);
+
+            lock (_bufferLock)
+            {
+                _flush?.Commit(ceiling);
+            }
+        }
+        finally
+        {
+            writeThrottle?.Release();
+            await batch.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void applyPendingWrite(IProjectionStorage<TDoc, TId> storage, TId id, PendingWrite write,
+        bool previouslyFlushed)
+    {
+        if (write.ArchiveStream)
+        {
+            storage.ArchiveStream(id, storage.TenantId);
+        }
+
+        switch (write.Action)
+        {
+            case ActionType.Delete:
+                storage.Delete(id);
+                break;
+            case ActionType.Store:
+                storage.StoreProjectionForRebuildFlush(write.Snapshot!, write.LastEvent, Projection.Scope,
+                    previouslyFlushed);
+                break;
+            case ActionType.HardDelete:
+                storage.HardDelete(write.Snapshot!);
+                break;
+            case ActionType.UnDeleteAndStore:
+                storage.UnDelete(write.Snapshot!);
+                storage.StoreProjectionForRebuildFlush(write.Snapshot!, write.LastEvent, Projection.Scope,
+                    previouslyFlushed);
+                break;
+            case ActionType.StoreThenSoftDelete:
+                storage.StoreProjectionForRebuildFlush(write.Snapshot!, write.LastEvent, Projection.Scope,
+                    previouslyFlushed);
+                storage.Delete(id);
+                break;
+        }
+    }
+
+    // jasperfx#525
+    public void DiscardDeferredRebuildWrites()
+    {
+        lock (_bufferLock)
+        {
+            _flush = null;
+            _deferWrites = false;
+        }
+    }
+
+    // jasperfx#525: test seam mirroring what BuildBatchAsync does when a deferred rebuild is active, so unit
+    // tests can drive ApplyChangesAsync/flush directly without standing up a full batch build.
+    internal void BeginDeferredRebuildWindowForTesting()
+    {
+        _deferWrites = true;
+        lock (_bufferLock)
+        {
+            _flush ??= new RebuildFlushWindow();
+        }
+    }
+
+    internal readonly record struct PendingWrite(
+        ActionType Action,
+        TDoc? Snapshot,
+        IEvent? LastEvent,
+        bool ArchiveStream);
+
+    // jasperfx#525: one flush window's worth of pending writes plus the set of ids already flushed earlier in
+    // this rebuild. Not thread-safe on its own — always accessed under AggregationRunner._bufferLock.
+    private sealed class RebuildFlushWindow
+    {
+        // Per tenant: the single latest pending write per aggregate id in the CURRENT window. A repeat write to
+        // the same id overwrites the entry, which is the dedup that yields one op per aggregate per flush.
+        private readonly Dictionary<string, Dictionary<TId, PendingWrite>> _pending = new();
+
+        // Per tenant: ids already written in an EARLIER window this rebuild. A reflush of one of these routes as
+        // an UPSERT rather than an INSERT.
+        private readonly Dictionary<string, HashSet<TId>> _flushed = new();
+
+        private bool _floorSet;
+
+        public int DirtyCount { get; private set; }
+
+        // The event-sequence floor of the CURRENT (un-flushed) window == the projection's committed progression
+        // right now. The flush batch must key its optimistic progression update on this value (Marten does
+        // `set last_seq_id = ceiling where last_seq_id = floor`), so it tracks the last flushed ceiling — seeded
+        // from the first buffered range's floor, then advanced to each flushed ceiling.
+        public long WindowFloor { get; private set; }
+
+        public void EnsureFloor(long rangeFloor)
+        {
+            if (!_floorSet)
+            {
+                WindowFloor = rangeFloor;
+                _floorSet = true;
+            }
+        }
+
+        public void Record(string tenantId, TId id, PendingWrite write)
+        {
+            if (!_pending.TryGetValue(tenantId, out var map))
+            {
+                map = new Dictionary<TId, PendingWrite>();
+                _pending[tenantId] = map;
+            }
+
+            if (!map.ContainsKey(id))
+            {
+                DirtyCount++;
+            }
+
+            map[id] = write;
+        }
+
+        public bool TryGetPending(string tenantId, TId id, out PendingWrite write)
+        {
+            if (_pending.TryGetValue(tenantId, out var map))
+            {
+                return map.TryGetValue(id, out write);
+            }
+
+            write = default;
+            return false;
+        }
+
+        public IEnumerable<(string TenantId, TId Id, PendingWrite Write, bool PreviouslyFlushed)> Drain()
+        {
+            foreach (var (tenantId, map) in _pending)
+            {
+                var alreadyFlushed = _flushed.TryGetValue(tenantId, out var set) ? set : null;
+                foreach (var (id, write) in map)
+                {
+                    yield return (tenantId, id, write, alreadyFlushed?.Contains(id) == true);
+                }
+            }
+        }
+
+        public void Commit(long ceiling)
+        {
+            // The just-flushed ceiling becomes the committed progression, so it is the next window's floor.
+            WindowFloor = ceiling;
+            _floorSet = true;
+
+            foreach (var (tenantId, map) in _pending)
+            {
+                if (!_flushed.TryGetValue(tenantId, out var set))
+                {
+                    set = new HashSet<TId>();
+                    _flushed[tenantId] = set;
+                }
+
+                foreach (var (id, write) in map)
+                {
+                    // #525: a store leaves a live row (a later window's write for it must UPSERT); a delete
+                    // removes the row, so drop it from the flushed set — a re-create is then a fresh INSERT.
+                    if (isRemoval(write.Action))
+                    {
+                        set.Remove(id);
+                    }
+                    else
+                    {
+                        set.Add(id);
+                    }
+                }
+            }
+
+            _pending.Clear();
+            DirtyCount = 0;
         }
     }
 

--- a/src/JasperFx.Events/Daemon/Command.cs
+++ b/src/JasperFx.Events/Daemon/Command.cs
@@ -28,6 +28,13 @@ public class Command
         return new Command { HighWaterMark = sequence, Type = CommandType.HighWater };
     }
 
+    // jasperfx#525: a deferred-rebuild range was buffered up to `ceiling` without committing. Carries the
+    // ceiling in LastCommitted purely to advance the buffered-ceiling back-pressure marker.
+    internal static Command RangeBuffered(long ceiling)
+    {
+        return new Command { LastCommitted = ceiling, Type = CommandType.RangeBuffered };
+    }
+
     public static Command Started(long highWater, long lastCommitted)
     {
         return new Command { HighWaterMark = highWater, LastCommitted = lastCommitted };

--- a/src/JasperFx.Events/Daemon/CommandType.cs
+++ b/src/JasperFx.Events/Daemon/CommandType.cs
@@ -8,5 +8,10 @@ internal enum CommandType
 
     // #4721: posted by the off-consumer optimized-rebuild task when it finishes, so the agent
     // reconciles its in-memory marks and resumes continuous operation on the command-loop thread.
-    ReplayCompleted
+    ReplayCompleted,
+
+    // jasperfx#525: posted by a deferred-rebuild execution after it has buffered (but NOT committed) a
+    // range. It advances the buffered ceiling — which drives loading back-pressure — so the daemon keeps
+    // pumping the next page, while committed progression (LastCommitted) stays put until the next flush.
+    RangeBuffered
 }

--- a/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
+++ b/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
@@ -69,6 +69,11 @@ public class GroupedProjectionExecution : ISubscriptionExecution
         _grouping.Complete();
         await _cancellation.CancelAsync().ConfigureAwait(false);
 
+        // jasperfx#525: drop any un-flushed deferred-rebuild writes. A rebuild that completed normally already
+        // flushed its final window (that's what let it complete), so this is a no-op there; a rebuild torn down
+        // early discards its accumulator so nothing partial is written and replay stays clean.
+        _runner.DiscardDeferredRebuildWrites();
+
         if (Disposables != null)
         {
             await Disposables.MaybeDisposeAllAsync().ConfigureAwait(false);
@@ -102,6 +107,9 @@ public class GroupedProjectionExecution : ISubscriptionExecution
     {
         await _cancellation.CancelAsync().ConfigureAwait(false);
         _grouping.Complete();
+
+        // jasperfx#525: a hard stop mid-rebuild throws away the un-flushed accumulator (see DisposeAsync).
+        _runner.DiscardDeferredRebuildWrites();
     }
 
     public async Task ProcessImmediatelyAsync(SubscriptionAgent subscriptionAgent, EventPage page,
@@ -212,14 +220,38 @@ public class GroupedProjectionExecution : ISubscriptionExecution
 
             if (range.BatchBehavior == BatchBehavior.Individual)
             {
-                try
+                if (_runner.DefersRebuildWrites(Mode, range))
                 {
-                    // Executing the SQL commands for the ProjectionUpdateBatch
-                    await applyBatchOperationsToDatabaseAsync(range, batch).ConfigureAwait(false);
-                }
-                finally
-                {
+                    // jasperfx#525: the per-slice writes were accumulated in the runner during BuildBatchAsync,
+                    // so the batch built here carries no operations — dispose it (it was only used to load prior
+                    // snapshots) and flush the accumulator into its own batch at the threshold or the rebuild
+                    // ceiling, rather than committing per range. Progress advances only at those flushes.
                     await batch.DisposeAsync();
+
+                    if (_runner.DeferredFlushDue(range))
+                    {
+                        await _runner
+                            .FlushDeferredRebuildWritesAsync(range, range.SequenceCeiling, _cancellation.Token)
+                            .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // jasperfx#525: nothing flushed, so committed progression stays put — but tell the agent
+                        // this range was buffered so its loader keeps pumping the next page instead of stalling.
+                        await range.Agent.MarkRangeBufferedAsync(range.SequenceCeiling).ConfigureAwait(false);
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        // Executing the SQL commands for the ProjectionUpdateBatch
+                        await applyBatchOperationsToDatabaseAsync(range, batch).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        await batch.DisposeAsync();
+                    }
                 }
             }
 

--- a/src/JasperFx.Events/Daemon/IGroupedProjectionRunner.cs
+++ b/src/JasperFx.Events/Daemon/IGroupedProjectionRunner.cs
@@ -36,4 +36,42 @@ public interface IGroupedProjectionRunner : IAsyncDisposable
     /// (see marten#4730). No-op for runners that don't keep a cache.
     /// </summary>
     void ApplyPendingCacheUpdates() { }
+
+    /// <summary>
+    /// jasperfx#525: does this runner defer projected-document writes for the given range instead of writing
+    /// per page? True only for an Individual aggregation batch during a rebuild when
+    /// <see cref="AsyncOptions.RebuildFlushThreshold"/> is greater than 0. When true the execution accumulates
+    /// across ranges and flushes at the threshold or the rebuild ceiling rather than committing per range.
+    /// Defaults to false so every other runner keeps the flush-per-page behavior.
+    /// </summary>
+    bool DefersRebuildWrites(ShardExecutionMode mode, EventRange range) => false;
+
+    /// <summary>
+    /// jasperfx#525: the number of distinct aggregates with a pending (un-flushed) write in the current
+    /// deferred-rebuild flush window. Used to decide when the threshold has been reached.
+    /// </summary>
+    int DeferredWriteCount => 0;
+
+    /// <summary>
+    /// jasperfx#525: is a deferred-rebuild flush due after processing <paramref name="range"/>? True when the
+    /// dirty-aggregate count has reached <see cref="AsyncOptions.RebuildFlushThreshold"/>, or when the range
+    /// reaches the rebuild's target ceiling (the final range), which must always flush so progress advances to
+    /// the ceiling and the rebuild can complete. Defaults to false.
+    /// </summary>
+    bool DeferredFlushDue(EventRange range) => false;
+
+    /// <summary>
+    /// jasperfx#525: emit exactly one store/delete operation per pending aggregate into a fresh batch, execute
+    /// it, advance progress to <paramref name="ceiling"/>, and open the next flush window. Aggregates written
+    /// in an earlier window this rebuild are routed as UPSERTs; first-time writes may take the store's
+    /// INSERT-only fast path. No-op for runners that don't defer.
+    /// </summary>
+    Task FlushDeferredRebuildWritesAsync(EventRange range, long ceiling, CancellationToken cancellation) =>
+        Task.CompletedTask;
+
+    /// <summary>
+    /// jasperfx#525: discard the current deferred-rebuild accumulator without writing anything. Called when a
+    /// shard is stopped or cancelled mid-rebuild — nothing was marked as committed, so replay is clean.
+    /// </summary>
+    void DiscardDeferredRebuildWrites() { }
 }

--- a/src/JasperFx.Events/Daemon/IProjectionStorage.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionStorage.cs
@@ -23,6 +23,18 @@ public interface IProjectionStorage<TDoc, TId> : IIdentitySetter<TDoc, TId>
     void StoreProjection(TDoc aggregate, IEvent? lastEvent, AggregationScope scope);
     void ArchiveStream(TId sliceId, string tenantId);
     Task<TDoc> LoadAsync(TId id, CancellationToken cancellation);
+
+    /// <summary>
+    /// jasperfx#525: store a projected document as part of a deferred rebuild flush. When
+    /// <paramref name="previouslyFlushed"/> is false the aggregate is appearing for the first time this
+    /// rebuild (post-TRUNCATE), so a store may route it through an INSERT-only fast path (e.g. binary COPY);
+    /// when true the aggregate was already written in an earlier flush window (an overflow reflush) and must
+    /// be routed as an UPSERT. The default implementation ignores the hint and behaves exactly like
+    /// <see cref="StoreProjection"/>, so a store that has not opted into the optimization stays correct.
+    /// </summary>
+    void StoreProjectionForRebuildFlush(TDoc aggregate, IEvent? lastEvent, AggregationScope scope,
+        bool previouslyFlushed)
+        => StoreProjection(aggregate, lastEvent, scope);
 }
 
 public static class ProjectionStorageExtensions

--- a/src/JasperFx.Events/Daemon/ISubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/ISubscriptionAgent.cs
@@ -9,6 +9,14 @@ public interface ISubscriptionAgent : ISubscriptionController
     long Position { get; }
     AgentStatus Status { get; }
 
+    /// <summary>
+    /// jasperfx#525: the effective high-water ceiling this agent is driving toward. During a rebuild this is
+    /// the target the replay stops at (the store-wide high water, or a bounded ceiling such as the jasperfx#480
+    /// prior-version mark), so a deferred-flush execution can recognize the final range and force a flush. The
+    /// default returns 0 for agents that don't track it; the daemon's own agent overrides with the real value.
+    /// </summary>
+    long HighWaterMark => 0;
+
     DateTimeOffset? PausedTime { get; }
     ISubscriptionMetrics Metrics { get; }
     void MarkHighWater(long sequence);

--- a/src/JasperFx.Events/Daemon/ISubscriptionController.cs
+++ b/src/JasperFx.Events/Daemon/ISubscriptionController.cs
@@ -17,6 +17,14 @@ public interface ISubscriptionController
     ValueTask MarkSuccessAsync(long processedCeiling);
 
     /// <summary>
+    ///     jasperfx#525: tell the governing agent that a deferred-rebuild range was buffered up to
+    ///     <paramref name="ceiling" /> in memory but NOT yet committed. This advances the loading back-pressure
+    ///     marker so the daemon keeps pumping pages during a deferred rebuild, while committed progression only
+    ///     advances at the next flush. No-op for controllers that never defer.
+    /// </summary>
+    ValueTask MarkRangeBufferedAsync(long ceiling) => default;
+
+    /// <summary>
     ///     Tell the governing subscription agent that there was a critical error that
     ///     should pause the subscription or projection
     /// </summary>

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -89,6 +89,12 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
     public long HighWaterMark { get; set; }
 
+    // jasperfx#525: highest range ceiling a deferred rebuild has BUFFERED (accumulated in memory) but not yet
+    // committed. Kept >= LastCommitted at all times. Loading back-pressure is measured against this rather than
+    // LastCommitted so a deferred rebuild — whose LastCommitted intentionally lags until the next flush — keeps
+    // pumping pages instead of stalling. Only touched on the command-loop thread.
+    private long _bufferedCeiling;
+
     public async ValueTask DisposeAsync()
     {
         if (_heartbeatTimer != null)
@@ -241,6 +247,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
         ErrorOptions = request.ErrorHandling;
         _runtime = request.Runtime;
         LastCommitted = request.Floor; // Force it to start here!
+        _bufferedCeiling = request.Floor; // jasperfx#525
 
         try
         {
@@ -303,6 +310,14 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
         });
     }
 
+    // jasperfx#525: a deferred-rebuild execution buffered a range without committing. Advance the buffered
+    // ceiling on the command loop so the loader keeps pumping the next page while committed progression waits
+    // for the next flush.
+    public async ValueTask MarkRangeBufferedAsync(long ceiling)
+    {
+        await _commandBlock.PostAsync(Command.RangeBuffered(ceiling));
+    }
+
     public void MarkHighWater(long sequence)
     {
         _commandBlock.Post(Command.HighWaterMarkUpdated(sequence));
@@ -341,6 +356,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
                 HighWaterMark = command.HighWaterMark;
                 LastCommitted = LastEnqueued = command.LastCommitted;
+                _bufferedCeiling = LastCommitted; // jasperfx#525
 
                 // The Mode guard matters for jasperfx#480: a bounded rebuild that disabled the
                 // optimized replay (ReplayAsync above) posts Start in Rebuild mode with a replay
@@ -387,12 +403,27 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
             case CommandType.RangeCompleted:
                 LastCommitted = command.LastCommitted;
+                if (LastCommitted > _bufferedCeiling)
+                {
+                    _bufferedCeiling = LastCommitted; // jasperfx#525: keep the buffered marker >= committed
+                }
+
                 await _tracker.PublishAsync(new ShardState(Name, LastCommitted));
 
                 if (LastCommitted == HighWaterMark && Mode == ShardExecutionMode.Rebuild)
                 {
                     // We're done, get out of here!
                     _rebuild?.TrySetResult();
+                }
+
+                break;
+
+            case CommandType.RangeBuffered:
+                // jasperfx#525: a deferred rebuild buffered up to this ceiling without committing. Advance the
+                // back-pressure marker (LastCommitted stays put) and fall through to keep pumping the next page.
+                if (command.LastCommitted > _bufferedCeiling)
+                {
+                    _bufferedCeiling = command.LastCommitted;
                 }
 
                 break;
@@ -409,7 +440,11 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
             return;
         }
 
-        var inflight = LastEnqueued - LastCommitted;
+        // jasperfx#525: measure in-flight (loaded-but-unprocessed) events against the buffered ceiling, not
+        // committed progression. During a deferred rebuild LastCommitted lags until the next flush, so using it
+        // here would make in-flight grow without bound and wedge the loader; the buffered ceiling advances as
+        // each page is processed, so this stays equal to LastEnqueued - LastCommitted in every non-deferred path.
+        var inflight = LastEnqueued - Math.Max(LastCommitted, _bufferedCeiling);
 
         // Back pressure, slow down
         if (inflight >= Options.MaximumHopperSize)

--- a/src/JasperFx.Events/Projections/AsyncOptions.cs
+++ b/src/JasperFx.Events/Projections/AsyncOptions.cs
@@ -70,6 +70,17 @@ public class AsyncOptions
     public int CacheLimitPerTenant { get; set; } = 0;
 
     /// <summary>
+    /// jasperfx#525, rebuild-mode only. When greater than 0, the async daemon defers projected-document
+    /// writes during a rebuild, accumulating only the latest snapshot (or a tombstone) per aggregate id in
+    /// memory and flushing to the database when the number of dirty aggregates reaches this threshold or the
+    /// rebuild reaches its target ceiling. This guarantees exactly one write per aggregate per flush window,
+    /// which is the prerequisite for INSERT-only (binary COPY) rebuild batches. 0 (the default) keeps the
+    /// flush-per-page behavior and is a complete no-op. Applies to Individual (non-composite) aggregation
+    /// batches only; composite projections are excluded in v1.
+    /// </summary>
+    public int RebuildFlushThreshold { get; set; } = 0;
+
+    /// <summary>
     ///     Add explicit teardown rule to delete all documents of type T
     ///     when this projection shard is rebuilt
     /// </summary>


### PR DESCRIPTION
Closes #525.

Opt-in, rebuild-only optimization: when `AsyncOptions.RebuildFlushThreshold > 0`, the async daemon defers projected-document writes for Individual aggregation batches during a rebuild, accumulating the latest snapshot (or a tombstone) per aggregate id in memory and flushing **one op per aggregate** when the dirty count reaches the threshold or the rebuild reaches its ceiling. This is the proven prerequisite for INSERT-only (binary COPY) rebuild batches and coalesces multi-page streams. **Default `0` is a complete no-op** (existing rebuild behavior unchanged); composites are excluded in v1.

## What's here
- **`AsyncOptions.RebuildFlushThreshold`** (default 0).
- **`IProjectionStorage.StoreProjectionForRebuildFlush(...)`** — default implementation delegates to `StoreProjection`, so downstream stores keep compiling. Carries a `previouslyFlushed` hint so a store can route first-appearance writes through INSERT/COPY and reflushed ids through UPSERT (the cross-repo contract Marten will consume as a follow-up).
- **`AggregationRunner` accumulator** — per-tenant dirty map + flushed-id set; in-flight **read-through** so a later page folds on the buffered snapshot instead of reloading null; **delete tombstones** removed from the pending upserts, the flushed-id set, and the in-flight read-through; the flush builds a fresh batch keyed on the window floor and advances committed progression.
- **Daemon pump fix** — deferring `MarkSuccessAsync` starved the loader (loading is driven by `RangeCompleted`). Added a **buffered-ceiling back-pressure marker** + a `RangeBuffered` command so the daemon keeps pumping pages during a deferred rebuild while committed progression only advances at each flush.

## Tests
- `AggregationRunnerDeferredRebuildTests` — 10 unit tests: gate, accumulate-without-writing, one-op-per-aggregate, overflow→UPSERT routing, delete tombstone/flushed-set handling, flush at threshold/ceiling, empty final flush advances progression, discard-on-cancel.
- Full JasperFx `EventTests` suite green (544).

## Local cross-repo verification (Marten, via project references)
- Multi-page single-stream rebuild (30 events, BatchSize 10) folds correctly **both flag-off and flag-on** — proves the in-flight read-through invariant against real storage.
- Benchmark (60 streams × 120 events, batch 100): baseline `447 ms` → deferred `335 ms` = **25% faster**, purely from coalescing multi-page writes (before the Marten-side COPY fast path, which is a tracked follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)