### PR TITLE
test: clear all 504 xunit analyzer warnings

### DIFF
--- a/src/CodegenTests/Samples/UsingSourceWriter.cs
+++ b/src/CodegenTests/Samples/UsingSourceWriter.cs
@@ -32,7 +32,16 @@ END
 
         _output.WriteLine(writer.Code());
     }
+}
 
+/// <summary>
+/// Documentation samples only -- never executed. These live outside UsingSourceWriter because a
+/// public, attribute-less method on a test class is xUnit1013, and the analyzer is right to flag
+/// it: on a class that does hold [Fact]s, that shape is indistinguishable from a test someone
+/// forgot to attribute. Keeping the methods public here preserves the snippet text verbatim.
+/// </summary>
+public class SourceWriterSamples
+{
     public void other_methods()
     {
         #region sample_other-sourcewriter-basics

--- a/src/CommandLineTests/Environment/HealthCheckIntegrationTests.cs
+++ b/src/CommandLineTests/Environment/HealthCheckIntegrationTests.cs
@@ -12,7 +12,7 @@ public class HealthCheckIntegrationTests
     {
         var services = new ServiceCollection();
         services.CheckEnvironmentHealthCheck<AlwaysHealthyCheck>();
-        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider());
+        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider(), TestContext.Current.CancellationToken);
 
         results.Succeeded().ShouldBeTrue();
         results.Successes.ShouldContain(s => s.Contains("AlwaysHealthyCheck"));
@@ -23,7 +23,7 @@ public class HealthCheckIntegrationTests
     {
         var services = new ServiceCollection();
         services.CheckEnvironmentHealthCheck<AlwaysUnhealthyCheck>();
-        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider());
+        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider(), TestContext.Current.CancellationToken);
 
         results.Succeeded().ShouldBeFalse();
         results.Failures.ShouldContain(f => f.Description.Contains("AlwaysUnhealthyCheck"));
@@ -34,7 +34,7 @@ public class HealthCheckIntegrationTests
     {
         var services = new ServiceCollection();
         services.CheckEnvironmentHealthCheck<DegradedCheck>();
-        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider());
+        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider(), TestContext.Current.CancellationToken);
 
         results.Succeeded().ShouldBeTrue();
         results.Successes.ShouldContain(s => s.Contains("degraded"));
@@ -47,7 +47,7 @@ public class HealthCheckIntegrationTests
         services.CheckEnvironment("Manual check", _ => { });
         services.CheckEnvironmentHealthCheck<AlwaysHealthyCheck>();
         services.CheckEnvironmentHealthCheck<AlwaysUnhealthyCheck>();
-        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider());
+        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider(), TestContext.Current.CancellationToken);
 
         results.Succeeded().ShouldBeFalse();
         results.Successes.Length.ShouldBeGreaterThanOrEqualTo(2);
@@ -59,7 +59,7 @@ public class HealthCheckIntegrationTests
     {
         var services = new ServiceCollection();
         services.CheckEnvironmentHealthCheck<ThrowingCheck>();
-        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider());
+        var results = await EnvironmentChecker.ExecuteAllEnvironmentChecks(services.BuildServiceProvider(), TestContext.Current.CancellationToken);
 
         results.Succeeded().ShouldBeFalse();
         results.Failures.ShouldContain(f => f.Description.Contains("ThrowingCheck"));

--- a/src/CommandLineTests/Resources/ResourceHostExtensionsTests.cs
+++ b/src/CommandLineTests/Resources/ResourceHostExtensionsTests.cs
@@ -6,7 +6,14 @@ using Shouldly;
 
 namespace CommandLineTests.Resources;
 
-public class ResourceHostExtensionsTests : ResourceCommandContext
+/// <summary>
+/// Documentation samples only -- never executed. These live outside ResourceHostExtensionsTests
+/// because a public, attribute-less method on a test class is xUnit1013, and the analyzer is right
+/// to flag it: on a class that does hold [Fact]s, that shape is indistinguishable from a test
+/// someone forgot to attribute. Keeping the methods public here preserves the snippet text verbatim
+/// -- sample_programmatically_control_resources includes its method signature.
+/// </summary>
+public class ResourceHostExtensionsSamples
 {
     public static async Task sample1()
     {
@@ -70,7 +77,10 @@ public class ResourceHostExtensionsTests : ResourceCommandContext
     }
 
     #endregion
+}
 
+public class ResourceHostExtensionsTests : ResourceCommandContext
+{
     [Fact]
     public void add_resource_startup()
     {
@@ -154,7 +164,7 @@ public class ResourceHostExtensionsTests : ResourceCommandContext
                 CopyResources(services);
                 services.AddResourceSetupOnStartup();
             })
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
 
         foreach (var resource in AllResources)
         {
@@ -189,7 +199,7 @@ public class ResourceHostExtensionsTests : ResourceCommandContext
                 CopyResources(services);
                 services.AddResourceSetupOnStartup(StartupAction.ResetState);
             })
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
 
         foreach (var resource in AllResources)
         {
@@ -217,7 +227,7 @@ public class ResourceHostExtensionsTests : ResourceCommandContext
         });
 
         using var host = await buildHost();
-        await host.SetupResources();
+        await host.SetupResources(TestContext.Current.CancellationToken);
 
         foreach (var resource in AllResources) await resource.Received().Setup(Arg.Any<CancellationToken>());
     }
@@ -241,7 +251,7 @@ public class ResourceHostExtensionsTests : ResourceCommandContext
         });
 
         using var host = await buildHost();
-        await host.ResetResourceState();
+        await host.ResetResourceState(TestContext.Current.CancellationToken);
 
         foreach (var resource in AllResources)
         {
@@ -269,7 +279,7 @@ public class ResourceHostExtensionsTests : ResourceCommandContext
         });
 
         using var host = await buildHost();
-        await host.TeardownResources();
+        await host.TeardownResources(TestContext.Current.CancellationToken);
 
         foreach (var resource in AllResources) await resource.Received().Teardown(Arg.Any<CancellationToken>());
     }

--- a/src/CommandLineTests/run_command_compliance.cs
+++ b/src/CommandLineTests/run_command_compliance.cs
@@ -35,7 +35,7 @@ public class run_command_compliance
 
             // Do not shut down until any redundant start has happened, or a stopping host would
             // mask it. A correct run never signals, so bound the wait to prove the negative.
-            await Task.WhenAny(redundantStart.Task, Task.Delay(2.Seconds()));
+            await Task.WhenAny(redundantStart.Task, Task.Delay(2.Seconds(), TestContext.Current.CancellationToken));
 
             host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
             await runTask.TimeoutAfterAsync(5000);

--- a/src/CoreTests/Blocks/BatchingChannelTests.cs
+++ b/src/CoreTests/Blocks/BatchingChannelTests.cs
@@ -43,11 +43,11 @@ public class BatchingChannelTests
             for (var i = 0; i < 20; i++)
             {
                 channel.Post(i);
-                await Task.Delay(25);
+                await Task.Delay(25, TestContext.Current.CancellationToken);
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
-        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds()));
+        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds(), TestContext.Current.CancellationToken));
         flushed.ShouldBe(firstBatch.Task,
             "the first batch should flush within the max age even though items keep trickling in");
 
