### PR TITLE
De-flake InMemoryQueue + RetryBlock timing tests

### DIFF
--- a/src/CoreTests/Blocks/InMemoryQueueTests.cs
+++ b/src/CoreTests/Blocks/InMemoryQueueTests.cs
@@ -133,13 +133,19 @@ public class InMemoryQueueTests
         // Post() waiting for capacity -- proving the item is back-pressured rather than dropped.
         const int count = 25_000;
         var processed = 0;
-        using var gate = new ManualResetEventSlim(false);
 
-        await using var queue = new Block<int>(1, Block<int>.DefaultBoundedCapacity, (_, token) =>
+        // The reader is held on an ASYNC gate, not a synchronous ManualResetEventSlim.Wait. The channel is
+        // built with AllowSynchronousContinuations, so the producer's first TryWrite can run the reader's
+        // continuation inline on the producer's own thread; with a blocking gate that hijacked the producer
+        // into the wait and it posted a single item before parking forever (Count==1 flake, net10). An
+        // awaited TCS yields the thread back instead, so the producer keeps filling regardless of which
+        // thread the continuation lands on.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var queue = new Block<int>(1, Block<int>.DefaultBoundedCapacity, async (_, token) =>
         {
-            gate.Wait(token);
+            await gate.Task.WaitAsync(token);
             Interlocked.Increment(ref processed);
-            return Task.CompletedTask;
         });
 
         var producer = Task.Run(() =>
@@ -151,7 +157,7 @@ public class InMemoryQueueTests
         });
 
         // Wait until the channel is saturated (producer is now blocked inside Post waiting for room).
-        var deadline = DateTime.UtcNow.AddSeconds(10);
+        var deadline = DateTime.UtcNow.AddSeconds(30);
         while (queue.Count < Block<int>.DefaultBoundedCapacity && DateTime.UtcNow < deadline)
         {
             await Task.Delay(10);
@@ -160,7 +166,7 @@ public class InMemoryQueueTests
         queue.Count.ShouldBeGreaterThanOrEqualTo((uint)Block<int>.DefaultBoundedCapacity);
         producer.IsCompleted.ShouldBeFalse(); // still blocked -> the overflow item was NOT dropped
 
-        gate.Set();
+        gate.SetResult();
 
         await producer;
         await queue.WaitForCompletionAsync();

--- a/src/CoreTests/Blocks/RetryBlockTests.cs
+++ b/src/CoreTests/Blocks/RetryBlockTests.cs
@@ -58,13 +58,18 @@ public class RetryBlockTests
     [Fact]
     public async Task disregard_after_too_many_failures()
     {
+        // Set the short pauses BEFORE posting: assigning them after Post races the block picking up the
+        // message, and a fast pickup would retry on the constructor's [1s,3s,5s] schedule instead, taking
+        // seconds and blowing past the poll window below (CI flake).
+        theBlock.Pauses = [0.Milliseconds(), 50.Milliseconds()];
+
         var theMessage = new SometimesFailingMessage(5, "Aubrey");
         theBlock.Post(theMessage);
 
-        theBlock.Pauses = [0.Milliseconds(), 50.Milliseconds()];
-
+        // Discard happens after ~50ms of pauses; poll generously (up to 5s) so a loaded CI runner that is
+        // slow to schedule the Task.Delay continuations doesn't fail before the block gets there.
         var tries = 0;
-        while (tries < 10 && !theLogger.Messages[LogLevel.Information].Any())
+        while (tries < 50 && !theLogger.Messages[LogLevel.Information].Any())
         {
             tries++;
             await Task.Delay(100.Milliseconds());


### PR DESCRIPTION
Two timing-sensitive `CoreTests.Blocks` tests intermittently failed CI (net10 in particular) and were blocking the current release. Both are **test-only** defects — the product code is correct.

### `synchronous_Post_does_not_drop_items_when_the_bounded_channel_fills`
The consumer was held on a synchronous `ManualResetEventSlim.Wait`. `Block<T>`'s channel is built with `AllowSynchronousContinuations = true`, so the producer's first `TryWrite` can run the reader's continuation **inline on the producer's own thread**, hijacking it into the blocking gate. The producer then posted a single item and parked forever — the failure showed `queue.Count` stuck at `1` after the 10s deadline (`should be greater than or equal to 10000, but was 1`).

Fix: hold the reader on an **awaited `TaskCompletionSource`** instead of a blocking wait. An inline continuation now yields the thread back rather than blocking it, so the producer keeps filling the channel regardless of which thread the continuation lands on. The regression's real guarantee (`processed == count`, i.e. no dropped items) is unchanged.

### `disregard_after_too_many_failures`
The short `[0ms, 50ms]` pause schedule was assigned **after** `Post`, racing the block's pickup of the message. A fast pickup retried on the constructor's `[1s, 3s, 5s]` schedule and blew past the 1s poll window. Fix: set the pauses **before** posting and widen the poll budget to 5s for slow/loaded runners.

### Verification
10/10 green on net10 under concurrent load, plus the full `CoreTests.Blocks` folder on net9 and net10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)