### PR TITLE
feat(#539): HighWaterAgent liveness heartbeat, staleness surface, and local restart seam

### DIFF
--- a/src/EventTests/Daemon/CrossProductRebuildCapTests.cs
+++ b/src/EventTests/Daemon/CrossProductRebuildCapTests.cs
@@ -473,6 +473,9 @@ public class CrossProductRebuildCapTests
         public Task CatchUpAsync(TimeSpan timeout, CancellationToken cancellation) => throw new NotSupportedException();
         public Task WaitForNonStaleData(TimeSpan timeout) => throw new NotSupportedException();
         public long HighWaterMark() => throw new NotSupportedException();
+        public DateTimeOffset? HighWaterLastPolledAt => throw new NotSupportedException();
+        public bool IsHighWaterStale => throw new NotSupportedException();
+        public Task RestartHighWaterAgentAsync(CancellationToken token) => throw new NotSupportedException();
         public Task WaitForShardToBeRunning(string shardName, TimeSpan timeout) => throw new NotSupportedException();
         public Task RewindSubscriptionAsync(string subscriptionName, CancellationToken token, long? sequenceFloor = 0, DateTimeOffset? timestamp = null) => throw new NotSupportedException();
         public IReadOnlyList<ISubscriptionAgent> CurrentAgents() => throw new NotSupportedException();

--- a/src/EventTests/Daemon/HighWater/HighWaterAgent_liveness_Tests.cs
+++ b/src/EventTests/Daemon/HighWater/HighWaterAgent_liveness_Tests.cs
@@ -1,0 +1,218 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// jasperfx#539: the store-global high-water poll loop (Path A) now publishes a per-cycle liveness heartbeat
+// — proof it is *cycling*, independent of whether the mark is *advancing* — surfaces staleness, and the
+// watchdog restarts a loop that has stopped completing cycles, not only one that faulted (#524). None of
+// the new behavior ever advances the high-water mark.
+public class HighWaterAgent_liveness_Tests
+{
+    private static HighWaterAgent buildAgent(IHighWaterDetector detector, ShardStateTracker tracker,
+        DaemonSettings settings, CancellationToken token, string meterName)
+        => new(new Meter(meterName), detector, tracker, NullLogger.Instance, settings, token);
+
+    // Every completed cycle publishes a Running HighWaterMark state carrying a heartbeat, and none of them
+    // pushes the mark past what the detector actually reports.
+    [Fact]
+    public async Task publishes_a_running_heartbeat_every_cycle_without_advancing_the_mark()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SteadyDetector(currentMark: 5);
+        var settings = new DaemonSettings
+        {
+            FastPollingTime = 20.Milliseconds(),
+            SlowPollingTime = 20.Milliseconds()
+        };
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+        var recorder = new RecordingObserver();
+        using var subscription = tracker.Subscribe(recorder);
+
+        var agent = buildAgent(detector, tracker, settings, cts.Token, "jasperfx.tests.highwater.heartbeat");
+        await agent.StartAsync();
+
+        // Several cycles' worth of heartbeats arrive, each Running.
+        (await recorder.WaitForCount(s => s.AgentStatus == "Running", 3, 5.Seconds())).ShouldBeTrue();
+
+        agent.LastPolledAt.ShouldNotBeNull();
+        agent.IsStale(5.Seconds(), DateTimeOffset.UtcNow).ShouldBeFalse();
+
+        // The detector never advances, so the heartbeats must never move the mark off 5.
+        tracker.HighWaterMark.ShouldBe(5);
+        recorder.States.ShouldAllBe(s => s.Sequence <= 5);
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    // A wakeup that stops firing (returns for its first calls, then blocks forever) wedges the loop: it stops
+    // completing cycles, so LastPolledAt ages out, IsStale trips, and the watchdog restarts it — publishing a
+    // Restarted state. The restart never advances the mark off the detector's value.
+    [Fact]
+    public async Task watchdog_restarts_a_wedged_loop_that_stopped_cycling()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SteadyDetector(currentMark: 7);
+        var wakeup = new BlockAfterWakeup(freeCalls: 2);
+        var settings = new DaemonSettings
+        {
+            Wakeup = wakeup,
+            FastPollingTime = 10.Milliseconds(),
+            SlowPollingTime = 10.Milliseconds(),
+            HealthCheckPollingTime = 40.Milliseconds(),
+            HighWaterStalenessThreshold = 200.Milliseconds()
+        };
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+        var recorder = new RecordingObserver();
+        using var subscription = tracker.Subscribe(recorder);
+
+        var agent = buildAgent(detector, tracker, settings, cts.Token, "jasperfx.tests.highwater.stale");
+        await agent.StartAsync();
+
+        // The loop parks in the wakeup after its free calls, goes stale, and the watchdog restarts it.
+        (await recorder.WaitForCount(s => s.Action == ShardAction.Restarted, 1, 5.Seconds())).ShouldBeTrue();
+        tracker.HighWaterMark.ShouldBe(7);
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    // The explicit restart seam re-establishes the loop, republishes a Restarted state, and never advances
+    // the mark — a health check can remediate in-process without risking a forced skip.
+    [Fact]
+    public async Task restart_async_re_establishes_the_loop_without_advancing_the_mark()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new SteadyDetector(currentMark: 3);
+        var settings = new DaemonSettings
+        {
+            FastPollingTime = 20.Milliseconds(),
+            SlowPollingTime = 20.Milliseconds()
+        };
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+        var recorder = new RecordingObserver();
+        using var subscription = tracker.Subscribe(recorder);
+
+        var agent = buildAgent(detector, tracker, settings, cts.Token, "jasperfx.tests.highwater.restart");
+        await agent.StartAsync();
+        (await recorder.WaitForCount(s => s.AgentStatus == "Running", 1, 5.Seconds())).ShouldBeTrue();
+
+        await agent.RestartAsync();
+
+        // The Restarted state is published through the tracker's async block, so wait for it to be observed
+        // rather than reading immediately after the await (which only guarantees it was posted).
+        (await recorder.WaitForCount(s => s.Action == ShardAction.Restarted, 1, 5.Seconds())).ShouldBeTrue();
+        agent.IsRunning.ShouldBeTrue();
+        tracker.HighWaterMark.ShouldBe(3);
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    // Reports a fixed, caught-up mark forever (CurrentMark == HighestSequence), so the loop cycles cleanly
+    // without ever advancing the mark — isolating the heartbeat/liveness behavior from mark movement.
+    private sealed class SteadyDetector : IHighWaterDetector
+    {
+        private readonly long _currentMark;
+        private static readonly DateTimeOffset Timestamp = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public SteadyDetector(long currentMark) => _currentMark = currentMark;
+
+        public Uri DatabaseUri { get; } = new("fake://liveness-db");
+        public bool SupportsTenantPartitioning => false;
+
+        private Task<HighWaterStatistics> stat()
+            => Task.FromResult(new HighWaterStatistics
+            {
+                CurrentMark = _currentMark, HighestSequence = _currentMark, LastMark = _currentMark,
+                Timestamp = Timestamp
+            });
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token) => stat();
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => stat();
+    }
+
+    // Returns immediately for its first N calls, then blocks forever (honoring cancellation) — modelling a
+    // custom IDaemonWakeup that stops firing while the loop is otherwise alive.
+    private sealed class BlockAfterWakeup : IDaemonWakeup
+    {
+        private readonly int _freeCalls;
+        private int _calls;
+
+        public BlockAfterWakeup(int freeCalls) => _freeCalls = freeCalls;
+
+        public Task WaitAsync(TimeSpan timeout, CancellationToken token)
+        {
+            return Interlocked.Increment(ref _calls) <= _freeCalls
+                ? Task.CompletedTask
+                : Task.Delay(Timeout.Infinite, token);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class RecordingObserver : IObserver<ShardState>
+    {
+        private readonly object _lock = new();
+        private readonly List<ShardState> _states = [];
+
+        public IReadOnlyList<ShardState> States
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _states.ToList();
+                }
+            }
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(ShardState value)
+        {
+            lock (_lock)
+            {
+                _states.Add(value);
+            }
+        }
+
+        public async Task<bool> WaitForCount(Func<ShardState, bool> predicate, int count, TimeSpan timeout)
+        {
+            var elapsed = TimeSpan.Zero;
+            var step = 20.Milliseconds();
+            while (elapsed < timeout)
+            {
+                lock (_lock)
+                {
+                    if (_states.Count(predicate) >= count)
+                    {
+                        return true;
+                    }
+                }
+
+                await Task.Delay(step);
+                elapsed += step;
+            }
+
+            lock (_lock)
+            {
+                return _states.Count(predicate) >= count;
+            }
+        }
+    }
+}