@@ -68,7 +68,7 @@ public class BatchingChannelTests
 
         channel.Post(42);
 
-        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds()));
+        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds(), TestContext.Current.CancellationToken));
         flushed.ShouldBe(firstBatch.Task);
 
         channel.Complete();
@@ -90,7 +90,7 @@ public class BatchingChannelTests
             channel.Post(i);
         }
 
-        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds()));
+        var flushed = await Task.WhenAny(firstBatch.Task, Task.Delay(2.Seconds(), TestContext.Current.CancellationToken));
         flushed.ShouldBe(firstBatch.Task, "a full batch should flush without waiting on the timer");
 
         channel.Complete();

--- a/src/CoreTests/Blocks/BlockErrorHandlingTests.cs
+++ b/src/CoreTests/Blocks/BlockErrorHandlingTests.cs
@@ -38,7 +38,7 @@ public class BlockErrorHandlingTests
         block.Post("poison");
         block.Post("second");
 
-        await secondItemProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await secondItemProcessed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         processed.ShouldBe(new[] { "first", "second" });
         failures.Count.ShouldBe(1);
@@ -71,7 +71,7 @@ public class BlockErrorHandlingTests
 
         block.Post("poison");
 
-        await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         block.Failure.ShouldNotBeNull();
         var aggregate = block.Failure.ShouldBeOfType<AggregateException>();
@@ -107,11 +107,11 @@ public class BlockErrorHandlingTests
         block.OnError = (_, _) => throw new InvalidCastException("kill the block");
 
         block.Post("poison");
-        await actionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await actionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         block.Post("buffered");
 
         // This producer has no capacity left and parks waiting for the consumer
-        var blockedProducer = Task.Run(async () => await block.PostAsync("parked"));
+        var blockedProducer = Task.Run(async () => await block.PostAsync("parked"), TestContext.Current.CancellationToken);
         blockedProducer.IsCompleted.ShouldBeFalse();
 
         // Now the action throws, the error callback throws, and the block faults. The parked
@@ -143,10 +143,10 @@ public class BlockErrorHandlingTests
         };
 
         block.Post("poison");
-        await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await faulted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Teardown paths call this on shutdown; a fault must not blow up the shutdown itself
-        await block.WaitForCompletionAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await block.WaitForCompletionAsync().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public class BlockErrorHandlingTests
             block.Post("poison");
             block.Post("after");
 
-            await processed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await processed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             await block.WaitForCompletionAsync();
 
             writer.ToString().ShouldContain("DivideByZeroException");

--- a/src/CoreTests/Blocks/InMemoryQueueTests.cs
+++ b/src/CoreTests/Blocks/InMemoryQueueTests.cs
@@ -64,10 +64,10 @@ public class InMemoryQueueTests
         };
         
         await Task.WhenAll([
-            Task.Run(() => publish(expected1)),
-            Task.Run(() => publish(expected2)),
-            Task.Run(() => publish(expected3)),
-            Task.Run(() => publish(expected4)),
+            Task.Run(() => publish(expected1), TestContext.Current.CancellationToken),
+            Task.Run(() => publish(expected2), TestContext.Current.CancellationToken),
+            Task.Run(() => publish(expected3), TestContext.Current.CancellationToken),
+            Task.Run(() => publish(expected4), TestContext.Current.CancellationToken),
             
             
             ]);
@@ -106,10 +106,10 @@ public class InMemoryQueueTests
         };
         
         await Task.WhenAll([
-            Task.Run(() => publish(expected1)),
-            Task.Run(() => publish(expected2)),
-            Task.Run(() => publish(expected3)),
-            Task.Run(() => publish(expected4)),
+            Task.Run(() => publish(expected1), TestContext.Current.CancellationToken),
+            Task.Run(() => publish(expected2), TestContext.Current.CancellationToken),
+            Task.Run(() => publish(expected3), TestContext.Current.CancellationToken),
+            Task.Run(() => publish(expected4), TestContext.Current.CancellationToken),
             
             
         ]);
@@ -154,13 +154,13 @@ public class InMemoryQueueTests
             {
                 queue.Post(i);
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         // Wait until the channel is saturated (producer is now blocked inside Post waiting for room).
         var deadline = DateTime.UtcNow.AddSeconds(30);
         while (queue.Count < Block<int>.DefaultBoundedCapacity && DateTime.UtcNow < deadline)
         {
-            await Task.Delay(10);
+            await Task.Delay(10, TestContext.Current.CancellationToken);
         }
 
         queue.Count.ShouldBeGreaterThanOrEqualTo((uint)Block<int>.DefaultBoundedCapacity);

--- a/src/CoreTests/Blocks/RetryBlockTests.cs
+++ b/src/CoreTests/Blocks/RetryBlockTests.cs
@@ -41,7 +41,11 @@ public class RetryBlockTests
             .ShouldBe("Completed Name: Aubrey");
     }
 
