### PR TITLE
Tenant-scoped QueryByTagsAsync + EventQuery.TenantId (#555)

### DIFF
--- a/src/EventTests/TenantScopedExplorerReadDefaultsTests.cs
+++ b/src/EventTests/TenantScopedExplorerReadDefaultsTests.cs
@@ -50,6 +50,14 @@ public class TenantScopedExplorerReadDefaultsTests
             return Task.FromResult<StreamMetadata?>(null);
         }
 
+        public async IAsyncEnumerable<EventRecord> QueryByTagsAsync(
+            IReadOnlyDictionary<string, string> tags, CancellationToken ct)
+        {
+            Calls.Add($"QueryByTagsAsync({tags.Count} tags)");
+            await Task.CompletedTask;
+            yield break;
+        }
+
         public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
         public Uri Subject => throw new NotImplementedException();
 
@@ -130,6 +138,38 @@ public class TenantScopedExplorerReadDefaultsTests
         await Should.ThrowAsync<NotSupportedException>(
             () => theStore.GetStreamMetadataAsync("stream-1", "tenant-1", CancellationToken.None));
         theRecorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task query_by_tags_for_null_tenant_delegates_to_store_global()
+    {
+        var tags = new Dictionary<string, string> { ["account"] = "abc" };
+        await foreach (var _ in theStore.QueryByTagsAsync(tags, tenantId: null, CancellationToken.None))
+        {
+        }
+
+        theRecorder.Calls.ShouldBe(["QueryByTagsAsync(1 tags)"]);
+    }
+
+    [Fact]
+    public void query_by_tags_for_a_tenant_throws_when_not_multi_tenanted()
+    {
+        // Same shape as ReadStreamAsync: the default is an expression-bodied member, so it throws on the
+        // call itself rather than deferring to the first MoveNextAsync. A caller that never enumerates
+        // still gets told the tenant scope was ignored.
+        var tags = new Dictionary<string, string> { ["account"] = "abc" };
+        Should.Throw<NotSupportedException>(
+            () => theStore.QueryByTagsAsync(tags, "tenant-1", CancellationToken.None));
+        theRecorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void event_query_tenant_id_defaults_to_store_global()
+    {
+        // The Event Explorer's metadata/event query carries its tenant scope on EventQuery itself
+        // (jasperfx#555). Default null preserves today's store-global behavior for every existing caller.
+        new EventQuery().TenantId.ShouldBeNull();
+        new EventQuery { TenantId = "tenant-1" }.TenantId.ShouldBe("tenant-1");
     }
 
     // A bare IEventDatabase whose only real member is the tenant-less head sequence, so the tenant

--- a/src/JasperFx.Events/EventQuery.cs
+++ b/src/JasperFx.Events/EventQuery.cs
@@ -27,6 +27,15 @@ public class EventQuery
     /// JasperFx/CritterWatch #629.
     /// </summary>
     public string? UserName { get; set; }
+
+    /// <summary>
+    /// Optional tenant partition to scope the query to. Null means store-global (today's behavior). On a
+    /// conjoined <c>UseTenantPartitionedEvents</c> store an untenanted query reads an ambiguous cross-tenant
+    /// union, so the Event Explorer sets this to scope the events/metadata query to a single tenant. Only
+    /// honored by stores that implement multi-tenancy; a store without a tenant dimension ignores it. See
+    /// jasperfx#555 (companion to the jasperfx#503 stream-read overloads).
+    /// </summary>
+    public string? TenantId { get; set; }
 }
 
 public class PagedEvents

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -230,6 +230,25 @@ public interface IEventStore
             "QueryByTagsAsync is not implemented on this IEventStore. Use Marten or Polecat 6+ for DCB tag queries.");
 
     /// <summary>
+    /// Stream events that match all of the supplied DCB tag values within a single tenant partition. A
+    /// null <paramref name="tenantId"/> is store-global and delegates to the tenant-less overload (today's
+    /// behavior). This overload exists because on a conjoined multi-tenant store the same tag can exist
+    /// under two tenants, so the tenant-less query resolves whichever tenant the default session happens
+    /// to carry. Event stores that implement multi-tenancy override this to open a tenant-scoped session;
+    /// the default throws for a non-null tenant rather than silently returning another tenant's events.
+    /// See jasperfx#555 (companion to the jasperfx#503 stream-read overloads).
+    /// </summary>
+    /// <param name="tags">Tag-name -> tag-value pairs to match.</param>
+    /// <param name="tenantId">Tenant partition to scope the query to. Null means store-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    IAsyncEnumerable<EventRecord> QueryByTagsAsync(
+        IReadOnlyDictionary<string, string> tags, string? tenantId, CancellationToken ct)
+        => tenantId == null
+            ? QueryByTagsAsync(tags, ct)
+            : throw new NotSupportedException(
+                "Per-tenant QueryByTagsAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
+
+    /// <summary>
     /// Rehydrate a DCB-projected entity by tag set, returning the
     /// projected state at its current version. The default implementation
     /// throws <see cref="NotImplementedException"/>.


### PR DESCRIPTION
Closes #555.

Two explorer read paths were left without a tenant dimension after jasperfx#503. On a conjoined `UseTenantPartitionedEvents` store the same stream id / the same tag can exist under two tenants, so an untenanted query reads an ambiguous cross-tenant union — the exact class of bug #503 fixed for the stream reads.

## Changes

- **`IEventStore.QueryByTagsAsync(tags, string? tenantId, ct)`** — new default interface member mirroring the #503 stream-read overloads. A `null` tenant is store-global and delegates to the tenant-less overload (today's behavior); a non-null tenant on a store that hasn't implemented multi-tenancy throws `NotSupportedException` rather than silently serving another tenant's events. Consistent with the `NotSupportedException` used by the #503 overloads.
- **`EventQuery.TenantId`** — the lighter-touch tenant scope for the Event Explorer's event/metadata query (event-type / correlation / causation / user filters). Defaults to `null` (store-global), so every existing caller is unaffected; keeps the paging/filter surface in one object.

Marten + Polecat then implement these against their `tenant_id`-columned event tables (tracked in companion issues). Unblocks CritterWatch #798 §4 (follow-on to #782, which already consumes the #503 overloads).

## Tests

`EventTests.TenantScopedExplorerReadDefaultsTests` gains three cases mirroring the #503 defaults contract:
- `QueryByTagsAsync` with a null tenant delegates to the store-global member;
- `QueryByTagsAsync` with a non-null tenant throws on the call itself (expression-bodied default, same as `ReadStreamAsync`);
- `EventQuery.TenantId` defaults to null and round-trips when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)