### PR TITLE
feat(#546): IDcbAggregateRegistry — runtime discovery of DCB aggregates

### DIFF
--- a/src/EventTests/Tags/DcbAggregateRegistryTests.cs
+++ b/src/EventTests/Tags/DcbAggregateRegistryTests.cs
@@ -1,0 +1,85 @@
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Tags;
+using Shouldly;
+
+namespace EventTests.Tags;
+
+// Coverage for jasperfx#546: runtime discovery of DCB aggregates used only inside a
+// DCB operation. The registry is populated lazily on first DCB use, so registration
+// must be idempotent, concurrency-safe, and surfaceable as descriptors by aggregate type.
+public class DcbAggregateRegistryTests
+{
+    private static readonly ITagTypeRegistration StudentTag = TagTypeRegistration.Create<StudentId>();
+    private static readonly ITagTypeRegistration CourseTag = TagTypeRegistration.Create<CourseId>();
+
+    [Fact]
+    public void register_is_idempotent_and_returns_the_first_registration()
+    {
+        var registry = new DcbAggregateRegistry();
+
+        var first = registry.Register(typeof(Enrollment), [StudentTag, CourseTag]);
+        var second = registry.Register(typeof(Enrollment), [StudentTag]); // second call, different tags
+
+        // First registration wins; a lazily-instrumented hot path never double-registers.
+        second.ShouldBeSameAs(first);
+        registry.Registrations.Count.ShouldBe(1);
+        first.TagTypes.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void try_find_locates_a_registered_aggregate_by_type()
+    {
+        var registry = new DcbAggregateRegistry();
+        registry.Register(typeof(Enrollment), [StudentTag]);
+
+        registry.TryFind(typeof(Enrollment), out var found).ShouldBeTrue();
+        found!.AggregateType.ShouldBe(typeof(Enrollment));
+
+        registry.TryFind(typeof(string), out var missing).ShouldBeFalse();
+        missing.ShouldBeNull();
+    }
+
+    [Fact]
+    public void registrations_snapshot_holds_every_discovered_aggregate()
+    {
+        var registry = new DcbAggregateRegistry();
+        registry.Register(typeof(Enrollment), [StudentTag]);
+        registry.Register(typeof(Attendance), [StudentTag, CourseTag]);
+
+        registry.Registrations.Select(x => x.AggregateType)
+            .ShouldBe([typeof(Enrollment), typeof(Attendance)], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void descriptor_mirrors_the_registration_type_and_tag_shape()
+    {
+        var registration = new DcbAggregateRegistration(typeof(Enrollment), [StudentTag, CourseTag]);
+
+        var descriptor = DcbAggregateDescriptor.For(registration);
+
+        descriptor.AggregateType.FullName.ShouldBe(typeof(Enrollment).FullName);
+        descriptor.Tags.Count.ShouldBe(2);
+        descriptor.Tags[0].TagType.FullName.ShouldBe(typeof(StudentId).FullName);
+        descriptor.Tags[0].Name.ShouldBe(nameof(StudentId));
+        descriptor.Tags[0].SimpleType.ShouldBe(typeof(string).FullName);
+        descriptor.Tags[1].TagType.FullName.ShouldBe(typeof(CourseId).FullName);
+    }
+
+    [Fact]
+    public void for_registry_snapshots_all_discovered_aggregates_as_descriptors()
+    {
+        var registry = new DcbAggregateRegistry();
+        registry.Register(typeof(Enrollment), [StudentTag]);
+        registry.Register(typeof(Attendance), [CourseTag]);
+
+        var descriptors = DcbAggregateDescriptor.ForRegistry(registry);
+
+        descriptors.Select(x => x.AggregateType.FullName)
+            .ShouldBe([typeof(Enrollment).FullName, typeof(Attendance).FullName], ignoreOrder: true);
+    }
+
+    // DCB aggregates that would live buried in handler code — no registered projection name.
+    private sealed class Enrollment;
+
+    private sealed class Attendance;
+}

--- a/src/JasperFx.Events/Descriptors/DcbAggregateDescriptor.cs
+++ b/src/JasperFx.Events/Descriptors/DcbAggregateDescriptor.cs
@@ -1,0 +1,55 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.Tags;
+
+namespace JasperFx.Events.Descriptors;
+
+/// <summary>
+/// Diagnostic mirror of a discovered <see cref="DcbAggregateRegistration"/>, suitable for
+/// the descriptor/lifecycle surface a monitoring tool (e.g. CritterWatch) reads. Carries the
+/// aggregate's type identity and its tag/slice shape as wire-safe descriptors so a discovered
+/// DCB aggregate — one with no registered projection name — can be surfaced as a steppable run
+/// target identified by <b>type</b>. See jasperfx#546.
+/// </summary>
+public sealed class DcbAggregateDescriptor
+{
+    /// <summary>
+    /// Type identity of the discovered DCB aggregate — the token a run target is identified by.
+    /// </summary>
+    public TypeDescriptor AggregateType { get; set; } = null!;
+
+    /// <summary>
+    /// The tag types that shape this aggregate's DCB slice, as wire-safe descriptors.
+    /// </summary>
+    public List<DcbTagDescriptor> Tags { get; set; } = new();
+
+    /// <summary>
+    /// Project a runtime <see cref="DcbAggregateRegistration"/> into its wire-safe descriptor.
+    /// </summary>
+    public static DcbAggregateDescriptor For(DcbAggregateRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        return new DcbAggregateDescriptor
+        {
+            AggregateType = TypeDescriptor.For(registration.AggregateType),
+            Tags = registration.TagTypes
+                .Select(tag => new DcbTagDescriptor(
+                    tag.TagType.Name,
+                    tag.SimpleType.FullName ?? tag.SimpleType.Name,
+                    TypeDescriptor.For(tag.TagType),
+                    Description: null))
+                .ToList()
+        };
+    }
+
+    /// <summary>
+    /// Snapshot every discovered aggregate in a registry as descriptors. Used when populating
+    /// an <see cref="EventStoreUsage"/> from a store's <see cref="IDcbAggregateRegistry"/>.
+    /// </summary>
+    public static List<DcbAggregateDescriptor> ForRegistry(IDcbAggregateRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+
+        return registry.Registrations.Select(For).ToList();
+    }
+}

--- a/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
+++ b/src/JasperFx.Events/Descriptors/EventStoreUsage.cs
@@ -119,6 +119,15 @@ public class EventStoreUsage : OptionsDescription
     public List<DcbTagDescriptor> DcbTagTypes { get; set; } = new();
 
     /// <summary>
+    /// DCB aggregates discovered at runtime — those used only inside a DCB
+    /// operation (nested handler/endpoint code) and therefore invisible to the
+    /// source generator and to the named-projection registry. Populated from the
+    /// store's <see cref="Tags.IDcbAggregateRegistry"/> so CritterWatch can surface
+    /// them as steppable run targets identified by type. See jasperfx#546.
+    /// </summary>
+    public List<DcbAggregateDescriptor> DiscoveredDcbAggregates { get; set; } = new();
+
+    /// <summary>
     /// Configured event-type registrations as known to the event store.
     /// Mirror of the store's event registry used by monitoring tools to
     /// list which event aliases are wired up and what their CLR types

--- a/src/JasperFx.Events/Tags/IDcbAggregateRegistry.cs
+++ b/src/JasperFx.Events/Tags/IDcbAggregateRegistry.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace JasperFx.Events.Tags;
+
+/// <summary>
+/// A single discovered DCB aggregate: its CLR type and the tag types that define
+/// its slice/consistency-boundary shape. Recorded the first time the aggregate is
+/// used inside a DCB operation, since such aggregates have no registered projection
+/// name and are not emitted by the source generator when constructed deep in handler
+/// or endpoint code.
+/// </summary>
+/// <param name="AggregateType">The DCB aggregate's CLR type — the token a run target is identified by.</param>
+/// <param name="TagTypes">The tag type registrations that shape this aggregate's DCB slice.</param>
+public sealed record DcbAggregateRegistration(
+    Type AggregateType,
+    IReadOnlyList<ITagTypeRegistration> TagTypes);
+
+/// <summary>
+/// Runtime registry of DCB aggregates that are only ever used <em>inside</em> a DCB
+/// operation — buried in nested handler/endpoint code where the source generator can't
+/// see them and where there is no registered named projection to identify them by.
+/// Marten/Polecat populate this <b>lazily on first DCB use</b> by instrumenting the DCB
+/// read entrypoints (<c>FetchForWritingByTags&lt;T&gt;</c>, <c>AggregateByTagsAsync&lt;T&gt;</c>),
+/// so these aggregates become steppable/inspectable run targets identified by <b>type</b>
+/// rather than by projection name, and become visible in CritterWatch's lifecycle/descriptor
+/// views. See jasperfx#546.
+/// </summary>
+public interface IDcbAggregateRegistry
+{
+    /// <summary>
+    /// Record a DCB aggregate on first use. Idempotent and safe to call concurrently —
+    /// the first registration for a given aggregate type wins and is returned on every
+    /// subsequent call, so instrumenting a hot read path costs one dictionary lookup.
+    /// </summary>
+    /// <param name="aggregateType">The DCB aggregate's CLR type.</param>
+    /// <param name="tagTypes">The tag type registrations that shape its slice.</param>
+    /// <returns>The stored registration (existing one if already registered).</returns>
+    DcbAggregateRegistration Register(Type aggregateType, IReadOnlyList<ITagTypeRegistration> tagTypes);
+
+    /// <summary>
+    /// Look up a previously discovered DCB aggregate by its CLR type.
+    /// </summary>
+    bool TryFind(Type aggregateType, [NotNullWhen(true)] out DcbAggregateRegistration? registration);
+
+    /// <summary>
+    /// Every DCB aggregate discovered so far, in an order-independent snapshot.
+    /// </summary>
+    IReadOnlyCollection<DcbAggregateRegistration> Registrations { get; }
+}
+
+/// <summary>
+/// Default thread-safe <see cref="IDcbAggregateRegistry"/>. Keyed by aggregate CLR type;
+/// registration is idempotent via <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd(TKey,Func{TKey,TValue})"/>
+/// so a lazily-instrumented hot DCB read path never double-registers or throws under contention.
+/// </summary>
+public sealed class DcbAggregateRegistry : IDcbAggregateRegistry
+{
+    private readonly ConcurrentDictionary<Type, DcbAggregateRegistration> _registrations = new();
+
+    /// <inheritdoc />
+    public DcbAggregateRegistration Register(Type aggregateType, IReadOnlyList<ITagTypeRegistration> tagTypes)
+    {
+        ArgumentNullException.ThrowIfNull(aggregateType);
+        ArgumentNullException.ThrowIfNull(tagTypes);
+
+        return _registrations.GetOrAdd(aggregateType, static (type, tags) =>
+            new DcbAggregateRegistration(type, tags), tagTypes);
+    }
+
+    /// <inheritdoc />
+    public bool TryFind(Type aggregateType, [NotNullWhen(true)] out DcbAggregateRegistration? registration)
+    {
+        return _registrations.TryGetValue(aggregateType, out registration);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<DcbAggregateRegistration> Registrations => _registrations.Values.ToArray();
+}


### PR DESCRIPTION
Closes #546.

Discovers **DCB aggregates that are only ever used inside a DCB operation** — buried in nested handler/endpoint code where the source generator can't see them and where there's no registered projection name to identify them by — so they become steppable / inspectable run targets identified by **type**.

## What's added

- **`DcbAggregateRegistration`** — a discovered aggregate's CLR type + the tag type registrations that shape its DCB slice.
- **`IDcbAggregateRegistry`** + **`DcbAggregateRegistry`** — thread-safe, **idempotent** registration (`ConcurrentDictionary.GetOrAdd`) so Marten/Polecat can instrument the DCB read entrypoints (`FetchForWritingByTags<T>`, `AggregateByTagsAsync<T>`) to register the aggregate type **on first invocation** without double-registering or throwing on a hot path.
- **`DcbAggregateDescriptor`** — wire-safe mirror (`TypeDescriptor` + `DcbTagDescriptor` tags), with `For(registration)` and `ForRegistry(registry)`.
- **`EventStoreUsage.DiscoveredDcbAggregates`** — surfaces the discovered set through the descriptor/lifecycle surface CritterWatch already reads, so a run target can be identified by discovered aggregate **type**, not only by projection name — and (the bonus) the aggregates become visible in CritterWatch's lifecycle/descriptor views, where they're absent today.

## Done-when

- ✅ A DCB aggregate used only inside a nested handler can be registered on first use and surfaced as a steppable target **by type** — the registry, descriptor, and `EventStoreUsage` surface make this possible in JasperFx; Marten/Polecat do the lazy population (below).

## Tests

`EventTests/Tags/DcbAggregateRegistryTests.cs`:
- `register_is_idempotent_and_returns_the_first_registration`
- `try_find_locates_a_registered_aggregate_by_type`
- `registrations_snapshot_holds_every_discovered_aggregate`
- `descriptor_mirrors_the_registration_type_and_tag_shape`
- `for_registry_snapshots_all_discovered_aggregates_as_descriptors`

## Downstream follow-up (separate repos)

Marten/Polecat populate the registry **lazily on first DCB use** (instrument `FetchForWritingByTags<T>` / `AggregateByTagsAsync<T>`) and expose it on `TryCreateUsage` via `DcbAggregateDescriptor.ForRegistry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)