### PR TITLE
More robust FSharp tuple and record type handling

### DIFF
--- a/src/CodegenTests.FSharpFixture/Generated.fs
+++ b/src/CodegenTests.FSharpFixture/Generated.fs
@@ -106,7 +106,7 @@ type GeneratedSyncTaskHandler(controlFlowService: FSharpCodegenTarget.ControlFlo
     let _controlFlowService = controlFlowService
 
     interface FSharpCodegenTarget.ISyncTaskHandler with
-        member this.HandleAsync(name: string) : System.Threading.Tasks.Task =
+        member this.HandleAsync(_name: string) : System.Threading.Tasks.Task =
             _controlFlowService.Record()
             System.Threading.Tasks.Task.CompletedTask
 

--- a/src/CodegenTests/CodegenTests.csproj
+++ b/src/CodegenTests/CodegenTests.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="FSharp.Core" Version="9.0.303" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/CodegenTests/FSharpCurriedMemberTests.cs
+++ b/src/CodegenTests/FSharpCurriedMemberTests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Microsoft.FSharp.Core;
+using Shouldly;
+
+namespace CodegenTests;
+
+/// <summary>
+///     Tests for <c>MethodCall.GenerateFSharpCode</c> when the target method carries
+///     <see cref="CompilationArgumentCountsAttribute" /> — the F# compiler's marker for class
+///     members that have multiple separate parameter groups (curried class members), e.g.:
+///     <code>static member Apply (a: string) (b: int) = ...</code>
+///     Without the fix, these would be emitted with C#-style parentheses <c>Apply(a, b)</c>,
+///     causing FS0001 type errors at compile time. The correct F# call syntax is space-separated:
+///     <c>Apply a b</c>.
+/// </summary>
+public class FSharpCurriedMemberTests
+{
+    /// <summary>
+    ///     Builds a dynamic type with a static method that carries
+    ///     <see cref="CompilationArgumentCountsAttribute" /> — mimicking what the F# compiler emits
+    ///     for <c>static member Apply (a: string) (b: int) = ...</c>.
+    /// </summary>
+    private static (Type OwnerType, MethodInfo Method) CreateCurriedStaticMethod()
+    {
+        var asmName = new AssemblyName("DynamicCurriedTest_" + Guid.NewGuid().ToString("N"));
+        var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+        var modBuilder = asmBuilder.DefineDynamicModule("Main");
+        var typeBuilder = modBuilder.DefineType("CurriedHelper",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Abstract);
+
+        var methodBuilder = typeBuilder.DefineMethod(
+            "Apply",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(string),
+            new[] { typeof(string), typeof(int) });
+
+        // Decorate with CompilationArgumentCountsAttribute([1; 1]):
+        // two parameter groups, each of arity 1 — identical to what the F# compiler emits for
+        // `static member Apply (a: string) (b: int) = ...`.
+        var attrCtor = typeof(CompilationArgumentCountsAttribute)
+            .GetConstructor(new[] { typeof(int[]) })!;
+        methodBuilder.SetCustomAttribute(
+            new CustomAttributeBuilder(attrCtor, new object[] { new int[] { 1, 1 } }));
+
+        var il = methodBuilder.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+
+        var dynamicType = typeBuilder.CreateType();
+        return (dynamicType, dynamicType.GetMethod("Apply")!);
+    }
+
+    [Fact]
+    public void curried_class_member_uses_space_separated_argument_syntax()
+    {
+        var (ownerType, method) = CreateCurriedStaticMethod();
+
+        var call = new MethodCall(ownerType, method);
+        call.Arguments[0] = Variable.For<string>("str");
+        call.Arguments[1] = Variable.For<int>("num");
+
+        var writer = new SourceWriter();
+        call.GenerateFSharpCode(GeneratedMethod.ForNoArg("Test"), writer);
+        var code = writer.Code();
+
+        // Curried (space-separated) call syntax — the F# compiler requires this for methods
+        // carrying CompilationArgumentCountsAttribute.
+        code.ShouldContain("Apply str num");
+        // Must NOT emit parenthesised C#-style call: Apply(str, num) would fail with FS0001.
+        code.ShouldNotContain("Apply(str, num)");
+    }
+
+    [Fact]
+    public void non_curried_method_uses_parenthesised_argument_syntax()
+    {
+        // Baseline: an ordinary static method (no CompilationArgumentCountsAttribute)
+        // should still use the parenthesised call syntax.
+        var call = new MethodCall(typeof(PlainHelper), nameof(PlainHelper.Combine));
+        call.Arguments[0] = Variable.For<string>("str");
+        call.Arguments[1] = Variable.For<int>("num");
+
+        var writer = new SourceWriter();
+        call.GenerateFSharpCode(GeneratedMethod.ForNoArg("Test"), writer);
+        var code = writer.Code();
+
+        code.ShouldContain("Combine(str, num)");
+    }
+
+    public static class PlainHelper
+    {
+        public static string Combine(string str, int num) => str + num;
+    }
+}

--- a/src/CodegenTests/FSharpGenerationTests.cs
+++ b/src/CodegenTests/FSharpGenerationTests.cs
@@ -336,7 +336,7 @@ public class FSharpGenerationTests
 
         var code = assembly.GenerateFSharpCode();
 
-        code.ShouldContain("let (red, blue, green) = _target.ReturnTuple()");
+        code.ShouldContain("let struct (red, blue, green) = _target.ReturnTuple()");
     }
 
     [Fact]
