### PR TITLE
Cancel and drain the old runner in ProjectionCoordinatorBase.StartAsync (#592)

### DIFF
--- a/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
+++ b/src/EventTests/Daemon/ProjectionCoordinatorBaseTests.cs
@@ -357,6 +357,86 @@ public class ProjectionCoordinatorBaseTests
         logger.Debugs.ShouldContain(x => x.Contains("already disposed"));
     }
 
+    // ---- #592: a second StartAsync must not orphan the previous leadership loop ----
+    //
+    // StartAsync used to do `_cancellation?.SafeDispose()` and build a fresh source + runner.
+    // Disposing a CancellationTokenSource does NOT cancel it, and _runner was overwritten, so the
+    // previous executeAsync kept polling forever over a task no drainRunner would ever await.
+    // ResumeAsync is StartAsync, so any resume that was not preceded by PauseAsync leaked a loop
+    // that outlived StopAsync — re-attaining leadership after ReleaseAllLocks, and stranding the
+    // advisory-lock handle it won after that lock had been disposed (JasperFx/weasel#396,
+    // JasperFx/marten#5090).
+
+    [Fact]
+    public async Task a_second_start_does_not_leave_an_orphaned_leadership_loop()
+    {
+        var set = new FakeProjectionSet("db1", [TheShard], 100);
+        var daemon = new FakeDaemon();
+        // Never "already held", always attainable => every poll calls TryAttainLockAsync, so
+        // AttainAttempts is a direct liveness counter for the loop.
+        var distributor = new FakeDistributor([set]);
+
+        var coordinator = BuildCoordinator(distributor, daemon, TimeSpan.FromMilliseconds(10));
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => distributor.AttainAttempts >= 1);
+
+        // The orphaning call: resume with no PauseAsync in between.
+        await coordinator.ResumeAsync();
+        var afterResume = distributor.AttainAttempts;
+        await WaitFor(() => distributor.AttainAttempts > afterResume);
+
+        await coordinator.StopAsync(CancellationToken.None);
+
+        // Nothing may poll after the coordinator has stopped and released its locks.
+        var afterStop = distributor.AttainAttempts;
+        await Task.Delay(250, TestContext.Current.CancellationToken);
+        distributor.AttainAttempts.ShouldBe(afterStop);
+    }
+
+    [Fact]
+    public async Task pause_then_resume_still_restarts_the_leadership_loop()
+    {
+        var set = new FakeProjectionSet("db1", [TheShard], 100);
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([set]);
+
+        var coordinator = BuildCoordinator(distributor, daemon, TimeSpan.FromMilliseconds(10));
+        await coordinator.StartAsync(CancellationToken.None);
+        await WaitFor(() => distributor.AttainAttempts >= 1);
+
+        await coordinator.PauseAsync();
+
+        // Paused means paused: the loop is drained, so the counter stops moving.
+        var afterPause = distributor.AttainAttempts;
+        await Task.Delay(150, TestContext.Current.CancellationToken);
+        distributor.AttainAttempts.ShouldBe(afterPause);
+
+        await coordinator.ResumeAsync();
+        await WaitFor(() => distributor.AttainAttempts > afterPause);
+        distributor.AttainAttempts.ShouldBeGreaterThan(afterPause);
+
+        await coordinator.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task repeated_start_stop_cycles_never_throw_on_a_spent_cancellation_source()
+    {
+        var daemon = new FakeDaemon();
+        var distributor = new FakeDistributor([]);
+
+        var coordinator = BuildCoordinator(distributor, daemon, TimeSpan.FromMilliseconds(10));
+
+        for (var i = 0; i < 3; i++)
+        {
+            await Should.NotThrowAsync(() => coordinator.StartAsync(CancellationToken.None));
+            await Should.NotThrowAsync(() => coordinator.StopAsync(CancellationToken.None));
+        }
+
+        // And a pause over an already-stopped coordinator is inert rather than cancelling a
+        // disposed source.
+        await Should.NotThrowAsync(() => coordinator.PauseAsync());
+    }
+
     // #352: a coordinator can be legitimately constructed but never started when the async
     // daemon is Disabled — the store's BuildDistributor returns null because there is nothing
     // to coordinate. The ctor must not reject that; the lifecycle methods must no-op cleanly.

--- a/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
+++ b/src/JasperFx.Events/Daemon/ProjectionCoordinatorBase.cs
@@ -115,33 +115,62 @@ public abstract class ProjectionCoordinatorBase : IProjectionCoordinator
     public abstract ValueTask<IReadOnlyList<IProjectionDaemon>> AllDaemonsAsync();
 
     /// <inheritdoc />
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         // No distributor means there is nothing to coordinate (e.g. a Disabled async daemon).
         // The coordinator was constructed but should never spin up its leadership loop. See #352.
         if (Distributor == null)
         {
-            return Task.CompletedTask;
+            return;
         }
 
-        _cancellation?.SafeDispose();
+        // #592: cancel AND drain any existing loop before starting another one. Disposing a
+        // CancellationTokenSource does not cancel it, so the previous StartAsync used to leave
+        // executeAsync polling forever against a token that never trips, over a task that no
+        // drainRunner would ever await. A bare ResumeAsync (no preceding PauseAsync) orphaned a
+        // live loop for the rest of the process, and that orphan then:
+        //
+        //  * re-attained the leadership lock right after StopAsync released it, so a stopped
+        //    coordinator quietly held leadership again, and
+        //  * stranded the advisory-lock handle it won after the lock's DisposeAsync had drained
+        //    (JasperFx/weasel#396) — a permanent 'idle in transaction' session that Marten's
+        //    high-water gap detection reads as a live pre-gap reserver (JasperFx/marten#5090).
+        //
+        // Draining here makes a double StartAsync equivalent to PauseAsync + StartAsync, which is
+        // what every caller already assumes.
+        await stopRunnerAsync().ConfigureAwait(false);
 
         _cancellation = new CancellationTokenSource();
         _runner = Task.Run(() => executeAsync(_cancellation.Token), _cancellation.Token);
-
-        return Task.CompletedTask;
     }
 