--- a/src/EventTests/Daemon/HighWater/TenantedHighWaterCoordinatorTests.cs
+++ b/src/EventTests/Daemon/HighWater/TenantedHighWaterCoordinatorTests.cs
@@ -138,4 +138,30 @@ public class TenantedHighWaterCoordinatorTests
         coordinator.CeilingFor("t1").ShouldBe(42);
         coordinator.CeilingFor("never-polled").ShouldBeNull();
     }
+
+    [Fact]
+    public async Task tracks_a_liveness_heartbeat_across_polls()
+    {
+        // jasperfx#539: the per-tenant path is the daemon's Path B. Each completed vectorized poll stamps a
+        // liveness heartbeat so the daemon can tell "no new events" from "the tenant high-water poll died".
+        var detector = new FakeVectorDetector();
+        detector.Enqueue(new HighWaterVector([stat("t1", 10, 10)]));
+
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1"]);
+
+        // No cycle has completed yet: no heartbeat, never stale.
+        coordinator.LastPolledAt.ShouldBeNull();
+        coordinator.IsStale(TimeSpan.FromSeconds(1), DateTimeOffset.UtcNow).ShouldBeFalse();
+
+        await coordinator.PollAndRouteAsync(
+            [agentFor(ShardName.Compose("Orders", "All", "t1"))], CancellationToken.None);
+
+        coordinator.LastPolledAt.ShouldNotBeNull();
+        // Fresh poll is not stale against a generous threshold...
+        coordinator.IsStale(TimeSpan.FromHours(1), DateTimeOffset.UtcNow).ShouldBeFalse();
+        // ...but is once "now" has advanced well past the last poll.
+        coordinator.IsStale(TimeSpan.FromSeconds(1), coordinator.LastPolledAt!.Value.AddSeconds(5))
+            .ShouldBeTrue();
+    }
 }