@@ -365,7 +365,7 @@ public class FSharpGenerationTests
         var code = assembly.GenerateFSharpCode();
 
         code.ShouldContain("task {");
-        code.ShouldContain("let! (red, blue, green) = _target.AsyncReturnTuple()");
+        code.ShouldContain("let! struct (red, blue, green) = _target.AsyncReturnTuple()");
     }
 
     public class UnsupportedFrame : SyncFrame

--- a/src/CodegenTests/FSharpGenerationTests.cs
+++ b/src/CodegenTests/FSharpGenerationTests.cs
@@ -336,7 +336,8 @@ public class FSharpGenerationTests
 
         var code = assembly.GenerateFSharpCode();
 
-        code.ShouldContain("let struct (red, blue, green) = _target.ReturnTuple()");
+        // None of the tuple members are consumed by a subsequent frame, so all slots become `_`.
+        code.ShouldContain("let struct (_, _, _) = _target.ReturnTuple()");
     }
 
     [Fact]
@@ -365,7 +366,8 @@ public class FSharpGenerationTests
         var code = assembly.GenerateFSharpCode();
 
         code.ShouldContain("task {");
-        code.ShouldContain("let! struct (red, blue, green) = _target.AsyncReturnTuple()");
+        // Only `red` (index 0) is wired to saveCall — `blue` and `green` become `_`.
+        code.ShouldContain("let! struct (red, _, _) = _target.AsyncReturnTuple()");
     }
 
     public class UnsupportedFrame : SyncFrame

--- a/src/CodegenTests/FSharpGenerationTests.cs
+++ b/src/CodegenTests/FSharpGenerationTests.cs
@@ -302,7 +302,8 @@ public class FSharpGenerationTests
 
         var code = assembly.GenerateFSharpCode();
 
-        code.ShouldContain("member this.HandleAsync(name: string) : System.Threading.Tasks.Task =");
+        // `name` is not consumed by any frame, so it is emitted with the `_` prefix to suppress FS1182.
+        code.ShouldContain("member this.HandleAsync(_name: string) : System.Threading.Tasks.Task =");
         code.ShouldContain("_service.Record()");
         // No state machine for a synchronous body — just yield a completed Task.
         code.ShouldNotContain("task {");

