### PR TITLE
Daemon start-registration + failure-reason fixes (closes #534, #535; wolverine#3519/#3520)

### DIFF
--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -406,6 +406,31 @@ public class PerTenantStartAgentAsyncTests
         agent.Status.ShouldBe(AgentStatus.Running);
     }
 
+    [Fact]
+    public async Task rewind_leaves_the_restarted_agent_registered_and_running()
+    {
+        // wolverine#3520: RewindSubscriptionAsync stops the running continuous agents, rewinds progress,
+        // then rebuilds and StartAsync-es fresh continuous agents. Before the fix those fresh agents were
+        // never registered in the daemon's running set, so CurrentAgents() (and StartAgentAsync(ShardName)
+        // via the same _agents lookup) still saw only the pre-rewind agent that stopRunningAgents() had
+        // just HardStopped — the shard was effectively orphaned under Wolverine-managed distribution, and
+        // a subsequent restart would spin up a DUPLICATE agent on the same progression row.
+        await using var harness = new DaemonHarness(new GlobalOnlyStubDetector(), shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All", CancellationToken.None);
+        var original = harness.Daemon.CurrentAgents().ShouldHaveSingleItem();
+        original.Status.ShouldBe(AgentStatus.Running);
+
+        await harness.Daemon.RewindSubscriptionAsync("Trip", CancellationToken.None, 0);
+
+        // Exactly one agent registered for the shard — the freshly restarted one, running — not the
+        // HardStopped pre-rewind instance, and never two agents on the same identity.
+        var restarted = harness.Daemon.CurrentAgents().ShouldHaveSingleItem();
+        restarted.Name.Identity.ShouldBe("Trip:All");
+        restarted.Status.ShouldBe(AgentStatus.Running);
+        ReferenceEquals(restarted, original).ShouldBeFalse();
+    }
+
     // Real daemon + real SubscriptionAgents over a substituted store/database. The store-global
     // high-water detector reading is pinned at mark 0, so any nonzero seed/floor a test observes can
     // only have come from the per-tenant coordinator.

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -23,6 +23,11 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     private readonly ILoggerFactory? _loggerFactory;
     private readonly ProjectionGraph<TProjection, TOperations, TQuerySession> _projections;
     private ImHashMap<string, ISubscriptionAgent> _agents = ImHashMap<string, ISubscriptionAgent>.Empty;
+
+    // wolverine#3519 / jasperfx#534: the last exception a start attempt caught, keyed by shard identity.
+    // tryStartAgentAsync swallows a faulted start into a bool; stashing the cause here lets
+    // StartAgentAsync(ShardName) attach it as the inner exception instead of throwing a causeless one.
+    private ImHashMap<string, Exception> _lastStartFailures = ImHashMap<string, Exception>.Empty;
     private CancellationTokenSource _cancellation = new();
     private readonly HighWaterAgent _highWater;
     private readonly IDisposable _breakSubscription;
@@ -222,6 +227,11 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         // Be idempotent, don't start an agent that is already running
         if (_agents.TryFind(agent.Name.Identity, out var running) && running.Status == AgentStatus.Running)
         {
+            // jasperfx#534: this false path was silent. It is benign (the agent is already running, so a
+            // TryFind by the caller succeeds), but logging it at Debug keeps the "why did my start return
+            // false" trail unbroken.
+            Logger.LogDebug("Start of agent {ShardName} skipped: an agent is already running for this shard",
+                agent.Name.Identity);
             return false;
         }
 
@@ -233,6 +243,8 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             // Be idempotent, don't start an agent that is already running now that we have the lock.
             if (_agents.TryFind(agent.Name.Identity, out running) && running.Status == AgentStatus.Running)
             {
+                Logger.LogDebug("Start of agent {ShardName} skipped: an agent is already running for this shard",
+                    agent.Name.Identity);
                 return false;
             }
 
@@ -274,11 +286,18 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             agent.MarkHighWater(highWaterMark);
 
             _agents = _agents.AddOrUpdate(agent.Name.Identity, agent);
+
+            // jasperfx#534: a prior failed start for this identity has now been superseded by a success.
+            _lastStartFailures = _lastStartFailures.Remove(agent.Name.Identity);
             syncTenantPolling();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error trying to start agent {ShardName}", agent.Name.Identity);
+
+            // jasperfx#534: stash the cause so StartAgentAsync(ShardName) can attach it to the exception it
+            // throws instead of a causeless "Unable to start" that fills a caller's retry log forever.
+            _lastStartFailures = _lastStartFailures.AddOrUpdate(agent.Name.Identity, ex);
             return false;
         }
         finally
@@ -610,10 +629,16 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         await StartAgentAsync(name.Identity, token);
         if (_agents.TryFind(name.Identity, out var agent)) return agent;
 