--- a/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
+++ b/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
@@ -602,6 +602,9 @@ public class ProjectionCoordinatorBaseTests
         public Task CatchUpAsync(TimeSpan timeout, CancellationToken cancellation) => throw new NotSupportedException();
         public Task WaitForNonStaleData(TimeSpan timeout) => throw new NotSupportedException();
         public long HighWaterMark() => throw new NotSupportedException();
+        public DateTimeOffset? HighWaterLastPolledAt => throw new NotSupportedException();
+        public bool IsHighWaterStale => throw new NotSupportedException();
+        public Task RestartHighWaterAgentAsync(CancellationToken token) => throw new NotSupportedException();
         public Task WaitForShardToBeRunning(string shardName, TimeSpan timeout) => throw new NotSupportedException();
         public Task RewindSubscriptionAsync(string subscriptionName, CancellationToken token, long? sequenceFloor = 0, DateTimeOffset? timestamp = null) => throw new NotSupportedException();
     }

--- a/src/JasperFx.Events/Daemon/DaemonSettings.cs
+++ b/src/JasperFx.Events/Daemon/DaemonSettings.cs
@@ -33,6 +33,14 @@ public interface IReadOnlyDaemonSettings
     TimeSpan HealthCheckPollingTime { get; }
 
     /// <summary>
+    ///     How long the high-water agent's poll loop may go without completing a cycle (its liveness
+    ///     heartbeat) before the health-check watchdog treats it as wedged and restarts it. This is
+    ///     measured against heartbeat age — the loop cycling — NOT against the mark advancing, so a
+    ///     quiet store with no new events is never considered stale. The default is 30 seconds.
+    /// </summary>
+    TimeSpan HighWaterStalenessThreshold { get; }
+
+    /// <summary>
     ///     Projection Daemon mode. The default is Disabled
     /// </summary>
     DaemonMode AsyncMode { get; }
@@ -88,6 +96,15 @@ public class DaemonSettings: IReadOnlyDaemonSettings
     ///     of its activities and try to restart anything that is not currently running
     /// </summary>
     public TimeSpan HealthCheckPollingTime { get; set; } = 5.Seconds();
+
+    /// <summary>
+    ///     jasperfx#539: how long the high-water agent's poll loop may go without completing a cycle (its
+    ///     liveness heartbeat) before the health-check watchdog treats it as wedged and restarts it. Measured
+    ///     against heartbeat age — the loop cycling — NOT against the mark advancing, so a quiet store with no
+    ///     new events is never considered stale. The default of 30 seconds sits comfortably above
+    ///     <see cref="SlowPollingTime"/> × several cycles plus <see cref="StaleSequenceThreshold"/>.
+    /// </summary>
+    public TimeSpan HighWaterStalenessThreshold { get; set; } = 30.Seconds();
 
     /// <summary>
     /// If a subscription has been paused for any reason

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
@@ -24,6 +24,25 @@ public class HighWaterAgent: IDisposable
     private readonly string _spanName;
     private readonly Counter<int> _skipping;
 
+    // jasperfx#539: AgentStatus string published on the HighWaterMark ShardState while the loop is cycling.
+    private const string RunningStatus = "Running";
+
+    // jasperfx#539: UtcTicks of the last completed poll cycle (0 == no cycle yet). This is the loop's
+    // liveness heartbeat and is read from the watchdog timer thread, so it is written/read via Interlocked.
+    private long _lastPolledAtTicks;
+
+    // jasperfx#539: watchdog remediation bookkeeping. _remediating serializes overlapping restarts (the
+    // health timer keeps firing while a restart is in flight); _lastRemediation caps restarts to once per
+    // staleness window. Both are only touched inside checkState under the _remediating guard.
+    private int _remediating;
+    private DateTimeOffset _lastRemediation;
+
+    // jasperfx#539: bumped on every StartAsync. Each poll loop captures its generation and exits the instant
+    // it observes a newer one. RestartAsync abandons a wedged loop without awaiting it (awaiting a hung loop
+    // would hang the remediation), so this guard is what guarantees an abandoned loop that later recovers
+    // can never run beside the fresh loop.
+    private int _loopGeneration;
+
     // ReSharper disable once ContextualLoggerProblem
     public HighWaterAgent(Meter meter, IHighWaterDetector detector, ShardStateTracker tracker,
         ILogger logger,
@@ -59,10 +78,17 @@ public class HighWaterAgent: IDisposable
 
         _current = await _detector.Detect(_token).ConfigureAwait(false);
 
+        // jasperfx#539: seed the liveness heartbeat so IsStale is meaningful from the first cycle and the
+        // Started state carries a heartbeat for consumers that only watch the live Tracker.
+        Interlocked.Exchange(ref _lastPolledAtTicks, DateTimeOffset.UtcNow.UtcTicks);
+
         await _tracker.PublishAsync(
             new ShardState(ShardState.HighWaterMark, _current.CurrentMark)
             {
-                Action = ShardAction.Started, LastAdvanced = lastAdvancedFrom(_current)
+                Action = ShardAction.Started,
+                LastAdvanced = lastAdvancedFrom(_current),
+                LastHeartbeat = DateTimeOffset.UtcNow,
+                AgentStatus = RunningStatus
             });
 
         // #4913: under per-tenant event partitioning the store-global high-water mark is not used to
@@ -81,11 +107,15 @@ public class HighWaterAgent: IDisposable
             return;
         }
 