-    //[Fact] -- unreliable in CI
+    // Was a bare commented-out [Fact], which left a public attribute-less method on a test class --
+    // xUnit1013, and indistinguishable from a test someone forgot to attribute. Skip states the
+    // same thing without hiding it: the test now shows up as skipped on every run rather than
+    // silently not existing.
+    [Fact(Skip = "Unreliable in CI - timing sensitive under load")]
     public async Task retry_within_threshold()
     {
         var theMessage = new SometimesFailingMessage(2, "Aubrey");
@@ -72,7 +76,7 @@ public class RetryBlockTests
         while (tries < 50 && !theLogger.Messages[LogLevel.Information].Any())
         {
             tries++;
-            await Task.Delay(100.Milliseconds());
+            await Task.Delay(100.Milliseconds(), TestContext.Current.CancellationToken);
         }
 
         theLogger.Messages[LogLevel.Information].Single()

--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -47,7 +47,7 @@ public class JasperFxOptionsTests
         using var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(s => s.AddJasperFx())
             .UseEnvironment("Development")
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
         
         var options = host.Services.GetRequiredService<JasperFxOptions>();
         
@@ -80,7 +80,7 @@ public class JasperFxOptionsTests
         using var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(s => s.AddJasperFx())
             .UseEnvironment("Development")
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
 
         var options = host.Services.GetRequiredService<JasperFxOptions>();
         options.ActiveProfile.ShouldBe(options.Development);
@@ -94,7 +94,7 @@ public class JasperFxOptionsTests
         using var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(s => s.AddJasperFx())
             .UseEnvironment("Production")
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
 
         var options = host.Services.GetRequiredService<JasperFxOptions>();
         options.ActiveProfile.ShouldBe(options.Production);
@@ -330,7 +330,7 @@ public class JasperFxOptionsTests
         using var host = await Host.CreateDefaultBuilder()
             .ConfigureServices(s => s.AddJasperFx())
             .UseEnvironment("Development")
-            .StartAsync();
+            .StartAsync(TestContext.Current.CancellationToken);
 
         var options = host.Services.GetRequiredService<JasperFxOptions>();
 

--- a/src/CoreTests/MultiTenancy/dynamic_tenancy_admin_surface.cs
+++ b/src/CoreTests/MultiTenancy/dynamic_tenancy_admin_surface.cs
@@ -20,7 +20,7 @@ public class dynamic_tenancy_admin_surface
     public async Task auto_assign_overload_is_used_when_a_source_supports_it()
     {
         var source = new AutoAssignTenantSource();
-        var resolved = await ((IDynamicTenantSource<string>)source).AddTenantAsync("acme");
+        var resolved = await ((IDynamicTenantSource<string>)source).AddTenantAsync("acme", TestContext.Current.CancellationToken);
         source.AutoAssigned.ShouldBe(["acme"]);
         resolved.ShouldBe("shard-acme"); // resolved database id / partition suffix
     }
@@ -42,7 +42,7 @@ public class dynamic_tenancy_admin_surface
         var source = new AutoAssignTenantSource();
         var services = provider(source);
 
-        var resolved = await services.AddTenantAsync("acme");
+        var resolved = await services.AddTenantAsync("acme", TestContext.Current.CancellationToken);
 
         source.AutoAssigned.ShouldBe(["acme"]);
         resolved.ShouldBe("shard-acme");
@@ -89,7 +89,7 @@ public class dynamic_tenancy_admin_surface
 
         // None of these should throw with no source registered
         await services.AddTenantAsync("acme", "Host=db1");
-        (await services.AddTenantAsync("acme")).ShouldBeNull(); // no source -> no resolved assignment
+        (await services.AddTenantAsync("acme", TestContext.Current.CancellationToken)).ShouldBeNull(); // no source -> no resolved assignment
         await services.DisableTenantAsync("acme");
         await services.EnableTenantAsync("acme");
         await services.RemoveTenantAsync("acme");

--- a/src/CoreTests/MultiTenancy/is_default_tenant.cs
+++ b/src/CoreTests/MultiTenancy/is_default_tenant.cs
@@ -10,7 +10,7 @@ public class is_default_tenant
     [InlineData(null, true)]
     [InlineData("", true)]
     [InlineData("blue", false)]
-    public void has_default_tenant_id(string value, bool isDefault)
+    public void has_default_tenant_id(string? value, bool isDefault)
     {
         var hasTenant = new StubHasTenantId { TenantId = value };
         hasTenant.IsDefaultTenant().ShouldBe(isDefault);

--- a/src/CoreTests/MultiTenancy/maybe_correct_tenant_id.cs
+++ b/src/CoreTests/MultiTenancy/maybe_correct_tenant_id.cs
@@ -20,8 +20,10 @@ public class maybe_correct_tenant_id
     [InlineData(TenantIdStyle.CaseSensitive, "One", "One")]
     [InlineData(TenantIdStyle.ForceLowerCase, "One", "one")]
     [InlineData(TenantIdStyle.ForceUpperCase, "One", "ONE")]
-    public void correct_tenant_id(TenantIdStyle tenantIdStyle, string raw, string corrected)
+    public void correct_tenant_id(TenantIdStyle tenantIdStyle, string? raw, string corrected)
     {
-        tenantIdStyle.MaybeCorrectTenantId(raw).ShouldBe(corrected);
+        // MaybeCorrectTenantId declares a non-nullable parameter, but null is exactly what the first
+        // three InlineData cases are here to pin down: it maps to the default tenant id.
+        tenantIdStyle.MaybeCorrectTenantId(raw!).ShouldBe(corrected);
     }
 }

--- a/src/CoreTests/TaskExtensionsTests.cs
+++ b/src/CoreTests/TaskExtensionsTests.cs
@@ -55,7 +55,12 @@ public class TaskExtensionsTests
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var wrapped = ((Task)tcs.Task).TimeoutAfterAsync(30_000);
 
+        // The only xUnit1051 in the repo that is genuinely wrong. SetCanceled(CancellationToken)
+        // records which token DID cancel the task; it does not observe one. Passing the test's
+        // (uncancelled) token here would assert something false about why this task ended.
+#pragma warning disable xUnit1051
         tcs.SetCanceled();
+#pragma warning restore xUnit1051
 
         await Should.ThrowAsync<TaskCanceledException>(wrapped);
     }

--- a/src/EventStoreTests/EventExtensionsTests.cs
+++ b/src/EventStoreTests/EventExtensionsTests.cs
@@ -15,7 +15,7 @@ public class EventExtensionsTests
     [InlineData(typeof(IEvent<AEvent>), typeof(AEvent))]
     [InlineData(typeof(Event<AEvent>), typeof(AEvent))]
     [InlineData(typeof(IEvent), null)]
-    public void unwrap_event_type(Type rawType, Type expectedType)
+    public void unwrap_event_type(Type rawType, Type? expectedType)
     {
         rawType.UnwrapEventType().ShouldBe(expectedType);
     }
@@ -58,11 +58,14 @@ public class EventExtensionsTests
         eventTypeFor(x => x.UseEventWrapperConcrete2(null, null)).ShouldBe(typeof(AEvent));
     }
     
-    public void UseConcreteEventType(AEvent e, MyAggregate aggregate){}
-    public void UseConcreteEventType2(MyAggregate aggregate, AEvent e){}
-    public void UseConcreteEventType3(MyAggregate aggregate, AEvent e, IEvent metadata){}
-    public void UseInterfaceEventType(ITabulator e, MyAggregate aggregate){}
-    
-    public void UseEventWrapperConcrete(IEvent<AEvent> e, MyAggregate aggregate){}
-    public void UseEventWrapperConcrete2(IEvent<AEvent> e, MyAggregate aggregate){}
+    // Reflection targets for get_event_type_from_method, not tests. Private keeps them out of
+    // xUnit1013's sights; the expression trees above still bind them because they are built inside
+    // this class, and GetEventType only reads the parameter list.
+    private void UseConcreteEventType(AEvent e, MyAggregate aggregate){}
+    private void UseConcreteEventType2(MyAggregate aggregate, AEvent e){}
+    private void UseConcreteEventType3(MyAggregate aggregate, AEvent e, IEvent metadata){}
+    private void UseInterfaceEventType(ITabulator e, MyAggregate aggregate){}
+
+    private void UseEventWrapperConcrete(IEvent<AEvent> e, MyAggregate aggregate){}
+    private void UseEventWrapperConcrete2(IEvent<AEvent> e, MyAggregate aggregate){}
 }

--- a/src/EventTests/CommandLine/ProjectionRebuildSelectionTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRebuildSelectionTests.cs
@@ -13,14 +13,14 @@ namespace EventTests.CommandLine;
 //     PROJECTION names (so a subscription name throws "No registered projection matches..."), and a
 //     rebuild would re-publish every historical event (contrary to SubscribeFromPresent()).
 //   - Inline and Async PROJECTIONS remain rebuildable.
