### PR TITLE
feat(#544): step-instrumented aggregation fold + MultiAggregateProjectionResult surface

### DIFF
--- a/src/EventTests/Projections/StepInstrumentedFoldTests.cs
+++ b/src/EventTests/Projections/StepInstrumentedFoldTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Projections;
+
+// Coverage for jasperfx#544: the step-instrumented aggregation fold on the shared
+// base. Drives the REAL slice -> group -> enrich -> Create/Apply/ShouldDelete path
+// (no reflection re-implementation) and captures a per-event before/after timeline
+// for every resulting identity, streaming each step to an observer.
+public class StepInstrumentedFoldTests
+{
+    private static readonly Func<object?, JsonElement?> Serialize =
+        state => state is null ? null : JsonSerializer.SerializeToElement(state);
+
+    private static EventRecord ToRecord(IEvent e) => new(
+        e.Id,
+        e.Sequence,
+        e.Version,
+        e.StreamId.ToString(),
+        e.EventType.Name,
+        JsonSerializer.SerializeToElement(e.Data),
+        null,
+        e.Timestamp,
+        e.TenantId,
+        null);
+
+    private static IEvent A(Guid stream, long seq, long version) =>
+        new Event<AEvent>(new AEvent()) { StreamId = stream, Sequence = seq, Version = version };
+
+    private static IEvent B(Guid stream, long seq, long version) =>
+        new Event<BEvent>(new BEvent()) { StreamId = stream, Sequence = seq, Version = version };
+
+    [Fact]
+    public async Task single_identity_produces_exactly_one_timeline_with_per_event_state()
+    {
+        var projection = new SteppingProjection();
+        projection.AssembleAndAssertValidity();
+
+        var stream = Guid.NewGuid();
+        var events = new[] { A(stream, 1, 1), A(stream, 2, 2), B(stream, 3, 3) };
+
+        var observer = new CollectingObserver();
+
+        var result = await projection.BuildTimelinesAsync(
+            events, new FakeSession(), Serialize, ToRecord, observer, CancellationToken.None);
+
+        result.ProjectionName.ShouldBe(projection.Name);
+        // Done-when: a single-identity aggregate projection produces exactly one timeline.
+        result.AggregatesByIdentity.Count.ShouldBe(1);
+
+        var timeline = result.AggregatesByIdentity[stream.ToString()];
+        timeline.Steps.Count.ShouldBe(3);
+
+        // Before of the very first step is null (no prior state); after of the first step exists.
+        timeline.Steps[0].Before.ShouldBeNull();
+        timeline.Steps[0].After.ShouldNotBeNull();
+
+        // Per-event before/after walk: A -> ACount 1, A -> ACount 2, B -> BCount 1.
+        StateOf(timeline.Steps[1].Before!.Value).ACount.ShouldBe(1);
+        StateOf(timeline.Steps[1].After!.Value).ACount.ShouldBe(2);
+        StateOf(timeline.Steps[2].After!.Value).BCount.ShouldBe(1);
+
+        var final = StateOf(timeline.FinalState!.Value);
+        final.ACount.ShouldBe(2);
+        final.BCount.ShouldBe(1);
+
+        // The observer saw every step, in apply order, tagged with the identity.
+        observer.Steps.Count.ShouldBe(3);
+        observer.Steps.ShouldAllBe(x => x.Identity == stream.ToString());
+    }
+
+    [Fact]
+    public async Task fans_a_single_event_list_out_across_multiple_identities()
+    {
+        var projection = new SteppingProjection();
+        projection.AssembleAndAssertValidity();
+
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        // One flat event list spanning two streams -> two timelines.
+        var events = new[]
+        {
+            A(stream1, 1, 1),
+            B(stream2, 2, 1),
+            A(stream1, 3, 2)
+        };
+
+        var result = await projection.BuildTimelinesAsync(
+            events, new FakeSession(), Serialize, ToRecord, null, CancellationToken.None);
+
+        result.AggregatesByIdentity.Count.ShouldBe(2);
+
+        StateOf(result.AggregatesByIdentity[stream1.ToString()].FinalState!.Value).ACount.ShouldBe(2);
+        StateOf(result.AggregatesByIdentity[stream2.ToString()].FinalState!.Value).BCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task captures_apply_errors_on_the_step_and_keeps_folding()
+    {
+        var projection = new ThrowsOnBProjection();
+        projection.AssembleAndAssertValidity();
+
+        var stream = Guid.NewGuid();
+        var events = new[] { A(stream, 1, 1), B(stream, 2, 2), A(stream, 3, 3) };
+
+        var result = await projection.BuildTimelinesAsync(
+            events, new FakeSession(), Serialize, ToRecord, null, CancellationToken.None);
+
+        var timeline = result.AggregatesByIdentity[stream.ToString()];
+        timeline.Steps.Count.ShouldBe(3);
+
+        // The poison B event records its error but does not abort the run...
+        timeline.Steps[1].Error.ShouldNotBeNull();
+        timeline.Steps[1].Error!.ShouldContain("no B allowed");
+
+        // ...and the surrounding A events still fold, so ACount reaches 2.
+        StateOf(timeline.FinalState!.Value).ACount.ShouldBe(2);
+    }
+
+    private static MyAggregate StateOf(JsonElement element) =>
+        element.Deserialize<MyAggregate>()!;
+
+    private sealed class CollectingObserver : IProjectionStepObserver
+    {
+        public List<(string Identity, ProjectionStepResultRaw Step)> Steps { get; } = new();
+
+        public ValueTask ObserveAsync(string identity, ProjectionStepResultRaw step, CancellationToken cancellation)
+        {
+            Steps.Add((identity, step));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    // Overrides Evolve directly so the fold is exercised without depending on the source generator.
+    private sealed class SteppingProjection : SingleStreamProjection<MyAggregate, Guid>
+    {
+        public override MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e)
+        {
+            snapshot ??= new MyAggregate { Id = id };
+            switch (e.Data)
+            {
+                case AEvent:
+                    snapshot.ACount++;
+                    break;
+                case BEvent:
+                    snapshot.BCount++;
+                    break;
+            }
+
+            return snapshot;
+        }
+    }
+
+    private sealed class ThrowsOnBProjection : SingleStreamProjection<MyAggregate, Guid>
+    {
+        public override MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e)
+        {
+            snapshot ??= new MyAggregate { Id = id };
+            switch (e.Data)
+            {
+                case AEvent:
+                    snapshot.ACount++;
+                    break;
+                case BEvent:
+                    throw new InvalidOperationException("no B allowed");
+            }
+
+            return snapshot;
+        }
+    }
+}

--- a/src/JasperFx.Events/Aggregation/ISteppableAggregation.cs
+++ b/src/JasperFx.Events/Aggregation/ISteppableAggregation.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using JasperFx.Descriptors;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Aggregation;
+
+/// <summary>
+/// Type-erased entry point for the step-instrumented aggregation fold. Implemented
+/// by <see cref="JasperFxAggregationProjectionBase{TDoc,TId,TOperations,TQuerySession}"/>
+/// so a store can look a projection up by name (where the concrete <c>TDoc</c>/<c>TId</c>
+/// are not statically known) and drive the real slice → group → enrich → fold path,
+/// capturing a per-event before/after timeline for every resulting identity.
+/// </summary>
+/// <typeparam name="TQuerySession">The store's query session type used for slicing and enrichment.</typeparam>
+public interface ISteppableAggregation<TQuerySession>
+{
+    /// <summary>
+    /// Fold <paramref name="events"/> through the projection's real execution path —
+    /// slicing, grouping, <c>EnrichEventsAsync</c>, then applying each event one at a
+    /// time via the projection's <c>Create</c>/<c>Apply</c>/<c>ShouldDelete</c> conventions
+    /// (i.e. <c>EvolveAsync</c>) — producing one <see cref="ProjectionTimelineRaw"/> per
+    /// aggregate identity. Nothing is persisted; this is a stateless replay.
+    /// </summary>
+    /// <remarks>
+    /// Enrichment reads present-day reference data even when replaying historical events —
+    /// the fold calls the same <c>EnrichEventsAsync</c> the async daemon uses, against the
+    /// supplied live session. Callers replaying old event sets should treat any enriched
+    /// values as reflecting the current state of that reference data, not the state at the
+    /// time the events were originally recorded.
+    /// </remarks>
+    /// <param name="events">Events to replay, in global apply order.</param>
+    /// <param name="session">Live query session used for slicing and enrichment.</param>
+    /// <param name="serialize">
+    /// Serializes an aggregate snapshot (or <see langword="null"/>) to JSON using the store's
+    /// own serializer so the captured state matches what the store would persist.
+    /// </param>
+    /// <param name="toRecord">Maps a folded <see cref="IEvent"/> back to its wire <see cref="EventRecord"/>.</param>
+    /// <param name="observer">Optional observer that receives each step as it is folded; may be <see langword="null"/>.</param>
+    /// <param name="cancellation">Cancellation token for the replay.</param>
+    Task<MultiAggregateProjectionResult> BuildTimelinesAsync(
+        IReadOnlyList<IEvent> events,
+        TQuerySession session,
+        Func<object?, JsonElement?> serialize,
+        Func<IEvent, EventRecord> toRecord,
+        IProjectionStepObserver? observer,
+        CancellationToken cancellation);
+}

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Stepping.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Stepping.cs
@@ -1,0 +1,119 @@
+using System.Diagnostics;
+using System.Text.Json;
+using JasperFx.Descriptors;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.Aggregation;
+
+public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOperations, TQuerySession>
+    : ISteppableAggregation<TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations where TDoc : notnull where TId : notnull
+{
+    /// <inheritdoc />
+    public async Task<MultiAggregateProjectionResult> BuildTimelinesAsync(
+        IReadOnlyList<IEvent> events,
+        TQuerySession session,
+        Func<object?, JsonElement?> serialize,
+        Func<IEvent, EventRecord> toRecord,
+        IProjectionStepObserver? observer,
+        CancellationToken cancellation)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(serialize);
+        ArgumentNullException.ThrowIfNull(toRecord);
+
+        // Run the *real* fan-out path: the same slicer the async daemon uses, so
+        // multi-stream projections fan a single event list out across every identity
+        // they touch and single-stream projections collapse to exactly one slice.
+        var slicer = BuildSlicer(session);
+        var groups = await slicer.SliceAsync(events).ConfigureAwait(false);
+
+        var byIdentity = new Dictionary<string, ProjectionTimelineRaw>();
+
+        foreach (var groupObject in groups)
+        {
+            if (groupObject is not SliceGroup<TDoc, TId> group)
+            {
+                continue;
+            }
+
+            // Faithful to the daemon: enrichment happens after slicing, before applying.
+            await EnrichEventsAsync(group, session, cancellation).ConfigureAwait(false);
+
+            foreach (var slice in group.Slices)
+            {
+                var identity = slice.Id?.ToString() ?? string.Empty;
+                var timeline = await foldSliceAsync(slice, session, serialize, toRecord, observer, cancellation)
+                    .ConfigureAwait(false);
+
+                // A multi-stream slicer never produces two slices for the same identity within
+                // a group, but guard anyway so a duplicate can't throw and lose the whole run.
+                byIdentity[identity] = timeline;
+            }
+        }
+
+        return new MultiAggregateProjectionResult(Name, byIdentity);
+    }
+
+    private async Task<ProjectionTimelineRaw> foldSliceAsync(
+        EventSlice<TDoc, TId> slice,
+        TQuerySession session,
+        Func<object?, JsonElement?> serialize,
+        Func<IEvent, EventRecord> toRecord,
+        IProjectionStepObserver? observer,
+        CancellationToken cancellation)
+    {
+        var identity = slice.Id?.ToString() ?? string.Empty;
+        var steps = new List<ProjectionStepResultRaw>();
+        var identitySetter = new NulloIdentitySetter<TDoc, TId>();
+
+        TDoc? snapshot = default;
+
+        foreach (var @event in slice.Events())
+        {
+            cancellation.ThrowIfCancellationRequested();
+
+            var before = serialize(snapshot);
+            string? error = null;
+
+            var start = Stopwatch.GetTimestamp();
+            try
+            {
+                // One event at a time so we can capture the state between each apply.
+                // DetermineActionAsync is the real dispatch used by the daemon — it routes
+                // to the projection's Create/Apply/ShouldDelete conventions (or an Evolve/
+                // DetermineAction override, or the source-generated evolver) and reports a
+                // delete via ActionType, so this honors user logic exactly rather than a
+                // reflection re-implementation.
+                var (result, action) = await DetermineActionAsync(
+                    session, snapshot, slice.Id, identitySetter, [@event], cancellation).ConfigureAwait(false);
+
+                snapshot = action == ActionType.Delete ? default : result;
+            }
+            catch (Exception e)
+            {
+                // Capture the failure on the step and keep the pre-apply snapshot so the
+                // remaining events still fold — the stepper wants to show the whole timeline,
+                // including the event that blew up, not stop at the first error. Unwrap the
+                // ApplyEventException the fold path adds so the step carries the projection's
+                // own apply-method message rather than the daemon's "Failure to apply event #n".
+                error = e is ApplyEventException { InnerException: { } inner } ? inner.Message : e.Message;
+            }
+
+            var elapsed = Stopwatch.GetElapsedTime(start);
+            var after = serialize(snapshot);
+
+            var step = new ProjectionStepResultRaw(toRecord(@event), before, after, elapsed, error);
+            steps.Add(step);
+
+            if (observer != null)
+            {
+                await observer.ObserveAsync(identity, step, cancellation).ConfigureAwait(false);
+            }
+        }
+
+        return new ProjectionTimelineRaw(steps, serialize(snapshot));
+    }
+}

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -341,6 +341,31 @@ public interface IEventStore
         CancellationToken ct)
         => throw new NotImplementedException(
             "RunProjectionByNameAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for projection step-through.");