+        // jasperfx#539: stamp this loop's generation so a later RestartAsync can retire it even if it is
+        // wedged (see _loopGeneration). Captured into the delegate below so there is no field-read race.
+        var generation = Interlocked.Increment(ref _loopGeneration);
+
         // #524 (defect C): StartNew over an async delegate hands back a Task<Task> that completes as soon as
         // detectChanges hits its first await — the real poll loop is the inner task. Unwrap so _loop *is* that
         // inner task; otherwise _loop.IsFaulted is always false and the checkState watchdog can never see the
         // loop fault, let alone restart it.
-        _loop = Task.Factory.StartNew(detectChanges, _token,
+        _loop = Task.Factory.StartNew(() => detectChanges(generation), _token,
             TaskCreationOptions.LongRunning | TaskCreationOptions.AttachedToParent, TaskScheduler.Default).Unwrap();
 
         _timer.Start();
@@ -125,7 +155,7 @@ public class HighWaterAgent: IDisposable
         }
     }
 
-    private async Task detectChanges()
+    private async Task detectChanges(int generation)
     {
         if (!IsRunning)
         {
@@ -152,10 +182,18 @@ public class HighWaterAgent: IDisposable
 
         while (!_token.IsCancellationRequested)
         {
-            if (!IsRunning)
+            // jasperfx#539: a superseded loop (RestartAsync bumped the generation) exits before doing any
+            // work, so a wedged loop that later recovers can never run beside its replacement.
+            if (!IsRunning || Volatile.Read(ref _loopGeneration) != generation)
             {
                 break;
             }
+
+            // jasperfx#539: stamp + publish the liveness heartbeat at the top of every cycle. Reaching here
+            // is proof the loop is cycling (a wedged wakeup or a hung Detect never returns to this point, so
+            // LastPolledAt ages out and the watchdog restarts the loop). The heartbeat carries the CURRENT
+            // mark — never a higher one — so it can never force the mark forward.
+            await heartbeatAsync().ConfigureAwait(false);
 
             using var activity = _settings.ActivitySource?.StartActivity(_spanName);
             activity?.AddTag(OtelConstants.DatabaseUri, _detector.DatabaseUri);
@@ -292,26 +330,158 @@ public class HighWaterAgent: IDisposable
     private static DateTimeOffset? lastAdvancedFrom(HighWaterStatistics statistics)
         => statistics.Timestamp == default ? null : statistics.Timestamp;
 
+    /// <summary>
+    /// jasperfx#539: heartbeat of the last completed poll cycle — proof the loop is *cycling*, independent
+    /// of whether the high-water mark is *advancing*. Null until the first cycle. Exposed in-memory so a
+    /// local health check can read it without the ExtendedProgression columns.
+    /// </summary>
+    public DateTimeOffset? LastPolledAt
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastPolledAtTicks);
+            return ticks == 0 ? null : new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+
+    /// <summary>
+    /// jasperfx#539: true when the poll loop has faulted with an unhandled exception.
+    /// </summary>
+    public bool Faulted => _loop is { IsFaulted: true };
+
+    /// <summary>
+    /// jasperfx#539: true when the poll loop has not completed a cycle within <paramref name="threshold"/> —
+    /// i.e. it is alive-but-wedged (a stuck connection or a custom <see cref="IDaemonWakeup"/> that stopped
+    /// firing). This is measured against heartbeat age, NOT against the mark advancing, so a quiet store with
+    /// no new events is never stale. Always false under per-tenant partitioning: there the store-global loop
+    /// does not run and liveness is owned by the daemon's tenant high-water path (Path B).
+    /// </summary>
+    public bool IsStale(TimeSpan threshold, DateTimeOffset now)
+    {
+        if (!IsRunning || _detector.SupportsTenantPartitioning)
+        {
+            return false;
+        }
+
+        var ticks = Interlocked.Read(ref _lastPolledAtTicks);
+        if (ticks == 0)
+        {
+            // No cycle has completed yet — can't be judged stale.
+            return false;
+        }
+
+        return now - new DateTimeOffset(ticks, TimeSpan.Zero) > threshold;
+    }
+
+    /// <summary>
+    /// jasperfx#539: stop then start the poll loop. StartAsync re-reads the real mark via Detect, so this
+    /// re-establishes the loop WITHOUT ever advancing the high-water mark. Publishes a <see cref="ShardAction.Restarted"/>
+    /// state so consumers can distinguish a remediation from an ordinary advance.
+    /// </summary>
+    public async Task RestartAsync()
+    {
+        if (_token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        // Detach the current loop WITHOUT awaiting it. A stale loop is wedged by definition — a hung Detect
+        // or a wakeup that stopped firing — so awaiting it, as a graceful StopAsync would, hangs the very
+        // remediation meant to recover from that. StartAsync bumps _loopGeneration, so the abandoned loop
+        // becomes a no-op the instant it ever resumes and cannot double-run beside the fresh loop.
+        _timer.Stop();
+        IsRunning = false;
+
+        await StartAsync().ConfigureAwait(false);
+        await publishStatusAsync(ShardAction.Restarted, "Restarted").ConfigureAwait(false);
+    }
+
+    // jasperfx#539: stamp the heartbeat and publish a Running HighWaterMark state carrying it. The published
+    // sequence is never higher than the current mark, so a heartbeat can never move the mark forward.
+    private ValueTask heartbeatAsync()
+    {
+        Interlocked.Exchange(ref _lastPolledAtTicks, DateTimeOffset.UtcNow.UtcTicks);
+        return publishStatusAsync(ShardAction.Updated, RunningStatus);
+    }
+
+    private ValueTask publishStatusAsync(ShardAction action, string status)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var mark = Math.Max(_current?.CurrentMark ?? 0L, _tracker.HighWaterMark);
+
+        return _tracker.PublishAsync(new ShardState(ShardState.HighWaterMark, mark)
+        {
+            Action = action,
+            AgentStatus = status,
+            LastHeartbeat = now,
+            LastAdvanced = _current == null ? null : lastAdvancedFrom(_current)
+        });
+    }
+
     private void TimerOnElapsed(object? sender, ElapsedEventArgs e)
     {
         _ = checkState();
     }
 
+    // jasperfx#539: the watchdog now restarts the loop when it has *faulted* OR gone *stale* (stopped
+    // completing cycles within HighWaterStalenessThreshold). Restarts are capped to once per threshold window
+    // and never overlap. Staleness is only meaningful for Path A — under partitioning the daemon governs the
+    // tenant high-water path instead, so this bails out early.
     private async Task checkState()
     {
-        if (_loop.IsFaulted && !_token.IsCancellationRequested)
+        if (_token.IsCancellationRequested || _detector.SupportsTenantPartitioning)
         {
-            _logger.LogError(_loop.Exception, "HighWaterAgent polling loop was faulted for database {Name}", _detector.DatabaseUri);
+            return;
+        }
 
-            try
+        var faulted = Faulted;
+        var now = DateTimeOffset.UtcNow;
+        var stale = IsStale(_settings.HighWaterStalenessThreshold, now);
+
+        if (!faulted && !stale)
+        {
+            return;
+        }
+
+        // Don't let overlapping timer ticks pile up concurrent restarts.
+        if (Interlocked.CompareExchange(ref _remediating, 1, 0) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            // Cap remediation to once per staleness window so a loop that fails to re-establish isn't
+            // thrashed by the (much faster) health-check timer.
+            if (_lastRemediation != default && now - _lastRemediation < _settings.HighWaterStalenessThreshold)
             {
-                _loop.Dispose();
-                await StartAsync().ConfigureAwait(false);
+                return;
             }
-            catch (Exception ex)
+
+            _lastRemediation = now;
+
+            if (faulted)
             {
-                _logger.LogError(ex, "Error trying to restart the HighWaterAgent for database {Name}", _detector.DatabaseUri);
+                _logger.LogWarning(_loop.Exception,
+                    "HighWaterAgent polling loop faulted for database {Name}; restarting", _detector.DatabaseUri);
+                await publishStatusAsync(ShardAction.Faulted, "Faulted").ConfigureAwait(false);
             }
+            else
+            {
+                _logger.LogWarning(
+                    "HighWaterAgent polling loop for database {Name} has not completed a cycle within {Threshold}; restarting",
+                    _detector.DatabaseUri, _settings.HighWaterStalenessThreshold);
+            }
+
+            await RestartAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error trying to restart the HighWaterAgent for database {Name}", _detector.DatabaseUri);
+        }
+        finally
+        {
+            Volatile.Write(ref _remediating, 0);
         }
     }
 

--- a/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
@@ -19,6 +19,11 @@ public class TenantedHighWaterCoordinator
     private readonly IHighWaterDetector _detector;
     private readonly ILogger _logger;
 
+    // jasperfx#539: UtcTicks of the last completed vectorized poll (0 == none yet). This is the liveness
+    // heartbeat for the per-tenant high-water path — proof the coordinator is cycling — read from the
+    // daemon watchdog thread, so written/read via Interlocked.
+    private long _lastPolledAtTicks;
+
     public TenantedHighWaterCoordinator(IHighWaterDetector detector, ILogger? logger = null)
     {
         _monitor = new VectorizedHighWaterMonitor(detector, logger);
@@ -27,6 +32,34 @@ public class TenantedHighWaterCoordinator
     }
 
     public PolledTenantSet PolledTenants => _monitor.PolledTenants;
+
+    /// <summary>
+    /// jasperfx#539: heartbeat of the last completed per-tenant poll cycle — proof the coordinator is
+    /// cycling, independent of whether any tenant's mark advanced. Null until the first poll.
+    /// </summary>
+    public DateTimeOffset? LastPolledAt
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastPolledAtTicks);
+            return ticks == 0 ? null : new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+    }
+
+    /// <summary>
+    /// jasperfx#539: true when the per-tenant poll has not completed a cycle within <paramref name="threshold"/>.
+    /// Measured against heartbeat age (the poll cycling), NOT against any mark advancing.
+    /// </summary>
+    public bool IsStale(TimeSpan threshold, DateTimeOffset now)
+    {
+        var ticks = Interlocked.Read(ref _lastPolledAtTicks);
+        if (ticks == 0)
+        {
+            return false;
+        }
+
+        return now - new DateTimeOffset(ticks, TimeSpan.Zero) > threshold;
+    }
 
     /// <summary>
     /// The rebuild ceiling for a tenant — its latest observed high-water mark. Null until first polled.
