### PR TITLE
fix: make DatabaseId's escaping survive a System.Uri round trip (#599)

### DIFF
--- a/src/CoreTests/Descriptors/DatabaseIdTests.cs
+++ b/src/CoreTests/Descriptors/DatabaseIdTests.cs
@@ -109,7 +109,7 @@ public class DatabaseIdTests
     {
         var id = new DatabaseId("server.with.dots", "name.with.dots");
 
-        id.ToString().ShouldBe("server%2Ewith%2Edots.name%2Ewith%2Edots");
+        id.ToString().ShouldBe("server!with!dots.name!with!dots");
         DatabaseId.Parse(id.ToString()).ShouldBe(id);
     }
 
@@ -119,5 +119,78 @@ public class DatabaseIdTests
         var id = new DatabaseId("server%2Ename", "db%25name");
 
         DatabaseId.Parse(id.ToString()).ShouldBe(id);
+    }
+
+    // GH-599: the escaped form's only consumer interpolates it into an agent URI and parses it back out of
+    // uri.Segments, so the escaping is worthless unless it survives System.Uri canonicalisation. "%2E"
+    // encodes '.', which is unreserved in RFC 3986, so Uri decodes it right back and the separator became
+    // ambiguous again.
+
+    [Theory]
+    [InlineData("localhost", "tenant1")]
+    [InlineData("server.with.dots", "name.with.dots")]
+    [InlineData("database-feature2.zorgdeclaraties-test.aws.topicus.healthcare", "feature2_claims2")]
+    [InlineData("/some/host", "tom")]
+    [InlineData("server%2Ename", "db%25name")]
+    [InlineData("host!with!bangs", "name!too")]
+    [InlineData("host~with~tildes", "name~too")]
+    [InlineData("localhost", "")]
+    public void survives_a_system_uri_round_trip(string server, string name)
+    {
+        var id = new DatabaseId(server, name);
+
+        var uri = new Uri($"marten://main/{id}/p/all/1");
+
+        // Uri.ToString() decodes percent-escapes; Uri.OriginalString does not. Both must agree, or the
+        // same identity reaches a client spelled two ways depending on how it travelled.
+        uri.ToString().ShouldBe(uri.OriginalString);
+        uri.AbsoluteUri.ShouldBe(uri.OriginalString);
+
+        DatabaseId.Parse(uri.Segments[1].Trim('/')).ShouldBe(id);
+    }
+
+    [Fact]
+    public void identity_and_to_string_are_the_same_spelling()
+    {
+        var id = new DatabaseId("server.with.dots", "name.with.dots");
+
+        id.Identity.ShouldBe(id.ToString());
+        DatabaseId.Parse(id.Identity).ShouldBe(id);
+    }
+
+    [Fact]
+    public void round_trips_a_literal_bang()
+    {
+        // '!' is the dot escape now, so a literal one has to be escaped in turn.
+        var id = new DatabaseId("host!name", "db!name");
+
+        id.ToString().ShouldBe("host!!name.db!!name");
+        DatabaseId.Parse(id.ToString()).ShouldBe(id);
+    }
+
+    [Fact]
+    public void round_trips_a_literal_tilde()
+    {
+        // Pre-existing hole: '~' is the slash escape but a literal '~' was never escaped, so
+        // new DatabaseId("a~b", "c") used to come back out as "a/b".
+        var id = new DatabaseId("host~name", "db~name");
+
+        DatabaseId.Parse(id.ToString()).ShouldBe(id);
+    }
+
+    [Fact]
+    public void still_parses_the_legacy_percent_2e_spelling()
+    {
+        // Agent URIs written before GH-599 are persisted; they must keep parsing.
+        var id = DatabaseId.Parse("server%2Ewith%2Edots.name%2Ewith%2Edots");
+
+        id.Server.ShouldBe("server.with.dots");
+        id.Name.ShouldBe("name.with.dots");
+    }
+
+    [Fact]
+    public void still_parses_the_legacy_tilde_as_a_slash()
+    {
+        DatabaseId.Parse("~some~host.tom").ShouldBe(new DatabaseId("/some/host", "tom"));
     }
 }