+
+    /// <summary>
+    /// Replay a projection referenced by name over a fixed in-memory event list,
+    /// fanning the events out across every aggregate identity the projection touches
+    /// and returning one <see cref="ProjectionTimelineRaw"/> per identity. Unlike
+    /// <see cref="RunProjectionByNameAsync"/> this drives the projection's full
+    /// slice → group → enrich → fold path against a live query session, so multi-stream
+    /// projections produce a timeline per resulting identity and single-stream
+    /// projections produce exactly one. Stateless — nothing is persisted. The default
+    /// implementation throws <see cref="NotImplementedException"/>.
+    /// </summary>
+    /// <remarks>
+    /// Enrichment reads present-day reference data even when replaying historical events;
+    /// enriched values reflect the current state of that reference data, not its state at
+    /// the time the events were originally recorded.
+    /// </remarks>
+    /// <param name="projectionName">Name of the projection to replay.</param>
+    /// <param name="events">Events to feed into the projection in global apply order.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<MultiAggregateProjectionResult> RunMultiStreamProjectionAsync(
+        string projectionName,
+        IReadOnlyList<EventRecord> events,
+        CancellationToken ct)
+        => throw new NotImplementedException(
+            "RunMultiStreamProjectionAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for projection step-through.");
 }
 
 public interface IEventStore<TOperations, TQuerySession> : IEventStore where TOperations : TQuerySession, IStorageOperations