-        // wolverine#3519: the string-overload start returned without throwing, yet nothing is registered
-        // under this identity. Callers (e.g. Wolverine's EventSubscriptionAgent) previously got a bare
-        // Exception with no context and wedged in a permanent retry loop with no way to see why. Surface
-        // the daemon state that explains the miss instead of masking it.
+        // wolverine#3519 / jasperfx#534: the string-overload start returned without throwing, yet nothing
+        // is registered under this identity. Callers (e.g. Wolverine's EventSubscriptionAgent) previously
+        // got a bare Exception with no context and wedged in a permanent retry loop with no way to see why.
+        // If a start attempt actually faulted, attach that cause; otherwise surface the daemon state that
+        // explains the miss instead of masking it.
+        if (_lastStartFailures.TryFind(name.Identity, out var cause))
+        {
+            throw new ShardStartException(name.Identity, cause);
+        }
+
         throw new ShardStartException(name.Identity, describeStartFailure(name));
     }
 
@@ -1261,6 +1286,13 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
     }
 
+    // jasperfx#535: a rebuild stops the projection's running continuous agents (below), replays through
+    // transient rebuild agents, drains those, and returns WITHOUT restarting the continuous agents it
+    // stopped. This is by contract: on a host with the store's own coordinator loop the coordinator
+    // resurrects the stopped shards, and on a coordinator-less host (e.g. Wolverine-managed
+    // event-subscription distribution) restoring continuous execution is the DRIVING CALLER's
+    // responsibility after RebuildProjectionAsync returns — see Wolverine's EventSubscriptionAgent.
+    // RebuildAsync. Restarting here unconditionally would double-start against a store coordinator.
     private async Task rebuildProjection(IProjectionSource<TOperations, TQuerySession> source, TimeSpan shardTimeout, CancellationToken token)
     {
         await Database.EnsureStorageExistsAsync(typeof(IEvent), token).ConfigureAwait(false);

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -610,8 +610,36 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         await StartAgentAsync(name.Identity, token);
         if (_agents.TryFind(name.Identity, out var agent)) return agent;
 
-        // Should not ever happen, but real life man
-        throw new Exception("Unable to start a subscription agent for " + name);
+        // wolverine#3519: the string-overload start returned without throwing, yet nothing is registered
+        // under this identity. Callers (e.g. Wolverine's EventSubscriptionAgent) previously got a bare
+        // Exception with no context and wedged in a permanent retry loop with no way to see why. Surface
+        // the daemon state that explains the miss instead of masking it.
+        throw new ShardStartException(name.Identity, describeStartFailure(name));
+    }
+
+    // wolverine#3519: turn the "agent not registered after a start that did not throw" miss into an
+    // actionable message. The usual causes are a startup race on multi-store / Wolverine-managed hosts
+    // (high-water detection still coming up, or a concurrent stop/replace evicting the just-registered
+    // agent) and a blue/green side-effect gate leaving the shard paused rather than continuous.
+    private string describeStartFailure(ShardName name)
+    {
+        if (_agents.TryFind(name.Identity, out var existing))
+        {
+            return $"An agent is registered for this shard in status '{existing.Status}' rather than running. It may have been paused by an error or a blue/green side-effect gate warm-up; check the log for the pause reason and restart the shard once resolved.";
+        }
+
+        if (!_highWater.IsRunning)
+        {
+            return "High-water detection is not running yet, so the shard could not be positioned. This is typically a transient startup race; retrying the start once high-water detection is up should succeed.";
+        }
+
+        var known = _store.AllShards().Select(x => x.Name.Identity).ToArray();
+        if (!known.Contains(name.Identity, StringComparer.OrdinalIgnoreCase))
+        {
+            return $"No such shard is registered with this store. Known shards are: {known.Join(", ")}.";
+        }
+
+        return "The shard is registered but did not start and did not report an error, which points at a startup race between concurrent agent starts on this daemon. Retrying the start usually succeeds.";
     }
 
     public Task StopAgentAsync(ShardName shardName, Exception? ex = null)
@@ -1480,7 +1508,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         await _store.RewindSubscriptionProgressAsync(Database, subscriptionName, token, sequenceFloor).ConfigureAwait(false);
 
         var agents = buildAgentsForSubscription(subscriptionName);
