### PR TITLE
BatchingChannel: batch timeout is a max-age, not a quiet-period debounce (wolverine#3490)

### DIFF
--- a/src/CoreTests/Blocks/BatchingChannelTests.cs
+++ b/src/CoreTests/Blocks/BatchingChannelTests.cs
@@ -1,0 +1,104 @@
+using JasperFx.Blocks;
+using JasperFx.Core;
+using Shouldly;
+using Xunit;
+
+namespace CoreTests.Blocks;
+
+// wolverine#3490: the flush timer was reset on every Post, making the timeout a quiet-period
+// debounce. A steady trickle arriving faster than the timeout postponed the flush indefinitely
+// until batchSize accumulated — measured as multi-second p50 delivery latency at 8 msg/s with
+// Wolverine's default (100, 250ms) sender batching. The timeout is now the maximum age of a
+// batch, armed by the batch's first item and untouched by later ones.
+public class BatchingChannelTests
+{
+    private static (BatchingChannel<int>, List<int[]>, TaskCompletionSource) channelWithCapture(
+        TimeSpan timeout, int batchSize)
+    {
+        var batches = new List<int[]>();
+        var firstBatch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var downstream = new Block<int[]>(batch =>
+        {
+            lock (batches)
+            {
+                batches.Add(batch);
+            }
+
+            firstBatch.TrySetResult();
+        });
+
+        return (new BatchingChannel<int>(timeout, downstream, batchSize), batches, firstBatch);
+    }
+
+    [Fact]
+    public async Task steady_trickle_faster_than_the_timeout_still_flushes_within_the_max_age()
+    {
+        var (channel, batches, firstBatch) = channelWithCapture(250.Milliseconds(), 100);
+
+        // 20 items at 25ms intervals: every gap is well under the 250ms timeout, and 20 < 100
+        // batch size. Under the old debounce semantics nothing would flush until the trickle
+        // stopped; under max-age semantics the first batch must land at ~250ms.
+        var posting = Task.Run(async () =>
+        {
+            for (var i = 0; i < 20; i++)
+            {
+                channel.Post(i);
+                await Task.Delay(25);
+            }
+        });
+
+        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds()));
+        flushed.ShouldBe(firstBatch.Task,
+            "the first batch should flush within the max age even though items keep trickling in");
+
+        await posting;
+        channel.Complete();
+        await channel.WaitForCompletionAsync();
+
+        lock (batches)
+        {
+            batches.SelectMany(x => x).OrderBy(x => x).ShouldBe(Enumerable.Range(0, 20));
+        }
+    }
+
+    [Fact]
+    public async Task lone_item_flushes_after_the_timeout()
+    {
+        var (channel, batches, firstBatch) = channelWithCapture(100.Milliseconds(), 100);
+
+        channel.Post(42);
+
+        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds()));
+        flushed.ShouldBe(firstBatch.Task);
+
+        channel.Complete();
+        await channel.WaitForCompletionAsync();
+
+        lock (batches)
+        {
+            batches.SelectMany(x => x).ShouldBe([42]);
+        }
+    }
+
+    [Fact]
+    public async Task reaching_the_batch_size_flushes_immediately()
+    {
+        var (channel, batches, firstBatch) = channelWithCapture(10.Minutes(), 10);
+
+        for (var i = 0; i < 10; i++)
+        {
+            channel.Post(i);
+        }
+
+        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds()));
+        flushed.ShouldBe(firstBatch.Task, "a full batch should flush without waiting on the timer");
+
+        channel.Complete();
+        await channel.WaitForCompletionAsync();
+
+        lock (batches)
+        {
+            batches.SelectMany(x => x).OrderBy(x => x).ShouldBe(Enumerable.Range(0, 10));
+        }
+    }
+}

--- a/src/JasperFx/Blocks/BatchingChannel.cs
+++ b/src/JasperFx/Blocks/BatchingChannel.cs
@@ -54,6 +54,8 @@ public class BatchingChannel<T> : BlockBase<T>
                 _downstream.Post(_current.ToArray());
                 _current.Clear();
             }
+
+            disarmTimer();
         }
     }
 
@@ -66,7 +68,43 @@ public class BatchingChannel<T> : BlockBase<T>
             {
                 _downstream.Post(_current.ToArray());
                 _current.Clear();
+                disarmTimer();
             }
+            else if (_current.Count == 1)
+            {
+                // First item of a new batch: arm the one-shot flush timer. The timer is
+                // deliberately NOT re-armed by later items — the timeout is the maximum age
+                // of a batch, not a quiet-period debounce. The previous behavior (reset the
+                // timer on every Post) meant a steady trickle arriving faster than the
+                // timeout postponed the flush indefinitely until batchSize accumulated:
+                // measured as multi-second p50 delivery latency at 8 msg/s with the default
+                // 100/250ms settings in wolverine#3490.
+                armTimer();
+            }
+        }
+    }
+
+    private void armTimer()
+    {
+        try
+        {
+            _trigger.Change(_timeOut, Timeout.InfiniteTimeSpan);
+        }
+        catch (Exception)
+        {
+            // ignored — the timer may already be disposed during shutdown
+        }
+    }
+
+    private void disarmTimer()
+    {
+        try
+        {
+            _trigger.Change(Timeout.Infinite, Timeout.Infinite);
+        }
+        catch (Exception)
+        {
+            // ignored — the timer may already be disposed during shutdown
         }
     }
 
@@ -96,29 +134,11 @@ public class BatchingChannel<T> : BlockBase<T>
 
     public override ValueTask PostAsync(T item)
     {
-        try
-        {
-            _trigger.Change(_timeOut, Timeout.InfiniteTimeSpan);
-        }
-        catch (Exception)
-        {
-            // ignored
-        }
-
         return _inner.PostAsync(item);
     }
 
     public override void Post(T item)
     {
-        try
-        {
-            _trigger.Change(_timeOut, Timeout.InfiniteTimeSpan);
-        }
-        catch (Exception)
-        {
-            // ignored
-        }
-
         _inner.Post(item);
     }
 }


### PR DESCRIPTION
## What

`BatchingChannel<T>`'s flush timer was reset to the full timeout on every `Post`/`PostAsync` — quiet-period debounce semantics. Any steady producer faster than the timeout postponed the flush indefinitely until `batchSize` accumulated.

## Why it matters

This is the root cause of the headline finding in JasperFx/wolverine#3490 (Wolverine-over-Kafka vs native Confluent latency gap). Measured on that issue's load rig with Wolverine's **default** subscriber batching (batch 100, timeout 250ms):

- 1Kb messages at a steady 8/s: **transit p50 = 5.77 seconds** (each post reset the timer; flush only happened when 100 messages accumulated over ~12.5s)
- a lone / slow-rate message stream: every message waits the **full** timeout (measured 263ms p50 at 0.6 msg/s)

## The fix

Arm the one-shot timer when a batch receives its **first** item; later items leave it alone, so the timeout is the maximum age of a batch. Reaching `batchSize` still flushes immediately (and disarms). `TriggerBatch()` disarms after a manual flush.

Worst-case latency contribution of batching is now bounded by the configured timeout by construction.

## Tests

`CoreTests/Blocks/BatchingChannelTests`: steady-trickle-faster-than-timeout flushes within the max age (fails on the old debounce), lone-item flush, immediate size-based flush. Blocks filter green on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4XSARYV567q5Y3fW6iwiu