### PR TITLE
Batch extended-progression heartbeat writes per database flush interval (#553)

### DIFF
--- a/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
@@ -4,7 +4,6 @@ using JasperFx.Events.Projections;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Shouldly;
 
 namespace EventTests.Daemon;
@@ -34,9 +33,9 @@ public class ExtendedProgressionWriterTests
         };
     }
 
-    private static ShardState heartbeat(string shardName = "Counters:All")
+    private static ShardState heartbeat(string shardName = "Counters:All", long sequence = 42)
     {
-        return new ShardState(shardName, 42)
+        return new ShardState(shardName, sequence)
         {
             Action = ShardAction.Updated,
             AgentStatus = "Running",
@@ -45,7 +44,7 @@ public class ExtendedProgressionWriterTests
     }
 
     [Fact]
-    public async Task writes_status_transitions_through_the_database()
+    public async Task writes_status_transitions_through_the_database_immediately()
     {
         theWriter.OnNext(transition(ShardAction.Started, "Running"));
         theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
@@ -57,6 +56,9 @@ public class ExtendedProgressionWriterTests
         writes[1].AgentStatus.ShouldBe("Paused");
         writes[1].PauseReason.ShouldBe("boom");
         writes[2].AgentStatus.ShouldBe("Stopped");
+
+        // A transition never waits on the flush interval: three transitions, three batches
+        (await theDatabase.Batches()).Count.ShouldBe(3);
     }
 
     [Fact]
@@ -96,25 +98,70 @@ public class ExtendedProgressionWriterTests
     }
 
     [Fact]