--- a/src/JasperFx.Events/Projections/IProjectionStepObserver.cs
+++ b/src/JasperFx.Events/Projections/IProjectionStepObserver.cs
@@ -1,0 +1,25 @@
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.Projections;
+
+/// <summary>
+/// Receives per-event, per-identity step results as a projection is folded over
+/// a fixed event set by the step-instrumented build path
+/// (<see cref="ISteppableAggregation{TQuerySession}.BuildTimelinesAsync"/>).
+/// Used by the event store explorer / CritterWatch projection-stepthrough to
+/// stream a projection's before/after state as it is being computed, rather than
+/// only receiving the completed timeline. The fold awaits each callback, so an
+/// observer may push to a channel, hub, or socket without racing the fold.
+/// </summary>
+public interface IProjectionStepObserver
+{
+    /// <summary>
+    /// Invoked once per event applied to a single aggregate identity, in apply order.
+    /// Called immediately after the event has been folded (successfully or not) so
+    /// the observer sees steps as they happen.
+    /// </summary>
+    /// <param name="identity">String form of the aggregate identity this step belongs to.</param>
+    /// <param name="step">Before/after JSON state, elapsed apply time, and any error for this event.</param>
+    /// <param name="cancellation">Cancellation token for the overall replay.</param>
+    ValueTask ObserveAsync(string identity, ProjectionStepResultRaw step, CancellationToken cancellation);
+}