--- a/src/CodegenTests/FSharpNameTests.cs
+++ b/src/CodegenTests/FSharpNameTests.cs
@@ -1,11 +1,54 @@
 using System.Collections.Generic;
 using JasperFx.Core.Reflection;
+using Microsoft.FSharp.Collections;
+using Microsoft.FSharp.Core;
 using Shouldly;
 
 namespace CodegenTests;
 
 public class FSharpNameTests
 {
+    // -------------------------------------------------------------------------
+    // FSharpList<T> → "T list" mapping
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void fsharp_list_maps_to_t_list_syntax()
+    {
+        // FSharpList<T> is the CLR name for the F# `list` type.
+        // FSharpName() must produce the F# source form "T list", not the CLR name.
+        typeof(FSharpList<string>).FSharpName().ShouldBe("string list");
+        typeof(FSharpList<int>).FSharpName().ShouldBe("int list");
+    }
+
+    // -------------------------------------------------------------------------
+    // IsFSharpRecord() detection
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void is_fsharp_record_returns_true_for_fsharp_ref_type()
+    {
+        // FSharpRef<T> is the CLR form of the F# record `type 'T ref = { mutable contents: 'T }`.
+        // It carries CompilationMappingAttribute(SourceConstructFlags.RecordType = 2).
+        typeof(FSharpRef<string>).IsFSharpRecord().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void is_fsharp_record_returns_false_for_csharp_class()
+    {
+        typeof(FSharpNameTests).IsFSharpRecord().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void is_fsharp_record_returns_false_for_csharp_record()
+    {
+        // C# positional records do not have CompilationMappingAttribute.
+        typeof(SomeCSharpRecord).IsFSharpRecord().ShouldBeFalse();
+    }
+
+    public record SomeCSharpRecord(string Name, int Count);
+
+
     [Theory]
     [InlineData(typeof(int), "int")]
     [InlineData(typeof(long), "int64")]

--- a/src/CodegenTests/FSharpRecordConstructorFrameTests.cs
+++ b/src/CodegenTests/FSharpRecordConstructorFrameTests.cs
@@ -1,0 +1,57 @@
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core.Reflection;
+using Microsoft.FSharp.Core;
+using Shouldly;
+
+namespace CodegenTests;
+
+/// <summary>
+///     Tests for <see cref="ConstructorFrame.FSharpInvocation" /> covering the two branches:
+///     <list type="bullet">
+///       <item>Non-F#-record types use positional constructor syntax: <c>TypeName(arg1, arg2)</c></item>
+///       <item>F# record types use record-expression syntax: <c>{ Field = val; ... }</c></item>
+///     </list>
+///     The F# record branch was added to fix "FS1133: No constructors available" errors that occur
+///     when generated F# code uses positional construction on an F# record type.
+/// </summary>
+public class FSharpRecordConstructorFrameTests
+{
+    [Fact]
+    public void non_record_type_uses_positional_constructor_call_syntax()
+    {
+        var ctor = typeof(MultiArgTarget).GetConstructors().Single();
+        var frame = new ConstructorFrame(ctor);
+        frame.Parameters[0] = Variable.For<int>("count");
+        frame.Parameters[1] = Variable.For<string>("name");
+
+        frame.FSharpInvocation()
+            .ShouldBe("CodegenTests.FSharpRecordConstructorFrameTests.MultiArgTarget(count, name)");
+    }
+
+    [Fact]
+    public void fsharp_record_type_uses_record_expression_syntax()
+    {
+        // FSharpRef<string> is the F# record `type 'T ref = { mutable contents: 'T }`.
+        // Its single constructor parameter is named "contents"; IsFSharpRecord() returns true.
+        // FSharpInvocation() must emit the F# record-expression form { Contents = arg }
+        // instead of the positional call FSharpRef<string>(arg), which the F# compiler rejects.
+        var ctor = typeof(FSharpRef<string>).GetConstructors().Single();
+        var frame = new ConstructorFrame(ctor);
+        frame.Parameters[0] = Variable.For<string>("myValue");
+
+        frame.FSharpInvocation().ShouldBe("{ Contents = myValue }");
+    }
+
+    public class MultiArgTarget
+    {
+        public MultiArgTarget(int count, string name)
+        {
+            Count = count;
+            Name = name;
+        }
+
+        public int Count { get; }
+        public string Name { get; }
+    }
+}

--- a/src/CodegenTests/FSharpTupleReturnTests.cs
+++ b/src/CodegenTests/FSharpTupleReturnTests.cs
@@ -1,0 +1,51 @@
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using Shouldly;
+
+namespace CodegenTests;
+
+/// <summary>
+///     Tests for the F# tuple destructuring emitted by <c>MethodCall.fsharpDetermineReturnValue</c>.
+///     F# uses different syntax depending on tuple kind and binding context:
+///     <list type="bullet">
+///       <item>Sync, any tuple: <c>let (a, b) = expr</c> — struct keyword is optional in sync context</item>
+///       <item>Async task-CE, struct tuple: <c>let! struct (a, b) = expr</c> — struct required</item>
+///       <item>Async task-CE, reference tuple: <c>let! (a, b) = expr</c></item>
+///     </list>
+///     Both <c>System.ValueTuple&lt;&gt;</c> and <c>System.Tuple&lt;&gt;</c> pass
+///     <c>IsValueTuple()</c>, so the codegen uses <c>Type.IsValueType</c> to distinguish them —
+///     but only in the async binding path where the distinction matters to the F# compiler.
+/// </summary>
+public class FSharpTupleReturnTests
+{
+    [Fact]
+    public void sync_struct_tuple_emits_struct_keyword()
+    {
+        // F# requires `struct` in the destructuring pattern for value tuples in ALL contexts
+        // (sync and async). `let (a, b) = structTupleValue` causes FS0001.
+        var call = new MethodCall(typeof(TupleHelpers), nameof(TupleHelpers.ReturnsStructTuple));
+        var writer = new SourceWriter();
+        call.GenerateFSharpCode(GeneratedMethod.ForNoArg("Test"), writer);
+
+        var code = writer.Code();
+        code.ShouldContain("let struct (");
+    }
+
+    [Fact]
+    public void sync_reference_tuple_does_not_emit_struct_keyword()
+    {
+        var call = new MethodCall(typeof(TupleHelpers), nameof(TupleHelpers.ReturnsReferenceTuple));
+        var writer = new SourceWriter();
+        call.GenerateFSharpCode(GeneratedMethod.ForNoArg("Test"), writer);
+
+        var code = writer.Code();
+        code.ShouldContain("let (");
+        code.ShouldNotContain("let struct (");
+    }
+
+    public static class TupleHelpers
+    {
+        public static (string Name, int Count) ReturnsStructTuple() => ("x", 1);
+        public static Tuple<string, int> ReturnsReferenceTuple() => Tuple.Create("x", 1);
+    }
+}

--- a/src/JasperFx/CodeGeneration/Frames/ConstructorFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/ConstructorFrame.cs
@@ -258,9 +258,23 @@ public class ConstructorFrame : SyncFrame
                 "F# code generation does not yet support constructor property setters.");
         }
 
+        // F# record types cannot be constructed with positional constructor syntax from F# code.
+        // Detect via CompilationMappingAttribute(SourceConstructFlags.RecordType = 2) and emit
+        // F# record expression syntax: { Field1 = val1; Field2 = val2; ... }
+        if (isFSharpRecord(BuiltType))
+        {
+            var ctorParams = Ctor.GetParameters();
+            var fields = ctorParams
+                .Zip(Parameters, (p, v) => $"{p.Name![0].ToString().ToUpperInvariant()}{p.Name[1..]} = {v.FSharpUsage}")
+                .Join("; ");
+            return $"{{ {fields} }}";
+        }
+
         // F# omits the `new` keyword for ordinary construction.
         return $"{BuiltType.FSharpName()}({Parameters.Select(x => x.FSharpUsage).Join(", ")})";
     }
