### PR TITLE
feat(#545): serializable rich EventTagQuery as a DCB source for replay / AggregateToMany

### DIFF
--- a/src/EventTests/Tags/EventTagQuerySpecTests.cs
+++ b/src/EventTests/Tags/EventTagQuerySpecTests.cs
@@ -1,0 +1,83 @@
+using JasperFx.Events.Tags;
+using Shouldly;
+
+namespace EventTests.Tags;
+
+// Coverage for jasperfx#545: a serializable EventTagQuery that survives a message hop
+// and resolves back to CLR types against the registered tag/event graph, carrying the
+// full rich query (OR conditions + AndEventsOfType event-type filters) rather than the
+// lossy AND-only Dictionary<string,string> form.
+public class EventTagQuerySpecTests
+{
+    // The "registered graph" the service side resolves against.
+    private static readonly Func<JasperFx.Descriptors.TypeDescriptor, Type?> Resolver =
+        EventTagQuerySpec.ResolverFor([
+            typeof(StudentId), typeof(CourseId),
+            typeof(AEvent), typeof(BEvent), typeof(CEvent)
+        ]);
+
+    [Fact]
+    public void round_trips_or_conditions_with_event_type_filters()
+    {
+        var original = new EventTagQuery()
+            .Or<AEvent, StudentId>(new StudentId("student-1"))
+            .Or<BEvent, CourseId>(new CourseId("course-1"));
+
+        var spec = EventTagQuerySpec.From(original);
+        var rehydrated = spec.Resolve(Resolver);
+
+        rehydrated.Conditions.Count.ShouldBe(2);
+
+        rehydrated.Conditions[0].EventType.ShouldBe(typeof(AEvent));
+        rehydrated.Conditions[0].TagType.ShouldBe(typeof(StudentId));
+        rehydrated.Conditions[0].TagValue.ShouldBe(new StudentId("student-1"));
+
+        rehydrated.Conditions[1].EventType.ShouldBe(typeof(BEvent));
+        rehydrated.Conditions[1].TagType.ShouldBe(typeof(CourseId));
+        rehydrated.Conditions[1].TagValue.ShouldBe(new CourseId("course-1"));
+    }
+
+    [Fact]
+    public void round_trips_tag_only_condition_with_null_event_type()
+    {
+        var original = new EventTagQuery()
+            .Or(new StudentId("student-9"));
+
+        var rehydrated = EventTagQuerySpec.From(original).Resolve(Resolver);
+
+        rehydrated.Conditions.Count.ShouldBe(1);
+        rehydrated.Conditions[0].EventType.ShouldBeNull();
+        rehydrated.Conditions[0].TagType.ShouldBe(typeof(StudentId));
+        rehydrated.Conditions[0].TagValue.ShouldBe(new StudentId("student-9"));
+    }
+
+    [Fact]
+    public void round_trips_and_events_of_type_fan_out()
+    {
+        // For(tag).AndEventsOfType<A,B,C>() expands to one condition per event type,
+        // all sharing the tag value — the expressiveness the dictionary form can't carry.
+        var original = EventTagQuery
+            .For(new StudentId("student-42"))
+            .AndEventsOfType<AEvent, BEvent, CEvent>();
+
+        var rehydrated = EventTagQuerySpec.From(original).Resolve(Resolver);
+
+        rehydrated.Conditions.Count.ShouldBe(3);
+        rehydrated.Conditions.Select(x => x.EventType)
+            .ShouldBe([typeof(AEvent), typeof(BEvent), typeof(CEvent)]);
+        rehydrated.Conditions.ShouldAllBe(x =>
+            x.TagType == typeof(StudentId) && x.TagValue.Equals(new StudentId("student-42")));
+    }
+
+    [Fact]
+    public void unresolvable_type_raises_a_precise_error()
+    {
+        var spec = EventTagQuerySpec.From(new EventTagQuery().Or(new StudentId("x")));
+
+        // A resolver that knows nothing → the tag type can't be resolved.
+        var ex = Should.Throw<UnknownTagQueryTypeException>(() =>
+            spec.Resolve(EventTagQuerySpec.ResolverFor([])));
+
+        ex.Descriptor.FullName.ShouldBe(typeof(StudentId).FullName);
+    }
+}

--- a/src/JasperFx.Events/Tags/EventTagQuery.cs
+++ b/src/JasperFx.Events/Tags/EventTagQuery.cs
@@ -23,6 +23,22 @@ public class EventTagQuery
     public IReadOnlyList<EventTagQueryCondition> Conditions => _conditions;
 
     /// <summary>
+    /// Build a query directly from an existing set of conditions. Used when
+    /// rehydrating a query that was carried over the wire as an
+    /// <see cref="EventTagQuerySpec"/> — the fluent builders can't reconstruct
+    /// an arbitrary condition set because their type arguments are only known
+    /// at compile time.
+    /// </summary>
+    public static EventTagQuery FromConditions(IEnumerable<EventTagQueryCondition> conditions)
+    {
+        ArgumentNullException.ThrowIfNull(conditions);
+
+        var query = new EventTagQuery();
+        query._conditions.AddRange(conditions);
+        return query;
+    }
+
+    /// <summary>
     /// Add a condition: events of type TEvent tagged with the given tag value.
     /// </summary>
     public EventTagQuery Or<TEvent, TTag>(TTag tagValue) where TTag : notnull

--- a/src/JasperFx.Events/Tags/EventTagQuerySpec.cs
+++ b/src/JasperFx.Events/Tags/EventTagQuerySpec.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.Tags;
+
+/// <summary>
+/// Wire-safe representation of a single <see cref="EventTagQueryCondition"/>: the
+/// tag type and event type are carried as <see cref="TypeDescriptor"/> name strings
+/// and the tag value as JSON, so the condition can cross a message hop without
+/// shipping CLR types.
+/// </summary>
+/// <param name="EventType">Descriptor of the event type filter, or <see langword="null"/> for "any event carrying this tag".</param>
+/// <param name="TagType">Descriptor of the strong-typed tag identity type.</param>
+/// <param name="TagValue">The tag value serialized as JSON, deserialized back against <paramref name="TagType"/> on the service side.</param>
+public sealed record EventTagQueryConditionSpec(
+    TypeDescriptor? EventType,
+    TypeDescriptor TagType,
+    JsonElement TagValue);
+
+/// <summary>
+/// Serializable, round-trippable form of an <see cref="EventTagQuery"/> — the full
+/// rich query (OR conditions plus <c>AndEventsOfType</c> event-type filters), not the
+/// lossy AND-only <c>IReadOnlyDictionary&lt;string,string&gt;</c> form. Lets a DCB-sourced
+/// projection replay / <c>AggregateToMany</c> carry a real Dynamic Consistency Boundary
+/// query over the wire and have it resolved back to CLR types on the service side against
+/// the registered tag/event graph. See jasperfx#545.
+/// </summary>
+/// <param name="Conditions">The OR'd conditions, mirroring <see cref="EventTagQuery.Conditions"/>.</param>
+public sealed record EventTagQuerySpec(IReadOnlyList<EventTagQueryConditionSpec> Conditions)
+{
+    /// <summary>
+    /// Flatten a live <see cref="EventTagQuery"/> into its wire form. Each condition's
+    /// tag value is serialized using its runtime type so a strong-typed id round-trips.
+    /// </summary>
+    /// <param name="query">The query to serialize.</param>
+    /// <param name="options">Optional serializer options; the same options must be supplied to <see cref="Resolve"/>.</param>
+    public static EventTagQuerySpec From(EventTagQuery query, JsonSerializerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var conditions = query.Conditions
+            .Select(c => new EventTagQueryConditionSpec(
+                c.EventType is null ? null : TypeDescriptor.For(c.EventType),
+                TypeDescriptor.For(c.TagType),
+                // Serialize under the value's *runtime* type; the compile-time type here is
+                // object, and object-typed serialization would emit an empty document.
+                JsonSerializer.SerializeToElement(c.TagValue, c.TagValue.GetType(), options)))
+            .ToList();
+
+        return new EventTagQuerySpec(conditions);
+    }
+
+    /// <summary>
+    /// Rehydrate the spec into a live <see cref="EventTagQuery"/>, resolving each tag/event
+    /// type name back to a CLR <see cref="Type"/> via <paramref name="resolveType"/> and
+    /// deserializing each tag value against its resolved tag type. The resolver is expected
+    /// to consult the store's registered tag/event graph.
+    /// </summary>
+    /// <param name="resolveType">Resolves a <see cref="TypeDescriptor"/> to its CLR type; see <see cref="ResolverFor"/> for a graph-backed default.</param>
+    /// <param name="options">Optional serializer options; must match those used by <see cref="From"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="resolveType"/> is null.</exception>
+    /// <exception cref="UnknownTagQueryTypeException">A tag or event type name cannot be resolved against the registered graph.</exception>
+    public EventTagQuery Resolve(Func<TypeDescriptor, Type?> resolveType, JsonSerializerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(resolveType);
+
+        var conditions = new List<EventTagQueryCondition>(Conditions.Count);
+        foreach (var spec in Conditions)
+        {
+            var tagType = resolveType(spec.TagType)
+                          ?? throw new UnknownTagQueryTypeException(spec.TagType);
+
+            Type? eventType = null;
+            if (spec.EventType is not null)
+            {
+                eventType = resolveType(spec.EventType)
+                            ?? throw new UnknownTagQueryTypeException(spec.EventType);
+            }
+
+            var tagValue = spec.TagValue.Deserialize(tagType, options)
+                           ?? throw new InvalidOperationException(
+                               $"Tag value for tag type '{spec.TagType.FullName}' deserialized to null.");
+
+            conditions.Add(new EventTagQueryCondition(eventType, tagType, tagValue));
+        }
+
+        return EventTagQuery.FromConditions(conditions);
+    }
+
+    /// <summary>
+    /// Build a <see cref="TypeDescriptor"/>-to-<see cref="Type"/> resolver over a known set of
+    /// types — the store's registered tag types and event types. Matches on full name (falling
+    /// back to simple name when full names are ambiguous only across differing assemblies is not
+    /// a concern for the registered graph). Returns <see langword="null"/> for an unknown type so
+    /// <see cref="Resolve"/> can raise a precise error.
+    /// </summary>
+    /// <param name="knownTypes">The registered tag/event graph types the query may reference.</param>
+    public static Func<TypeDescriptor, Type?> ResolverFor(IEnumerable<Type> knownTypes)
+    {
+        ArgumentNullException.ThrowIfNull(knownTypes);
+
+        var byFullName = new Dictionary<string, Type>();
+        foreach (var type in knownTypes)
+        {
+            if (type.FullName is { } fullName)
+            {
+                byFullName[fullName] = type;
+            }
+        }
+
+        return descriptor => descriptor.FullName is { } fullName && byFullName.TryGetValue(fullName, out var type)
+            ? type
+            : null;
+    }
+}
+
+/// <summary>
+/// Raised when an <see cref="EventTagQuerySpec"/> references a tag or event type that
+/// cannot be resolved against the registered tag/event graph on the service side.
+/// </summary>
+public sealed class UnknownTagQueryTypeException(TypeDescriptor descriptor)
+    : Exception($"Unable to resolve tag query type '{descriptor.FullName}' against the registered tag/event graph. " +
+                "Ensure the type is registered on the service side before replaying a DCB-sourced query.")
+{
+    /// <summary>The descriptor that could not be resolved.</summary>
+    public TypeDescriptor Descriptor { get; } = descriptor;
+}


### PR DESCRIPTION
Closes #545.

Lets a DCB-sourced projection replay / `AggregateToMany` carry a **rich `EventTagQuery`** (OR conditions + `.AndEventsOfType<>()` event-type filters) across a message hop, instead of the lossy AND-only `IReadOnlyDictionary<string,string>` the stepthrough pipes through today.

## What's added

- **`EventTagQuerySpec`** / **`EventTagQueryConditionSpec`** — the wire-safe form of `EventTagQuery`. Tag and event types are carried as `TypeDescriptor` name strings; each tag value is serialized as JSON **under its runtime type** so a strong-typed id survives the hop (a plain object-typed serialization would emit an empty document).
- **`EventTagQuerySpec.From(query)`** — flatten a live query to its spec.
- **`EventTagQuerySpec.Resolve(resolveType)`** — rehydrate on the service side, resolving each tag/event type name back to a CLR `Type` against the registered graph and deserializing each tag value against its resolved tag type. An unresolvable name raises `UnknownTagQueryTypeException` carrying the offending `TypeDescriptor`.
- **`EventTagQuerySpec.ResolverFor(knownTypes)`** — a ready `TypeDescriptor`→`Type` resolver built over a store's registered tag/event graph types.
- **`EventTagQuery.FromConditions(conditions)`** — reconstruct a query from an arbitrary condition set (the fluent builders can't: their type arguments are only known at compile time).

## Done-when

- ✅ A stepthrough / `AggregateToMany` can be sourced from an `EventTagQuery` with OR conditions **and** event-type filters, round-tripping over the wire.

## Tests

`EventTests/Tags/EventTagQuerySpecTests.cs`:
- `round_trips_or_conditions_with_event_type_filters`
- `round_trips_tag_only_condition_with_null_event_type`
- `round_trips_and_events_of_type_fan_out` — `For(tag).AndEventsOfType<A,B,C>()` expands to one condition per event type sharing the tag value (the expressiveness the dictionary form can't carry).
- `unresolvable_type_raises_a_precise_error`

## Downstream follow-up (separate repos)

Marten/Polecat accept the rich query on the DCB read path (`QueryByTagsAsync(EventTagQuery)` already exists in Marten's `EventStore.Dcb.cs`) and wire the serialized form through — the `TagQuerySpec.mode: 'expression'` seam from the CritterWatch FE selector work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)