-public class ProjectionRebuildSelectionTests : IProjectionHost
+public class ProjectionRebuildSelectionTests
 {
     private readonly ProjectionController theController;
-    private string[] _rebuiltNames = [];
+    private readonly RecordingProjectionHost theHost = new();
 
     public ProjectionRebuildSelectionTests()
     {
-        theController = new ProjectionController(this, new NulloConsoleView());
+        theController = new ProjectionController(theHost, new NulloConsoleView());
     }
 
     private static SubscriptionDescriptor descriptor(string name, ProjectionLifecycle lifecycle, SubscriptionType type)
@@ -52,7 +52,7 @@ public class ProjectionRebuildSelectionTests : IProjectionHost
     [Fact]
     public async Task rebuild_all_skips_subscriptions_and_live_but_keeps_projections()
     {
-        _usages =
+        theHost.Usages =
         [
             usageWith(
                 descriptor("AsyncProjection", ProjectionLifecycle.Async, SubscriptionType.SingleStreamProjection),
@@ -63,15 +63,15 @@ public class ProjectionRebuildSelectionTests : IProjectionHost
 
         await theController.Execute(new ProjectionInput { Action = ProjectionAction.rebuild });
 
-        _rebuiltNames.ShouldBe(["AsyncProjection", "InlineProjection"], ignoreOrder: true);
-        _rebuiltNames.ShouldNotContain("WolverineRelay");
-        _rebuiltNames.ShouldNotContain("LiveProjection");
+        theHost.RebuiltNames.ShouldBe(["AsyncProjection", "InlineProjection"], ignoreOrder: true);
+        theHost.RebuiltNames.ShouldNotContain("WolverineRelay");
+        theHost.RebuiltNames.ShouldNotContain("LiveProjection");
     }
 
     [Fact]
     public async Task named_rebuild_of_a_subscription_is_skipped()
     {
-        _usages =
+        theHost.Usages =
         [
             usageWith(
                 descriptor("WolverineRelay", ProjectionLifecycle.Async, SubscriptionType.Subscription))
@@ -82,21 +82,28 @@ public class ProjectionRebuildSelectionTests : IProjectionHost
             Action = ProjectionAction.rebuild, ProjectionFlag = "WolverineRelay"
         });
 
-        _rebuiltNames.ShouldBeEmpty();
+        theHost.RebuiltNames.ShouldBeEmpty();
     }
+}
 
-    #region IProjectionHost test double
+// Was implemented by the test class itself. Interface members have to be public, so every one of
+// them read as a public attribute-less method on a test class (xUnit1013) -- the same self-stub
+// shape that broke all 16 SliceGroupTests in #577, where a self-stubbed IAsyncDisposable ran as
+// test lifecycle instead of as a stub. Splitting it out removes the warnings and the footgun.
+internal class RecordingProjectionHost : IProjectionHost
+{
+    public IReadOnlyList<EventStoreUsage> Usages { get; set; } = [];
 
-    private IReadOnlyList<EventStoreUsage> _usages = [];
+    public string[] RebuiltNames { get; private set; } = [];
 
-    public Task<IReadOnlyList<EventStoreUsage>> AllStoresAsync() => Task.FromResult(_usages);
+    public Task<IReadOnlyList<EventStoreUsage>> AllStoresAsync() => Task.FromResult(Usages);
 
     public void ListenForUserTriggeredExit() { }
 
     public Task<RebuildStatus> TryRebuildShardsAsync(EventStoreDatabaseIdentifier databaseIdentifier,
         ProjectionInput input, string[] names, TimeSpan? shardTimeout = null)
     {
-        _rebuiltNames = names;
+        RebuiltNames = names;
         return Task.FromResult(RebuildStatus.Complete);
     }
 
@@ -107,8 +114,6 @@ public class ProjectionRebuildSelectionTests : IProjectionHost
 
     public Task AdvanceHighWaterMarkToLatestAsync(ProjectionSelection selection, CancellationToken none)
         => Task.CompletedTask;
-
-    #endregion
 }
 
 internal class NulloConsoleView : IConsoleView

--- a/src/EventTests/Daemon/BlueGreenSideEffectGateTests.cs
+++ b/src/EventTests/Daemon/BlueGreenSideEffectGateTests.cs
@@ -40,7 +40,7 @@ public class BlueGreenSideEffectGateTests
             options => options.GateSideEffectsBehindPriorVersion = true);
         harness.SetProgress("Trips:V2:All", 1000);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1000L));
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
@@ -56,7 +56,7 @@ public class BlueGreenSideEffectGateTests
             options => options.GateSideEffectsBehindPriorVersion = true);
         harness.SetProgress("Trips:V2:All", 1000);
 
-        await harness.Daemon.StartAgentAsync("Trips:V3:All", CancellationToken.None).WaitAsync(TestTimeout);
+        await harness.Daemon.StartAgentAsync("Trips:V3:All", TestContext.Current.CancellationToken).WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1000L));
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
@@ -75,7 +75,7 @@ public class BlueGreenSideEffectGateTests
         harness.SetProgress("Trips:V2:All", 1000);
         harness.SetProgress("Trips:V3:All", 400);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 400L, 1000L));
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
@@ -89,7 +89,7 @@ public class BlueGreenSideEffectGateTests
         await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3));
         harness.SetProgress("Trips:V2:All", 1000);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 0L, HighWater));
     }
@@ -100,7 +100,7 @@ public class BlueGreenSideEffectGateTests
         await using var harness = new GateHarness(ShardName.Compose("Trips"),
             options => options.GateSideEffectsBehindPriorVersion = true);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 0L, HighWater));
     }
@@ -115,7 +115,7 @@ public class BlueGreenSideEffectGateTests
         harness.SetProgress("Trips:V2:All", 1000);
         harness.SetProgress("Trips:V3:All", 1200);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1200L, HighWater));
     }
@@ -126,7 +126,7 @@ public class BlueGreenSideEffectGateTests
         await using var harness = new GateHarness(ShardName.Compose("Trips", version: 3),
             options => options.GateSideEffectsBehindPriorVersion = true);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 0L, HighWater));
     }
@@ -143,7 +143,7 @@ public class BlueGreenSideEffectGateTests
         harness.SetProgress("Trips:V4:All:tenant1", 5000);
         harness.SetProgress("Others:V4:All", 999);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1200L));
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1200L, HighWater));
@@ -163,12 +163,12 @@ public class BlueGreenSideEffectGateTests
             });
         harness.SetProgress("Trips:V2:All", 1000);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Daemon.StatusFor("Trips:V3:All").ShouldBe(AgentStatus.Running);
 
         // Give the command loop a beat: a wrongly-triggered warm-up would surface as a Rebuild page.
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         harness.Execution.RecordedPages.ShouldBeEmpty();
     }
 