+
+    private static bool isFSharpRecord(Type type) => type.IsFSharpRecord();
 
     public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
     {

--- a/src/JasperFx/CodeGeneration/Frames/Frame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/Frame.cs
@@ -146,7 +146,9 @@ public abstract class Frame
             throw new InvalidOperationException($"Frame {this} could not resolve one of its variables");
         }
 
-        uses.AddRange(variables.Where(x => x != null));
+        var resolved = variables.Where(x => x != null).ToArray();
+        uses.AddRange(resolved);
+        foreach (var v in resolved) v.IsReferenced = true;
 
         _hasResolved = true;
     }

--- a/src/JasperFx/CodeGeneration/Frames/Frame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/Frame.cs
@@ -148,7 +148,9 @@ public abstract class Frame
 
         var resolved = variables.Where(x => x != null).ToArray();
         uses.AddRange(resolved);
-        foreach (var v in resolved) v.IsReferenced = true;
+        // Mark all uses (including any pre-populated in constructors) as referenced so that
+        // F# tuple codegen emits `_` only for genuinely unused slots.
+        foreach (var v in uses) v.IsReferenced = true;
 
         _hasResolved = true;
     }

--- a/src/JasperFx/CodeGeneration/Frames/IfBlock.cs
+++ b/src/JasperFx/CodeGeneration/Frames/IfBlock.cs
@@ -11,6 +11,7 @@ public class IfBlock : CompositeFrame
 
     public IfBlock(Variable variable, params Frame[] inner) : this(variable.Usage, inner)
     {
+        uses.Add(variable);
     }
 
     public string Condition { get; }

