### PR TITLE
chore: bump Aspire 13.3.1 → 13.4.6 to clear MessagePack advisories

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,9 +55,9 @@
 
   <!-- Shipping dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.3.1" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.1" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.1" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.39" />
     <PackageVersion Include="FastExpressionCompiler" Version="5.4.1" />
     <PackageVersion Include="FSharp.Core" Version="9.0.303" />


### PR DESCRIPTION
Every restore emitted **eleven** `NU1902`/`NU1903` warnings for `MessagePack 2.5.192`, reached transitively via `Aspire.Hosting` → `KubernetesClient`. One is high severity ([GHSA-vh6j-jc39-fggf](https://github.com/advisories/GHSA-vh6j-jc39-fggf), [GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x)); the rest are moderate. All eleven are patched in **2.5.301** on the 2.x line.

## Fixed at the source, not pinned

Aspire 13.4.6 brings `KubernetesClient 19.0.2`, which depends on `MessagePack 2.5.302` — already past the patched floor. No direct `MessagePack` reference needed.

| | 13.3.1 | 13.4.6 |
|---|---|---|
| KubernetesClient | 18.0.13 | 19.0.2 |
| MessagePack | 2.5.192 ⚠️ | **2.5.302** ✅ |
| MessagePack.Annotations | 2.5.192 | 2.5.302 |

## Why not the other two options

- **A direct `PackageReference`** would add a dependency `JasperFx.Aspire` doesn't use to the shipped package's dependency graph, purely to force a floor.
- **`CentralPackageTransitivePinningEnabled`** pins *every* transitive that has a `PackageVersion` entry. This repo pins `Microsoft.Extensions.*` at 9.0.0/10.0.0 while Aspire pulls newer ones (`Microsoft.Extensions.AI.Abstractions 10.3.0`), so it risked silently downgrading Aspire's own dependencies.

## Verification

Restore is free of `NU1902`/`NU1903` across the whole solution. All 51 Aspire tests pass; full `./build.sh test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)