-    /// <inheritdoc />
-    public async Task PauseAsync()
+    // Cancel the leadership loop, wait for it to actually exit, and clear the bookkeeping so
+    // nothing can await or cancel a dead runner twice.
+    private async Task stopRunnerAsync()
     {
-        _logger.LogInformation("Pausing ProjectionCoordinator");
+        if (_cancellation == null && _runner == null) return;
+
         if (_cancellation != null)
         {
             await _cancellation.CancelAsync().ConfigureAwait(false);
         }
 
         await drainRunner().ConfigureAwait(false);
+
+        _cancellation?.SafeDispose();
+        _cancellation = null;
+        _runner = null;
+    }
+
+    /// <inheritdoc />
+    public async Task PauseAsync()
+    {
+        _logger.LogInformation("Pausing ProjectionCoordinator");
+
+        // #592: same cancel-then-drain the start path uses, so the loop is provably gone before
+        // anything downstream (StopAsync's ReleaseAllLocks) runs, and the spent source is not left
+        // behind for a later call to cancel or dispose a second time.
+        await stopRunnerAsync().ConfigureAwait(false);
 
         foreach (var daemon in ResolvedDaemons())
         {


### PR DESCRIPTION
Closes #592.

`StartAsync` disposed the previous `CancellationTokenSource` and built a fresh source + runner:

```csharp
_cancellation?.SafeDispose();   // disposes — never cancels
_cancellation = new CancellationTokenSource();
_runner = Task.Run(() => executeAsync(_cancellation.Token), _cancellation.Token);
```

Disposing a CTS does not cancel it, and `_runner` was overwritten, so the previous `executeAsync` kept polling forever over a token that never trips and a task no `drainRunner()` would ever await. `ResumeAsync()` is `StartAsync(default)`, so any resume not preceded by `PauseAsync` orphaned a live leadership loop for the rest of the process.

Two consequences, both observed:

1. The orphan re-attains the leadership advisory lock right after `StopAsync` called `ReleaseAllLocks` — a stopped coordinator quietly holding leadership again.
2. It strands the advisory-lock handle it wins after that lock's `DisposeAsync` has drained (JasperFx/weasel#396), leaving a permanent `idle in transaction` session on `pg_try_advisory_xact_lock` that Marten's high-water gap detection reads as a live pre-gap reserver — JasperFx/marten#5090.

## Change

`StartAsync` and `PauseAsync` now share one `stopRunnerAsync()`: cancel, drain, dispose the spent source, clear the bookkeeping. A double `StartAsync` becomes equivalent to `PauseAsync` + `StartAsync`, which is what every caller already assumed, and no spent source is left behind to be cancelled or disposed a second time.

`StartAsync` becomes `async Task` (it awaits the drain). The signature is unchanged.

## Tests

- `a_second_start_does_not_leave_an_orphaned_leadership_loop` — bare `ResumeAsync`, then `StopAsync`, then assert the distributor sees no further lock attempts. **Verified RED before the fix** (the only failure of the 19).
- `pause_then_resume_still_restarts_the_leadership_loop` — the drain must not break the legitimate pause/resume cycle.
- `repeated_start_stop_cycles_never_throw_on_a_spent_cancellation_source`.

Local: `ProjectionCoordinatorBaseTests` 19/19, `test-events` and `test-event-store` green on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)