--- a/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
+++ b/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
@@ -423,10 +423,47 @@ public class MethodCall : Frame
             methodName += $"<{Method.GetGenericArguments().Select(x => x.FSharpName()).Join(", ")}>";
         }
 
-        var callingCode = $"{methodName}({Arguments.Select(x => x.FSharpUsage).Join(", ")})";
+        string callingCode;
+        if (needsFSharpCurriedSyntax())
+        {
+            callingCode = Arguments.Any()
+                ? $"{methodName} {Arguments.Select(x => x.FSharpUsage).Join(" ")}"
+                : $"{methodName}()";
+        }
+        else
+        {
+            callingCode = $"{methodName}({Arguments.Select(x => x.FSharpUsage).Join(", ")})";
+        }
 
         return $"{fsharpDetermineTarget()}{callingCode}";
     }
+
+    private static bool isFSharpModule(Type? type)
+    {
+        if (type == null) return false;
+        var attr = type.GetCustomAttributes(false)
+            .FirstOrDefault(a => a.GetType().FullName == "Microsoft.FSharp.Core.CompilationMappingAttribute");
+        if (attr == null) return false;
+        var prop = attr.GetType().GetProperty("SourceConstructFlags");
+        if (prop == null) return false;
+        var flags = (int)prop.GetValue(attr)!;
+        return (flags & 4) != 0; // SourceConstructFlags.Module = 4
+    }
+
+    private bool isFSharpModuleFunction() => Method.IsStatic && isFSharpModule(Method.DeclaringType);
+
+    // F# class members with multiple separate parameter groups (e.g. `static member Apply (a: A) (b: B) = ...`)
+    // are compiled as regular .NET multi-param methods BUT must be called with curried (space-separated) syntax
+    // from F# because the F# type-checker tracks the separate-group arity. The compiler attaches
+    // CompilationArgumentCountsAttribute to mark these so tooling can distinguish them from
+    // single-group methods (which use tuple/comma syntax).
+    private bool isFSharpCurriedMember()
+    {
+        return Method.GetCustomAttributes(false)
+            .Any(a => a.GetType().FullName == "Microsoft.FSharp.Core.CompilationArgumentCountsAttribute");
+    }
+
+    private bool needsFSharpCurriedSyntax() => isFSharpModuleFunction() || isFSharpCurriedMember();
 
     private string fsharpDetermineTarget()
     {
@@ -467,8 +504,13 @@ public class MethodCall : Frame
         if (ReturnVariable.VariableType.IsValueTuple())
         {
             var tuple = (ValueTypeReturnVariable)ReturnVariable;
-            var fsharpTuple = "(" + tuple.Inners.Select(x => x.Inner.FSharpUsage).Join(", ") + ")";
-            return IsAsync && insideTaskBlock ? $"let! {fsharpTuple} = " : $"let {fsharpTuple} = ";
+            // F# requires `struct` in the pattern for both sync and async struct tuple destructuring:
+            // `let struct (a, b) = ...` and `let! struct (a, b) = ...`
+            // Omitting it causes FS0001 "one tuple type is a struct tuple, the other is a reference tuple".
+            var tuplePrefix = ReturnVariable.VariableType.IsValueType ? "struct " : "";
+            var fsharpTuple = $"{tuplePrefix}(" + tuple.Inners.Select(x => x.Inner.FSharpUsage).Join(", ") + ")";
+            var asyncBinding = IsAsync && insideTaskBlock;
+            return asyncBinding ? $"let! {fsharpTuple} = " : $"let {fsharpTuple} = ";
         }
 
         var awaited = IsAsync && insideTaskBlock;

--- a/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
+++ b/src/JasperFx/CodeGeneration/Frames/MethodCall.cs
@@ -508,7 +508,9 @@ public class MethodCall : Frame
             // `let struct (a, b) = ...` and `let! struct (a, b) = ...`
             // Omitting it causes FS0001 "one tuple type is a struct tuple, the other is a reference tuple".
             var tuplePrefix = ReturnVariable.VariableType.IsValueType ? "struct " : "";
-            var fsharpTuple = $"{tuplePrefix}(" + tuple.Inners.Select(x => x.Inner.FSharpUsage).Join(", ") + ")";
+            // Emit `_` for tuple slots that no downstream frame consumes — avoids FS1182 in generated code.
+            var slots = tuple.Inners.Select(x => x.Inner.IsReferenced ? x.Inner.FSharpUsage : "_");
+            var fsharpTuple = $"{tuplePrefix}(" + slots.Join(", ") + ")";
             var asyncBinding = IsAsync && insideTaskBlock;
             return asyncBinding ? $"let! {fsharpTuple} = " : $"let {fsharpTuple} = ";
         }

