### PR TITLE
ci: run the three test suites that never ran

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -87,6 +87,19 @@ jobs:
         run: ./build.sh test-event-store
         shell: bash
 
+      # Covers both Roslyn source generator suites. These built in CI all along (they are in the
+      # solution, so `compile` catches compile breaks) but nothing ever ran them, so a generator
+      # could emit wrong code without failing the build.
+      - name: test-source-generators
+        if: ${{ success() || failure() }}
+        run: ./build.sh test-source-generators
+        shell: bash
+
+      - name: test-aspire
+        if: ${{ success() || failure() }}
+        run: ./build.sh test-aspire
+        shell: bash
+
       # End-to-end CLI smoke tests, including `codegen preview --language fsharp`: proves the F# flag
       # is wired through the CLI and the F# emit path runs without throwing. It does NOT prove the
       # output compiles -- `preview` only prints, and GeneratorTarget feeds codegen a raw C# CodeFrame

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -32,12 +32,14 @@
         "SmokeTestAot",
         "SmokeTestCommands",
         "Test",
+        "TestAspire",
         "TestCodegen",
         "TestCodegenFSharp",
         "TestCommandLine",
         "TestCore",
         "TestEvents",
-        "TestEventStore"
+        "TestEventStore",
+        "TestSourceGenerators"
       ]
     },
     "Verbosity": {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -50,7 +50,7 @@ partial class Build : NukeBuild
                 .EnableNoRestore());
         });
 
-    Target Test => _ => _.DependsOn(TestCore, TestCodegen, TestCodegenFSharp, TestCommandLine, TestEvents, TestEventStore, SmokeTestAot);
+    Target Test => _ => _.DependsOn(TestCore, TestCodegen, TestCodegenFSharp, TestCommandLine, TestEvents, TestEventStore, TestSourceGenerators, TestAspire, SmokeTestAot);
     
     Target TestCore => _ => _
         .DependsOn(Compile)
@@ -121,6 +121,40 @@ partial class Build : NukeBuild
         {
             DotNetTest(c => c
                 .SetProjectFile(Solution.EventStoreTests)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore());
+        });
+
+    // Both source generator suites. These are in the solution (so `compile` builds them, and they
+    // break the build if they stop compiling) but were in no test target, meaning 45 tests covering
+    // the two Roslyn generators built and never ran. Single-framework by project: both test
+    // projects pin TargetFramework=net9.0 to match the netstandard2.0 generators they host.
+    Target TestSourceGenerators => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile(Solution.src.JasperFx_SourceGenerator_Tests)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore());
+
+            DotNetTest(c => c
+                .SetProjectFile(Solution.src.JasperFx_Events_SourceGenerator_Tests)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore());
+        });
+
+    // Aspire integration surface. net10.0-only, matching JasperFx.Aspire itself (Aspire 13 is
+    // net10-first). Was likewise in the solution but in no test target.
+    Target TestAspire => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile(Solution.src.JasperFx_Aspire_Tests)
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
                 .EnableNoRestore());


### PR DESCRIPTION
Stacked on #577 (base is `chore/xunit-v3`, will retarget to `main` once that merges).

## The gap

`JasperFx.SourceGenerator.Tests` (19), `JasperFx.Events.SourceGenerator.Tests` (26) and `JasperFx.Aspire.Tests` (51) are all in the solution — so `compile` built them and a *compile* break would fail CI — but they were in **no Nuke test target and no workflow step**. 96 tests built and never executed. A source generator could emit wrong code, or the Aspire integration could regress, without anything going red.

Found while baselining test counts for the xunit 3 migration.

## Changes

- `TestSourceGenerators` — runs both generator suites
- `TestAspire` — runs the Aspire suite
- Both hang off the aggregate `Test` target
- One workflow step each, using the existing `if: ${{ success() || failure() }}` pattern so a single failure doesn't mask the remaining suites

Framework coverage follows each project rather than the repo default: the two generator suites pin `net9.0` to match the `netstandard2.0` generators they host, and the Aspire suite is `net10.0`-only like `JasperFx.Aspire` itself.

## Verification

`./build.sh test` now runs 11 targets; all green. All 96 previously-dark tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)