@@ -183,7 +183,7 @@ public class BlueGreenSideEffectGateTests
             options => options.GateSideEffectsBehindPriorVersion = true, withReplayExecutor: true);
         harness.SetProgress("Trips:V2:All", 1000);
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Rebuild, 0L, 1000L));
         (await harness.Execution.NextPageAsync()).ShouldBe((ShardExecutionMode.Continuous, 1000L, HighWater));
@@ -203,7 +203,7 @@ public class BlueGreenSideEffectGateTests
         harness.SetProgress("Trips:V2:All", 1000);
         harness.Loader.ThrowOnLoad = true;
 
-        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StartAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Daemon.StatusFor("Trips:V3:All").ShouldBe(AgentStatus.Paused);
         harness.Execution.RecordedPages.ShouldBeEmpty();

--- a/src/EventTests/Daemon/CrossProductRebuildCapTests.cs
+++ b/src/EventTests/Daemon/CrossProductRebuildCapTests.cs
@@ -71,7 +71,7 @@ public class CrossProductRebuildCapTests
             (await harness.Loader.NextEntryAsync()).SetResult();
         }
 
-        await rebuilds.WaitAsync(TestTimeout);
+        await rebuilds.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Loader.PeakConcurrency.ShouldBe(3);
         harness.Loader.CellsLoaded.OrderBy(x => x)
@@ -112,7 +112,7 @@ public class CrossProductRebuildCapTests
             (await harness.Loader.NextEntryAsync()).SetResult();
         }
 
-        await rebuild.WaitAsync(TestTimeout);
+        await rebuild.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Loader.PeakConcurrency.ShouldBe(2);
         harness.Loader.CellsLoaded.OrderBy(x => x).ShouldBe(expectedCells(["ProjA"], tenants));
@@ -132,9 +132,9 @@ public class CrossProductRebuildCapTests
         harness.Daemon.MaxConcurrentRebuildsPerDatabase = cap;
 
         await Task.WhenAll(
-                harness.Daemon.RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, CancellationToken.None),
-                harness.Daemon.RebuildProjectionAsync("ProjB", tenantId: null, TestTimeout, CancellationToken.None))
-            .WaitAsync(TestTimeout);
+                harness.Daemon.RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, TestContext.Current.CancellationToken),
+                harness.Daemon.RebuildProjectionAsync("ProjB", tenantId: null, TestTimeout, TestContext.Current.CancellationToken))
+            .WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Loader.CellsLoaded.OrderBy(x => x)
             .ShouldBe(expectedCells(["ProjA", "ProjB"], tenants));
@@ -147,8 +147,8 @@ public class CrossProductRebuildCapTests
         await using var harness = new RebuildHarness(tenants, ["ProjA"], gated: false);
 
         await harness.Daemon
-            .RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, CancellationToken.None)
-            .WaitAsync(TestTimeout);
+            .RebuildProjectionAsync("ProjA", tenantId: null, TestTimeout, TestContext.Current.CancellationToken)
+            .WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Loader.CellsLoaded.OrderBy(x => x).ShouldBe(expectedCells(["ProjA"], tenants));
     }
@@ -198,7 +198,7 @@ public class CrossProductRebuildCapTests
             (await daemon.NextEntryAsync()).SetResult();
         }
 
-        var rebuilt = await rebuild.WaitAsync(TestTimeout);
+        var rebuilt = await rebuild.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         rebuilt.OrderBy(x => x).ShouldBe(tenants.OrderBy(x => x));
         daemon.PeakConcurrency.ShouldBe(2);

--- a/src/EventTests/Daemon/DeadLetterCountDefaultsTests.cs
+++ b/src/EventTests/Daemon/DeadLetterCountDefaultsTests.cs
@@ -49,14 +49,14 @@ public class DeadLetterCountDefaultsTests
     [Fact]
     public async Task count_dead_letters_default_returns_zero()
     {
-        var count = await theDatabase.CountDeadLetterEventsAsync(new ShardName("Fake"));
+        var count = await theDatabase.CountDeadLetterEventsAsync(new ShardName("Fake"), TestContext.Current.CancellationToken);
         count.ShouldBe(0);
     }
 
     [Fact]
     public async Task fetch_dead_letter_counts_default_returns_empty()
     {
-        var counts = await theDatabase.FetchDeadLetterCountsAsync();
+        var counts = await theDatabase.FetchDeadLetterCountsAsync(TestContext.Current.CancellationToken);
         counts.ShouldBeEmpty();
     }
 
@@ -64,7 +64,7 @@ public class DeadLetterCountDefaultsTests
     public async Task fetch_dead_letter_counts_for_null_tenant_delegates_to_store_global()
     {
         // jasperfx#450: the tenant overload with a null tenant is store-global and reuses today's behavior.
-        var counts = await theDatabase.FetchDeadLetterCountsAsync(tenantId: null);
+        var counts = await theDatabase.FetchDeadLetterCountsAsync(tenantId: null, token: TestContext.Current.CancellationToken);
         counts.ShouldBeEmpty();
     }
 

--- a/src/EventTests/Daemon/DeleteProjectionProgressByShardNameDefaultsTests.cs
+++ b/src/EventTests/Daemon/DeleteProjectionProgressByShardNameDefaultsTests.cs
@@ -96,7 +96,7 @@ public class DeleteProjectionProgressByShardNameDefaultsTests
     public async Task override_receives_the_raw_shard_identity_verbatim()
     {
         var database = new CapturingEventDatabase();
-        await database.DeleteProjectionProgressByShardNameAsync("claim_lines:V9:All");
+        await database.DeleteProjectionProgressByShardNameAsync("claim_lines:V9:All", TestContext.Current.CancellationToken);
         database.DeletedIdentity.ShouldBe("claim_lines:V9:All");
     }
 }

--- a/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
@@ -231,7 +231,7 @@ public class ExtendedProgressionWriterTests
         var dispose = theWriter.DisposeAsync().AsTask();
 
         // The write is parked on the gate, so DisposeAsync cannot have completed yet
-        await Task.Delay(100);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
         dispose.IsCompleted.ShouldBeFalse();
 
         // Let the write through; only now may DisposeAsync complete

--- a/src/EventTests/Daemon/HighWater/HighWaterAgent_check_now_committed_ceiling_Tests.cs
+++ b/src/EventTests/Daemon/HighWater/HighWaterAgent_check_now_committed_ceiling_Tests.cs
@@ -32,7 +32,7 @@ public class HighWaterAgent_check_now_committed_ceiling_Tests
         var agent = buildAgent(detector, tracker, cts.Token, "jasperfx.tests.checknow.committed");
 
         var completed = agent.CheckNowAsync();
-        var winner = await Task.WhenAny(completed, Task.Delay(5.Seconds()));
+        var winner = await Task.WhenAny(completed, Task.Delay(5.Seconds(), TestContext.Current.CancellationToken));
 
         winner.ShouldBe(completed);
         tracker.HighWaterMark.ShouldBe(12);
@@ -50,7 +50,7 @@ public class HighWaterAgent_check_now_committed_ceiling_Tests
         var agent = buildAgent(detector, tracker, cts.Token, "jasperfx.tests.checknow.waits");
 
         var completed = agent.CheckNowAsync();