-        
+
         foreach (var agent in agents)
         {
             Tracker.MarkAsRestarted(agent.Name);
@@ -1488,6 +1516,32 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             await agent.StartAsync(new SubscriptionExecutionRequest(sequenceFloor!.Value, ShardExecutionMode.Continuous,
                 errorOptions, this)).ConfigureAwait(false);
             agent.MarkHighWater(HighWaterMark());
+
+            // wolverine#3520: register the restarted agent in the running set. Before this, rewind started
+            // continuous agents that were never tracked in _agents: _agents still pointed at the agent
+            // stopRunningAgents() had just HardStopped, StartAgentAsync(ShardName) could not find the live
+            // agent, and any subsequent restart through the registered path spun up a DUPLICATE agent on
+            // the same progression row. Under a store-owned coordinator this was masked; under
+            // Wolverine-managed distribution (no coordinator) it left the shard effectively orphaned.
+            await registerStartedAgentAsync(agent).ConfigureAwait(false);
+        }
+    }
+
+    // wolverine#3520: adopt an already-started agent into the running set under the registry lock,
+    // replacing any prior (now-stopped) registration for the same identity. Kept separate from
+    // tryStartAgentAsync because the rewind path has already determined its own floor and started the
+    // agent in Continuous mode; this only reconciles _agents and the tenant-polling set.
+    private async Task registerStartedAgentAsync(ISubscriptionAgent agent)
+    {
+        await _semaphore.WaitAsync(_cancellation.Token).ConfigureAwait(false);
+        try
+        {
+            _agents = _agents.AddOrUpdate(agent.Name.Identity, agent);
+            syncTenantPolling();
+        }
+        finally
+        {
+            _semaphore.Release();
         }
     }
     

--- a/src/JasperFx.Events/Daemon/ShardStartException.cs
+++ b/src/JasperFx.Events/Daemon/ShardStartException.cs
@@ -6,7 +6,12 @@ namespace JasperFx.Events.Daemon;
 public class ShardStartException: Exception
 {
     internal ShardStartException(string projectionIdentity, Exception innerException): base(
-        $"Failure while trying to stop '{projectionIdentity}'", innerException)
+        $"Failure while trying to start '{projectionIdentity}'", innerException)
+    {
+    }
+
+    internal ShardStartException(string projectionIdentity, string reason): base(
+        $"Unable to start a subscription agent for '{projectionIdentity}'. {reason}")
     {
     }
 }


### PR DESCRIPTION
Closes #534 and #535. Companion JasperFx.Events fixes for JasperFx/wolverine#3519 and JasperFx/wolverine#3520 — the daemon-side halves those Wolverine issues reference. The Wolverine-side change for #3520 rides on top of this (JasperFx/wolverine#3523).

## #534 — `StartAgentAsync(ShardName)` masked the failure reason

`tryStartAgentAsync` swallowed a faulted start into a `bool`, so `StartAgentAsync(ShardName)` could only throw a **causeless** `Exception("Unable to start a subscription agent for …")`, filling a retrying caller's log with identical stackless stacks.

- Stash the caught start exception per shard identity (`_lastStartFailures`) and **attach it as the inner exception** when the wrapper throws; clear it on a later successful start.
- When no exception was captured (the start returned `false` from a non-throwing path), throw a `ShardStartException` whose message **describes the daemon state** that explains the miss — a registered-but-paused agent (with its status), high-water detection not yet running, an unknown shard, or a concurrent-start race.
- Log the two previously-**silent** "already running" idempotent `return false` paths at Debug so the "why did my start return false" trail is unbroken (the side-effect gate and catch paths already logged).
- Fix the `ShardStartException` message that said "stop" on a start failure.

## #535 — rebuild/rewind lifecycle gaps on coordinator-less hosts

**Part 2 (rewind bypasses the registry) — fixed.** `RewindSubscriptionAsync` stopped the running continuous agents, rewound progress, then rebuilt and `StartAsync`ed fresh continuous agents that were **never registered in `_agents`**. `CurrentAgents()` and `StartAgentAsync(ShardName)` (both read `_agents`) kept seeing only the pre-rewind agent that `stopRunningAgents()` had just HardStopped — so the shard was orphaned under Wolverine-managed distribution, and a later restart spun up a **duplicate** agent on the same progression row. Now each restarted agent is registered under the registry lock (`registerStartedAgentAsync`), making a subsequent `StartAgentAsync` idempotent.

**Part 1 (rebuild never restarts) — documented as contract.** `rebuildProjection` stops the continuous agents and intentionally does not restart them: a store coordinator resurrects them, and on coordinator-less hosts restoring continuous execution is the **driving caller's** responsibility (Wolverine's `EventSubscriptionAgent.RebuildAsync`, JasperFx/wolverine#3523). Restarting here unconditionally would double-start against a store coordinator, so this is a doc-note rather than a behavior change.

## Tests

`PerTenantStartAgentAsyncTests.rewind_leaves_the_restarted_agent_registered_and_running` — starts a store-global agent, rewinds, and asserts exactly one agent is registered afterward, running, and a fresh instance (not the HardStopped pre-rewind one). Verified red before the registration fix, green after. All 240 `EventTests.Daemon` tests pass on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LDiv9GqbQkkAuU1nf4H6S

---

**Related issues**
- Closes #534
- Closes #535
- Wolverine issues addressed: JasperFx/wolverine#3519, JasperFx/wolverine#3520
- Wolverine-side PR: JasperFx/wolverine#3523