@@ -58,6 +91,10 @@ public class TenantedHighWaterCoordinator
         IReadOnlyList<ISubscriptionAgent> agents, CancellationToken token)
     {
         var readings = await _monitor.PollAsync(token).ConfigureAwait(false);
+
+        // jasperfx#539: a completed vectorized poll is one cycle of the per-tenant high-water path — stamp
+        // the liveness heartbeat even when no tenant's mark moved.
+        Interlocked.Exchange(ref _lastPolledAtTicks, DateTimeOffset.UtcNow.UtcTicks);
 
         foreach (var reading in readings)
         {

--- a/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionDaemon.cs
@@ -236,6 +236,31 @@ public interface IProjectionDaemon: IDisposable
     Task WaitForNonStaleData(TimeSpan timeout);
 
     public long HighWaterMark();
+
+    /// <summary>
+    /// jasperfx#539: heartbeat of the last completed high-water poll cycle — proof the high-water path is
+    /// *cycling*, independent of whether the mark is *advancing*. Delegates to whichever path is active
+    /// (store-global agent or the per-tenant coordinator). Null until the first cycle completes. Lets a
+    /// health check distinguish "no new events" from "the high-water agent died" without the mark alone.
+    /// </summary>
+    DateTimeOffset? HighWaterLastPolledAt { get; }
+
+    /// <summary>
+    /// jasperfx#539: true when the active high-water path has not completed a poll cycle within the
+    /// configured <see cref="IReadOnlyDaemonSettings.HighWaterStalenessThreshold"/> — i.e. the loop is
+    /// alive-but-wedged. Measured against heartbeat age, NOT against the mark advancing, so a quiet store
+    /// with no new events is never reported stale.
+    /// </summary>
+    bool IsHighWaterStale { get; }
+
+    /// <summary>
+    /// jasperfx#539: local restart seam for the high-water path. Restarts whichever path is active without
+    /// ever advancing the mark. Intended for a health check that has observed staleness and wants to
+    /// remediate in-process.
+    /// </summary>
+    /// <param name="token"></param>
+    Task RestartHighWaterAgentAsync(CancellationToken token);
+
     AgentStatus StatusFor(string shardName);
 
     /// <summary>

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -51,6 +51,16 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     private DateTimeOffset _lastTenantHighWaterPoll;
     private int _tenantHighWaterPollInFlight;
 
+    // jasperfx#539: highest store-global mark that has already driven a per-tenant poll. OnNext re-triggers a
+    // tenant poll only on a genuine advance past this, so the per-cycle high-water HEARTBEAT publications
+    // (which carry the same, non-advancing mark) can't feed back into an unbounded poll → publish → poll loop.
+    private long _lastTenantPollTriggerMark;
+
+    // jasperfx#539: Path B (per-tenant) watchdog bookkeeping, mirroring HighWaterAgent's. Serializes
+    // overlapping restarts and caps them to once per staleness window.
+    private int _tenantHighWaterRemediating;
+    private DateTimeOffset _lastTenantHighWaterRemediation;
+
     // jasperfx#494 (epic #486 WS2): shared by every agent loader this daemon builds so the
     // database's connection footprint stays O(databases), not O(agents). Null = unthrottled.
     private SemaphoreSlim? _loadThrottle;
@@ -989,6 +999,35 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         return Tracker.HighWaterMark;
     }
 
+    // jasperfx#539: delegate the high-water liveness surface to whichever path is active. Under per-tenant
+    // partitioning the store-global loop is skipped and the tenant coordinator owns liveness (Path B);
+    // otherwise it's the store-global HighWaterAgent (Path A).
+    public DateTimeOffset? HighWaterLastPolledAt =>
+        _tenantHighWater != null ? _tenantHighWater.LastPolledAt : _highWater.LastPolledAt;
+
+    public bool IsHighWaterStale
+    {
+        get
+        {
+            var now = DateTimeOffset.UtcNow;
+            return _tenantHighWater != null
+                ? _tenantHighWater.IsStale(_projections.HighWaterStalenessThreshold, now)
+                : _highWater.IsStale(_projections.HighWaterStalenessThreshold, now);
+        }
+    }
+
+    public async Task RestartHighWaterAgentAsync(CancellationToken token)
+    {
+        if (_tenantHighWater != null)
+        {
+            await publishHighWaterStatusAsync(ShardAction.Restarted, "Restarted").ConfigureAwait(false);
+            restartTenantHighWater();
+            return;
+        }
+
+        await _highWater.RestartAsync().ConfigureAwait(false);
+    }
+
     void IObserver<ShardState>.OnCompleted()
     {
         // Nothing
@@ -1037,8 +1076,13 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
                 agent.MarkHighWater(value.Sequence);
             }
 
-            if (_tenantHighWater != null)
+            // jasperfx#539: only a genuine advance of the store-global mark drives a per-tenant poll. Without
+            // this guard the high-water heartbeat (published every cycle carrying the SAME mark) would loop
+            // back through here into pollTenantHighWaterAsync, which publishes another heartbeat, forever.
+            if (_tenantHighWater != null && value.Sequence > _lastTenantPollTriggerMark)
             {
+                _lastTenantPollTriggerMark = value.Sequence;
+
                 // Reuse the global high-water cadence to drive one vectorized per-tenant poll.
                 _ = pollTenantHighWaterAsync();
             }
@@ -1059,10 +1103,98 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         try
         {
             await _tenantHighWater.PollAndRouteAsync(CurrentAgents(), _cancellation.Token).ConfigureAwait(false);
+
+            // jasperfx#539: publish the per-cycle liveness heartbeat for Path B. The coordinator has already
+            // stamped its in-memory LastPolledAt; this surfaces the same beat on the live Tracker (and the
+            // ExtendedProgression columns) so remote consumers can tell "no new events" from "the tenant
+            // high-water poll died". Carries the store-global mark unchanged, so it never advances it and,
+            // by the OnNext guard above, never re-triggers a poll.
+            await publishHighWaterStatusAsync(ShardAction.Updated, "Running").ConfigureAwait(false);
         }
         catch (Exception e)
         {
             Logger.LogError(e, "Error polling per-tenant high water for database {Name}", Database.Identifier);
+        }
+    }
+
+    // jasperfx#539: publish a HighWaterMark ShardState carrying a liveness/status beat without moving the
+    // mark. Used by the Path B heartbeat and the Path B watchdog (Faulted/Restarted). The OnNext re-trigger
+    // guard keeps a same-mark publication from feeding back into another tenant poll.
+    private ValueTask publishHighWaterStatusAsync(ShardAction action, string status)
+    {
+        return Tracker.PublishAsync(new ShardState(ShardState.HighWaterMark, Tracker.HighWaterMark)
+        {
+            Action = action,
+            AgentStatus = status,
+            LastHeartbeat = DateTimeOffset.UtcNow
+        });
+    }
+
+    // jasperfx#539: Path B restart seam. The per-tenant path is timer-driven, so remediation is a stop/re-arm
+    // of the cadence timer plus clearing any wedged in-flight guard so a fresh poll can start. A hung poll is
+    // abandoned (its result is ignored on completion), mirroring HighWaterAgent's non-blocking restart.
+    private void restartTenantHighWater()
+    {
+        if (_tenantHighWaterTimer == null)
+        {
+            return;
+        }
+
+        Volatile.Write(ref _tenantHighWaterPollInFlight, 0);
+        _tenantHighWaterTimer.Stop();
+
+        if (!_cancellation.IsCancellationRequested)
+        {
+            syncTenantHighWaterInterval();
+            _tenantHighWaterTimer.Start();
+        }
+    }
+
+    // jasperfx#539: Path B watchdog, fired off the tenant cadence timer. Restart the per-tenant poll when it
+    // has stopped completing cycles within the staleness threshold. Capped to once per window and never
+    // overlapping, exactly like HighWaterAgent.checkState governs Path A.
+    private async Task checkTenantHighWaterStalenessAsync()
+    {
+        if (_tenantHighWater == null || !_highWater.IsRunning || _cancellation.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (!_tenantHighWater.IsStale(_projections.HighWaterStalenessThreshold, now))
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _tenantHighWaterRemediating, 1, 0) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_lastTenantHighWaterRemediation != default &&
+                now - _lastTenantHighWaterRemediation < _projections.HighWaterStalenessThreshold)
+            {
+                return;
+            }
+
+            _lastTenantHighWaterRemediation = now;
+
+            Logger.LogWarning(
+                "Per-tenant high-water poll for database {Name} has not completed a cycle within {Threshold}; restarting the tenant high-water poll",
+                Database.Identifier, _projections.HighWaterStalenessThreshold);
+
+            await publishHighWaterStatusAsync(ShardAction.Restarted, "Restarted").ConfigureAwait(false);
+            restartTenantHighWater();
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error restarting per-tenant high water for database {Name}", Database.Identifier);
+        }
+        finally
+        {
+            Volatile.Write(ref _tenantHighWaterRemediating, 0);
         }
     }
 
