### PR TITLE
chore: migrate tests to xunit v3

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,9 +21,15 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   pg_db: marten_testing
   pg_user: postgres
+  # CONFIGURATION binds to the Nuke [Parameter] of the same name (Nuke reads parameters from the
+  # environment), so it genuinely selects the Release build. FRAMEWORK and
+  # DISABLE_TEST_PARALLELIZATION used to sit here too but bound to nothing: there is no Framework
+  # parameter, and no test project, runner config, or build target ever read the latter. The two
+  # suites that actually must not run concurrently (CodegenTests mutates process-wide statics and
+  # compiles assemblies; CommandLineTests redirects Console) declare that in code via
+  # [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)], which xunit v3 still
+  # honors, so the serialization is enforced where it can't be silently dropped.
   CONFIGURATION: Release
-  FRAMEWORK: net9.0
-  DISABLE_TEST_PARALLELIZATION: true
   NUKE_TELEMETRY_OPTOUT: true
 
 jobs:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,11 +80,11 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/CodegenTests.FSharp/CodegenTests.FSharp.csproj
+++ b/src/CodegenTests.FSharp/CodegenTests.FSharp.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CodegenTests.FSharp/FSharpCompilationGate.cs
+++ b/src/CodegenTests.FSharp/FSharpCompilationGate.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Shouldly;
-using Xunit.Abstractions;
 
 namespace CodegenTests.FSharp;
 

--- a/src/CodegenTests/CodeGeneration_ordering_determinism.cs
+++ b/src/CodegenTests/CodeGeneration_ordering_determinism.cs
@@ -3,7 +3,6 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CodegenTests;
 

--- a/src/CodegenTests/CodegenTests.csproj
+++ b/src/CodegenTests/CodegenTests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="System.Collections.Immutable" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CodegenTests/FSharpControlFlowTests.cs
+++ b/src/CodegenTests/FSharpControlFlowTests.cs
@@ -2,7 +2,6 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Shouldly;
-using Xunit.Abstractions;
 
 namespace CodegenTests;
 

--- a/src/CodegenTests/GeneratedTypeTests.cs
+++ b/src/CodegenTests/GeneratedTypeTests.cs
@@ -2,7 +2,6 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core;
 using Shouldly;
-using Xunit.Abstractions;
 
 namespace CodegenTests;
 

--- a/src/CodegenTests/MethodCallTester.cs
+++ b/src/CodegenTests/MethodCallTester.cs
@@ -3,7 +3,6 @@ using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using NSubstitute;
 using Shouldly;
-using Xunit.Sdk;
 
 namespace CodegenTests;
 
@@ -478,5 +477,15 @@ public class MethodCallTarget
 
 public interface IMartenOp
 {
-    
+
+}
+
+/// <summary>
+///     A return type for the MethodCallTarget probes below. The tests only assert that
+///     MethodCall infers this exact type (and the argument name derived from it), so any reference
+///     type does; it previously borrowed Xunit.Sdk.ErrorMessage via a stray `using Xunit.Sdk`,
+///     which quietly tied a codegen test to xunit's internals and broke on the v3 upgrade.
+/// </summary>
+public class ErrorMessage
+{
 }

--- a/src/CodegenTests/Samples/Frames.cs
+++ b/src/CodegenTests/Samples/Frames.cs
@@ -3,7 +3,6 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Samples;
 

--- a/src/CodegenTests/Samples/HelloWorld.cs
+++ b/src/CodegenTests/Samples/HelloWorld.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using JasperFx.RuntimeCompiler;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Samples;
 

--- a/src/CodegenTests/Samples/InjectedFieldUsage.cs
+++ b/src/CodegenTests/Samples/InjectedFieldUsage.cs
@@ -3,7 +3,6 @@ using JasperFx.CodeGeneration;
 using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Samples;
 

--- a/src/CodegenTests/Samples/UsingSourceWriter.cs
+++ b/src/CodegenTests/Samples/UsingSourceWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using JasperFx.CodeGeneration;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Samples;
 

--- a/src/CodegenTests/Services/BruteForceTests.cs
+++ b/src/CodegenTests/Services/BruteForceTests.cs
@@ -5,7 +5,6 @@ using JasperFx.CodeGeneration.Services;
 using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Services;
 

--- a/src/CodegenTests/Services/inline_enumerable_with_mixed_lifetimes.cs
+++ b/src/CodegenTests/Services/inline_enumerable_with_mixed_lifetimes.cs
@@ -7,7 +7,6 @@ using JasperFx.CodeGeneration.Services;
 using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Services;
 

--- a/src/CodegenTests/Services/keyed_constructor_injection.cs
+++ b/src/CodegenTests/Services/keyed_constructor_injection.cs
@@ -6,7 +6,6 @@ using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Services;
 

