### PR TITLE
Daemon shutdown: drain extended-progression writer + guard batch-write throttle (#557)

### DIFF
--- a/src/EventTests/Daemon/BatchWriteThrottleExtensionsTests.cs
+++ b/src/EventTests/Daemon/BatchWriteThrottleExtensionsTests.cs
@@ -1,0 +1,33 @@
+using JasperFx.Events.Daemon;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+public class BatchWriteThrottleExtensionsTests
+{
+    [Fact]
+    public void safe_release_swallows_object_disposed_from_a_disposed_throttle()
+    {
+        // jasperfx#557: the daemon can dispose the shared batch-write throttle while an in-flight batch is
+        // still unwinding to its finally. The release must be a no-op then, not an ObjectDisposedException.
+        var throttle = new SemaphoreSlim(1);
+        throttle.Dispose();
+
+        Should.NotThrow(() => throttle.SafeRelease());
+    }
+
+    [Fact]
+    public void safe_release_is_a_no_op_on_null()
+    {
+        SemaphoreSlim? throttle = null;
+        Should.NotThrow(() => throttle.SafeRelease());
+    }
+
+    [Fact]
+    public void safe_release_actually_releases_a_live_throttle()
+    {
+        using var throttle = new SemaphoreSlim(0, 1);
+        throttle.SafeRelease();
+        throttle.CurrentCount.ShouldBe(1);
+    }
+}

--- a/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
@@ -218,6 +218,31 @@ public class ExtendedProgressionWriterTests
     }
 
     [Fact]