@@ -1076,6 +1208,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         {
             syncTenantHighWaterInterval();
             _ = pollTenantHighWaterOnCadenceAsync();
+            _ = checkTenantHighWaterStalenessAsync();
         };
         timer.Start();
         return timer;

--- a/src/JasperFx.Events/Daemon/ShardAction.cs
+++ b/src/JasperFx.Events/Daemon/ShardAction.cs
@@ -25,7 +25,20 @@ public enum ShardAction
     
     /// <summary>
     /// Recorded for the high water mark when it had to "skip" over stale
-    /// data and potential holes in the event sequence 
+    /// data and potential holes in the event sequence
     /// </summary>
-    Skipped
+    Skipped,
+
+    /// <summary>
+    /// jasperfx#539: recorded for the high water mark when its poll loop was observed to have faulted
+    /// (the watchdog saw an unhandled exception on the loop) before it is restarted.
+    /// </summary>
+    Faulted,
+
+    /// <summary>
+    /// jasperfx#539: recorded for the high water mark when the watchdog restarted the poll loop after it
+    /// faulted or went stale (stopped completing cycles within the configured staleness threshold). The
+    /// restart never advances the mark — it only re-establishes the loop.
+    /// </summary>
+    Restarted
 }


### PR DESCRIPTION
Closes #539.

