### PR TITLE
feat(#537): wire the extended progression write path into the async daemon

### DIFF
--- a/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
@@ -1,0 +1,258 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class ExtendedProgressionWriterTests
+{
+    private readonly IEventStore theStore = Substitute.For<IEventStore>();
+    private readonly RecordingEventDatabase theDatabase = new();
+    private readonly FakeTimeProvider theTime = new();
+    private readonly ExtendedProgressionWriter theWriter;
+
+    public ExtendedProgressionWriterTests()
+    {
+        theStore.ExtendedProgressionEnabled.Returns(true);
+        theWriter = new ExtendedProgressionWriter(theStore, theDatabase, theTime, NullLogger.Instance);
+    }
+
+    private static ShardState transition(ShardAction action, string status, string? pauseReason = null,
+        string shardName = "Counters:All")
+    {
+        return new ShardState(shardName, 42)
+        {
+            Action = action,
+            AgentStatus = status,
+            PauseReason = pauseReason,
+            LastHeartbeat = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static ShardState heartbeat(string shardName = "Counters:All")
+    {
+        return new ShardState(shardName, 42)
+        {
+            Action = ShardAction.Updated,
+            AgentStatus = "Running",
+            LastHeartbeat = DateTimeOffset.UtcNow
+        };
+    }
+
+    [Fact]
+    public async Task writes_status_transitions_through_the_database()
+    {
+        theWriter.OnNext(transition(ShardAction.Started, "Running"));
+        theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
+        theWriter.OnNext(transition(ShardAction.Stopped, "Stopped"));
+
+        var writes = await theDatabase.WaitForWrites(3);
+
+        writes[0].AgentStatus.ShouldBe("Running");
+        writes[1].AgentStatus.ShouldBe("Paused");
+        writes[1].PauseReason.ShouldBe("boom");
+        writes[2].AgentStatus.ShouldBe("Stopped");
+    }
+
+    [Fact]
+    public async Task no_writes_at_all_when_the_store_has_not_opted_in()
+    {
+        theStore.ExtendedProgressionEnabled.Returns(false);
+
+        theWriter.OnNext(transition(ShardAction.Started, "Running"));
+        theWriter.OnNext(heartbeat());
+        theWriter.OnNext(transition(ShardAction.Stopped, "Stopped"));
+
+        await theDatabase.AssertNoWrites();
+    }
+
+    [Fact]
+    public async Task skips_high_water_mark_and_all_projections_states()
+    {
+        theWriter.OnNext(new ShardState(ShardState.HighWaterMark, 100)
+        {
+            AgentStatus = "Running", LastHeartbeat = DateTimeOffset.UtcNow
+        });
+        theWriter.OnNext(new ShardState(ShardState.AllProjections, 100)
+        {
+            AgentStatus = "Running", LastHeartbeat = DateTimeOffset.UtcNow
+        });
+
+        await theDatabase.AssertNoWrites();
+    }
+
+    [Fact]
+    public async Task skips_plain_progress_publications_with_no_agent_telemetry()
+    {
+        // e.g. the RangeCompleted publication from a rebuild
+        theWriter.OnNext(new ShardState("Counters:All", 42));
+
+        await theDatabase.AssertNoWrites();
+    }
+
+    [Fact]
+    public async Task throttles_heartbeat_writes_per_shard_but_never_transitions()
+    {
+        theWriter.OnNext(heartbeat());
+        theWriter.OnNext(heartbeat()); // same instant, throttled
+        theWriter.OnNext(heartbeat("Others:All")); // different shard, its own budget
+
+        var writes = await theDatabase.WaitForWrites(2);
+        writes.Count(x => x.ShardName == "Counters:All").ShouldBe(1);
+        writes.Count(x => x.ShardName == "Others:All").ShouldBe(1);
+
+        // A transition inside the throttle window still writes immediately
+        theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
+        await theDatabase.WaitForWrites(3);
+
+        // And once the interval passes, heartbeats flow again
+        theTime.Advance(theWriter.HeartbeatWriteInterval + TimeSpan.FromMilliseconds(1));
+        theWriter.OnNext(heartbeat());
+        var all = await theDatabase.WaitForWrites(4);
+        all.Count(x => x.ShardName == "Counters:All").ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_throwing_database_write_is_swallowed_and_does_not_stop_subsequent_writes()
+    {
+        theDatabase.FailNextWrite = true;
+
+        theWriter.OnNext(transition(ShardAction.Started, "Running"));
+        theWriter.OnNext(transition(ShardAction.Stopped, "Stopped"));
+
+        // The first write threw, so only the second lands — and the writer kept going
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].AgentStatus.ShouldBe("Stopped");
+    }
+
+    [Fact]
+    public async Task carries_the_assigned_node_number_into_running_on_node()
+    {
+        var state = transition(ShardAction.Started, "Running");
+        state.AssignedNodeNumber = 3;
+
+        theWriter.OnNext(state);
+
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].RunningOnNode.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task does_not_clobber_an_explicit_running_on_node()
+    {
+        var state = transition(ShardAction.Started, "Running");
+        state.AssignedNodeNumber = 3;
+        state.RunningOnNode = 7;
+
+        theWriter.OnNext(state);
+
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].RunningOnNode.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task subscription_agent_lifecycle_flows_through_a_tracker_into_the_database()
+    {
+        // End-to-end through the real tracker + a real SubscriptionAgent: start (Running heartbeat)
+        // then stop (Stopped), proving the daemon-published states reach the store write
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+        tracker.Subscribe(theWriter);
+
+        var agent = new SubscriptionAgent(new ShardName("Counters"), new AsyncOptions(), theTime,
+            Substitute.For<IEventLoader>(), Substitute.For<ISubscriptionExecution>(), tracker,
+            Substitute.For<ISubscriptionMetrics>(), NullLogger.Instance);
+
+        await agent.StartAsync(new SubscriptionExecutionRequest(0, ShardExecutionMode.Continuous,
+            new ErrorHandlingOptions(), new NulloDaemonRuntime()));
+
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].ShardName.ShouldBe("Counters:All");
+        writes[0].AgentStatus.ShouldBe("Running");
+        writes[0].LastHeartbeat.ShouldNotBeNull();
+
+        await agent.StopAndDrainAsync(CancellationToken.None);
+
+        writes = await theDatabase.WaitForWrites(2);
+        writes[1].AgentStatus.ShouldBe("Stopped");
+    }
+
+    private class RecordingEventDatabase : IEventDatabase
+    {
+        private readonly List<ShardState> _writes = new();
+        private readonly SemaphoreSlim _signal = new(0);
+
+        public bool FailNextWrite { get; set; }
+
+        public Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+        {
+            if (FailNextWrite)
+            {
+                FailNextWrite = false;
+                _signal.Release();
+                throw new InvalidOperationException("The database is grumpy");
+            }
+
+            lock (_writes)
+            {
+                _writes.Add(state);
+            }
+
+            _signal.Release();
+            return Task.CompletedTask;
+        }
+
+        public async Task<IReadOnlyList<ShardState>> WaitForWrites(int count)
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (true)
+            {
+                lock (_writes)
+                {
+                    if (_writes.Count >= count) return _writes.ToList();
+                }
+
+                await _signal.WaitAsync(timeout.Token);
+            }
+        }
+
+        public async Task AssertNoWrites()
+        {
+            // Give the background block a beat to (not) do its thing
+            await Task.Delay(100);
+            lock (_writes)
+            {
+                _writes.ShouldBeEmpty();
+            }
+        }
+
+        // Unused IEventDatabase surface
+        public string Identifier => "recording";
+        public Uri DatabaseUri => new("db://recording");
+        public ShardStateTracker Tracker => null!;
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent,
+            CancellationToken token) => Task.CompletedTask;
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token) => Task.CompletedTask;
+
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout) => Task.CompletedTask;
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => Task.FromResult(0L);
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => Task.FromResult<long?>(null);
+
+        public string StorageIdentifier => "recording";
+
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token) => Task.FromResult(0L);
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => Task.FromResult<IReadOnlyList<ShardState>>([]);
+    }
+}