+    public async Task dispose_awaits_the_in_flight_write_rather_than_draining_in_the_background()
+    {
+        // jasperfx#557: DisposeAsync must not return until the queued Stopped write has actually been
+        // persisted. If it drains in the background, that late Stopped write can overtake a later
+        // deliberate write to the same progression row and silently roll the status back to Stopped.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        theDatabase.GateWrites = gate;
+
+        theWriter.OnNext(transition(ShardAction.Stopped, "Stopped"));
+
+        var dispose = theWriter.DisposeAsync().AsTask();
+
+        // The write is parked on the gate, so DisposeAsync cannot have completed yet
+        await Task.Delay(100);
+        dispose.IsCompleted.ShouldBeFalse();
+
+        // Let the write through; only now may DisposeAsync complete
+        gate.SetResult();
+        await dispose;
+
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].AgentStatus.ShouldBe("Stopped");
+    }
+
+    [Fact]
     public async Task the_default_batch_implementation_degrades_to_single_state_writes()
     {
         // A store that has not implemented the batched overload keeps working through the
@@ -301,9 +326,18 @@ public class ExtendedProgressionWriterTests
 
         public bool FailNextWrite { get; set; }
 
-        public Task WriteExtendedProgressionAsync(IReadOnlyList<ShardState> states,
+        // When set, a write parks on this gate before it records anything, so a test can observe whether
+        // DisposeAsync waits for the in-flight write to finish (jasperfx#557).
+        public TaskCompletionSource? GateWrites { get; set; }
+
+        public async Task WriteExtendedProgressionAsync(IReadOnlyList<ShardState> states,
             CancellationToken token = default)
         {
+            if (GateWrites != null)
+            {
+                await GateWrites.Task;
+            }
+
             if (FailNextWrite)
             {
                 FailNextWrite = false;
@@ -317,7 +351,6 @@ public class ExtendedProgressionWriterTests
             }
 
             _signal.Release();
-            return Task.CompletedTask;
         }
 
         public async Task<IReadOnlyList<ShardState>> WaitForWrites(int count)

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -595,7 +595,7 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
         }
         finally
         {
-            writeThrottle?.Release();
+            writeThrottle.SafeRelease();
             await batch.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/src/JasperFx.Events/Daemon/BatchWriteThrottleExtensions.cs
+++ b/src/JasperFx.Events/Daemon/BatchWriteThrottleExtensions.cs
@@ -1,0 +1,23 @@
+namespace JasperFx.Events.Daemon;
+
+internal static class BatchWriteThrottleExtensions
+{
+    /// <summary>
+    /// Release the shared batch-write throttle from a batch execution's <c>finally</c> without letting an
+    /// <see cref="ObjectDisposedException"/> escape. The throttle is owned by the daemon
+    /// (<c>JasperFxAsyncDaemon._batchWriteThrottle</c>) and disposed on shutdown; an in-flight batch can
+    /// reach its release after that disposal and race it. A disposed throttle means the daemon is already
+    /// gone, so the release is a no-op rather than a fault (jasperfx#557).
+    /// </summary>
+    public static void SafeRelease(this SemaphoreSlim? throttle)
+    {
+        try
+        {
+            throttle?.Release();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The daemon disposed the shared throttle out from under this unwinding batch — nothing to release.
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
+++ b/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
@@ -134,13 +134,14 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
     {
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         // Push any coalesced-but-unflushed states (e.g. the Stopped states published during shutdown
-        // arrive flushed already, but a trailing heartbeat may not be) and let the queued writes
-        // drain in the background rather than dropping them on the floor
+        // arrive flushed already, but a trailing heartbeat may not be), then AWAIT the drain. Returning
+        // before the queued writes complete let a Stopped write land in the background *after* the daemon
+        // was reported stopped and clobber a later deliberate write to the same progression row
+        // (jasperfx#557). WaitForCompletionAsync completes the block, then awaits its in-flight writes.
         flush(_timeProvider.GetUtcNow());
-        _block.Complete();
-        return ValueTask.CompletedTask;
+        await _block.WaitForCompletionAsync().ConfigureAwait(false);
     }
 }

--- a/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
+++ b/src/JasperFx.Events/Daemon/GroupedProjectionExecution.cs
@@ -350,7 +350,7 @@ public class GroupedProjectionExecution : ISubscriptionExecution
         }
         finally
         {
-            writeThrottle?.Release();
+            writeThrottle.SafeRelease();
             await batch.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -34,8 +34,10 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
     // jasperfx#537: persists agent status transitions + heartbeat ticks onto the store's extended
     // progression columns when the store opts in via IEventStore.ExtendedProgressionEnabled
-    private readonly ExtendedProgressionWriter _extendedProgression;
-    private readonly IDisposable _extendedProgressionSubscription;
+    // Not readonly: StopAllAsync drains (completes) the writer while the daemon is quiesced, then
+    // rebuilds it so a subsequent StartAllAsync resumes persisting extended progression (jasperfx#557).
+    private ExtendedProgressionWriter _extendedProgression;
+    private IDisposable _extendedProgressionSubscription;
     private RetryBlock<DeadLetterEvent> _deadLetterBlock;
     private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
@@ -154,10 +156,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _breakSubscription = database.Tracker.Subscribe(this);
 
-        // jasperfx#537: subscribe unconditionally; the writer checks the store's
-        // ExtendedProgressionEnabled flag live per publication so runtime opt-in is honored
-        _extendedProgression = new ExtendedProgressionWriter(store, database, store.TimeProvider,
-            loggerFactory.CreateLogger<ExtendedProgressionWriter>());
+        _extendedProgression = buildExtendedProgressionWriter();
         _extendedProgressionSubscription = Tracker.Subscribe(_extendedProgression);
 
         _deadLetterBlock = buildDeadLetterBlock();
@@ -191,8 +190,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
         _breakSubscription = database.Tracker.Subscribe(this);
 
-        // jasperfx#537: see the ILoggerFactory constructor overload for the rationale
-        _extendedProgression = new ExtendedProgressionWriter(store, database, store.TimeProvider, logger);
+        _extendedProgression = buildExtendedProgressionWriter();
         _extendedProgressionSubscription = Tracker.Subscribe(_extendedProgression);
 
         _deadLetterBlock = buildDeadLetterBlock();
@@ -215,6 +213,13 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             await Database.StoreDeadLetterEventAsync(_store, deadLetterEvent, token).ConfigureAwait(false);
         }, Logger, _cancellation.Token);
     }
+
+    // jasperfx#537: subscribe unconditionally; the writer checks the store's ExtendedProgressionEnabled
+    // flag live per publication so runtime opt-in is honored. Built through a helper so StopAllAsync can
+    // rebuild it after draining, exactly as it rebuilds the dead-letter block (jasperfx#557).
+    private ExtendedProgressionWriter buildExtendedProgressionWriter()
+        => new(_store, Database, _store.TimeProvider,
+            _loggerFactory?.CreateLogger<ExtendedProgressionWriter>() ?? Logger);
 
     public IEventDatabase Database { get; }
 
@@ -900,11 +905,31 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
                 Logger.LogError(e, "Error trying to finish all outstanding DeadLetterEvent persistence");
             }
 