## Problem

The high-water watchdog (`HighWaterAgent.checkState`) restarted the poll loop **only on `_loop.IsFaulted`**. A loop that is *alive but no longer completing cycles* — a custom `IDaemonWakeup` that stops firing, a stuck connection — never faults, so it was never restarted and the high-water mark froze with no signal. Downstream, a frozen mark is ambiguous: `AddMartenAsyncDaemonHealthCheck` measures projection lag *against* the mark, so a dead high-water agent actually reads **Healthy**.

The disambiguating plumbing already existed (ExtendedProgression `heartbeat`/`agent_status` from #424, `ShardState.LastHeartbeat`) but only `SubscriptionAgent` wrote heartbeats — `HighWaterAgent` never did.

## What this does

Gives the high-water path a **liveness heartbeat** — proof the loop is *cycling*, independent of whether the mark *advances* — plus a clean restart seam. **Nothing here ever forces the mark forward**; remediation is a stop+start of the poll loop only.

Both high-water code paths are covered:

**Path A — store-global `HighWaterAgent`**
- Publishes a `Running` `HighWaterMark` `ShardState` (with `LastHeartbeat` / `AgentStatus`) at the top of **every** cycle, carrying the current mark (never higher).
- New surface: `LastPolledAt`, `Faulted`, `IsStale(threshold, now)`, `RestartAsync()`.
- `checkState` restarts on **`Faulted` OR `IsStale`**, capped to once per staleness window and never overlapping.
- `RestartAsync` is **non-blocking and generation-guarded**: a wedged loop is abandoned without awaiting it (awaiting a hung loop would hang the remediation), and a generation counter guarantees an abandoned loop that later recovers can't run beside its replacement.

**Path B — per-tenant `TenantedHighWaterCoordinator`**
- `LastPolledAt` / `IsStale` mirrored; stamped on each completed vectorized poll.
- The daemon publishes a heartbeat per tenant poll and re-arms the tenant timer on staleness.
- `OnNext`'s tenant-poll re-trigger is now guarded to a **genuine mark advance**, so the per-cycle heartbeat can't feed back into an unbounded `poll → publish → poll` loop.

**Shared surface**
- `IProjectionDaemon`: `RestartHighWaterAgentAsync(token)`, `HighWaterLastPolledAt`, `IsHighWaterStale` — delegating to whichever path is active.
- `DaemonSettings.HighWaterStalenessThreshold` (default 30s).
- `ShardAction`: `Faulted` + `Restarted`.

## ⚠️ Downstream heads-up

This adds three members to the public `IProjectionDaemon` interface. `JasperFxAsyncDaemon` (the base daemon Marten/Polecat inherit) implements them, so those stores get the behavior for free — but any **external** direct implementer of `IProjectionDaemon` will need the new members. The two in-repo test doubles are updated here.

## Tests

New `HighWaterAgent_liveness_Tests` (heartbeat-without-advancing, watchdog restarts a wedged loop, explicit `RestartAsync`) + a Path B coordinator liveness test. Full `EventTests` suite green (568). The existing #524 loop-robustness tests still pass unchanged.

## Consumers
marten#4982 (staleness health check + optional local restart), polecat#339 (parity), CritterWatch#774 (`HighWaterStale` / `HighWaterAgentRestarted` alerts).

## Related
#524 (defects A + C), #424 (ExtendedProgression columns this rides), marten#4961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)