### PR TITLE
fix: ship FSharp.Core with the F# fixture assemblies

### DIFF
--- a/src/CodegenTests.FSharpFixture/CodegenTests.FSharpFixture.fsproj
+++ b/src/CodegenTests.FSharpFixture/CodegenTests.FSharpFixture.fsproj
@@ -29,6 +29,12 @@
         <!-- The scoped-DI sample's generated code references IServiceScopeFactory / GetRequiredService /
              CreateAsyncScope (jasperfx#397). -->
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+
+        <!-- Explicit because central package management turns off the F# SDK's implicit FSharp.Core
+             reference (#580). Without it fsc silently falls back to the copy bundled with whichever
+             SDK is running, so the gate would compile against a different FSharp.Core than the one
+             the repo pins. -->
+        <PackageReference Include="FSharp.Core" />
     </ItemGroup>
 
 </Project>

--- a/src/CoreTests/Reflection/FSharpTypesFixtureTests.cs
+++ b/src/CoreTests/Reflection/FSharpTypesFixtureTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using FSharpTypes;
+using Shouldly;
+
+namespace CoreTests.Reflection;
+
+/// <summary>
+/// Guards the FSharpTypes fixture itself rather than anything in JasperFx.
+///
+/// FSharpTypes exists so the reflection tests have real F# types to work over. That is only
+/// worth anything if the assembly can actually be reflected over -- and for a long time it
+/// could not, because FSharp.Core never reached the output directory (#580). The tests that
+/// use the fixture kept passing anyway, since typeof() and member lookup don't force the
+/// assembly-level attributes to resolve, so the gap stayed invisible until the xunit v3
+/// migration (#577) pointed JasperFxOptions.HasReferenceToJasperFxTool at CoreTests.dll and
+/// its walk over referenced assemblies hit FSharpTypes.
+///
+/// These tests exercise the parts that DO force FSharp.Core to load, so the fixture can't
+/// silently rot back into being un-reflectable.
+/// </summary>
+public class FSharpTypesFixtureTests
+{
+    private static readonly Assembly theFSharpAssembly = typeof(FSharpGuidId).Assembly;
+
+    [Fact]
+    public void the_assembly_level_attributes_can_be_resolved()
+    {
+        // The F# compiler stamps FSharpInterfaceDataVersionAttribute on every assembly it emits,
+        // and that attribute type lives in FSharp.Core. Without FSharp.Core alongside the output
+        // this threw FileNotFoundException.
+        var attributes = Should.NotThrow(() => theFSharpAssembly.GetCustomAttributes().ToArray());
+
+        attributes.ShouldContain(x => x.GetType().Name == "FSharpInterfaceDataVersionAttribute");
+    }
+
+    [Fact]
+    public void every_type_in_the_fixture_can_be_loaded()
+    {
+        // Unlike its siblings this one passed even with FSharp.Core missing -- type loading never
+        // forces the attributes to resolve. That is exactly why the gap hid for so long. Kept as a
+        // sanity check on what the fixture actually contains.
+        var types = Should.NotThrow(() => theFSharpAssembly.GetTypes());
+
+        types.ShouldContain(typeof(FSharpGuidId));
+        types.ShouldContain(typeof(FSharpStringId));
+        types.ShouldContain(typeof(FSharpIntId));
+        types.ShouldContain(typeof(FSharpSaga));
+    }
+
+    [Fact]
+    public void the_fsharp_types_carry_resolvable_fsharp_core_attributes()
+    {
+        // CompilationMappingAttribute is what marks these as discriminated unions, and it too
+        // comes from FSharp.Core. Reading it proves the reference resolves at the type level and
+        // not just at the assembly level.
+        var attributes = Should.NotThrow(() => typeof(FSharpGuidId).GetCustomAttributes().ToArray());
+
+        attributes.ShouldContain(x => x.GetType().Name == "CompilationMappingAttribute");
+    }
+
+    [Fact]
+    public void fsharp_core_is_an_actual_reference_of_the_fixture()
+    {
+        var fsharpCore = theFSharpAssembly
+            .GetReferencedAssemblies()
+            .SingleOrDefault(x => x.Name == "FSharp.Core");
+
+        fsharpCore.ShouldNotBeNull();
+
+        // This is the walk JasperFxOptions.HasReferenceToJasperFxTool performs over the entry
+        // assembly's references. It is best-effort and swallows failures now, but it should not
+        // have anything to swallow here.
+        Should.NotThrow(() => Assembly.Load(fsharpCore).GetCustomAttributes().ToArray());
+    }
+}

--- a/src/FSharpTypes/FSharpTypes.fsproj
+++ b/src/FSharpTypes/FSharpTypes.fsproj
@@ -8,6 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!--
+          Must be explicit. The F# SDK normally adds FSharp.Core implicitly, but
+          Microsoft.FSharp.NetSdk.props sets DisableImplicitFSharpCoreReference=true whenever
+          ManagePackageVersionsCentrally is on (#576) - so without this line the project compiles
+          but ships no FSharp.Core, and nothing can reflect over the output assembly: the F#
+          compiler stamps FSharpInterfaceDataVersionAttribute on it, and that attribute type lives
+          in FSharp.Core (#580).
+        -->
+        <PackageReference Include="FSharp.Core" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Compile Include="Types.fs"/>
     </ItemGroup>
 


### PR DESCRIPTION
Closes #580

## Root cause

The issue reported the symptom (no `FSharp.Core` in `FSharpTypes`' output, no entry in its `deps.json`) but not the mechanism. It's in the F# SDK:

```xml
<!-- sdk/10.0.101/FSharp/Microsoft.FSharp.NetSdk.props:83-86 -->
<PropertyGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
  <DisableImplicitFSharpCoreReference Condition="...">true</DisableImplicitFSharpCoreReference>
</PropertyGroup>
```

**Central package management turns off the F# SDK's implicit `FSharp.Core` reference.** Confirmed directly:

```
$ dotnet msbuild src/FSharpTypes/FSharpTypes.fsproj -getProperty:DisableImplicitFSharpCoreReference
  "DisableImplicitFSharpCoreReference": "true"
```

The projects compiled anyway because `fsc` falls back to the `FSharp.Core` bundled with whichever SDK is running when nothing else supplies one. That's what made this fail quietly instead of loudly — and it also means the fixtures were being compiled against a *different* `FSharp.Core` than the repo pins, varying with the installed SDK.

Reflecting over the output then threw `FileNotFoundException` for `FSharp.Core, Version=10.0.0.0` — the SDK-bundled version it had been compiled against, which was never deployed.

## Fix

An explicit `<PackageReference Include="FSharp.Core" />` in both F# projects — `src/FSharpTypes` and `src/CodegenTests.FSharpFixture`. Under CPM this resolves to the existing central **9.0.303**, so it reconciles with `CodegenTests`' pin rather than adding a second conflicting one, as the issue asked.

`src/FSharpCodegenTarget` was also flagged as worth checking — it's a C# project, so it never had the gap; it now picks up `FSharp.Core` transitively.

## Verification

Before/after on `CoreTests`' output directory:

```
BEFORE:  FSharpTypes.dll
AFTER:   FSharp.Core.dll   FSharpTypes.dll
```

## Answering "what is the fixture actually proving today?"

The issue asked this, and the answer is worth recording: the existing `ValueTypeInfoTests` F# tests were passing on a broken fixture. `typeof()` and member lookup never force assembly-level attributes to resolve, so they never touched the missing dependency.

New `src/CoreTests/Reflection/FSharpTypesFixtureTests.cs` guards the fixture itself. Removing the `PackageReference` again:

```
Failed  fsharp_core_is_an_actual_reference_of_the_fixture      System.IO.FileNotFoundException
Failed  the_assembly_level_attributes_can_be_resolved          System.IO.FileNotFoundException
Failed  the_fsharp_types_carry_resolvable_fsharp_core_attributes  System.IO.FileNotFoundException
Passed  every_type_in_the_fixture_can_be_loaded
```

The exact exception from the issue, and the one that passes either way is `GetTypes` — which is exactly why this hid for so long. That's noted in the test so nobody mistakes it for a guard.

## Test results

| Suite | Result |
|---|---|
| CoreTests (net9.0) | 479 passed (475 baseline + 4 new) |
| CoreTests (net10.0) | 479 passed |
| CodegenTests (net9.0) | 419 passed |
| CodegenTests.FSharp compile gate | 1 passed |

No new compiler warnings — the fixture's four pre-existing `FS3261` nullness warnings are unchanged in count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)