### PR TITLE
fix: never adopt a test runner as the application assembly (#600)

### DIFF
--- a/jasperfx.slnx
+++ b/jasperfx.slnx
@@ -40,6 +40,7 @@
     <Project Path="src/Widgets3/Widgets3.csproj" />
     <Project Path="src/Widgets4/Widgets4.csproj" />
     <Project Path="src/Widgets5/Widgets5.csproj" />
+    <Project Path="src/TestRunnerStandIn/TestRunnerStandIn.csproj" />
   </Folder>
   <Project Path="build/Build.csproj">
     <Build Project="false" />

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -27,6 +27,7 @@
         <ProjectReference Include="..\Widgets4\Widgets4.csproj" />
         <ProjectReference Include="..\FSharpTypes\FSharpTypes.fsproj" />
         <ProjectReference Include="..\Widgets5\Widgets5.csproj" />
+        <ProjectReference Include="..\TestRunnerStandIn\TestRunnerStandIn.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -337,4 +337,62 @@ public class JasperFxOptionsTests
         options.RegistrationCallingAssembly.ShouldBe(GetType().Assembly);
         options.ApplicationAssemblyReuseWarning.ShouldBeNull();
     }
+
+    // GH-600: DetermineCallingAssembly walks out from JasperFx to the first frame that isn't System*,
+    // Microsoft* or a test runner. Under an async fixture the intervening frames belong to the runner, so
+    // without the runner filter the walk adopts something like "xunit.v3.core" and every consumer scans an
+    // assembly containing none of the suite's types.
+
+    [Theory]
+    [InlineData("xunit.v3.core")]
+    [InlineData("xunit.execution.dotnet")]
+    [InlineData("xunit.runner.utility.netcoreapp10")]
+    [InlineData("nunit.framework")]
+    [InlineData("NUnit3.TestAdapter")]
+    [InlineData("TUnit.Engine")]
+    [InlineData("MSTest.TestAdapter")]
+    [InlineData("testhost")]
+    [InlineData("ReSharperTestRunner64")]
+    [InlineData("JetBrains.ReSharper.TestRunner.Merged")]
+    [InlineData("NCrunch.TestHost")]
+    public void recognizes_test_runner_assemblies(string assemblyName)
+    {
+        JasperFxOptions.IsTestRunnerAssembly(assemblyName).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("CoreTests")]
+    [InlineData("MyApp")]
+    [InlineData("MyApp.Tests")]
+    [InlineData("Wolverine")]
+    [InlineData("Marten")]
+    // Guard against over-eager prefixes: an ordinary application assembly must never be mistaken for a
+    // runner just because its name happens to start with a runner-ish word.
+    [InlineData("JetBrainsFanClub")]
+    [InlineData("NCrunchyGranola")]
+    public void does_not_mistake_application_assemblies_for_test_runners(string assemblyName)
+    {
+        JasperFxOptions.IsTestRunnerAssembly(assemblyName).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void walks_past_a_test_runner_frame_out_to_the_test_assembly()
+    {
+        // RunnerFrame lives in an assembly named "xunit.v3.stackwalk.standin", so calling through it puts
+        // a runner-named frame between JasperFx and this test -- the layout an async test fixture produces
+        // for real, where the frames above JasperFx belong to the runner rather than the test assembly.
+        // Before the fix the walk stopped on that frame and adopted the runner.
+        var assembly = TestRunnerStandIn.RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
+
+        assembly.ShouldBe(GetType().Assembly);
+    }
+
+    [Fact]
+    public void never_adopts_a_test_runner_as_the_calling_assembly()
+    {
+        var assembly = TestRunnerStandIn.RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
+
+        assembly.ShouldNotBeNull();
+        JasperFxOptions.IsTestRunnerAssembly(assembly.GetName().Name!).ShouldBeFalse();
+    }
 }

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -240,7 +240,8 @@ public class JasperFxOptions : SystemPartBase
                 continue;
             }
 
-            if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft") || assemblyName.StartsWith("ReSharperTestRunner"))
+            if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft") ||
+                IsTestRunnerAssembly(assemblyName))
             {
                 continue;
             }
@@ -249,6 +250,27 @@ public class JasperFxOptions : SystemPartBase
         }
 
         return Assembly.GetEntryAssembly();