-    public async Task throttles_heartbeat_writes_per_shard_but_never_transitions()
+    public async Task coalesces_heartbeats_into_one_batched_write_per_flush_interval()
     {
-        theWriter.OnNext(heartbeat());
-        theWriter.OnNext(heartbeat()); // same instant, throttled
-        theWriter.OnNext(heartbeat("Others:All")); // different shard, its own budget
+        // The very first heartbeat flushes immediately (nothing to wait for)
+        theWriter.OnNext(heartbeat(sequence: 1));
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].Sequence.ShouldBe(1);
+
+        // Everything landing inside the flush interval is coalesced, latest state per shard wins
+        theWriter.OnNext(heartbeat(sequence: 2));
+        theWriter.OnNext(heartbeat(sequence: 3));
+        theWriter.OnNext(heartbeat("Others:All", sequence: 7));
+        await theDatabase.AssertWriteCountStaysAt(1);
+
+        // Once the interval passes, the next publication flushes the whole pending set as ONE batch
+        theTime.Advance(theWriter.HeartbeatWriteInterval + TimeSpan.FromMilliseconds(1));
+        theWriter.OnNext(heartbeat("Others:All", sequence: 8));
+
+        writes = await theDatabase.WaitForWrites(3);
+        var batches = await theDatabase.Batches();
+        batches.Count.ShouldBe(2);
+        batches[1].Length.ShouldBe(2);
+        batches[1].Single(x => x.ShardName == "Counters:All").Sequence.ShouldBe(3);
+        batches[1].Single(x => x.ShardName == "Others:All").Sequence.ShouldBe(8);
+        writes.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_transition_flushes_immediately_and_carries_the_pending_heartbeats_along()
+    {
+        // Seed a flush so the interval throttle is active
+        theWriter.OnNext(heartbeat(sequence: 1));
+        await theDatabase.WaitForWrites(1);
+
+        // These queue up inside the interval
+        theWriter.OnNext(heartbeat("Others:All", sequence: 7));
+
+        // A transition inside the interval must not wait -- and takes the pending batch with it
+        theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
+
+        var writes = await theDatabase.WaitForWrites(3);
+        var batches = await theDatabase.Batches();
+        batches.Count.ShouldBe(2);
+        batches[1].Single(x => x.ShardName == "Others:All").Sequence.ShouldBe(7);
+        batches[1].Single(x => x.ShardName == "Counters:All").AgentStatus.ShouldBe("Paused");
+        writes.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_transition_replaces_a_pending_heartbeat_for_the_same_shard()
+    {
+        theWriter.OnNext(heartbeat(sequence: 1));
+        await theDatabase.WaitForWrites(1);
+
+        // Heartbeat queued, then a transition for the SAME shard lands: latest state wins,
+        // the stale heartbeat must not overwrite the Paused status afterwards
+        theWriter.OnNext(heartbeat(sequence: 2));
+        theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
 
         var writes = await theDatabase.WaitForWrites(2);
-        writes.Count(x => x.ShardName == "Counters:All").ShouldBe(1);
-        writes.Count(x => x.ShardName == "Others:All").ShouldBe(1);
-
-        // A transition inside the throttle window still writes immediately
-        theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
-        await theDatabase.WaitForWrites(3);
-
-        // And once the interval passes, heartbeats flow again
-        theTime.Advance(theWriter.HeartbeatWriteInterval + TimeSpan.FromMilliseconds(1));
-        theWriter.OnNext(heartbeat());
-        var all = await theDatabase.WaitForWrites(4);
-        all.Count(x => x.ShardName == "Counters:All").ShouldBe(3);
+        var batches = await theDatabase.Batches();
+        batches.Count.ShouldBe(2);
+        batches[1].Length.ShouldBe(1);
+        batches[1][0].AgentStatus.ShouldBe("Paused");
+        writes.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -156,6 +203,37 @@ public class ExtendedProgressionWriterTests
     }
 
     [Fact]
+    public async Task disposing_flushes_the_pending_batch()
+    {
+        theWriter.OnNext(heartbeat(sequence: 1));
+        await theDatabase.WaitForWrites(1);
+
+        // Queued inside the interval, would normally wait for the next flush
+        theWriter.OnNext(heartbeat(sequence: 2));
+
+        await theWriter.DisposeAsync();
+
+        var writes = await theDatabase.WaitForWrites(2);
+        writes[1].Sequence.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task the_default_batch_implementation_degrades_to_single_state_writes()
+    {
+        // A store that has not implemented the batched overload keeps working through the
+        // default interface member, one single-state write per shard
+        var singlesOnly = new SingleWriteOnlyDatabase();
+        IEventDatabase database = singlesOnly;
+
+        await database.WriteExtendedProgressionAsync([heartbeat(sequence: 1), heartbeat("Others:All", sequence: 2)],
+            CancellationToken.None);
+
+        singlesOnly.Writes.Count.ShouldBe(2);
+        singlesOnly.Writes[0].ShardName.ShouldBe("Counters:All");
+        singlesOnly.Writes[1].ShardName.ShouldBe("Others:All");
+    }
+
+    [Fact]
     public async Task subscription_agent_lifecycle_flows_through_a_tracker_into_the_database()
     {
         // End-to-end through the real tracker + a real SubscriptionAgent: start (Running heartbeat)
@@ -181,14 +259,50 @@ public class ExtendedProgressionWriterTests
         writes[1].AgentStatus.ShouldBe("Stopped");
     }
 
+    private class SingleWriteOnlyDatabase : IEventDatabase
+    {
+        public List<ShardState> Writes { get; } = new();
+
+        public Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+        {
+            Writes.Add(state);
+            return Task.CompletedTask;
+        }
+
+        public string Identifier => "singles";
+        public Uri DatabaseUri => new("db://singles");
+        public ShardStateTracker Tracker => null!;
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent,
+            CancellationToken token) => Task.CompletedTask;
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token) => Task.CompletedTask;
+
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout) => Task.CompletedTask;
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => Task.FromResult(0L);
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => Task.FromResult<long?>(null);
+
+        public string StorageIdentifier => "singles";
+
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token) => Task.FromResult(0L);
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => Task.FromResult<IReadOnlyList<ShardState>>([]);
+    }
+
     private class RecordingEventDatabase : IEventDatabase
     {
-        private readonly List<ShardState> _writes = new();
+        private readonly List<ShardState[]> _batches = new();
         private readonly SemaphoreSlim _signal = new(0);
 
         public bool FailNextWrite { get; set; }
 
-        public Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+        public Task WriteExtendedProgressionAsync(IReadOnlyList<ShardState> states,
+            CancellationToken token = default)
         {
             if (FailNextWrite)
             {
@@ -197,9 +311,9 @@ public class ExtendedProgressionWriterTests
                 throw new InvalidOperationException("The database is grumpy");
             }
 
-            lock (_writes)
+            lock (_batches)
             {
-                _writes.Add(state);
+                _batches.Add(states.ToArray());
             }
 
             _signal.Release();
@@ -211,12 +325,23 @@ public class ExtendedProgressionWriterTests
             using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             while (true)
             {
-                lock (_writes)
+                lock (_batches)
                 {
-                    if (_writes.Count >= count) return _writes.ToList();
+                    var flattened = _batches.SelectMany(x => x).ToList();
+                    if (flattened.Count >= count) return flattened;
                 }
 
                 await _signal.WaitAsync(timeout.Token);
+            }
+        }
+
+        public async Task<IReadOnlyList<ShardState[]>> Batches()
+        {
+            // Give the background block a beat to finish posting
+            await Task.Delay(50);
+            lock (_batches)
+            {
+                return _batches.ToList();
             }
         }
 
@@ -224,9 +349,18 @@ public class ExtendedProgressionWriterTests
         {
             // Give the background block a beat to (not) do its thing
             await Task.Delay(100);
-            lock (_writes)
+            lock (_batches)
             {
-                _writes.ShouldBeEmpty();
+                _batches.ShouldBeEmpty();
+            }
+        }
+
+        public async Task AssertWriteCountStaysAt(int count)
+        {
+            await Task.Delay(100);
+            lock (_batches)
+            {
+                _batches.SelectMany(x => x).Count().ShouldBe(count);
             }
         }
 

--- a/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
+++ b/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
@@ -1,4 +1,3 @@
-using ImTools;
 using JasperFx.Blocks;
 using JasperFx.Events.Projections;
 using Microsoft.Extensions.Logging;
@@ -8,7 +7,7 @@ namespace JasperFx.Events.Daemon;
 /// <summary>
 /// Subscribes to a daemon's <see cref="ShardStateTracker"/> and persists the extended progression
 /// telemetry (heartbeat, agent status, pause reason, running node) that the subscription agents
-/// already compute in process, by driving <see cref="IEventDatabase.WriteExtendedProgressionAsync"/>.
+/// already compute in process, by driving <see cref="IEventDatabase.WriteExtendedProgressionAsync(System.Collections.Generic.IReadOnlyList{ShardState},System.Threading.CancellationToken)"/>.
 /// This is the missing write half of extended progression tracking — the schema columns and the read
 /// surface existed, but no daemon path ever persisted them (jasperfx#537, "built and never connected"
 /// per #519).
@@ -18,13 +17,16 @@ namespace JasperFx.Events.Daemon;
 /// <list type="bullet">
 /// <item>Gated on <see cref="IEventStore.ExtendedProgressionEnabled"/>, read live per publication —
 /// nothing is written (or even queued) for stores that have not opted in.</item>
+/// <item>Heartbeat/telemetry publications (<see cref="ShardAction.Updated"/> — the ~10s heartbeat
+/// timer ticks and the per-batch commit publications) are coalesced per shard (latest state wins)
+/// and flushed as ONE batched database write per <see cref="HeartbeatWriteInterval"/> for the whole
+/// database. The write rate is therefore constant per database instead of O(shards): under
+/// per-tenant agent fan-out (agents = projections × tenants) the previous
+/// one-connection-rent-per-shard-per-interval write path drove a sharded multi-tenant deployment
+/// to its database server's connection ceiling (jasperfx#553).</item>
 /// <item>Agent status transitions (<see cref="ShardAction.Started"/>, <see cref="ShardAction.Paused"/>,
-/// <see cref="ShardAction.Stopped"/>) are always written, immediately — a paused/stopped shard is
-/// exactly when the persisted status matters most.</item>
-/// <item><see cref="ShardAction.Updated"/> publications carrying agent telemetry (the ~10s heartbeat
-/// timer ticks and the per-batch commit publications) are throttled to at most one write per
-/// <see cref="HeartbeatWriteInterval"/> per shard, so a fast-committing shard does not turn every
-/// batch into an extra progression-table write.</item>
+/// <see cref="ShardAction.Stopped"/>) flush immediately — a paused/stopped shard is exactly when the
+/// persisted status matters most. The pending heartbeat batch rides along in the same write.</item>
 /// <item>Writes are best-effort and serialized on a background block: a failed write is logged at
 /// debug and can never fail or stall the shard, and a slow database can never back up the
 /// tracker's publication loop.</item>
@@ -37,10 +39,11 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
     private readonly IEventDatabase _database;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
-    private readonly Block<ShardState> _block;
+    private readonly Block<ShardState[]> _block;
 
     // Only ever touched from the tracker's single publication consumer, so no synchronization needed
-    private ImHashMap<string, DateTimeOffset> _lastWrites = ImHashMap<string, DateTimeOffset>.Empty;
+    private readonly Dictionary<string, ShardState> _pending = new();
+    private DateTimeOffset _lastFlush = DateTimeOffset.MinValue;
 
     public ExtendedProgressionWriter(IEventStore store, IEventDatabase database, TimeProvider timeProvider,
         ILogger logger)
@@ -50,18 +53,20 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
         _timeProvider = timeProvider;
         _logger = logger;
 
-        _block = new Block<ShardState>(writeAsync);
+        _block = new Block<ShardState[]>(writeAsync);
 
         // Belt and braces: writeAsync already swallows its own failures, but a failure escaping the
         // block must still never take anything else down
-        _block.OnError = (state, ex) =>
-            _logger.LogDebug(ex, "Failed to persist extended progression for shard {ShardName}", state.ShardName);
+        _block.OnError = (states, ex) =>
+            _logger.LogDebug(ex, "Failed to persist extended progression for {Count} shard(s)", states.Length);
     }
 
     /// <summary>
