### PR TITLE
GH-540: tear down a faulted shard start so it can't orphan the shard

### DIFF
--- a/src/EventTests/Daemon/SubscriptionAgentTests.cs
+++ b/src/EventTests/Daemon/SubscriptionAgentTests.cs
@@ -249,4 +249,29 @@ public class SubscriptionAgentTests
         theAgent.LastCommitted.ShouldBe(7000); // no change
         theAgent.HighWaterMark.ShouldBe(highWaterMark);
     }
+
+    // jasperfx#540: a faulted start is now torn down at the point of failure AND the daemon start caller
+    // still disposes the agent on a false return, so the same agent can be disposed twice. DisposeAsync
+    // must be idempotent so the second call is a harmless no-op rather than re-disposing the execution.
+    [Fact]
+    public async Task dispose_is_idempotent()
+    {
+        await theAgent.DisposeAsync();
+        await theAgent.DisposeAsync();
+
+        await theExecution.Received(1).DisposeAsync();
+    }
+
+    // jasperfx#540: the teardown of a partially-started agent goes through HardStopAsync (hard-stop the
+    // execution loop + dispose), and the caller's subsequent DisposeAsync must not tear the execution down
+    // a second time.
+    [Fact]
+    public async Task hard_stop_then_dispose_tears_the_execution_down_exactly_once()
+    {
+        await theAgent.HardStopAsync();
+        await theAgent.DisposeAsync();
+
+        await theExecution.Received(1).HardStopAsync();
+        await theExecution.Received(1).DisposeAsync();
+    }
 }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -316,6 +316,25 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             // jasperfx#534: stash the cause so StartAgentAsync(ShardName) can attach it to the exception it
             // throws instead of a causeless "Unable to start" that fills a caller's retry log forever.
             _lastStartFailures = _lastStartFailures.AddOrUpdate(agent.Name.Identity, ex);
+
+            // jasperfx#540: agent.StartAsync may have already spun up the execution pipeline and heartbeat
+            // and begun advancing before it faulted. This agent was NEVER added to _agents, so no later
+            // StopAgentAsync can reach it -- returning now would leave it orphaned, still holding the
+            // shard's execution loop. On multi-store / Wolverine-managed hosts that is a candidate for the
+            // permanent first-start wedge in wolverine#3519. Hard-stop it here so a faulted start is always
+            // fully released at the point of failure, independent of what the caller does. Guarded so a
+            // secondary teardown failure never masks the original cause.
+            try
+            {
+                await agent.HardStopAsync().ConfigureAwait(false);
+            }
+            catch (Exception teardownEx)
+            {
+                Logger.LogDebug(teardownEx,
+                    "Error tearing down partially-started agent {ShardName} after a failed start",
+                    agent.Name.Identity);
+            }
+
             return false;
         }
         finally

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -95,8 +95,21 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     // pumping pages instead of stalling. Only touched on the command-loop thread.
     private long _bufferedCeiling;
 
+    private bool _disposed;
+
     public async ValueTask DisposeAsync()
     {
+        // jasperfx#540: be idempotent. A faulted start is now torn down at the point of failure (see
+        // JasperFxAsyncDaemon.tryStartAgentAsync), and the daemon's start caller ALSO disposes the agent
+        // on a false return -- so the same agent can legitimately be disposed twice. Guard so the second
+        // call is a harmless no-op rather than re-cancelling/re-completing/re-disposing the execution.
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
         if (_heartbeatTimer != null)
         {
             await _heartbeatTimer.DisposeAsync().ConfigureAwait(false);


### PR DESCRIPTION
Closes the "orphaned partial start" half of #540 (filed from the wolverine#3519 investigation).

## Context

On `main`, `JasperFxAsyncDaemon.tryStartAgentAsync` already:
- stashes the caught start exception in `_lastStartFailures` so `StartAgentAsync(ShardName)` can attach the real cause (#534), and
- has its single caller (`startContinuousShardAsync`) dispose the throwaway agent on a `false` return.

The residual gap (#540 Problem 1): a start that **faults after `agent.StartAsync` has already spun up the execution pipeline / heartbeat** leaves an agent that was **never added to `_agents`** — so no later `StopAgentAsync` can reach it — and the only teardown was the caller's weaker `DisposeAsync`, not a real stop of the execution loop. On multi-store / Wolverine-managed hosts an orphan holding the shard's execution loop is a candidate for the permanent first-start wedge in wolverine#3519.

## Change

- **`tryStartAgentAsync`** now tears the faulted agent down **at the point of failure** via `HardStopAsync()` (hard-stop the execution + dispose + publish `Stopped`), guarded so a secondary teardown failure never masks the original cause. Teardown no longer depends on the caller's contract.
- **`SubscriptionAgent.DisposeAsync`** is now **idempotent** (a `_disposed` guard) so the caller's existing dispose-on-`false` remains a safe no-op after the hard stop.

## Tests

`SubscriptionAgentTests`:
- `dispose_is_idempotent` — two `DisposeAsync` calls tear the execution down once.
- `hard_stop_then_dispose_tears_the_execution_down_exactly_once` — the teardown path (`HardStopAsync` then a redundant `DisposeAsync`) disposes the execution exactly once.

Both **red-verified** without the `_disposed` guard. Full `EventTests` `SubscriptionAgentTests` + `PerTenantStartAgentAsyncTests` green (30 tests); the success path (and its existing `DaemonHarness` coverage) is unchanged, since the new teardown only runs on the fault path.

> Note: the daemon-level fault path is exercised indirectly (existing `DaemonHarness` regression + the unit-tested teardown primitive) — forcing a mid-start fault at the daemon level needs a real store, so it isn't unit-tested directly here.

_Follow-up from wolverine#3519 / wolverine#3550._