### PR TITLE
fix(#560): pass the resource to the Aspire command environment callback context

### DIFF
--- a/docs/cli/aspire.md
+++ b/docs/cli/aspire.md
@@ -133,9 +133,18 @@ dotnet run --project <api>.csproj --no-build -- <verb> <args>
 
 The child inherits the AppHost's environment, and on top of that the resource's *resolved*
 environment is applied — evaluated from the resource's Aspire environment annotations (the same
-values Aspire injects into the running process, such as `ConnectionStrings__*`). The child's
-`stdout`/`stderr` stream into the resource's **Console logs** in the dashboard, and its exit code
-maps to a success or failure toast.
+values Aspire injects into the running process, such as `ConnectionStrings__*`). Those annotations
+are evaluated against a callback context that is **associated with the resource**, so Aspire's own
+reference/endpoint population (everything a `WithReference(...)` contributes) resolves correctly
+rather than failing to find its resource. The child's `stdout`/`stderr` stream into the resource's
+**Console logs** in the dashboard, and its exit code maps to a success or failure toast.
+
+Environment resolution is **resilient per variable**: if an individual annotation callback throws or
+a single value can't be resolved, that one variable is logged and skipped while every other variable
+still flows through — a single broken reference never blanks out the whole environment. If resolution
+can't run **at all** (a genuine misconfiguration, such as a missing Aspire execution context), the
+command **fails loudly** with the error in the dashboard rather than silently launching the child
+against a half-populated environment.
 
 ```mermaid
 sequenceDiagram

--- a/src/JasperFx.Aspire.Tests/JasperFxCommandExecutorTests.cs
+++ b/src/JasperFx.Aspire.Tests/JasperFxCommandExecutorTests.cs
@@ -1,4 +1,7 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
 using JasperFx.Aspire;
+using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 
 namespace JasperFx.Aspire.Tests;
@@ -6,6 +9,102 @@ namespace JasperFx.Aspire.Tests;
 public class JasperFxCommandExecutorTests
 {
     private static readonly Dictionary<string, string> NoEnv = new();
+
+    // A minimal concrete resource so the environment-resolution tests don't need a full AppHost.
+    private sealed class TestResource(string name) : Resource(name);
+
+    // Reproduces GH #560: Aspire's own environment callbacks (e.g. the endpoint/reference population
+    // registered by WithReference) read EnvironmentCallbackContext.Resource. When the executor built
+    // the callback context without the resource, that getter threw
+    // "Resource is not set. This callback context is not associated with a resource.",
+    // the resolution was abandoned, and the child process launched with none of the Aspire-managed
+    // environment (connection strings, service discovery), so Critter apps failed at startup.
+    [Fact]
+    public async Task resolve_environment_associates_the_resource_with_the_callback_context()
+    {
+        var resource = new TestResource("server-eyzqhsqj");
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            // Same access pattern as Aspire.Hosting's CreateEndpointReferenceEnvironmentPopulationCallback.
+            context.EnvironmentVariables[$"services__{context.Resource.Name}__http__0"] = "http://localhost:5000";
+            return Task.CompletedTask;
+        }));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+
+        var environment = await JasperFxCommandExecutor.ResolveEnvironmentAsync(
+            resource, executionContext, NullLogger.Instance, CancellationToken.None);
+
+        environment["services__server-eyzqhsqj__http__0"].ShouldBe("http://localhost:5000");
+    }
+
+    // Straightforward WithEnvironment values (no resource association needed) must still come through.
+    [Fact]
+    public async Task resolve_environment_captures_plain_environment_values()
+    {
+        var resource = new TestResource("api");
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"] = "Development";
+            return Task.CompletedTask;
+        }));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+
+        var environment = await JasperFxCommandExecutor.ResolveEnvironmentAsync(
+            resource, executionContext, NullLogger.Instance, CancellationToken.None);
+
+        environment["ASPNETCORE_ENVIRONMENT"].ShouldBe("Development");
+    }
+
+    // A failing callback (e.g. a WithReference whose endpoint can't be evaluated) must not throw away
+    // the environment contributed by the other, healthy callbacks — the GH #560 regression.
+    [Fact]
+    public async Task resolve_environment_keeps_healthy_values_when_one_callback_fails()
+    {
+        var resource = new TestResource("api");
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["ConnectionStrings__postgres"] = "Host=localhost;Port=5432";
+            return Task.CompletedTask;
+        }));
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(_ =>
+            throw new InvalidOperationException("boom")));
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"] = "Development";
+            return Task.CompletedTask;
+        }));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+
+        var environment = await JasperFxCommandExecutor.ResolveEnvironmentAsync(
+            resource, executionContext, NullLogger.Instance, CancellationToken.None);
+
+        environment["ConnectionStrings__postgres"].ShouldBe("Host=localhost;Port=5432");
+        environment["ASPNETCORE_ENVIRONMENT"].ShouldBe("Development");
+    }
+
+    // Cancellation is not a resolution failure to swallow — it must propagate so the command reports
+    // Canceled rather than silently launching the child with a partial environment.
+    [Fact]
+    public async Task resolve_environment_propagates_cancellation()
+    {
+        var resource = new TestResource("api");
+        using var cts = new CancellationTokenSource();
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(_ =>
+        {
+            cts.Cancel();
+            cts.Token.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }));
+
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+
+        await Should.ThrowAsync<OperationCanceledException>(() =>
+            JasperFxCommandExecutor.ResolveEnvironmentAsync(
+                resource, executionContext, NullLogger.Instance, cts.Token));
+    }
 
     [Fact]
     public void build_start_info_runs_dotnet_run_with_no_build_and_the_verb()

--- a/src/JasperFx.Aspire/JasperFxCommandExecutor.cs
+++ b/src/JasperFx.Aspire/JasperFxCommandExecutor.cs
@@ -45,12 +45,21 @@ internal sealed class JasperFxCommandExecutor
         {
             environment = await ResolveEnvironmentAsync(context, logger);
         }
+        catch (OperationCanceledException)
+        {
+            return CommandResults.Canceled();
+        }
         catch (Exception e)
         {
-            logger.LogWarning(e,
-                "Unable to resolve the Aspire-managed environment for '{Resource}'; the child process will inherit the AppHost environment only.",
+            // Per-callback failures are already tolerated inside ResolveEnvironmentAsync; reaching here
+            // means resolution could not run at all (e.g. a missing DistributedApplicationExecutionContext
+            // service). That is a misconfiguration, not a degraded environment — fail loudly rather than
+            // silently launching the child with only the AppHost environment and a mysterious downstream
+            // startup crash.
+            logger.LogError(e,
+                "Unable to resolve the Aspire-managed environment for '{Resource}'; aborting the JasperFx command.",
                 context.ResourceName);
-            environment = new Dictionary<string, string>();
+            return CommandResults.Failure(e);
         }
 
         var startInfo = BuildStartInfo(projectPath, workingDirectory, _verb, _arguments, environment);
@@ -78,29 +87,88 @@ internal sealed class JasperFxCommandExecutor
     /// Aspire-managed connection strings and explicit <c>WithEnvironment</c> values. The spawned child
     /// also inherits the AppHost process environment (ProcessStartInfo default), so these add on top.
     /// </summary>
-    private async Task<IReadOnlyDictionary<string, string>> ResolveEnvironmentAsync(
+    private Task<IReadOnlyDictionary<string, string>> ResolveEnvironmentAsync(
         ExecuteCommandContext context, ILogger logger)
     {
         var executionContext = context.ServiceProvider.GetRequiredService<DistributedApplicationExecutionContext>();
-        var callbackContext = new EnvironmentCallbackContext(executionContext, cancellationToken: context.CancellationToken);
+        return ResolveEnvironmentAsync(_resource, executionContext, logger, context.CancellationToken);
+    }
 
-        foreach (var annotation in _resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
+    /// <summary>
+    /// Evaluate a resource's <see cref="EnvironmentCallbackAnnotation"/>s against an
+    /// <see cref="EnvironmentCallbackContext"/> that is associated with the resource. The resource
+    /// association matters: Aspire's own callbacks (e.g. the endpoint/reference population added by
+    /// <c>WithReference</c>) read <see cref="EnvironmentCallbackContext.Resource"/>, which throws
+    /// "Resource is not set" when the context is built without one — leaving connection strings and
+    /// other Aspire-managed variables unresolved (see GH #560).
+    /// </summary>
+    internal static async Task<IReadOnlyDictionary<string, string>> ResolveEnvironmentAsync(
+        IResource resource,
+        DistributedApplicationExecutionContext executionContext,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var callbackContext = new EnvironmentCallbackContext(executionContext, resource, cancellationToken: cancellationToken);
+
+        // Resolution is best-effort and resilient per-item: one failing callback or unresolvable value
+        // must not discard everything else that resolved successfully. A single broken WithReference
+        // used to leave the child process with an empty environment (see GH #560); now we keep what we
+        // can and report the shortfall. Cancellation still propagates.
+        var failures = 0;
+        foreach (var annotation in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
         {
-            await annotation.Callback(callbackContext);
+            try
+            {
+                await annotation.Callback(callbackContext);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                failures++;
+                logger.LogWarning(e,
+                    "An Aspire environment callback failed for '{Resource}'; continuing with the remaining callbacks. Some environment variables may be missing.",
+                    resource.Name);
+            }
         }
 
         var resolved = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var (key, rawValue) in callbackContext.EnvironmentVariables)
         {
-            var value = await ResolveValueAsync(rawValue, context.CancellationToken);
-            if (value != null)
+            try
             {
-                resolved[key] = value;
+                var value = await ResolveValueAsync(rawValue, cancellationToken);
+                if (value != null)
+                {
+                    resolved[key] = value;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                failures++;
+                logger.LogWarning(e,
+                    "Unable to resolve the value of environment variable '{Key}' for '{Resource}'; it will be omitted from the JasperFx command child process.",
+                    key, resource.Name);
             }
         }
 
-        logger.LogInformation("Resolved {Count} environment variable(s) for the JasperFx command child process.",
-            resolved.Count);
+        if (failures > 0)
+        {
+            logger.LogWarning(
+                "Resolved {Count} environment variable(s) for the JasperFx command child process with {Failures} failure(s); the child may be missing some Aspire-managed configuration.",
+                resolved.Count, failures);
+        }
+        else
+        {
+            logger.LogInformation("Resolved {Count} environment variable(s) for the JasperFx command child process.",
+                resolved.Count);
+        }
 
         return resolved;
     }


### PR DESCRIPTION
Fixes #560.

## Problem

When a JasperFx verb is invoked from the Aspire dashboard, `JasperFxCommandExecutor` spawns a short-lived `dotnet run --project <csproj> --no-build -- <verb>` child and layers the resource's *resolved* Aspire environment (connection strings, service discovery, `WithEnvironment` values) on top of it.

That environment was evaluated against an `EnvironmentCallbackContext` constructed **without** the resource:

```csharp
var callbackContext = new EnvironmentCallbackContext(executionContext, cancellationToken: ...);
```

Aspire's own environment callbacks — notably the endpoint/reference population that `WithReference(...)` registers — read `context.Resource`, which throws `InvalidOperationException: Resource is not set. This callback context is not associated with a resource.` The executor caught that, logged the "child will inherit the AppHost environment only" warning, and **abandoned the entire environment** (empty dictionary). The child then launched without any Aspire-managed connection strings and the Critter app failed at startup — exactly the reporter's symptom.

## Fix

- **Associate the resource with the callback context** via the `EnvironmentCallbackContext(executionContext, resource, ...)` overload (present since the pinned Aspire.Hosting 13.3.1), so reference/endpoint callbacks resolve.
- **Resilient per-variable resolution**: a single failing callback or unresolvable value is logged and skipped, while everything else still flows through — one broken reference no longer blanks the whole environment. The failure count is surfaced in the logs.
- **Cancellation propagates** to a `Canceled` result instead of being swallowed into a partial run.
- **Fail loudly** when resolution can't run at all (a genuine misconfiguration, e.g. a missing execution context) rather than silently launching against a half-populated environment.
- Extracted an `internal static ResolveEnvironmentAsync` seam so the behavior is testable without a full AppHost.

## Tests

`src/JasperFx.Aspire.Tests/JasperFxCommandExecutorTests.cs`:

- `resolve_environment_associates_the_resource_with_the_callback_context` — the #560 reproduction; verified failing with the exact issue exception (`Resource is not set`) against the old constructor and passing with the fix.
- `resolve_environment_captures_plain_environment_values` — plain `WithEnvironment` still resolves.
- `resolve_environment_keeps_healthy_values_when_one_callback_fails` — a throwing callback between two healthy ones no longer discards their variables.
- `resolve_environment_propagates_cancellation` — cancellation surfaces as `OperationCanceledException`.

Full `JasperFx.Aspire.Tests` suite: **51/51 passing.**

## Docs

Updated `docs/cli/aspire.md` ("How it works") to describe the resource-associated callback context, the per-variable resilience, and the fail-loud-on-misconfiguration behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)