+    }
+
+    // GH-600: under an async test fixture the frames between JasperFx and the test class belong to the
+    // test *runner*, not the test assembly, so the walk above would otherwise adopt something like
+    // "xunit.v3.core" as the application assembly and every consumer would scan an assembly holding none
+    // of the suite's types. The symptom is entirely downstream (a handler/document/projection type simply
+    // not being discovered) and it is intermittent rather than consistently wrong, because a stack walk
+    // over async continuations is sensitive to frame layout. Skipping the runner lets the walk continue
+    // out to the test assembly; where nothing else matches, the Assembly.GetEntryAssembly() fallback is
+    // the test assembly anyway. "ReSharperTestRunner" was here first -- this class of problem was already
+    // known, xUnit and friends were simply never added.
+    internal static bool IsTestRunnerAssembly(string assemblyName)
+    {
+        return assemblyName.StartsWith("xunit", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("nunit", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("TUnit", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("MSTest", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("testhost", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("ReSharperTestRunner", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("JetBrains.", StringComparison.OrdinalIgnoreCase)
+               || assemblyName.StartsWith("NCrunch.", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/TestRunnerStandIn/RunnerFrame.cs
+++ b/src/TestRunnerStandIn/RunnerFrame.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+
+namespace TestRunnerStandIn;
+
+/// <summary>
+/// Stands in for a real test runner (xUnit, NUnit, ...) in the one respect that matters to
+/// <c>JasperFxOptions.DetermineCallingAssembly</c>: it puts a frame from a runner-named assembly between
+/// JasperFx and the test assembly, the way an async test fixture's runner frames do. See GH-600.
+/// </summary>
+public static class RunnerFrame
+{
+    /// <summary>
+    /// Invokes <paramref name="action" /> so that this assembly -- named "xunit.v3.stackwalk.standin" --
+    /// owns the calling frame. Pass a method group rather than a lambda: a lambda's closure method belongs
+    /// to the caller's assembly and would put the caller straight back on top of the stack.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static T Invoke<T>(Func<T> action)
+    {
+        var result = action();
+
+        // Keeps the JIT from turning the call above into a tail call, which would drop this frame and
+        // defeat the whole point of the stand-in.
+        GC.KeepAlive(action);
+
+        return result;
+    }
+}

--- a/src/TestRunnerStandIn/TestRunnerStandIn.csproj
+++ b/src/TestRunnerStandIn/TestRunnerStandIn.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <!-- GH-600: the point of this project is its assembly NAME. DetermineCallingAssembly walks the
+             stack out of JasperFx and adopts the first frame that isn't System*/Microsoft*/a test runner,
+             and the bug was that a real runner ("xunit.v3.core") satisfied that filter. Reproducing the
+             frame layout deterministically means having a frame whose assembly is named like a runner
+             sitting between JasperFx and the test assembly, which is exactly what this stand-in is. -->
+        <AssemblyName>xunit.v3.stackwalk.standin</AssemblyName>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #600.

## The defect

`JasperFxOptions.DetermineCallingAssembly()` walks out of JasperFx to the first frame that isn't `System*` / `Microsoft*` / `ReSharperTestRunner*`. Under an **async test fixture** the frames between JasperFx and the test class belong to the test *runner*, so `xunit.v3.core` satisfies that filter and is returned. Every consumer that uses `JasperFxOptions.ApplicationAssembly` for type discovery then scans an assembly containing none of the suite's types.

The `ReSharperTestRunner` entry shows this class of problem was already known — xUnit and friends were simply never added. The `HasReferenceToJasperFxTool(Assembly.GetEntryAssembly())` short-circuit above the walk doesn't save you either: it returns `False` for an ordinary test project, so the stack walk always runs.

Root cause of JasperFx/wolverine#3776. Wolverine has been defended at its own boundary; Marten and Polecat hosts have the same exposure.

## The fix

Extend the skip list to the common runners, factored into `JasperFxOptions.IsTestRunnerAssembly`:

`xunit` · `nunit` · `TUnit` · `MSTest` · `testhost` · `ReSharperTestRunner` · `JetBrains.` · `NCrunch.`

Skipping the runner lets the walk continue out to the test assembly; where nothing else matches, the existing `Assembly.GetEntryAssembly()` fallback is the test assembly anyway.

## The regression test

The check the issue asks for needs a runner frame to actually be *on the stack*, which a direct call from a test method never produces — I confirmed a naive `await Task.Yield()` + direct-call test passes on the unfixed code, so it would not have caught this.

`src/TestRunnerStandIn` is a tiny project whose only purpose is its assembly name — `xunit.v3.stackwalk.standin`. Calling `DetermineCallingAssembly` through it reproduces the layout deterministically:

```
JasperFx                        DetermineCallingAssembly   <- anchor
xunit.v3.stackwalk.standin      RunnerFrame.Invoke         <- was adopted; now skipped
CoreTests                       the test method            <- correct answer
```

Verified both directions: `walks_past_a_test_runner_frame_out_to_the_test_assembly` and `never_adopts_a_test_runner_as_the_calling_assembly` **fail** against the old walk and pass against the new one. Full `CoreTests` suite green (517 passed, 1 skipped).

## Note, not fixed here

`JasperFx.Core.TypeScanning.CallingAssembly.Find()` — used by `AssemblyScanner.TheCallingAssembly()` — has the same defect (it only ignores `System.` / `Microsoft.` prefixes). Left alone deliberately: different API, different consumers, and out of scope for #600. Happy to fold it in or file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)