### PR TITLE
Fix BatchingChannel delivering its trailing batch twice on shutdown

### DIFF
--- a/src/CoreTests/Blocks/BatchingChannelTests.cs
+++ b/src/CoreTests/Blocks/BatchingChannelTests.cs
@@ -62,6 +62,41 @@ public class BatchingChannelTests
     }
 
     [Fact]
+    public async Task the_trailing_batch_is_delivered_exactly_once_when_completion_races_the_timer()
+    {
+        // WaitForCompletionAsync used to read and post the trailing partial batch WITHOUT taking
+        // _syncLock and without clearing it, while the flush timer armed by that batch's first item was
+        // still live. When the timer fired at the same moment, TriggerBatch posted and cleared the same
+        // items the completion drain was also posting, so the batch shipped TWICE. It showed up as an
+        // intermittent CI failure of the trickle test above, on net9.0 only, with items 10-19 duplicated.
+        //
+        // The race is timing-dependent, so this drives it repeatedly with Complete() landing right on
+        // top of the timer's deadline. Any duplicate at all is a failure — this asserts exactly-once,
+        // not merely "everything arrived".
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            var (channel, batches, _) = channelWithCapture(20.Milliseconds(), 100);
+
+            for (var i = 0; i < 5; i++)
+            {
+                channel.Post(i);
+            }
+
+            // Land the completion drain in the timer's window rather than safely before or after it.
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+
+            channel.Complete();
+            await channel.WaitForCompletionAsync();
+
+            lock (batches)
+            {
+                batches.SelectMany(x => x).OrderBy(x => x)
+                    .ShouldBe(Enumerable.Range(0, 5), $"attempt {attempt} delivered a duplicated batch");
+            }
+        }
+    }
+
+    [Fact]
     public async Task lone_item_flushes_after_the_timeout()
     {
         var (channel, batches, firstBatch) = channelWithCapture(100.Milliseconds(), 100);

--- a/src/JasperFx/Blocks/BatchingChannel.cs
+++ b/src/JasperFx/Blocks/BatchingChannel.cs
@@ -117,11 +117,32 @@ public class BatchingChannel<T> : BlockBase<T>
     public override async Task WaitForCompletionAsync()
     {
         await _inner.WaitForCompletionAsync();
-        // ReSharper disable once InconsistentlySynchronizedField
-        if (_current.Any())
+
+        // The trailing partial batch has to be drained under _syncLock, and the timer disarmed, or the
+        // same items can be delivered TWICE on shutdown: this method used to read and post _current
+        // unsynchronized and never clear it, while the flush timer armed by that batch's first item was
+        // still live. A timer firing concurrently ran TriggerBatch, which posts AND clears, so both paths
+        // shipped the same items. Reproduced as a duplicated trailing batch under a steady trickle
+        // (BatchingChannelTests.steady_trickle_faster_than_the_timeout_still_flushes_within_the_max_age).
+        // Disarming first also closes the window where the timer fires after this drain. A callback
+        // already parked on the lock is harmless — whichever side wins clears _current, and the other
+        // then sees it empty.
+        T[]? trailing = null;
+        lock (_syncLock)
         {
-            // ReSharper disable once InconsistentlySynchronizedField
-            await _downstream.PostAsync(_current.ToArray());
+            disarmTimer();
+
+            if (_current.Count > 0)
+            {
+                trailing = _current.ToArray();
+                _current.Clear();
+            }
+        }
+
+        // Deliberately outside the lock — _syncLock guards the buffer, never a downstream await.
+        if (trailing != null)
+        {
+            await _downstream.PostAsync(trailing);
         }
 
         await _downstream.WaitForCompletionAsync();


### PR DESCRIPTION
`BatchingChannel.WaitForCompletionAsync` read and posted the trailing partial batch **without taking `_syncLock`**, and never cleared `_current` afterward — while the flush timer armed by that batch's first item was still live. A timer firing at the same moment ran `TriggerBatch`, which posts *and* clears, so both paths shipped the same items and the downstream block saw the batch twice.

### How it surfaced

As the intermittent `test-core` failure that has been reddening unrelated PRs — most recently #591, which is otherwise green and has nothing to do with this code:

```
BatchingChannelTests.steady_trickle_faster_than_the_timeout_still_flushes_within_the_max_age (net9.0)
  [0, 1, ..., 9, 10, 10, 11, 11, 12, 12, ... 19, 19]
    should be
  [0, 1, ..., 19]
```

The values are **duplicated**, not missing or late — which is what identifies this as real double delivery rather than a timing-sensitive assertion. net10.0 passed in the same run; the race just lands differently there.

### The fix

The drain now happens under `_syncLock`, disarms the timer *first*, and clears `_current`, so exactly one of the two paths can ship any given item. A timer callback already parked on the lock is harmless — whichever side wins clears the buffer and the other sees it empty. The downstream post stays outside the lock: `_syncLock` guards the buffer, never an `await`.

### Tests

`the_trailing_batch_is_delivered_exactly_once_when_completion_races_the_timer` drives `Complete()` into the timer's window 50 times over and asserts exactly-once delivery. Verified in both directions: it fails at ~attempt 23 against the old code and passes against the new. Full `CoreTests` green on net9.0 and net10.0 locally.

### Worth noting

This is a **product bug on the sender-batching path**, not only a test fix — any `BatchingChannel` shutdown with a partial batch pending could double-deliver downstream. Wolverine's batched senders sit on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)