--- a/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
+++ b/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
@@ -1,0 +1,131 @@
+using ImTools;
+using JasperFx.Blocks;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging;
+
+namespace JasperFx.Events.Daemon;
+
+/// <summary>
+/// Subscribes to a daemon's <see cref="ShardStateTracker"/> and persists the extended progression
+/// telemetry (heartbeat, agent status, pause reason, running node) that the subscription agents
+/// already compute in process, by driving <see cref="IEventDatabase.WriteExtendedProgressionAsync"/>.
+/// This is the missing write half of extended progression tracking — the schema columns and the read
+/// surface existed, but no daemon path ever persisted them (jasperfx#537, "built and never connected"
+/// per #519).
+///
+/// <para>
+/// Behavior:
+/// <list type="bullet">
+/// <item>Gated on <see cref="IEventStore.ExtendedProgressionEnabled"/>, read live per publication —
+/// nothing is written (or even queued) for stores that have not opted in.</item>
+/// <item>Agent status transitions (<see cref="ShardAction.Started"/>, <see cref="ShardAction.Paused"/>,
+/// <see cref="ShardAction.Stopped"/>) are always written, immediately — a paused/stopped shard is
+/// exactly when the persisted status matters most.</item>
+/// <item><see cref="ShardAction.Updated"/> publications carrying agent telemetry (the ~10s heartbeat
+/// timer ticks and the per-batch commit publications) are throttled to at most one write per
+/// <see cref="HeartbeatWriteInterval"/> per shard, so a fast-committing shard does not turn every
+/// batch into an extra progression-table write.</item>
+/// <item>Writes are best-effort and serialized on a background block: a failed write is logged at
+/// debug and can never fail or stall the shard, and a slow database can never back up the
+/// tracker's publication loop.</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDisposable
+{
+    private readonly IEventStore _store;
+    private readonly IEventDatabase _database;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger _logger;
+    private readonly Block<ShardState> _block;
+
+    // Only ever touched from the tracker's single publication consumer, so no synchronization needed
+    private ImHashMap<string, DateTimeOffset> _lastWrites = ImHashMap<string, DateTimeOffset>.Empty;
+
+    public ExtendedProgressionWriter(IEventStore store, IEventDatabase database, TimeProvider timeProvider,
+        ILogger logger)
+    {
+        _store = store;
+        _database = database;
+        _timeProvider = timeProvider;
+        _logger = logger;
+
+        _block = new Block<ShardState>(writeAsync);
+
+        // Belt and braces: writeAsync already swallows its own failures, but a failure escaping the
+        // block must still never take anything else down
+        _block.OnError = (state, ex) =>
+            _logger.LogDebug(ex, "Failed to persist extended progression for shard {ShardName}", state.ShardName);
+    }
+
+    /// <summary>
+    /// Minimum spacing between two persisted heartbeat/telemetry writes for the same shard on the
+    /// non-transition (<see cref="ShardAction.Updated"/>) path. Status transitions are never throttled.
+    /// Defaults to 5 seconds so every tick of the agents' 10 second heartbeat timer lands.
+    /// </summary>
+    public TimeSpan HeartbeatWriteInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    public void OnNext(ShardState value)
+    {
+        if (!_store.ExtendedProgressionEnabled) return;
+
+        // Only real projection/subscription shards have a progression row to decorate
+        if (value.ShardName == ShardState.HighWaterMark || value.ShardName == ShardState.AllProjections) return;
+
+        // Plain progress publications (e.g. rebuild range completions) carry no agent telemetry
+        if (value.AgentStatus == null && value.LastHeartbeat == null) return;
+
+        var isTransition = value.Action is ShardAction.Started or ShardAction.Paused or ShardAction.Stopped;
+        var now = _timeProvider.GetUtcNow();
+
+        if (!isTransition)
+        {
+            if (_lastWrites.TryFind(value.ShardName, out var last) && now - last < HeartbeatWriteInterval)
+            {
+                return;
+            }
+        }
+
+        _lastWrites = _lastWrites.AddOrUpdate(value.ShardName, now);
+
+        // Carry the assigned node through to the persisted running_on_node column when a
+        // distribution layer (e.g. Wolverine-managed subscription distribution) stamped it
+        if (value.RunningOnNode == null && value.AssignedNodeNumber != 0)
+        {
+            value.RunningOnNode = value.AssignedNodeNumber;
+        }
+
+        _block.Post(value);
+    }
+
+    private async Task writeAsync(ShardState state, CancellationToken token)
+    {
+        try
+        {
+            await _database.WriteExtendedProgressionAsync(state, token).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            // Best-effort telemetry: a failed extended-progression write must NEVER fail or
+            // stall the shard
+            _logger.LogDebug(e, "Failed to persist extended progression for shard {ShardName} on database {Database}",
+                state.ShardName, _database.Identifier);
+        }
+    }
+
+    public void OnCompleted()
+    {
+    }
+
+    public void OnError(Exception error)
+    {
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        // Lets any queued final writes (e.g. the Stopped state published during shutdown) drain
+        // in the background rather than dropping them on the floor
+        _block.Complete();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -31,6 +31,11 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     private CancellationTokenSource _cancellation = new();
     private readonly HighWaterAgent _highWater;
     private readonly IDisposable _breakSubscription;
+
+    // jasperfx#537: persists agent status transitions + heartbeat ticks onto the store's extended
+    // progression columns when the store opts in via IEventStore.ExtendedProgressionEnabled
+    private readonly ExtendedProgressionWriter _extendedProgression;
+    private readonly IDisposable _extendedProgressionSubscription;
     private RetryBlock<DeadLetterEvent> _deadLetterBlock;
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
@@ -139,6 +144,12 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _breakSubscription = database.Tracker.Subscribe(this);
 
+        // jasperfx#537: subscribe unconditionally; the writer checks the store's
+        // ExtendedProgressionEnabled flag live per publication so runtime opt-in is honored
+        _extendedProgression = new ExtendedProgressionWriter(store, database, store.TimeProvider,
+            loggerFactory.CreateLogger<ExtendedProgressionWriter>());
+        _extendedProgressionSubscription = Tracker.Subscribe(_extendedProgression);
+
         _deadLetterBlock = buildDeadLetterBlock();
 
         MaxConcurrentEventLoadsPerDatabase = _projections.MaxConcurrentEventLoadsPerDatabase;
@@ -169,6 +180,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
 
         _breakSubscription = database.Tracker.Subscribe(this);
+
+        // jasperfx#537: see the ILoggerFactory constructor overload for the rationale
+        _extendedProgression = new ExtendedProgressionWriter(store, database, store.TimeProvider, logger);
+        _extendedProgressionSubscription = Tracker.Subscribe(_extendedProgression);
 
         _deadLetterBlock = buildDeadLetterBlock();
 
@@ -202,6 +217,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         _tenantHighWaterTimer?.Stop();
         _tenantHighWaterTimer?.Dispose();
         _breakSubscription.Dispose();
+        _extendedProgressionSubscription.Dispose();
+        // Completes the writer's queue so a final Stopped write can drain in the background
+        _ = _extendedProgression.DisposeAsync();
         _deadLetterBlock.Dispose();
         _loadThrottle?.Dispose();
         _batchWriteThrottle?.Dispose();

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -132,6 +132,39 @@ public interface IEventDatabase
             "DeleteProjectionProgressByShardNameAsync is not implemented on this IEventDatabase. Use an event store (Marten or Polecat) that supports deleting a projection-progression row by its raw shard identity.");
 
     /// <summary>
+    ///     Persist the extended progression telemetry for a single projection/subscription shard —
+    ///     heartbeat, agent status, pause reason, running node — onto the store's progression row for
+    ///     <see cref="ShardState.ShardName" /> (the raw shard identity). This is the write half of the
+    ///     extended progression tracking feature (<see cref="IEventStoreInstrumentation.ExtendedProgressionEnabled" />):
+    ///     the daemon computes these values in process (agent status transitions, the ~10s heartbeat
+    ///     timer) and drives this method through <see cref="Daemon.ExtendedProgressionWriter" />, so a
+    ///     monitoring consumer polling the database (e.g. CritterWatch when the publishing node is down)
+    ///     can see shard health without an in-process channel. See jasperfx#537.
+    ///     <para>
+    ///     Contract for implementations:
+    ///     <list type="bullet">
+    ///     <item>Best-effort telemetry — never throw for a missing row; a shard that has not yet
+    ///     committed any progression simply has nowhere to record status, and the write should no-op.
+    ///     Transient failures may throw; the caller logs at debug and never fails the shard.</item>
+    ///     <item>Do NOT advance or regress <c>last_seq_id</c>-equivalent progression from this path.
+    ///     Progression is owned by the projection batch commit; this write updates only the extended
+    ///     telemetry columns, so it can never race a concurrent batch commit into losing progress.</item>
+    ///     </list>
+    ///     </para>
+    ///     The default implementation is a graceful no-op so existing stores compile and degrade
+    ///     silently until they implement the write (the established graceful-no-op pattern).
+    /// </summary>
+    /// <param name="state">
+    ///     The published shard state carrying <see cref="ShardState.AgentStatus" />,
+    ///     <see cref="ShardState.PauseReason" />, <see cref="ShardState.LastHeartbeat" /> and
+    ///     <see cref="ShardState.RunningOnNode" /> for the shard named by
+    ///     <see cref="ShardState.ShardName" />.
+    /// </param>
+    /// <param name="token"></param>
+    Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+        => Task.CompletedTask;
+
+    /// <summary>
     ///     Count the stored dead letter events for a single projection/subscription shard. With
     ///     <c>SkipApplyErrors</c> on (the JasperFx.Events 2.0 default), a failed <c>Apply()</c> is
     ///     recorded as a <see cref="DeadLetterEvent" /> and the shard keeps advancing, so the

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -64,6 +64,20 @@ public interface IEventStore
     bool DistributesAgentsPerTenant => false;
 
     /// <summary>
+    ///     Whether extended progression tracking is enabled for this store — the store-level opt-in that
+    ///     creates the extended progression columns (heartbeat, agent_status, pause_reason,
+    ///     running_on_node) and, as of jasperfx#537, gates the daemon's write path onto them: when true,
+    ///     the async daemon subscribes an <see cref="Daemon.ExtendedProgressionWriter" /> publication of
+    ///     agent status transitions and heartbeat ticks through
+    ///     <see cref="IEventDatabase.WriteExtendedProgressionAsync" />. Concrete stores override this to
+    ///     reflect their own opt-in flag (Marten's <c>EnableExtendedProgressionTracking</c> /
+    ///     <see cref="IEventStoreInstrumentation.ExtendedProgressionEnabled" />); the default is false so
+    ///     nothing changes for stores that have not opted in. Read live per publication, so a runtime
+    ///     flip is honored.
+    /// </summary>
+    bool ExtendedProgressionEnabled => false;
+
+    /// <summary>
     ///     Resolve every <see cref="IEventDatabase" /> backing this event store, store-agnostically.
     ///     This is the store-neutral counterpart to Marten's <c>IMartenStorage.AllDatabases()</c> — it lets
     ///     monitoring/tooling code (e.g. CritterWatch) obtain an <see cref="IEventDatabase" /> to call the read


### PR DESCRIPTION
Closes #537. Companion Marten filing: JasperFx/marten#4981; surfaced by JasperFx/CritterWatch#750.

## What

Extended progression tracking (`ExtendedProgressionEnabled`) created the schema columns (`heartbeat`, `agent_status`, `pause_reason`, `running_on_node`) and a faithful read surface, but **no daemon path ever persisted them** — "built and never connected" (#519). This PR adds the daemon-level write path, flowing through the store abstraction so Marten and Polecat implement only the store-side write.

## Design

- **`IEventDatabase.WriteExtendedProgressionAsync(ShardState, CancellationToken)`** — the store-side persistence hook, default-implemented as a graceful no-op (the established pattern), so every existing store compiles and degrades silently until it implements the write. The documented contract forbids touching progression (`last_seq_id`-equivalents) from this path, so a telemetry write can never race a concurrent batch commit into losing or regressing progress.
- **`IEventStore.ExtendedProgressionEnabled`** (default `false`) — store-level gate, read live per publication so a runtime flip (e.g. CritterWatch's forced enable of the DI-registered `IEventStoreInstrumentation`) is honored.
- **`ExtendedProgressionWriter`** — a `ShardStateTracker` observer subscribed by `JasperFxAsyncDaemon` at construction (the same shape as `StoreUriStampingObserver` / `SkippedEventsCountObserver`):
  - Agent status transitions (`Started` / `Paused` + `pause_reason` / `Stopped`) write **immediately** — a paused or stalled shard is exactly when persisted status matters most (the CritterWatch node-down / HWM-frozen alerting case).
  - Heartbeat ticks (the agents' existing ~10s timer) and per-batch-commit publications are throttled to one write per 5s per shard, so the heartbeat column advances on every tick without turning every batch commit into an extra progression-table write. The heartbeat write path is deliberately **not** coupled to progress advance.
  - Writes are serialized on a background block and strictly best-effort: a throwing store write is logged at debug and never fails or stalls the shard; a slow database never backs up the tracker's publication loop.
  - Carries `AssignedNodeNumber` through to `running_on_node` when a distribution layer stamped it.

## Test evidence

New `EventTests.Daemon.ExtendedProgressionWriterTests` (9 tests): transitions write through; heartbeats throttle per shard (FakeTimeProvider); zero writes when the store hasn't opted in; HighWaterMark/AllProjections and telemetry-less publications skipped; a throwing database write is swallowed and subsequent writes continue; node-number carry; and an end-to-end pass through a real `ShardStateTracker` + `SubscriptionAgent` (start → Running write with heartbeat, stop → Stopped write).

Full local runs green: EventTests 562/562, EventStoreTests 72/72, CoreTests 470/470.

**Clean-room end-to-end (with the companion Marten branch implementing the store write):** the preserved #537 repro (plain `AddMarten().AddAsyncDaemon(Solo)`, one async projection, flag forced via the DI `IEventStoreInstrumentation`) on locally-packed JasperFx.Events `2.31.0-dev.1` + Marten `9.17.0-dev.1`:

```
--- running, t+15s ---  Counters:All  seq=47   heartbeat=4:50:40 PM  agent_status=Running  pause_reason=NULL
--- running, t+30s ---  Counters:All  seq=97   heartbeat=4:50:55 PM  agent_status=Running  pause_reason=NULL
--- running, t+45s ---  Counters:All  seq=146  heartbeat=4:51:10 PM  agent_status=Running  pause_reason=NULL
=== stopping host ===
--- after host stop --- Counters:All  seq=146  heartbeat=4:51:15 PM  agent_status=Stopped
```

Previously (2.29.0/2.30.1/2.30.2 × Marten 9.16.x): every one of those columns NULL at all times.

## Store-side follow-ups

- **Marten** (required for end-to-end): `MartenDatabase.WriteExtendedProgressionAsync` as an UPDATE-only decoration of `mt_event_progression` + the `IEventStore.ExtendedProgressionEnabled` override — companion PR on JasperFx/marten referencing #4981.
- **Polecat**: inherits the graceful no-op until it implements the write (polecat#323 remains the tracker; its heartbeat-on-progress-advance path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)