-        var winner = await Task.WhenAny(completed, Task.Delay(5.Seconds()));
+        var winner = await Task.WhenAny(completed, Task.Delay(5.Seconds(), TestContext.Current.CancellationToken));
 
         winner.ShouldBe(completed);
         tracker.HighWaterMark.ShouldBe(12);
@@ -70,7 +70,7 @@ public class HighWaterAgent_check_now_committed_ceiling_Tests
         agent.CheckNowTimeout = 300.Milliseconds();
 
         var completed = agent.CheckNowAsync();
-        var winner = await Task.WhenAny(completed, Task.Delay(5.Seconds()));
+        var winner = await Task.WhenAny(completed, Task.Delay(5.Seconds(), TestContext.Current.CancellationToken));
 
         winner.ShouldBe(completed);
         tracker.HighWaterMark.ShouldBe(8);

--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -179,7 +179,7 @@ public class PerTenantStartAgentAsyncTests
         var deadline = DateTime.UtcNow.AddSeconds(15);
         while (detector.TenantPollCount < pollsAtStart + 3 && DateTime.UtcNow < deadline)
         {
-            await Task.Delay(25);
+            await Task.Delay(25, TestContext.Current.CancellationToken);
         }
 
         detector.TenantPollCount.ShouldBeGreaterThanOrEqualTo(pollsAtStart + 3);
@@ -383,7 +383,7 @@ public class PerTenantStartAgentAsyncTests
         var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
         while (Math.Abs(timer.Interval - 400) > 1 && DateTimeOffset.UtcNow < deadline)
         {
-            await Task.Delay(25);
+            await Task.Delay(25, TestContext.Current.CancellationToken);
         }
 
         timer.Interval.ShouldBe(400);

--- a/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
+++ b/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
@@ -200,7 +200,7 @@ public class ProjectionCoordinatorBaseTests
         await WaitFor(() => daemon.Started.Contains(TheShard.Identity));
 
         // Let several more leadership cycles run.
-        await Task.Delay(250);
+        await Task.Delay(250, TestContext.Current.CancellationToken);
 
         await coordinator.StopAsync(CancellationToken.None);
 
@@ -234,7 +234,7 @@ public class ProjectionCoordinatorBaseTests
         await WaitFor(() => distributor.AttainAttempts >= 1);
 
         // Give a re-polling loop ample opportunity to fire again (poll time is 10ms).
-        await Task.Delay(250);
+        await Task.Delay(250, TestContext.Current.CancellationToken);
         distributor.AttainAttempts.ShouldBe(1);
 
         // No agents were started against the dead data source.

--- a/src/EventTests/Daemon/ShardStateTrackerTests.cs
+++ b/src/EventTests/Daemon/ShardStateTrackerTests.cs
@@ -533,7 +533,7 @@ public class ShardStateTrackerTests : IDisposable
             {
                 ready.Wait();
                 await tracker.PublishAsync(new ShardState("Trip:All", 45) { AgentStatus = "Running" });
-            });
+            }, TestContext.Current.CancellationToken);
 
             ready.Set();
 

--- a/src/EventTests/Daemon/StopAndDrainTimeoutTests.cs
+++ b/src/EventTests/Daemon/StopAndDrainTimeoutTests.cs
@@ -53,11 +53,11 @@ public class StopAndDrainTimeoutTests
         // Well past the old 5s bound would be unreasonable in a test; what matters is that the drain
         // owns the decision to finish. Hold it long enough that an immediate/short bound would have
         // fired, then let it complete normally.
-        await Task.Delay(750);
+        await Task.Delay(750, TestContext.Current.CancellationToken);
         drain.Token.IsCancellationRequested.ShouldBeFalse();
         drain.Release();
 
-        await stop.WaitAsync(TestTimeout);
+        await stop.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Execution.DrainCompletedUncancelled.ShouldBeTrue();
         harness.Daemon.CurrentAgents().ShouldBeEmpty();
@@ -77,7 +77,7 @@ public class StopAndDrainTimeoutTests
         var stop = harness.Daemon.StopAgentAsync("Trip:All");
 
         // The execution parks on the token, so only the configured bound can release it.
-        await stop.WaitAsync(TestTimeout);
+        await stop.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
         stopwatch.Stop();
 
         harness.Execution.LastDrainToken!.Value.IsCancellationRequested.ShouldBeTrue();
@@ -95,7 +95,7 @@ public class StopAndDrainTimeoutTests
         await harness.Daemon.StartAgentAsync("Trip:All", CancellationToken.None);
 
         var stopwatch = Stopwatch.StartNew();
-        await harness.Daemon.StopAllAsync().WaitAsync(TestTimeout);
+        await harness.Daemon.StopAllAsync().WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
         stopwatch.Stop();
 
         harness.Execution.LastDrainToken!.Value.IsCancellationRequested.ShouldBeTrue();
@@ -122,11 +122,11 @@ public class StopAndDrainTimeoutTests
         var stop = harness.Daemon.StopAgentAsync("Trip:All");
         var drain = await harness.Execution.NextDrainAsync();
 
-        await Task.Delay(500);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
         drain.Token.IsCancellationRequested.ShouldBeFalse();
         drain.Release();
 
-        await stop.WaitAsync(TestTimeout);
+        await stop.WaitAsync(TestTimeout, TestContext.Current.CancellationToken);
 
         harness.Execution.DrainCompletedUncancelled.ShouldBeTrue();
     }

--- a/src/EventTests/Daemon/StoreUriStampingObserverTests.cs
+++ b/src/EventTests/Daemon/StoreUriStampingObserverTests.cs
@@ -62,7 +62,7 @@ public class StoreUriStampingObserverTests
     }
 
     [Fact]
