### PR TITLE
feat(#531): promote ITenanted marker interface into JasperFx.MultiTenancy

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.29.1</JasperFxVersion>
+        <JasperFxVersion>2.30.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx/MultiTenancy/ITenanted.cs
+++ b/src/JasperFx/MultiTenancy/ITenanted.cs
@@ -1,0 +1,12 @@
+namespace JasperFx.MultiTenancy;
+
+/// <summary>
+/// Marker interface that opts a document or entity type into conjoined
+/// multi-tenancy within Critter Stack tools (Marten, Polecat, Wolverine).
+/// The framework is responsible for setting <see cref="IHasTenantId.TenantId"/>
+/// when the entity is written and for populating it from storage when the
+/// entity is loaded, so application code should treat the value as framework-managed.
+/// </summary>
+public interface ITenanted : IHasTenantId
+{
+}


### PR DESCRIPTION
Closes #531

Part of the Wolverine conjoined EF Core multi-tenancy epic (JasperFx/wolverine#3465).

## What's here

- Adds `JasperFx.MultiTenancy.ITenanted : IHasTenantId`, the shared marker interface that Marten (`Marten.Metadata.ITenanted`) and Polecat (`Polecat.Metadata.ITenanted`) currently declare separately, and that Wolverine is about to need for conjoined EF Core tenancy. The XML docs capture the contract both libraries already imply: the framework sets `TenantId` on write and populates it from storage on load.
- Bumps `JasperFxVersion` 2.29.1 → **2.30.0** for the next lockstep release, which the Wolverine epic keys off.

Follow-up work in Marten and Polecat will re-point their `ITenanted` declarations at this interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)