### PR DESCRIPTION
Closes #544.

Adds the load-bearing **session-backed, step-instrumented aggregation fold** the CritterWatch projection-stepthrough epic depends on, implemented in the **shared aggregation base** so Marten and Polecat inherit it rather than each re-implementing the reflection-`Apply` path (which has no session, can't call `EnrichEventsAsync`, can't run the slicer, and silently diverges from user `Create`/`Apply`/`ShouldDelete` overrides).

## What's added

- **`IProjectionStepObserver`** (`JasperFx.Events.Projections`) — receives a `ProjectionStepResultRaw` per event per identity as the fold runs. The fold awaits each callback so an observer can stream to a channel/hub/socket without racing.
- **`ISteppableAggregation<TQuerySession>`** — type-erased entry point so a store can look a projection up by name (where `TDoc`/`TId` aren't statically known) and drive the real fold.
- **`JasperFxAggregationProjectionBase.BuildTimelinesAsync`** — runs the **real** execution path: `BuildSlicer` → slice → `EnrichEventsAsync(group, session, ct)` → fold each event **one at a time** through `DetermineActionAsync` (the daemon's own `Create`/`Apply`/`ShouldDelete` dispatch; deletes reported via `ActionType`). Captures before/after JSON, elapsed time, and the unwrapped apply error per step, producing one `ProjectionTimelineRaw` per resulting identity in a `MultiAggregateProjectionResult`.
- **`IEventStore.RunMultiStreamProjectionAsync`** — default-throwing surface returning `MultiAggregateProjectionResult` (mirrors the existing `RunProjectionByNameAsync` convention) for Marten/Polecat to implement over their own session.

## Done-when

- ✅ Folds an event set into N timelines (one per identity), enrichment invoked per group.
- ✅ Single-identity aggregate projections produce **exactly one** timeline (no behavior change for existing MVP consumers).
- ✅ `MultiAggregateProjectionResult` is the return type and is populated.

Apply errors are captured on the step (unwrapped from the daemon's `ApplyEventException`) and the fold **continues**, so the whole timeline stays visible including the event that blew up.

**Enrichment note:** reads present-day reference data even when replaying historical events — documented on the new surfaces; it calls the same `EnrichEventsAsync` the async daemon uses against the supplied live session.

## Tests

`EventTests/Projections/StepInstrumentedFoldTests.cs`:
- `single_identity_produces_exactly_one_timeline_with_per_event_state` — walks per-event before/after and the streamed observer.
- `fans_a_single_event_list_out_across_multiple_identities` — one flat event list over two streams → two timelines.
- `captures_apply_errors_on_the_step_and_keeps_folding` — poison event records its (unwrapped) message, surrounding events still fold.

## Downstream follow-up (separate repos)

Marten/Polecat wire `RunMultiStreamProjectionAsync` to convert `EventRecord`↔`IEvent`, open a query session, and call `BuildTimelinesAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)