### PR TITLE
chore: pin NuGet transitives in build/ to clear 8 advisories

### DIFF
--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -13,6 +13,23 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="10.1.0" />
+
+    <!--
+      Nuke.Common 10.1.0 (the latest release) pulls NuGet.Packaging 6.12.1, which in turn pulls
+      System.Security.Cryptography.Xml 9.0.0 - seven high-severity advisories (NU1903). Nuke can't
+      be bumped past this, so pin the transitive up to the patched floor directly. 9.0.15 clears
+      only four of the seven; 9.0.18 covers all of them.
+
+      Nothing is shipped from build/, so this has no consumer impact. Drop the pin once Nuke ships
+      against a NuGet.Packaging that doesn't drag in a vulnerable version.
+    -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.18" />
+
+    <!--
+      Same story one level up: NuGet.Packaging 6.12.1 carries the low-severity GHSA-g4vj-cjjj-v7hg
+      (NU1901). 6.12.5 is the patched release on the same 6.12.x line Nuke already builds against.
+    -->
+    <PackageReference Include="NuGet.Packaging" Version="6.12.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #584

## What

`build/Build.csproj` pulled 8 advisories transitively through `Nuke.Common 10.1.0`:

```
Nuke.Common 10.1.0
  └─ NuGet.Packaging 6.12.1                      (NU1901, low:  GHSA-g4vj-cjjj-v7hg)
       └─ System.Security.Cryptography.Xml 9.0.0 (NU1903 x7, high)
```

`Nuke.Common 10.1.0` is already the latest release, so this can't be fixed by bumping Nuke. Both transitives are pinned up directly instead:

- `System.Security.Cryptography.Xml` → **9.0.18**, the patched floor covering all seven high-severity advisories (`9.0.15` clears only four of them).
- `NuGet.Packaging` → **6.12.5**, the patched release on the same `6.12.x` line Nuke already builds against.

The issue only proposed the crypto pin and left the low-severity `NuGet.Packaging` one open pending Nuke. It turned out to be fixable the same way — `6.12.5` is a patch on the line Nuke targets, not a line move — so restore now comes back completely clean rather than one-warning clean.

## Why it was invisible locally

`build/Build.csproj` is marked `<Build Project="false" />` in `jasperfx.slnx`, so `dotnet restore jasperfx.slnx` skips it. Only `./build.sh` restores it, which is why these showed up in CI logs but never in a local solution restore.

## Risk

Contained. Nothing is shipped from `build/` — it's the dev/CI-time Nuke orchestrator only, so adding dependencies there has zero consumer impact. `build/` already opts out of central package management via its own `Directory.Packages.props`, so inline versions are the established pattern in that directory.

## Verification

```
$ dotnet restore build/Build.csproj
  (no NU1901 / NU1903 — no warnings at all)

$ dotnet build build/Build.csproj
  Build succeeded. 0 Warning(s) 0 Error(s)

$ ./build.sh clean
  NUKE Execution Engine version 10.1.0 (OSX,.NETCoreApp,Version=v10.0)
  Clean  Succeeded
```

The Nuke host still bootstraps and runs against the pinned `NuGet.Packaging`. Full `./build.sh test` runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)