--- a/src/JasperFx/Descriptors/DatabaseId.cs
+++ b/src/JasperFx/Descriptors/DatabaseId.cs
@@ -1,8 +1,13 @@
+using System.Text;
+
 namespace JasperFx.Descriptors;
 
 public record DatabaseId(string Server, string Name)
 {
-    public string Identity => $"{Server}.{Name}";
+    // GH-599: one identity, one spelling. This used to be the unescaped "{Server}.{Name}" while ToString()
+    // produced an escaped form, so a single database reached a client spelled two ways depending on which
+    // one it travelled as, and joins between the two silently missed (see CritterWatch#878).
+    public string Identity => ToString();
 
     public static DatabaseId Parse(string text)
     {
@@ -40,19 +45,64 @@ public record DatabaseId(string Server, string Name)
         return $"{EscapeSegment(Server)}.{EscapeSegment(Name)}";
     }
 
+    // GH-599: the escaped form has to survive a System.Uri round trip, because the only consumer of it
+    // interpolates it into an agent URI (Wolverine's EventSubscriptionAgentFamily.UriFor) and parses it
+    // back out of uri.Segments. '.' is *unreserved* in RFC 3986, so Uri canonicalisation decodes "%2E"
+    // straight back to '.' -- the escaping this used to do delivered none of the disambiguation it was
+    // written for. '!' is a sub-delimiter, which Uri preserves verbatim, so it does.
+    //
+    // Order matters. '!' and '~' are the two escape characters, so a literal one has to be escaped before
+    // anything else is allowed to produce one:
+    //
+    //   %  -> %25    ("%25" survives Uri canonicalisation; only percent-encoded *unreserved* chars don't)
+    //   !  -> !!
+    //   ~  -> !~
+    //   /  -> ~      (unchanged; already survived, and existing persisted URIs use it)
+    //   .  -> !
     private static string EscapeSegment(string value)
     {
         return value
             .Replace("%", "%25", StringComparison.Ordinal)
+            .Replace("!", "!!", StringComparison.Ordinal)
+            .Replace("~", "!~", StringComparison.Ordinal)
             .Replace("/", "~", StringComparison.Ordinal)
-            .Replace(".", "%2E", StringComparison.Ordinal);
+            .Replace(".", "!", StringComparison.Ordinal);
     }
 
     private static string UnescapeSegment(string value)
     {
-        return value
+        var builder = new StringBuilder(value.Length);
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+
+            if (c == '!' && i + 1 < value.Length && (value[i + 1] == '!' || value[i + 1] == '~'))
+            {
+                builder.Append(value[i + 1]);
+                i++;
+            }
+            else if (c == '!')
+            {
+                builder.Append('.');
+            }
+            else if (c == '~')
+            {
+                // A bare '~' is '/' -- both in the current grammar and in every URI persisted before it.
+                builder.Append('/');
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+
+        // "%2E" is only ever produced by a version of this type that predates GH-599, but those spellings
+        // are persisted in agent URIs, so keep decoding them. It has to run before the "%25" pass: a value
+        // holding the literal text "%2E" is written as "%252E", which contains no "%2E" of its own and so
+        // survives this pass untouched, then decodes correctly in the next one.
+        return builder.ToString()
             .Replace("%2E", ".", StringComparison.OrdinalIgnoreCase)
-            .Replace("~", "/", StringComparison.Ordinal)
             .Replace("%25", "%", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Fixes #599.

## The defect

`DatabaseId.ToString()` escaped `.` as `%2E` so `TryParse` could find the `Server`/`Name` separator. But the only consumer of that string interpolates it into a `System.Uri` (Wolverine's `EventSubscriptionAgentFamily.UriFor`) and parses it back out of `uri.Segments` — and `.` is *unreserved* in RFC 3986, so `Uri` canonicalisation decodes `%2E` straight back to `.`.

Confirmed on .NET 10:

| input | survives `new Uri(...)`? |
|---|---|
| `%2E` | **no** — decoded to `.` |
| `%25` | yes |
| `~` | yes |
| `!` `$` `,` `;` `'` `*` `(` `)` `+` `=` | yes |

So the escaping delivered none of the disambiguation it was written for, and the separator search fell back on `LastIndexOf('.')` — right only while the database *name* holds no dots, which is why nothing failed loudly.

## The two spellings

`Uri.ToString()` decodes; `System.Text.Json` serialises a `Uri` through `OriginalString`, which does not. And `Identity` used literal dots while `ToString()` used `%2E`. One agent identity therefore reached a client spelled two ways depending on how it travelled, and joins between the two silently missed — [CritterWatch#878](https://github.com/JasperFx/CritterWatch/issues/878), where agent health rendered as "unknown".

## The fix

Escape `.` as `!` — a sub-delimiter, which `Uri` preserves verbatim.

```
new DatabaseId("server.with.dots", "name.with.dots")

  before -> server%2Ewith%2Edots.name%2Ewith%2Edots
            (Uri decodes to server.with.dots.name.with.dots -- ambiguous)

  after  -> server!with!dots.name!with!dots
            (survives the round trip verbatim)
```

Full escape alphabet, in application order — `!` and `~` are the escape characters, so a literal one is escaped before anything else can produce one:

| | |
|---|---|
| `%` → `%25` | unchanged; `%25` already survived |
| `!` → `!!` | new |
| `~` → `!~` | new |
| `/` → `~` | unchanged |
| `.` → `!` | was `%2E` |

`Identity` now returns the same escaped spelling as `ToString()`, so there is exactly one form of one identity.

Also closes a pre-existing hole: `~` was the `/` escape but a literal `~` was never escaped, so `new DatabaseId("a~b", "c")` came back out as `a/b`.

## Backwards compatibility

Persisted agent URIs keep parsing. `%2E` is still decoded on the way in (before the `%25` pass — a value holding the literal text `%2E` is written `%252E`, which contains no `%2E` of its own, so it survives that pass and decodes correctly in the next), and a bare `~` is still read as `/`.

The one thing that changes for an old value is a segment containing a literal `!`: written before this change it was left alone, and it now reads back as `.`.

## Tests

`survives_a_system_uri_round_trip` is the check that was missing — it builds an agent-shaped URI, asserts `ToString()`/`AbsoluteUri`/`OriginalString` all agree, and parses the id back out of `uri.Segments`. Verified it **fails** on the old implementation (along with `identity_and_to_string_are_the_same_spelling`, `round_trips_a_literal_bang` and `round_trips_a_literal_tilde` — 7 failures total) and passes on the new one. Full `CoreTests` suite green.

## Downstream

The CritterWatch side was already worked around by canonicalising to the decoded form; with one spelling now coming out of JasperFx that workaround can be retired. Worth a look at whether Wolverine's `EventSubscriptionAgentFamily` wants the `Segments` index revisited at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)