+            // jasperfx#557: drain the extended-progression writer here, on the async stop path where the
+            // agents are already stopped-and-drained and the daemon is genuinely quiesced, so a Stopped
+            // heartbeat queued during shutdown is fully persisted before StopAllAsync returns. Left to the
+            // sync Dispose() it would drain fire-and-forget in the background and could overtake a later
+            // deliberate write to the same progression row.
+            try
+            {
+                _extendedProgressionSubscription.Dispose();
+                await _extendedProgression.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Error trying to drain the extended progression writer");
+            }
+
             _agents = ImHashMap<string, ISubscriptionAgent>.Empty;
             syncTenantPolling();
 
             _cancellation.TryReset();
             _deadLetterBlock = buildDeadLetterBlock();
+
+            // Rebuild the drained writer + resubscribe so a subsequent StartAllAsync (e.g. resume after a
+            // rebuild) keeps persisting extended progression, mirroring the dead-letter block rebuild above.
+            _extendedProgression = buildExtendedProgressionWriter();
+            _extendedProgressionSubscription = Tracker.Subscribe(_extendedProgression);
         }
         finally
         {

--- a/src/JasperFx.Events/Projections/ProjectionExecution.cs
+++ b/src/JasperFx.Events/Projections/ProjectionExecution.cs
@@ -244,7 +244,7 @@ public class ProjectionExecution<TOperations, TQuerySession> : ISubscriptionExec
         }
         finally
         {
-            writeThrottle?.Release();
+            writeThrottle.SafeRelease();
             await batch.DisposeAsync().ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
Closes #557.

Async daemon shutdown disposed two shutdown primitives without first awaiting the in-flight work that still touches them. Both are surfaced downstream in [marten#5022](https://github.com/JasperFx/marten/issues/5022) (test-only mitigation [marten#5023](https://github.com/JasperFx/marten/pull/5023)); this is the product-side root cause.

## Fixes

**1. Await the writer drain.** `ExtendedProgressionWriter.DisposeAsync` now `await`s `_block.WaitForCompletionAsync()` instead of returning `ValueTask.CompletedTask`. A `Stopped` heartbeat queued during shutdown is fully persisted before the call returns, so it can no longer drain fire-and-forget in the background and overtake a later deliberate write — the flaky `should be "Paused" but was "Stopped"` in marten#5022.

**2. Drain on the async stop path.** `JasperFxAsyncDaemon.StopAllAsync` drains the writer where the daemon is genuinely quiesced (agents already `StopAndDrainAsync`'d, dead-letter block drained), **then rebuilds + resubscribes** it so a subsequent `StartAllAsync` (e.g. resume after a rebuild) keeps persisting extended progression — mirroring the existing dead-letter block rebuild. The writer fields are no longer `readonly`; both constructors now build it through a shared `buildExtendedProgressionWriter()` helper. The sync `Dispose()` keeps its fire-and-forget drain only as the last-resort path for callers that never called `StopAllAsync`.

**3. Guard the throttle release.** The shared `_batchWriteThrottle` `SemaphoreSlim` could be disposed while an in-flight batch was still mid-`finally`, throwing `ObjectDisposedException` from `Release()`. All three batch-execution finally sites (`GroupedProjectionExecution`, `AggregationRunner`, `ProjectionExecution`) now call `writeThrottle.SafeRelease()`, which treats a disposed throttle as a no-op (a disposed throttle means the daemon is already gone).

## Tests

- `ExtendedProgressionWriterTests.dispose_awaits_the_in_flight_write_rather_than_draining_in_the_background` — a gated database write proves `DisposeAsync` does not return until the queued `Stopped` write actually lands.
- `BatchWriteThrottleExtensionsTests` — `SafeRelease` swallows `ObjectDisposedException` on a disposed throttle, no-ops on null, and still releases a live throttle.
- Full `EventTests` suite green on net9 and net10 (594 tests), confirming the daemon constructor refactor is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)