-    /// Minimum spacing between two persisted heartbeat/telemetry writes for the same shard on the
-    /// non-transition (<see cref="ShardAction.Updated"/>) path. Status transitions are never throttled.
-    /// Defaults to 5 seconds so every tick of the agents' 10 second heartbeat timer lands.
+    /// Spacing between two batched heartbeat/telemetry flushes for the database. All shard states
+    /// that arrive within the interval are coalesced (latest state per shard) into the next flush,
+    /// so no heartbeat is ever more than one interval stale. Status transitions flush immediately,
+    /// carrying any pending batch with them. Defaults to 5 seconds so every tick of the agents'
+    /// 10 second heartbeat timer lands.
     /// </summary>
     public TimeSpan HeartbeatWriteInterval { get; set; } = TimeSpan.FromSeconds(5);
 
@@ -75,19 +80,6 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
         // Plain progress publications (e.g. rebuild range completions) carry no agent telemetry
         if (value.AgentStatus == null && value.LastHeartbeat == null) return;
 
-        var isTransition = value.Action is ShardAction.Started or ShardAction.Paused or ShardAction.Stopped;
-        var now = _timeProvider.GetUtcNow();
-
-        if (!isTransition)
-        {
-            if (_lastWrites.TryFind(value.ShardName, out var last) && now - last < HeartbeatWriteInterval)
-            {
-                return;
-            }
-        }
-
-        _lastWrites = _lastWrites.AddOrUpdate(value.ShardName, now);
-
         // Carry the assigned node through to the persisted running_on_node column when a
         // distribution layer (e.g. Wolverine-managed subscription distribution) stamped it
         if (value.RunningOnNode == null && value.AssignedNodeNumber != 0)
