### PR TITLE
GH-3521 (Wolverine): warn on divergent process-pinned application assembly

### DIFF
--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -219,4 +219,122 @@ public class JasperFxOptionsTests
             DynamicCodeBuilder.WithinCodegenCommand = originalValue;
         }
     }
+
+    // GH-3521: the application assembly is a process-wide value pinned by whichever host starts FIRST in the
+    // process. A later host that adopts it while it was registered from a DIFFERENT assembly silently scans
+    // the wrong assembly. These tests pin the behavior of the divergence detection surfaced on JasperFxOptions.
+
+    [Fact]
+    public void warns_when_adopted_assembly_diverges_from_where_the_host_registered()
+    {
+        var original = JasperFxOptions.RememberedApplicationAssembly;
+        try
+        {
+            // Simulate an earlier host in the process having pinned a different assembly...
+            var pinned = typeof(JasperFxOptions).Assembly;
+            JasperFxOptions.RememberedApplicationAssembly = pinned;
+
+            var options = new JasperFxOptions
+            {
+                // ...while THIS host was registered from the test assembly.
+                RegistrationCallingAssembly = GetType().Assembly
+            };
+
+            options.ReadHostEnvironment(new StubHostEnvironment());
+
+            options.ApplicationAssembly.ShouldBe(pinned);
+            options.ApplicationAssemblyReuseWarning.ShouldNotBeNull();
+            options.ApplicationAssemblyReuseWarning.ShouldContain(pinned.GetName().Name!);
+            options.ApplicationAssemblyReuseWarning.ShouldContain(GetType().Assembly.GetName().Name!);
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = original;
+        }
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_adopted_assembly_matches_where_the_host_registered()
+    {
+        var original = JasperFxOptions.RememberedApplicationAssembly;
+        try
+        {
+            JasperFxOptions.RememberedApplicationAssembly = GetType().Assembly;
+
+            var options = new JasperFxOptions
+            {
+                RegistrationCallingAssembly = GetType().Assembly
+            };
+
+            options.ReadHostEnvironment(new StubHostEnvironment());
+
+            options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = original;
+        }
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_registration_assembly_could_not_be_resolved()
+    {
+        var original = JasperFxOptions.RememberedApplicationAssembly;
+        try
+        {
+            JasperFxOptions.RememberedApplicationAssembly = typeof(JasperFxOptions).Assembly;
+
+            // RegistrationCallingAssembly left null — we don't warn on a value we couldn't attribute.
+            var options = new JasperFxOptions();
+
+            options.ReadHostEnvironment(new StubHostEnvironment());
+
+            options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = original;
+        }
+    }
+
+    [Fact]
+    public void does_not_warn_when_the_application_assembly_is_set_explicitly()
+    {
+        var original = JasperFxOptions.RememberedApplicationAssembly;
+        try
+        {
+            JasperFxOptions.RememberedApplicationAssembly = typeof(JasperFxOptions).Assembly;
+
+            var options = new JasperFxOptions
+            {
+                // An explicit choice short-circuits establishApplicationAssembly entirely.
+                ApplicationAssembly = GetType().Assembly,
+                RegistrationCallingAssembly = GetType().Assembly
+            };
+
+            options.ReadHostEnvironment(new StubHostEnvironment());
+
+            options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = original;
+        }
+    }
+
+    [Fact]
+    public async Task a_normal_single_assembly_host_does_not_warn()
+    {
+        // False-positive guard: a real host registered and resolved from the test assembly must not warn,
+        // and the registration assembly must be captured as THIS assembly (not "JasperFx").
+        using var host = await Host.CreateDefaultBuilder()
+            .ConfigureServices(s => s.AddJasperFx())
+            .UseEnvironment("Development")
+            .StartAsync();
+
+        var options = host.Services.GetRequiredService<JasperFxOptions>();
+
+        options.RegistrationCallingAssembly.ShouldBe(GetType().Assembly);
+        options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+    }
 }

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -35,7 +35,24 @@ public class JasperFxOptions : SystemPartBase
     ///     that assuming that the IDE or test runner assembly is the application assembly
     /// </summary>
     public static Assembly? RememberedApplicationAssembly;
-    
+
+    // GH-3521: the assembly this host's own AddJasperFx call resolved to, captured while the caller's frame
+    // was still on the stack (see JasperFxServiceCollectionExtensions.AddJasperFx). Compared later against
+    // the application assembly actually adopted for code generation and type discovery — which, for an
+    // implicit host, is the process-pinned RememberedApplicationAssembly set by whichever host started
+    // FIRST. Null when a caller assembly could not be resolved.
+    internal Assembly? RegistrationCallingAssembly { get; set; }
+
+    /// <summary>
+    ///     GH-3521: set to a human-readable warning when this host adopts an application assembly that was
+    ///     pinned by an EARLIER host in the same process (a process-wide value) and it differs from where
+    ///     this host was actually registered. This typically only bites a test harness that stands up
+    ///     multiple Critter Stack hosts across different assemblies, where a later implicit host silently
+    ///     scans the first host's assembly. Null when there is nothing to warn about. Consumers (e.g.
+    ///     Wolverine) surface this at startup where a logger is available.
+    /// </summary>
+    public string? ApplicationAssemblyReuseWarning { get; internal set; }
+
     public JasperFxOptions() : base("JasperFx Options", new Uri("system://jasperfx"))
     {
         ActiveProfile = Development;
@@ -135,6 +152,10 @@ public class JasperFxOptions : SystemPartBase
         else if (RememberedApplicationAssembly != null)
         {
             ApplicationAssembly = RememberedApplicationAssembly;
+
+            // GH-3521: we're adopting a process-wide pinned assembly. If it differs from where this host
+            // was registered, discovery will silently scan the wrong assembly — record a warning.
+            checkForDivergentApplicationAssembly(RememberedApplicationAssembly);
         }
         else
         {
@@ -145,6 +166,31 @@ public class JasperFxOptions : SystemPartBase
         {
             throw new InvalidOperationException("Unable to determine an application assembly");
         }
+    }
+
+    // GH-3521: record a warning (surfaced later by a consumer that has a logger at startup) when the
+    // application assembly adopted for discovery differs from where this host was registered. Only
+    // meaningful for an implicit host — an explicit ApplicationAssembly / SetApplicationProject never
+    // reaches establishApplicationAssembly, so it stays silent. The first host never diverges: it pins
+    // RememberedApplicationAssembly to its own registration assembly.
+    private void checkForDivergentApplicationAssembly(Assembly adopted)
+    {
+        var registered = RegistrationCallingAssembly;
+        if (registered == null)
+        {
+            return;
+        }
+
+        if (string.Equals(registered.GetName().Name, adopted.GetName().Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        ApplicationAssemblyReuseWarning =
+            $"JasperFx adopted application assembly '{adopted.GetName().Name}' for code generation and type discovery, but this host was registered from '{registered.GetName().Name}'. " +
+            $"The application assembly is a process-wide value pinned by whichever Critter Stack host started FIRST in this process (GH-3521), so discovery will NOT scan '{registered.GetName().Name}'. " +
+            $"This typically only bites a test harness that stands up multiple hosts across different assemblies. If types defined in '{registered.GetName().Name}' appear to be missing, " +
+            $"set the application assembly explicitly on this host (e.g. opts.ApplicationAssembly = typeof(SomeType).Assembly, or the equivalent on the owning Critter Stack tool).";
     }
     
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the call stack via StackTrace + StackFrame.GetMethod() to determine the calling assembly. AOT-publishing apps should call SetApplicationProject(Assembly) explicitly.")]

--- a/src/JasperFx/JasperFxServiceCollectionExtensions.cs
+++ b/src/JasperFx/JasperFxServiceCollectionExtensions.cs
@@ -51,15 +51,19 @@ public static class JasperFxServiceCollectionExtensions
     /// Annotation-free for trim/AOT — see the remarks on <see cref="CritterStackDefaults"/>.
     /// </remarks>
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-        Justification = "Two reachable RUC call sites are stack-walk fallbacks that only execute when the consumer hasn't pre-set the application assembly: DetermineCallingAssembly is guarded by `RememberedApplicationAssembly == null`, and ReadHostEnvironment's establishApplicationAssembly fallback is guarded by `ApplicationAssembly == null`. AOT consumers are expected to call `JasperFxOptions.SetApplicationProject(typeof(Program).Assembly)` before AddJasperFx per the AOT publishing guide, which short-circuits both fallbacks. Apps that omit that call are by definition on the runtime-codegen path. See docs/codegen/aot.md.")]
+        Justification = "Two reachable RUC call sites are stack-walk fallbacks that only run on the runtime-codegen path: DetermineCallingAssembly (used to seed RememberedApplicationAssembly for the first host and, for GH-3521, to capture the registering assembly of every host) and ReadHostEnvironment's establishApplicationAssembly fallback, guarded by `ApplicationAssembly == null`. AOT consumers set the application assembly explicitly per the AOT publishing guide, which routes them through the `ApplicationAssembly != null` short-circuit; and under NativeAOT the frames carry no method metadata, so DetermineCallingAssembly falls back to Assembly.GetEntryAssembly() without throwing and its result is unused. See docs/codegen/aot.md.")]
     public static IServiceCollection AddJasperFx(this IServiceCollection services, Action<JasperFxOptions>? configure = null)
     {
-        // It's actually important to do this as close as possible to this call
+        // GH-3521: capture the assembly this AddJasperFx call was made from while the caller's frame is
+        // still on the stack. This lets a later host that adopts an application assembly pinned by an
+        // EARLIER host in the same process (the classic multi-host test harness) warn instead of silently
+        // scanning the wrong assembly. It's actually important to do this as close as possible to this call.
+        var registrationAssembly = JasperFxOptions.DetermineCallingAssembly();
         if (JasperFxOptions.RememberedApplicationAssembly == null)
         {
-            JasperFxOptions.RememberedApplicationAssembly = JasperFxOptions.DetermineCallingAssembly();
+            JasperFxOptions.RememberedApplicationAssembly = registrationAssembly;
         }
-        
+
         bool exists = services.Any(x => !x.IsKeyedService && x.ServiceType == typeof(JasperFxOptions));
         
         var optionsBuilder = services.AddOptions<JasperFxOptions>();
@@ -68,7 +72,13 @@ public static class JasperFxServiceCollectionExtensions
         {
             optionsBuilder.Configure(configure!);
         }
-        
+
+        // GH-3521: stash the registering assembly onto the options instance (the local is resolved eagerly
+        // above; this lambda only assigns it). ??= keeps the first registration when AddJasperFx is called
+        // more than once against the same container. Compared later in establishApplicationAssembly against
+        // the assembly actually adopted for discovery.
+        optionsBuilder.Configure(o => o.RegistrationCallingAssembly ??= registrationAssembly);
+
         services.TryAddSingleton<IHostEnvironment, HostingEnvironment>();
         
         if (!exists)


### PR DESCRIPTION
Ports the [wolverine#3521](https://github.com/JasperFx/wolverine/issues/3521) diagnostic into JasperFx itself. The Wolverine side (asks 1 & 2) already shipped in [wolverine#3530](https://github.com/JasperFx/wolverine/pull/3530); that PR flagged the **`JasperFxOptions` twin** as the follow-up, since `JasperFxOptions.RememberedApplicationAssembly` is the *dominant* process-wide static (Wolverine reads `jasperfx.ApplicationAssembly` first).

## The trap

The application assembly JasperFx scans for code generation and type discovery is cached in a **process-wide static** pinned by whichever host starts **first** in the process. In a normal single-host app that's harmless. In a **test process that stands up multiple Critter Stack hosts across different assemblies**, a later implicit host silently inherits the first host's assembly — so types defined in a *different* assembly vanish for the whole run. It's **order-dependent**: passes in isolation, fails in full-suite runs, flips between builds as recompilation reshuffles test order.

## The fix (diagnosability only)

Wolverine already detects this for **Wolverine** hosts. This makes JasperFx detect it for **any** JasperFx host (Marten, etc.):

1. `AddJasperFx` captures the registering assembly (`DetermineCallingAssembly()`) **while the caller's frame is still live**, and stashes it on the options instance as `RegistrationCallingAssembly`.
2. `establishApplicationAssembly` compares the **adopted** (process-pinned) assembly against it and, on divergence, records a human-readable `ApplicationAssemblyReuseWarning`.

**Detection-only** (per discussion on the Wolverine side): JasperFx exposes `ApplicationAssemblyReuseWarning` as a **public property**; consumers that have a logger at startup surface it. JasperFx is a library with no always-on startup hosted service, so it intentionally does **not** emit here — Wolverine already emits its own (richer) message, and other consumers can read the property. No double-firing.

An **explicit** `ApplicationAssembly` / `SetApplicationProject` stays **silent** (never reaches `establishApplicationAssembly`), and the **first** host never diverges from itself.

### AOT note

`DetermineCallingAssembly()` now runs on every `AddJasperFx` (previously only when `RememberedApplicationAssembly == null`). Multi-host test processes are never AOT-published; a single AOT host that sets the application assembly explicitly routes through the `ApplicationAssembly != null` short-circuit, and under NativeAOT the stack frames carry no method metadata so the call falls back to `Assembly.GetEntryAssembly()` without throwing and its result is unused. The `[UnconditionalSuppressMessage]` justification is updated accordingly.

## Tests

`JasperFxOptionsTests` (CoreTests), with `RememberedApplicationAssembly` static save/restore:
- `warns_when_adopted_assembly_diverges_from_where_the_host_registered` — red-verified (fails with the divergence check disabled).
- `does_not_warn_when_the_adopted_assembly_matches_where_the_host_registered`
- `does_not_warn_when_the_registration_assembly_could_not_be_resolved`
- `does_not_warn_when_the_application_assembly_is_set_explicitly`
- `a_normal_single_assembly_host_does_not_warn` — real-host false-positive guard; also pins that the registration assembly is captured as the test assembly (not `JasperFx`).

## Not addressed

- No new always-on hosted service in JasperFx (would be a behavior addition to every Critter Stack host); emission stays with consumers.
- Wolverine needs no change — it already covers Wolverine hosts. A future Marten follow-up could surface `ApplicationAssemblyReuseWarning` from its own startup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)