### PR TITLE
feat(#435): exact ReadProjectionProgressAsync(ShardName) overload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.28.1</JasperFxVersion>
+        <JasperFxVersion>2.29.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/Daemon/ReadProjectionProgressDefaultsTests.cs
+++ b/src/EventTests/Daemon/ReadProjectionProgressDefaultsTests.cs
@@ -59,6 +59,13 @@ public class ReadProjectionProgressDefaultsTests
                 ? new ValueTask<ProjectionProgressRow?>(
                     new ProjectionProgressRow("Orders", tenantId, 42, "Running", null))
                 : new ValueTask<ProjectionProgressRow?>((ProjectionProgressRow?)null);
+
+        public override ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(
+            ShardName name, CancellationToken token)
+            => name.Identity == "Orders:All"
+                ? new ValueTask<ProjectionProgressRow?>(
+                    new ProjectionProgressRow("Orders", null, 42, null, null))
+                : new ValueTask<ProjectionProgressRow?>((ProjectionProgressRow?)null);
     }
 
     // Split out so the overriding stub does not have to restate every unrelated member.
@@ -66,6 +73,10 @@ public class ReadProjectionProgressDefaultsTests
     {
         public virtual ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(
             string projectionName, string? tenantId, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public virtual ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(
+            ShardName name, CancellationToken token)
             => throw new NotImplementedException();
 
         public string Identifier => throw new NotImplementedException();
@@ -133,6 +144,26 @@ public class ReadProjectionProgressDefaultsTests
     {
         var row = await theProgressionDatabase.ReadProjectionProgressAsync("Unobserved", null, CancellationToken.None);
         row.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task default_throws_for_the_shard_name_overload_too()
+    {
+        // The exact ShardName overload ships as a default interface member for the same reason: an
+        // unimplemented store must surface "not implemented", never borrow the "no row" null.
+        await Should.ThrowAsync<NotSupportedException>(async () =>
+            await theBareDatabase.ReadProjectionProgressAsync(ShardName.Compose("Orders"), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task an_implementing_store_can_return_a_row_by_shard_name()
+    {
+        var row = await theProgressionDatabase.ReadProjectionProgressAsync(
+            ShardName.Compose("Orders"), CancellationToken.None);
+
+        row.ShouldNotBeNull();
+        row.ProjectionName.ShouldBe("Orders");
+        row.Sequence.ShouldBe(42);
     }
 
     [Fact]

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -218,4 +218,28 @@ public interface IEventDatabase
         CancellationToken token)
         => throw new NotSupportedException(
             "ReadProjectionProgressAsync is not implemented on this IEventDatabase. Use an event store (Marten or Polecat) that supports reading a single projection progression row.");
+
+    /// <summary>
+    ///     Exact per-cell progression read: look up the single progression row whose stored identity equals
+    ///     <paramref name="name" />'s <see cref="ShardName.Identity" />. Unlike the
+    ///     <see cref="ReadProjectionProgressAsync(string,string?,CancellationToken)" /> overload there is no
+    ///     version/shard collapsing — the caller supplies the full <see cref="ShardName" /> it already holds
+    ///     (for example a cell from <see cref="AllProjectionProgress(CancellationToken)" />), so a blue/green
+    ///     deploy's versions, a sliced projection's shard keys, and per-tenant partitions each address their
+    ///     own row unambiguously. A <see cref="ShardName.ShardKey" /> of <c>All</c> is the projection's global
+    ///     cell, matching the store's "All means the whole projection" convention. Returns null when no row
+    ///     exists for that identity yet.
+    ///     <para>
+    ///     Like the other overload the default implementation throws rather than returning null: null is the
+    ///     meaningful "no row yet" answer and must not be borrowed by a store that has not implemented this.
+    ///     Event stores (Marten, Polecat) override it against their progression table. See jasperfx#435.
+    ///     </para>
+    /// </summary>
+    /// <param name="name">Full shard identity of the cell to read.</param>
+    /// <param name="token"></param>
+    ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(
+        ShardName name,
+        CancellationToken token)
+        => throw new NotSupportedException(
+            "ReadProjectionProgressAsync is not implemented on this IEventDatabase. Use an event store (Marten or Polecat) that supports reading a single projection progression row.");
 }


### PR DESCRIPTION
Adds a second, **exact** per-cell progression read on `IEventDatabase` alongside the existing `(projectionName, tenantId)` overload:

```csharp
ValueTask<ProjectionProgressRow?> ReadProjectionProgressAsync(ShardName name, CancellationToken token);
```

The caller supplies the full `ShardName` it already holds (e.g. a cell from `AllProjectionProgress`), so the store looks up the single row whose stored identity equals `name.Identity` — **no version/shard collapsing**. A blue/green deploy's versions, a sliced projection's shard keys, and per-tenant partitions each address their own row unambiguously; a `ShardKey` of `All` is the projection's global cell, matching the store's "All means the whole projection" convention.

Ships as a **default interface member that throws** `NotSupportedException` — same contract as the existing overload (jasperfx#519): `null` is the meaningful "no row yet" answer and must not be borrowed by a store that hasn't implemented this. Event stores adopt it in follow-ups (Marten JasperFx/marten, Polecat JasperFx/polecat).

Extends `ReadProjectionProgressDefaultsTests` (default-throws + implementing-store-returns-a-row for the new overload). Bumps to **2.29.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)