--- a/src/CodegenTests/Services/keyed_service_location.cs
+++ b/src/CodegenTests/Services/keyed_service_location.cs
@@ -5,7 +5,6 @@ using JasperFx.CodeGeneration.Services;
 using JasperFx.RuntimeCompiler;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
-using Xunit.Abstractions;
 
 namespace CodegenTests.Services;
 

--- a/src/CommandLineTests/CommandExecutorTester.cs
+++ b/src/CommandLineTests/CommandExecutorTester.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using JasperFx.CommandLine;
 using JasperFx.Core;
 using Shouldly;
+using Spectre.Console;
 
 namespace CommandLineTests
 {
@@ -22,6 +23,17 @@ namespace CommandLineTests
         public CommandExecutorTester()
         {
             Console.SetOut(theOutput);
+
+            // CommandExecutor renders failures through Spectre's AnsiConsole, which caches the
+            // TextWriter it binds to on first use anywhere in the process. Console.SetOut alone
+            // therefore does NOT redirect the failure path -- whichever test touched Spectre first
+            // has already pinned the writer. That made run_an_async_command_that_fails pass or fail
+            // purely on test ordering (it survived xunit v2's order and broke under v3's). Bind
+            // Spectre explicitly so this class captures failure output regardless of order.
+            AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Out = new AnsiConsoleOutput(theOutput)
+            });
 
             executor = CommandExecutor.For(_ =>
             {

--- a/src/CommandLineTests/CommandLineTests.csproj
+++ b/src/CommandLineTests/CommandLineTests.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CoreTests/Core/data_segregation.cs
+++ b/src/CoreTests/Core/data_segregation.cs
@@ -1,5 +1,4 @@
 using JasperFx.Core;
-using Xunit.Abstractions;
 
 namespace CoreTests.Core;
 

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/DocSamples/DocSamples.csproj
+++ b/src/DocSamples/DocSamples.csproj
@@ -5,16 +5,13 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
+    <!--
+      No test packages here on purpose. This project holds compile-checked documentation samples
+      (mdsnippets sources), contains zero [Fact]/[Theory] methods, and is not in jasperfx.slnx or
+      any Nuke target. It carried xunit + the VSTest runner + Microsoft.NET.Test.Sdk purely as
+      inherited boilerplate; xunit.v3 would additionally have forced OutputType=Exe on a
+      Microsoft.NET.Sdk.Web project for no benefit.
+    -->
     <ItemGroup>
         <ProjectReference Include="..\JasperFx\JasperFx.csproj" />
         <ProjectReference Include="..\JasperFx.RuntimeCompiler\JasperFx.RuntimeCompiler.csproj" />

--- a/src/EventStoreTests/EventStoreTests.csproj
+++ b/src/EventStoreTests/EventStoreTests.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventStoreTests/TestingSupport/TestLogger.cs
+++ b/src/EventStoreTests/TestingSupport/TestLogger.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace EventStoreTests.TestingSupport;
 

--- a/src/EventTests/EventTests.csproj
+++ b/src/EventTests/EventTests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NSubstitute" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventTests/Projections/SliceGroupTests.cs
+++ b/src/EventTests/Projections/SliceGroupTests.cs
@@ -544,9 +544,12 @@ public class SliceGroupTests : IProjectionStorage<User, string>, IStorageOperati
         throw new NotImplementedException();
     }
 
+    // Part of the IProjectionStorage contract this class self-stubs, NOT xunit lifecycle -- but
+    // xunit v3 disposes a test class that implements IAsyncDisposable, so a throwing stub here
+    // fails every test in the class during teardown. Nothing in these tests needs disposal.
     ValueTask IAsyncDisposable.DisposeAsync()
     {
-        throw new NotImplementedException();
+        return ValueTask.CompletedTask;
     }
 
     Task<IProjectionStorage<TDoc, TId>> IStorageOperations.FetchProjectionStorageAsync<TDoc, TId>(string tenantId, CancellationToken cancellationToken)

--- a/src/EventTests/TestingSupport/TestLogger.cs
+++ b/src/EventTests/TestingSupport/TestLogger.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace EventTests.TestingSupport;
 

--- a/src/JasperFx.Aspire.Tests/JasperFx.Aspire.Tests.csproj
+++ b/src/JasperFx.Aspire.Tests/JasperFx.Aspire.Tests.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JasperFx.Events.SourceGenerator.Tests/JasperFx.Events.SourceGenerator.Tests.csproj
+++ b/src/JasperFx.Events.SourceGenerator.Tests/JasperFx.Events.SourceGenerator.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JasperFx.SourceGenerator.Tests/JasperFx.SourceGenerator.Tests.csproj
+++ b/src/JasperFx.SourceGenerator.Tests/JasperFx.SourceGenerator.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Shouldly" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -22,8 +22,21 @@ public class JasperFxOptions : SystemPartBase
         var names = assembly.GetReferencedAssemblies();
         foreach (var name in names)
         {
-            var reference = Assembly.Load(name);
-            if (reference != null && reference.HasAttribute<JasperFxToolAttribute>()) return true;
+            // Best-effort detection: an application's assembly graph routinely contains references
+            // that cannot be loaded or reflected over at runtime -- optional dependencies that were
+            // never deployed, assemblies trimmed away, or (as here) a reference whose own
+            // dependencies are missing from the output so that enumerating its custom attributes
+            // throws. None of that means the app is a JasperFx tool, and none of it is worth
+            // failing host startup over, so skip the assembly and keep looking.
+            try
+            {
+                var reference = Assembly.Load(name);
+                if (reference != null && reference.HasAttribute<JasperFxToolAttribute>()) return true;
+            }
+            catch (Exception)
+            {
+                // Intentionally ignored; see above.
+            }
         }
 
         return false;


### PR DESCRIPTION
Builds on #576. The package swap itself is now a **4-line edit** in `Directory.Packages.props`:

| Package | From | To |
|---|---|---|
| `xunit` → `xunit.v3` | 2.9.3 | **3.2.2** |
| `xunit.runner.visualstudio` | 3.0.0 | **3.1.5** |
| `Microsoft.NET.Test.Sdk` | 17.12.0 | **18.8.1** |

Staying on the **VSTest bridge** deliberately — `dotnet test`, the Nuke `DotNetTest` targets, and `coverlet.collector` all keep working untouched. Microsoft Testing Platform is a clean follow-up now that v3 is in.

## Mechanical changes

- **`Xunit.Abstractions` is gone**; `ITestOutputHelper` moved into `Xunit`, already a global `Using`. 15 stray usings deleted, nothing else.
- **DocSamples drops its test packages** rather than migrating — zero `[Fact]`/`[Theory]` methods, holds compile-checked doc samples, and isn't in `jasperfx.slnx` or any Nuke target. `xunit.v3` would also have forced `OutputType=Exe` onto a `Microsoft.NET.Sdk.Web` project for nothing.
- **`MethodCallTester`** borrowed `Xunit.Sdk.ErrorMessage` as a return type for its codegen probes via a stray `using Xunit.Sdk`. The tests only assert the inferred type identity, so any reference type does — replaced with a local one, dropping an accidental dependency on xunit internals.

Zero `IAsyncLifetime` implementations and zero `IClassFixture`/`ICollectionFixture` usages in the repo, so none of the usual v3 migration work applied.

## Three real failures — none mechanical

All three are latent problems v2 happened to hide. Worth reviewing individually:

**1. `HasReferenceToJasperFxTool` had no guard — this is a product bug, not a test bug.**

It loads every referenced assembly and reads its attributes. v3 test projects are executables, so `Assembly.GetEntryAssembly()` is now the test assembly instead of `testhost.exe`, and the walk reached a project reference whose own dependency is missing from the output → `FileNotFoundException` straight out of host startup.

This affects real consumers today: **any** application whose assembly graph contains an unresolvable reference — an optional dependency never deployed, something trimmed — crashes identically. Detection is best-effort, so unloadable assemblies are now skipped.

**2. `SliceGroupTests` self-stubs `IProjectionStorage`**, which extends `IAsyncDisposable`, and left `DisposeAsync` throwing `NotImplementedException`. v2 never called it; v3 disposes test classes implementing `IAsyncDisposable`, so all 16 tests in the class failed *in teardown*. The stub belongs to the storage contract, not xunit lifecycle — now a no-op.

**3. `run_an_async_command_that_fails` was passing on test ordering alone.** It asserts on output captured via `Console.SetOut`, but `CommandExecutor` renders failures through Spectre's `AnsiConsole`, which **caches the writer it binds to on first use, process-wide**. `Console.SetOut` cannot redirect an already-pinned Spectre console. The sibling happy-path tests passed only because they use plain `Console.WriteLine`. Now binds `AnsiConsole` explicitly, so it no longer depends on order.

## Dead CI config retired

`FRAMEWORK` bound to no Nuke parameter, and `DISABLE_TEST_PARALLELIZATION` was read by **nothing** — no test project, runner config, or build target. The two suites that genuinely must not run concurrently already declare it in code via `[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]`, which v3 still honors, so serialization is enforced where it can't be silently dropped. `CONFIGURATION` stays — it does bind.

## Verification

Test counts match the v2 baseline **exactly** on both frameworks — no discovery loss:

| Suite | net9.0 | net10.0 |
|---|---|---|
| CoreTests | 475 | 475 |
| CodegenTests | 419 | 419 |
| CommandLineTests | 295 | 295 |
| EventTests | 648 | 648 |
| EventStoreTests | 72 | 72 |
| CodegenTests.FSharp | 1 | — |

Stable over three consecutive full runs (the order/parallelism risk of a v3 swap). `smoke-test-aot` and `smoke-test-commands` also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)