--- a/src/JasperFx/CodeGeneration/GeneratedMethod.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedMethod.cs
@@ -205,7 +205,7 @@ public class GeneratedMethod : IGeneratedMethod
 
         Header?.Write(writer);
 
-        var arguments = Arguments.Select(x => $"{x.Usage}: {x.VariableType.FSharpName()}").Join(", ");
+        var arguments = Arguments.Select(x => $"{(x.IsReferenced ? x.Usage : "_" + x.Usage)}: {x.VariableType.FSharpName()}").Join(", ");
         var returnType = ReturnType.FSharpName();
         var keyword = Overrides ? "override" : "member";
 

--- a/src/JasperFx/CodeGeneration/Model/Variable.cs
+++ b/src/JasperFx/CodeGeneration/Model/Variable.cs
@@ -156,6 +156,13 @@ public class Variable
     public virtual string Usage { get; protected set; }
 
     /// <summary>
+    ///     Set to true during frame arrangement when any downstream frame resolves this variable
+    ///     as a dependency. Used by F# codegen to emit <c>_</c> for unused tuple slots instead
+    ///     of a named binding, avoiding FS1182 warnings in generated code.
+    /// </summary>
+    public bool IsReferenced { get; internal set; }
+
+    /// <summary>
     ///     How the variable is used within assignments. Default is
     ///     $"var {Usage}"
     /// </summary>

