### PR TITLE
chore: drop redundant System.Collections.Immutable reference (NU1510)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,6 @@
     <PackageVersion Include="Npgsql" Version="9.0.2" />
     <PackageVersion Include="Polly.Core" Version="8.6.5" />
     <PackageVersion Include="Spectre.Console" Version="0.55.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
   </ItemGroup>
 
   <!--

--- a/src/CodegenTests/CodegenTests.csproj
+++ b/src/CodegenTests/CodegenTests.csproj
@@ -9,7 +9,6 @@
         <PackageReference Include="coverlet.collector" />
         <PackageReference Include="FSharp.Core" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="System.Collections.Immutable" />
         <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Closes #583

## What

Every restore emitted:

```
src/CodegenTests/CodegenTests.csproj : warning NU1510: PackageReference
System.Collections.Immutable will not be pruned. Consider removing this package
from your dependencies, as it is likely unnecessary.
```

`CodegenTests` genuinely uses the type — `src/CodegenTests/VariableTests.cs:62` references `ImmutableHashSet<string>` — but `System.Collections.Immutable` has been in-box since .NET Core 3.x, and this project targets `net9.0;net10.0`. The type resolves from the framework either way, so the explicit reference adds nothing.

Beyond the one line the issue called for: `CodegenTests` was the only consumer, so the matching `PackageVersion` entry in `Directory.Packages.props` is removed too rather than left behind as a dangling central version.

## Why it matters

This was the last remaining restore warning in the solution now that #579 cleared the MessagePack advisories (and #585 clears the `build/` ones). `dotnet restore jasperfx.slnx` is now completely clean — which is the point: it makes future restore warnings actually visible instead of arriving in a pile of known noise.

## Verification

```
$ dotnet restore jasperfx.slnx
  (no NU1510 — no warnings at all)

$ dotnet test src/CodegenTests --framework net9.0
  Passed! - Failed: 0, Passed: 419, Skipped: 0, Total: 419
```

419 matches the baseline recorded in #581. `VariableTests.cs` compiles unchanged on the framework-provided type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)