-    public void subscribe_with_store_uri_stamp_routes_through_tracker_and_stamps()
+    public async Task subscribe_with_store_uri_stamp_routes_through_tracker_and_stamps()
     {
         var tracker = new ShardStateTracker(new NulloLogger());
         var inner = new RecordingObserver();
@@ -75,9 +75,8 @@ public class StoreUriStampingObserverTests
 
         // Publish through the real Tracker; the stamper should run before
         // `inner` sees the state.
-        var task = tracker.PublishAsync(new ShardState("Trip:V1:All", 7)).AsTask();
-        task.Wait();
-        tracker.Complete().Wait();
+        await tracker.PublishAsync(new ShardState("Trip:V1:All", 7));
+        await tracker.Complete();
 
         inner.States.ShouldHaveSingleItem();
         inner.States[0].StoreUri.ShouldBe("marten://itarievenstore",
@@ -87,7 +86,7 @@ public class StoreUriStampingObserverTests
     }
 
     [Fact]
-    public void subscribe_with_store_uri_stamp_falls_back_to_direct_subscription_when_daemon_has_no_uri()
+    public async Task subscribe_with_store_uri_stamp_falls_back_to_direct_subscription_when_daemon_has_no_uri()
     {
         // Test scaffolding / very old client: StoreUri is null. The extension
         // should still hook the observer up so legacy callers don't lose
@@ -101,8 +100,8 @@ public class StoreUriStampingObserverTests
 
         using var subscription = daemon.SubscribeWithStoreUriStamp(inner);
 
-        tracker.PublishAsync(new ShardState("Trip:V1:All", 7)).AsTask().Wait();
-        tracker.Complete().Wait();
+        await tracker.PublishAsync(new ShardState("Trip:V1:All", 7));
+        await tracker.Complete();
 
         inner.States.ShouldHaveSingleItem();
         inner.States[0].StoreUri.ShouldBeNull();

--- a/src/EventTests/Daemon/SubscriptionAgent_optimized_rebuild_no_deadlock.cs
+++ b/src/EventTests/Daemon/SubscriptionAgent_optimized_rebuild_no_deadlock.cs
@@ -53,7 +53,7 @@ public class SubscriptionAgent_optimized_rebuild_no_deadlock
         var deadline = DateTimeOffset.UtcNow.AddSeconds(15);
         while (agent.LastCommitted < PageCount && DateTimeOffset.UtcNow < deadline)
         {
-            await Task.Delay(25);
+            await Task.Delay(25, TestContext.Current.CancellationToken);
         }
 
         agent.LastCommitted.ShouldBe(PageCount);

--- a/src/EventTests/EventExtensionsTests.cs
+++ b/src/EventTests/EventExtensionsTests.cs
@@ -14,7 +14,7 @@ public class EventExtensionsTests
     [InlineData(typeof(IEvent<AEvent>), typeof(AEvent))]
     [InlineData(typeof(Event<AEvent>), typeof(AEvent))]
     [InlineData(typeof(IEvent), null)]
-    public void unwrap_event_type(Type rawType, Type expectedType)
+    public void unwrap_event_type(Type rawType, Type? expectedType)
     {
         rawType.UnwrapEventType().ShouldBe(expectedType);
     }
@@ -57,11 +57,14 @@ public class EventExtensionsTests
         eventTypeFor(x => x.UseEventWrapperConcrete2(null, null)).ShouldBe(typeof(AEvent));
     }
     
-    public void UseConcreteEventType(AEvent e, MyAggregate aggregate){}
-    public void UseConcreteEventType2(MyAggregate aggregate, AEvent e){}
-    public void UseConcreteEventType3(MyAggregate aggregate, AEvent e, IEvent metadata){}
-    public void UseInterfaceEventType(ITabulator e, MyAggregate aggregate){}
-    
-    public void UseEventWrapperConcrete(IEvent<AEvent> e, MyAggregate aggregate){}
-    public void UseEventWrapperConcrete2(IEvent<AEvent> e, MyAggregate aggregate){}
+    // Reflection targets for get_event_type_from_method, not tests. Private keeps them out of
+    // xUnit1013's sights; the expression trees above still bind them because they are built inside
+    // this class, and GetEventType only reads the parameter list.
+    private void UseConcreteEventType(AEvent e, MyAggregate aggregate){}
+    private void UseConcreteEventType2(MyAggregate aggregate, AEvent e){}
+    private void UseConcreteEventType3(MyAggregate aggregate, AEvent e, IEvent metadata){}
+    private void UseInterfaceEventType(ITabulator e, MyAggregate aggregate){}
+
+    private void UseEventWrapperConcrete(IEvent<AEvent> e, MyAggregate aggregate){}
+    private void UseEventWrapperConcrete2(IEvent<AEvent> e, MyAggregate aggregate){}
 }

--- a/src/EventTests/Projections/AggregateVersioningTests.cs
+++ b/src/EventTests/Projections/AggregateVersioningTests.cs
@@ -19,7 +19,7 @@ public class AggregateVersioningTests
     [InlineData(typeof(ConventionalVersionedAggregate6), "VersionOverride")]
     [InlineData(typeof(ConventionalVersionedAggregate6Field), "VersionOverride")]
     [InlineData(typeof(ConventionalVersionedAggregate7), null)]
-    public void find_conventional_property_or_field(Type aggregateType, string expectedMemberName)
+    public void find_conventional_property_or_field(Type aggregateType, string? expectedMemberName)
     {
         var versioning =
             typeof(AggregateVersioning<,>).CloseAndBuildAs<IAggregateVersioning>(
@@ -69,7 +69,11 @@ public class AggregateVersioningTests
         var aggregate = Activator.CreateInstance(aggregateType);
         versioning.TrySetVersion(aggregate, e);
 
-
+        // xUnit1026 flagged 'expected' as unused, and it was: this theory ran ten cases and
+        // asserted nothing at all, so it only ever proved TrySetVersion() doesn't throw. The
+        // assertion below is what the InlineData was always describing -- SingleStream versioning
+        // takes the event's Version, MultiStream takes its Sequence.
+        versioning.GetVersion(aggregate).ShouldBe(expected);
     }
 }
 

--- a/src/EventTests/Projections/SingleStreamProjectionTests.cs
+++ b/src/EventTests/Projections/SingleStreamProjectionTests.cs
@@ -19,7 +19,11 @@ public class SingleStreamProjectionTests
     [InlineData("Overrides EnrichEventsAsync with conventional Apply", typeof(OverridesEnrichEventsAsyncWithConventionalApply))]
     public void validation_is_good_with_only_conventional_methods(string explanation, Type type)
     {
-        Activator.CreateInstance(type).As<ProjectionBase>().AssembleAndAssertValidity();
+        // 'explanation' names the case; xUnit1026 flagged it as unused. Feeding it to Should.NotThrow
+        // keeps it as the label it was always meant to be, and now it shows up in the failure message.
+        Should.NotThrow(
+            () => Activator.CreateInstance(type).As<ProjectionBase>().AssembleAndAssertValidity(),
+            explanation);
     }
 
     // Regression for #298: tryUseAssemblyRegisteredEvolver was short-circuiting on

--- a/src/EventTests/Projections/SliceGroupTests.cs
+++ b/src/EventTests/Projections/SliceGroupTests.cs
@@ -457,7 +457,7 @@ public class SliceGroupTests : IProjectionStorage<User, string>, IStorageOperati
                 }
 
                 return Task.CompletedTask;
-            });
+            }, TestContext.Current.CancellationToken);
 
         theGroup.Slices[id1].Events().OfType<IEvent<AssignedToUser>>().Single().Data.User.UserName.ShouldBe("Bill");
         theGroup.Slices[id2].Events().OfType<IEvent<AssignedToUser>>().Single().Data.User.UserName.ShouldBe("Tom");

--- a/src/EventTests/event_parameter_naming_convention.cs
+++ b/src/EventTests/event_parameter_naming_convention.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JasperFx.Events.Projections;
 using Shouldly;
 using Xunit;
@@ -12,9 +13,11 @@ public class event_parameter_naming_convention
 
     // Two concrete candidate parameters, so the event cannot be inferred by type
     // alone. The conventional event parameter name decides which one is the event.