@@ -95,21 +87,42 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
             value.RunningOnNode = value.AssignedNodeNumber;
         }
 
-        _block.Post(value);
+        // Latest state per shard wins; a transition that lands on top of a queued heartbeat
+        // simply replaces it
+        _pending[value.ShardName] = value;
+
+        var isTransition = value.Action is ShardAction.Started or ShardAction.Paused or ShardAction.Stopped;
+        var now = _timeProvider.GetUtcNow();
+
+        if (isTransition || now - _lastFlush >= HeartbeatWriteInterval)
+        {
+            flush(now);
+        }
     }
 
-    private async Task writeAsync(ShardState state, CancellationToken token)
+    private void flush(DateTimeOffset now)
+    {
+        if (_pending.Count == 0) return;
+
+        var batch = _pending.Values.ToArray();
+        _pending.Clear();
+        _lastFlush = now;
+
+        _block.Post(batch);
+    }
+
+    private async Task writeAsync(ShardState[] states, CancellationToken token)
     {
         try
         {
-            await _database.WriteExtendedProgressionAsync(state, token).ConfigureAwait(false);
+            await _database.WriteExtendedProgressionAsync(states, token).ConfigureAwait(false);
         }
         catch (Exception e)
         {
             // Best-effort telemetry: a failed extended-progression write must NEVER fail or
-            // stall the shard
-            _logger.LogDebug(e, "Failed to persist extended progression for shard {ShardName} on database {Database}",
-                state.ShardName, _database.Identifier);
+            // stall the shards
+            _logger.LogDebug(e, "Failed to persist extended progression for {Count} shard(s) on database {Database}",
+                states.Length, _database.Identifier);
         }
     }
 
