### PR TITLE
Slice ID support for RaiseSideEffects

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -472,7 +472,20 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
     {
         return new ValueTask();
     }
-    
+
+    /// <summary>
+    /// Potentially raise "side effects" during projection processing to either emit additional events,
+    /// or publish messages. The identity of the current slice is supplied as <paramref name="id"/>.
+    /// </summary>
+    /// <param name="operations"></param>
+    /// <param name="id"></param>
+    /// <param name="slice"></param>
+    /// <returns></returns>
+    public virtual ValueTask RaiseSideEffects(TOperations operations, TId id, IEventSlice<TDoc> slice)
+    {
+        return RaiseSideEffects(operations, slice);
+    }
+
     public SubscriptionDescriptor Describe(IEventStore store)
     {
         return new SubscriptionDescriptor(this, store);

--- a/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxMultiStreamProjectionBase.cs
@@ -135,7 +135,7 @@ public abstract class JasperFxMultiStreamProjectionBase<TDoc, TId, TOperations, 
                 
                 if (operations.EnableSideEffectsOnInlineProjections)
                 {
-                    await RaiseSideEffects(operations, slice);
+                    await RaiseSideEffects(operations, slice.Id, slice);
                     if (slice.RaisedEvents != null)
                     {
                         throw new InvalidOperationException(

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -125,7 +125,7 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
             Snapshot = transformed
         };
 
-        await RaiseSideEffects(session, slice);
+        await RaiseSideEffects(session, id, slice);
         if (slice.RaisedEvents != null)
         {
             throw new InvalidOperationException(

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -768,7 +768,7 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
     private async Task processPossibleSideEffects(IProjectionBatch batch, TOperations operations,
         EventSlice<TDoc, TId> slice)
     {
-        await Projection.RaiseSideEffects(operations, slice);
+        await Projection.RaiseSideEffects(operations, slice.Id, slice);
 
         if (slice.RaisedEvents != null)
         {

--- a/src/JasperFx.Events/Daemon/IAggregationProjection.cs
+++ b/src/JasperFx.Events/Daemon/IAggregationProjection.cs
@@ -24,6 +24,18 @@ public interface IAggregationProjection<TDoc, TId, in TOperations, in TQuerySess
     /// <returns></returns>
     ValueTask RaiseSideEffects(TOperations operations, IEventSlice<TDoc> slice);
 
+    /// <summary>
+    /// Use to create "side effects" when running an aggregation (single stream, custom projection, multi-stream)
+    /// asynchronously in a continuous mode (i.e., not in rebuilds). The identity of the current slice is
+    /// supplied as <paramref name="id"/>.
+    /// </summary>
+    /// <param name="operations"></param>
+    /// <param name="id"></param>
+    /// <param name="slice"></param>
+    /// <returns></returns>
+    ValueTask RaiseSideEffects(TOperations operations, TId id, IEventSlice<TDoc> slice)
+        => RaiseSideEffects(operations, slice);
+
     AggregationScope Scope { get; }
     
     bool MatchesAnyDeleteType(IReadOnlyList<IEvent> events);

--- a/src/JasperFx.Events/Projections/ContainerScoped/ScopedAggregationProjection.cs
+++ b/src/JasperFx.Events/Projections/ContainerScoped/ScopedAggregationProjection.cs
@@ -27,6 +27,11 @@ internal class ScopedAggregationProjection<TSource, TDoc, TId, TOperations, TQue
         return _inner.RaiseSideEffects(operations, slice);
     }
 
+    public ValueTask RaiseSideEffects(TOperations operations, TId id, IEventSlice<TDoc> slice)
+    {
+        return _inner.RaiseSideEffects(operations, id, slice);
+    }
+
     public Task EnrichEventsAsync(SliceGroup<TDoc, TId> group, TQuerySession querySession, CancellationToken cancellation)
     {
         return _inner.EnrichEventsAsync(group, querySession, cancellation);


### PR DESCRIPTION
Added RaiseSideEffects overload to support injecting strongly-typed slide ID into parameters while maintaining backwards-compatibility.