-    public void by_event_name(Helper helper, FooEvent @event) { }
-    public void by_e_name(Helper helper, FooEvent e) { }
-    public void by_ev_name(Helper helper, FooEvent ev) { }
+    // Private so they aren't mistaken for un-attributed tests (xUnit1013); the lookup
+    // below passes the matching BindingFlags.
+    private void by_event_name(Helper helper, FooEvent @event) { }
+    private void by_e_name(Helper helper, FooEvent e) { }
+    private void by_ev_name(Helper helper, FooEvent ev) { }
 
     [Theory]
     [InlineData(nameof(by_event_name))]
@@ -22,7 +25,7 @@ public class event_parameter_naming_convention
     [InlineData(nameof(by_ev_name))]
     public void conventional_event_parameter_names_disambiguate(string methodName)
     {
-        var method = GetType().GetMethod(methodName)!;
+        var method = GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)!;
         method.GetEventType(null).ShouldBe(typeof(FooEvent));
     }
 }

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -1174,7 +1174,7 @@ public class MyAggregate
     public void Apply(NewEvent e) { Count++; }
 }
 ";
-        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, cancellationToken: TestContext.Current.CancellationToken);
 
         var references = new List<MetadataReference>
         {
@@ -1194,7 +1194,7 @@ public class MyAggregate
 
         var generator = new AggregateEvolverGenerator();
         GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
-        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _, TestContext.Current.CancellationToken);
 
         // Generated trees are everything in the output compilation except the input source
         var generatedTrees = outputCompilation.SyntaxTrees.Where(t => t != syntaxTree).ToHashSet();
@@ -1205,7 +1205,7 @@ public class MyAggregate
             .ShouldBeTrue();
 
         // And no obsolete-usage diagnostic may originate from the generated code
-        var obsoleteFromGenerated = outputCompilation.GetDiagnostics()
+        var obsoleteFromGenerated = outputCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(d => d.Id is "CS0618" or "CS0612")
             .Where(d => d.Location.SourceTree != null && generatedTrees.Contains(d.Location.SourceTree!))
             .ToList();
@@ -1260,7 +1260,7 @@ public class Tally
 }
 ";
 
-        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, cancellationToken: TestContext.Current.CancellationToken);
 
         var references = new List<MetadataReference>
         {
@@ -1281,9 +1281,9 @@ public class Tally
         // Two instances of the same generator == the analyzer bundled in two referenced packages.
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             new AggregateEvolverGenerator(), new AggregateEvolverGenerator());
-        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _, TestContext.Current.CancellationToken);
 
-        var collisionErrors = outputCompilation.GetDiagnostics()
+        var collisionErrors = outputCompilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(d => d.Severity == DiagnosticSeverity.Error && d.Id is "CS0111" or "CS0101" or "CS0102")
             .Select(d => $"{d.Id}: {d.GetMessage()}")
             .ToArray();


### PR DESCRIPTION
Closes #582

## The 504 is really 129

Parsing the build log by unique `(rule, file, line, col)` shows the 504 warnings come from **129 distinct source locations** — the rest is per-TFM (`net9.0`/`net10.0`) and per-node duplication. That changed the plan: 129 is small enough to fix every one by hand, so **nothing is suppressed wholesale** and there is no blanket `NoWarn`.

| Rule | Locations | What was done |
|---|---:|---|
| xUnit1051 | 89 | `TestContext.Current.CancellationToken` threaded through |
| xUnit1013 | 26 | Triaged individually — see below |
| xUnit1012 | 8 | Theory parameters made nullable |
| xUnit1031 | 4 | Two sync tests converted to async |
| xUnit1026 | 2 | One was a real gap — see below |

## xUnit1013 was worth the hand triage

The issue predicted actual bugs could hide here. Two did:

**`ProjectionRebuildSelectionTests` implemented `IProjectionHost` on itself.** Interface members have to be public, so all four read as un-attributed test methods — the exact self-stub shape that broke all 16 `SliceGroupTests` in #577, where a self-stubbed `IAsyncDisposable.DisposeAsync` ran as test lifecycle instead of as a stub. Extracted to a `RecordingProjectionHost` class, which removes the warnings and the footgun together.

**`RetryBlockTests.retry_within_threshold` was a commented-out `//[Fact]`** — a test that had silently ceased to exist. Now `[Fact(Skip = "Unreliable in CI - timing sensitive under load")]`, so it shows up as skipped on every run instead of vanishing. This is the one intentional baseline change: CoreTests reports **476 total, 475 passed, 1 skipped**.

The rest were benign but fixed properly rather than suppressed:

- **Documentation samples** on test classes (`ResourceHostExtensionsTests`, `UsingSourceWriter`) moved to sibling non-test classes. Deliberately *not* made private — `sample_programmatically_control_resources` includes its own method signature inside the `#region`, so reducing visibility would have changed published docs. Moving keeps the snippet text byte-for-byte identical.
- **Reflection targets** (`EventExtensionsTests` ×2, `event_parameter_naming_convention`) made private, with `BindingFlags.Instance | BindingFlags.NonPublic` added where the lookup needed it. The expression-tree lookups bind private methods fine from inside the class.

## xUnit1026 found a test asserting nothing

`AggregateVersioningTests.set_version_single_stream_on_internal` ran **ten** `InlineData` cases and had an empty body after `TrySetVersion` — no assertion at all. `expected` was unused because the assertion was never written. It only ever proved `TrySetVersion()` doesn't throw.

```diff
 versioning.TrySetVersion(aggregate, e);
-
-
+ versioning.GetVersion(aggregate).ShouldBe(expected);
```

It passes — the behavior was right, the test just wasn't checking it.

## xUnit1031

`StoreUriStampingObserverTests` had two sync tests calling `.Wait()` on tasks. Both are now `async Task` with `await`.

## xUnit1051 — one documented exception

All 89 got the token threaded through, except one where the analyzer's advice is wrong:

```csharp
// SetCanceled(CancellationToken) records which token DID cancel the task; it does not
// observe one. Passing the test's (uncancelled) token would assert something false.
#pragma warning disable xUnit1051
tcs.SetCanceled();
#pragma warning restore xUnit1051
```

## Verification

```
Clean rebuild:  504 xunit warnings  ->  0
CS warnings:    1920                ->  1920   (unchanged)
```

The CS count is the check that matters — no warnings were traded for others, and no nullable-annotation changes leaked new ones.

| Suite | Result | #581 baseline |
|---|---|---|
| CoreTests | 475 passed, 1 skipped | 475 |
| CodegenTests | 419 | 419 |
| CommandLineTests | 295 | 295 |
| EventTests | 648 | 648 |
| EventStoreTests | 72 | 72 |
| CodegenTests.FSharp | 1 | 1 |
| JasperFx.SourceGenerator.Tests | 19 | 19 |
| JasperFx.Events.SourceGenerator.Tests | 26 | 26 |

CoreTests and EventTests also verified green on `net10.0`.

## Not included

I did not add `WarningsAsErrors` for these rules to stop them creeping back — that changes your build's failure behavior and wasn't part of the ask. Happy to add it if you want the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)