@@ -123,8 +136,10 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
 
     public ValueTask DisposeAsync()
     {
-        // Lets any queued final writes (e.g. the Stopped state published during shutdown) drain
-        // in the background rather than dropping them on the floor
+        // Push any coalesced-but-unflushed states (e.g. the Stopped states published during shutdown
+        // arrive flushed already, but a trailing heartbeat may not be) and let the queued writes
+        // drain in the background rather than dropping them on the floor
+        flush(_timeProvider.GetUtcNow());
         _block.Complete();
         return ValueTask.CompletedTask;
     }

--- a/src/JasperFx.Events/IEventDatabase.cs
+++ b/src/JasperFx.Events/IEventDatabase.cs
@@ -165,6 +165,32 @@ public interface IEventDatabase
         => Task.CompletedTask;
 
     /// <summary>
+    ///     Persist the extended progression telemetry for a batch of shards in as few database
+    ///     round-trips as the store can manage — ideally one. The <see cref="Daemon.ExtendedProgressionWriter" />
+    ///     coalesces the heartbeat publications of every shard on a database into one batch per flush
+    ///     interval and drives this overload, because the per-shard single-row write does not scale
+    ///     under per-tenant agent fan-out: agents = projections × tenants, and one connection
+    ///     rent + round-trip per agent per heartbeat interval drove a sharded multi-tenant deployment
+    ///     to its database server's connection ceiling (jasperfx#553).
+    ///     <para>
+    ///     Same contract as the single-state overload: best-effort telemetry, never advance or
+    ///     regress progression, missing rows no-op. The batch is at-most-one-state-per-shard
+    ///     (the writer keeps only the latest state per shard between flushes).
+    ///     </para>
+    ///     The default implementation degrades to the single-state overload per shard so existing
+    ///     stores keep working unchanged until they implement a true batched write.
+    /// </summary>
+    /// <param name="states">The latest published state per shard, at most one entry per shard name.</param>
+    /// <param name="token"></param>
+    async Task WriteExtendedProgressionAsync(IReadOnlyList<ShardState> states, CancellationToken token = default)
+    {
+        foreach (var state in states)
+        {
+            await WriteExtendedProgressionAsync(state, token).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     ///     Count the stored dead letter events for a single projection/subscription shard. With
     ///     <c>SkipApplyErrors</c> on (the JasperFx.Events 2.0 default), a failed <c>Apply()</c> is
     ///     recorded as a <see cref="DeadLetterEvent" /> and the shard keeps advancing, so the


### PR DESCRIPTION
Closes #553.

`ExtendedProgressionWriter` throttled correctly per shard, but the total write rate was O(shards) = O(projections × tenants) under per-tenant agent fan-out, and each write rented its own connection for a single-row function call. On the sharded multi-tenant deployment in #553 that meant ~780 `mt_mark_event_progression_extended` calls/sec per shard database (~95 average active sessions including the `DISCARD ALL` pool-reset churn), driving the server to its connection ceiling.

Changes:

- The writer now coalesces heartbeat/telemetry publications per shard (latest state wins) and flushes them as **one batched database write per `HeartbeatWriteInterval`**, so the write rate is constant per database instead of O(shards). No heartbeat is ever more than one interval stale.
- Status transitions still flush immediately — a paused/stopped shard is exactly when the persisted status matters most — and carry the pending batch along. A transition landing on top of a queued heartbeat for the same shard replaces it, so a stale heartbeat can never overwrite a Paused status.
- Disposal flushes the trailing batch before completing the block.
- `IEventDatabase` gains a batched `WriteExtendedProgressionAsync(IReadOnlyList<ShardState>)` overload whose default implementation degrades to the single-state overload per shard, so existing stores keep working unchanged until they implement a true batched write. Marten's single-round-trip implementation lands separately (marten PR incoming, no schema change — plain `UPDATE ... FROM unnest` join).

Test updates in `EventTests.Daemon.ExtendedProgressionWriterTests` cover the coalescing, transition-carries-pending-batch, latest-state-wins, dispose-flush, and default-degrade behaviors; the tracker + real `SubscriptionAgent` end-to-end test is unchanged and still passes.