--- a/src/JasperFx/Core/Reflection/TypeNameExtensions.cs
+++ b/src/JasperFx/Core/Reflection/TypeNameExtensions.cs
@@ -94,6 +94,24 @@ public static class TypeNameExtensions
     };
 
     /// <summary>
+    ///     Returns true when <paramref name="type"/> is an F# record type, detected via
+    ///     <c>Microsoft.FSharp.Core.CompilationMappingAttribute</c> with
+    ///     <c>SourceConstructFlags.RecordType = 2</c>. F# record types require record-expression
+    ///     construction syntax <c>{ Field = value; ... }</c> rather than positional constructor
+    ///     syntax from F# code.
+    /// </summary>
+    public static bool IsFSharpRecord(this Type type)
+    {
+        var attr = type.GetCustomAttributes(false)
+            .FirstOrDefault(a => a.GetType().FullName == "Microsoft.FSharp.Core.CompilationMappingAttribute");
+        if (attr == null) return false;
+        var prop = attr.GetType().GetProperty("SourceConstructFlags");
+        if (prop == null) return false;
+        var flags = (int)prop.GetValue(attr)!;
+        return flags == 2; // SourceConstructFlags.RecordType = 2
+    }
+
+    /// <summary>
     ///     EXPERIMENTAL. Derives the full type name *as it would appear in F# code*. Handles the
     ///     primitive aliases (see <see cref="FSharpAliases" />), arrays, and closed generic types.
     ///     Throws <see cref="NotSupportedException" /> on cases the F# code generator does not yet
@@ -133,6 +151,13 @@ public static class TypeNameExtensions
             {
                 throw new NotSupportedException(
                     $"F# code generation does not yet support the tuple type '{type}'.");
+            }
+
+            // F# list type: Microsoft.FSharp.Collections.FSharpList<T> → "T list" in F# source
+            if (definition.FullName == "Microsoft.FSharp.Collections.FSharpList`1")
+            {
+                var elementArg = type.GetGenericArguments()[0].FSharpName();
+                return $"{elementArg} list";
             }
 
             var cleanName = type.Name.Split('`').First();


### PR DESCRIPTION
da245cd — feat: type reflection helpers for F# codegen
src/JasperFx/Core/Reflection/TypeNameExtensions.cs
- IsFSharpRecord() — detects F# record types via CompilationMappingAttribute
- FSharpName() — FSharpList<T> → "T list"

92720ab — feat: emit record-expression syntax for F# records in ConstructorFrame
src/JasperFx/CodeGeneration/Frames/ConstructorFrame.cs
- FSharpInvocation() emits { Field = val; ... } instead of positional Type(arg) for F# records

dc24184 — feat: curried call syntax and struct-tuple destructuring in MethodCall F# codegen
src/JasperFx/CodeGeneration/Frames/MethodCall.cs
- CompilationArgumentCountsAttribute detection → space-separated curried call syntax
- isFSharpModuleFunction() for module-level functions
- Struct tuple destructuring → always emits struct (...) in both sync and async contexts (let (a, b) = structTuple is FS0001 — F# requires struct in the pattern regardless of context)

a6f764c — test: unit tests for F# codegen frame changes (updated)
src/CodegenTests/FSharpTupleReturnTests.cs    ← sync struct/ref tuple distinction
src/CodegenTests/FSharpGenerationTests.cs     ← corrected two pre-existing tests:
                                                 sync:  `let struct (...)` (was `let (...)`)
                                                 async: `let! struct (...)` (was `let! (...)`)
                                                 Both had wrong expectations — only caught now
                                                 because the compile gate never exercised
                                                 sync struct tuple destructuring via MethodCall
                                                 
cb62581 — feat & tests: emit _ for tuple values that are unused in the rest of the handler. This avoids warning FS1182 when compiling the generated code.