### PR TITLE
Stamp AssignedNodeNumber on daemon-published ShardState (#550, marten#5001)

### DIFF
--- a/src/EventTests/Daemon/ShardStateTrackerTests.cs
+++ b/src/EventTests/Daemon/ShardStateTrackerTests.cs
@@ -43,6 +43,56 @@ public class ShardStateTrackerTests : IDisposable
     }
 
     [Fact]
+    public async Task stamps_the_assigned_node_number_onto_published_states()
+    {
+        theTracker.AssignedNodeNumber = 4;
+
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        var state = new ShardState("Trip:All", 30) { AgentStatus = "Running" };
+        await theTracker.PublishAsync(state);
+        await theTracker.Complete();
+
+        observer.States.Last().AssignedNodeNumber.ShouldBe(4);
+
+        theTracker.Finish();
+    }
+
+    [Fact]
+    public async Task does_not_clobber_a_state_that_already_carries_a_node()
+    {
+        theTracker.AssignedNodeNumber = 4;
+
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        var state = new ShardState("Trip:All", 30) { AgentStatus = "Running", AssignedNodeNumber = 9 };
+        await theTracker.PublishAsync(state);
+        await theTracker.Complete();
+
+        observer.States.Last().AssignedNodeNumber.ShouldBe(9);
+
+        theTracker.Finish();
+    }
+
+    [Fact]
+    public async Task stamps_nothing_when_the_assigned_node_number_is_unset()
+    {
+        // Default AssignedNodeNumber == 0 (unset) — e.g. non-managed / single-node — leaves states alone.
+        var observer = new Observer();
+        theTracker.Subscribe(observer);
+
+        var state = new ShardState("Trip:All", 30) { AgentStatus = "Running" };
+        await theTracker.PublishAsync(state);
+        await theTracker.Complete();
+
+        observer.States.Last().AssignedNodeNumber.ShouldBe(0);
+
+        theTracker.Finish();
+    }
+
+    [Fact]
     public async Task mark_skipping()
     {
         var observer1 = new Observer();

--- a/src/JasperFx.Events/Daemon/ShardStateTracker.cs
+++ b/src/JasperFx.Events/Daemon/ShardStateTracker.cs
@@ -43,6 +43,17 @@ public class ShardStateTracker: IObservable<ShardState>, IObserver<ShardState>, 
     /// </summary>
     public string? DatabaseIdentifier { get; set; }
 
+    /// <summary>
+    ///     Node number this database's daemon is running on. Stamped onto every published
+    ///     <see cref="ShardState" /> that doesn't already carry one, so the
+    ///     <see cref="ExtendedProgressionWriter" /> can persist <see cref="ShardState.RunningOnNode" />.
+    ///     A distribution layer that owns the node assignment (e.g. Wolverine-managed subscription
+    ///     distribution) sets this when this node takes ownership of the daemon — the daemon only runs the
+    ///     agents assigned to its node, so the local node number is the assigned node for every state it
+    ///     publishes. Zero (the default) means unset, and nothing is stamped. See JasperFx/marten#5001.
+    /// </summary>
+    public int AssignedNodeNumber { get; set; }
+
     void IDisposable.Dispose()
     {
         _subscription.Dispose();
@@ -89,6 +100,13 @@ public class ShardStateTracker: IObservable<ShardState>, IObserver<ShardState>, 
         // progress and the high water agent's marks alike. A state that already names a database (a
         // republish, or a publisher that knows better) keeps its own.
         state.DatabaseIdentifier ??= DatabaseIdentifier;
+
+        // Same idea for the assigned node (marten#5001): stamp the running node so ExtendedProgressionWriter
+        // can carry it into running_on_node. A state that already carries a node (a republish) keeps its own.
+        if (AssignedNodeNumber != 0 && state.AssignedNodeNumber == 0)
+        {
+            state.AssignedNodeNumber = AssignedNodeNumber;
+        }
 
         return _block.PostAsync(state);
     }


### PR DESCRIPTION
Closes #550.

## What

`ShardStateTracker` gains an `AssignedNodeNumber` that `PublishAsync` stamps onto every published `ShardState` that doesn't already carry one — the **same single stamp point** that already stamps `DatabaseIdentifier`.

```csharp
state.DatabaseIdentifier ??= DatabaseIdentifier;
if (AssignedNodeNumber != 0 && state.AssignedNodeNumber == 0)
    state.AssignedNodeNumber = AssignedNodeNumber;   // <-- added
```

## Why

This is the daemon-publish-surface half of the `running_on_node` fix ([marten#5001](https://github.com/JasperFx/marten/issues/5001)). The existing `ExtendedProgressionWriter` carry (`RunningOnNode ??= AssignedNodeNumber`) is dead today because **nothing supplies `AssignedNodeNumber` on the runtime publish path** — every `ShardState` a `SubscriptionAgent` publishes carries `AgentStatus`/`LastHeartbeat` but `AssignedNodeNumber == 0`.

The companion (separate repo): a distribution layer that owns the node assignment — Wolverine-managed subscription distribution — sets `Tracker.AssignedNodeNumber = Options.Durability.AssignedNodeNumber` when this node takes ownership of the daemon. The daemon only runs the agents assigned to its node, so the local node number is the assigned node for every state it publishes. Zero (the default) means unset, so non-managed / single-node stores stamp nothing.

## Tests

`ShardStateTrackerTests`: stamps when set; does not clobber a state that already carries a node; stamps nothing when unset. `ExtendedProgressionWriterTests` (the carry) stay green.