### PR TITLE
fix: attribute registration to the app, not the extension that registered for it (#601)

### DIFF
--- a/jasperfx.slnx
+++ b/jasperfx.slnx
@@ -41,6 +41,7 @@
     <Project Path="src/Widgets4/Widgets4.csproj" />
     <Project Path="src/Widgets5/Widgets5.csproj" />
     <Project Path="src/TestRunnerStandIn/TestRunnerStandIn.csproj" />
+    <Project Path="src/ExtensionStandIn/ExtensionStandIn.csproj" />
   </Folder>
   <Project Path="build/Build.csproj">
     <Build Project="false" />

--- a/src/CoreTests/CoreTests.csproj
+++ b/src/CoreTests/CoreTests.csproj
@@ -28,6 +28,7 @@
         <ProjectReference Include="..\FSharpTypes\FSharpTypes.fsproj" />
         <ProjectReference Include="..\Widgets5\Widgets5.csproj" />
         <ProjectReference Include="..\TestRunnerStandIn\TestRunnerStandIn.csproj" />
+        <ProjectReference Include="..\ExtensionStandIn\ExtensionStandIn.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -1,3 +1,4 @@
+using ExtensionStandIn;
 using JasperFx;
 using JasperFx.CodeGeneration;
 using JasperFx.CommandLine.Descriptions;
@@ -394,5 +395,98 @@ public class JasperFxOptionsTests
 
         assembly.ShouldNotBeNull();
         JasperFxOptions.IsTestRunnerAssembly(assembly.GetName().Name!).ShouldBeFalse();
+    }
+
+    // GH-601: UseWolverine() and AddMarten() both call services.AddJasperFx() from inside their own
+    // assembly, so the first frame outside JasperFx belongs to the extension rather than the application.
+
+    [Theory]
+    [InlineData("JasperFx")]
+    [InlineData("JasperFx.Events")]
+    [InlineData("JasperFx.RuntimeCompiler")]
+    [InlineData("Wolverine")]
+    [InlineData("Wolverine.SqlServer")]
+    [InlineData("WolverineFx.RabbitMQ")]
+    [InlineData("Marten")]
+    [InlineData("Marten.AspNetCore")]
+    [InlineData("Weasel.Postgresql")]
+    [InlineData("Polecat")]
+    [InlineData("CritterWatch.Server")]
+    [InlineData("Oakton")]
+    public void recognizes_critter_stack_framework_assemblies(string assemblyName)
+    {
+        JasperFxOptions.IsCritterStackAssembly(assemblyName).ShouldBeTrue();
+    }
+
+    [Theory]
+    // An application is not framework code just because it is named for a product. Matching is by exact
+    // name or dotted prefix, never a bare StartsWith.
+    [InlineData("MartenPlayground")]
+    [InlineData("WolverineDemo")]
+    [InlineData("JasperFxSamples")]
+    [InlineData("MyApp")]
+    [InlineData("CoreTests")]
+    // And the Critter Stack repos' own test assemblies ARE the application under test -- their handlers
+    // and documents are the types discovery has to find.
+    [InlineData("Wolverine.RabbitMQ.Tests")]
+    [InlineData("Marten.Testing")]
+    [InlineData("JasperFx.Events.Tests")]
+    public void does_not_mistake_applications_or_suites_for_framework_assemblies(string assemblyName)
+    {
+        JasperFxOptions.IsCritterStackAssembly(assemblyName).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task registration_is_attributed_to_the_app_not_the_extension_that_registered_for_it()
+    {
+        var original = JasperFxOptions.RememberedApplicationAssembly;
+        try
+        {
+            JasperFxOptions.RememberedApplicationAssembly = null;
+
+            // AddSomeCritterStackTool lives in an assembly named "Wolverine.StackWalkStandIn" and calls
+            // AddJasperFx() on our behalf, which is exactly what UseWolverine()/AddMarten() do.
+            using var host = await Host.CreateDefaultBuilder()
+                .ConfigureServices(s => s.AddSomeCritterStackTool())
+                .UseEnvironment("Development")
+                .StartAsync(TestContext.Current.CancellationToken);
+
+            var options = host.Services.GetRequiredService<JasperFxOptions>();
+
+            options.RegistrationCallingAssembly.ShouldBe(GetType().Assembly);
+
+            // ...and because registration is now attributed correctly, the GH-3521 divergence warning
+            // stays quiet on a host where nothing is actually wrong.
+            options.ApplicationAssemblyReuseWarning.ShouldBeNull();
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = original;
+        }
+    }
+
+    [Fact]
+    public void an_extension_registration_does_not_pin_the_extension_as_the_application_assembly()
+    {
+        var original = JasperFxOptions.RememberedApplicationAssembly;
+        try
+        {
+            JasperFxOptions.RememberedApplicationAssembly = null;
+
+            // No meaningful IHostEnvironment.ApplicationName here, so establishApplicationAssembly falls
+            // through to the process-wide pin that AddJasperFx seeded from the same stack walk. Before the
+            // fix that pin -- and therefore type discovery -- was the extension assembly.
+            var services = new ServiceCollection();
+            services.AddSomeCritterStackTool();
+
+            var options = services.BuildServiceProvider().GetRequiredService<JasperFxOptions>();
+
+            options.ApplicationAssembly.ShouldBe(GetType().Assembly);
+            JasperFxOptions.RememberedApplicationAssembly.ShouldBe(GetType().Assembly);
+        }
+        finally
+        {
+            JasperFxOptions.RememberedApplicationAssembly = original;
+        }
     }
 }

--- a/src/ExtensionStandIn/CritterStackExtension.cs
+++ b/src/ExtensionStandIn/CritterStackExtension.cs
@@ -1,0 +1,18 @@
+using JasperFx;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExtensionStandIn;
+
+/// <summary>
+/// Stands in for a Critter Stack extension in the one respect that matters to
+/// <c>JasperFxOptions.DetermineCallingAssembly</c>: it calls <c>AddJasperFx()</c> from inside its own
+/// assembly on the application's behalf, exactly the way <c>UseWolverine()</c> and <c>AddMarten()</c> do.
+/// This assembly is named "Wolverine.StackWalkStandIn" so the walk sees it as framework code. See GH-601.
+/// </summary>
+public static class CritterStackExtension
+{
+    public static IServiceCollection AddSomeCritterStackTool(this IServiceCollection services)
+    {
+        return services.AddJasperFx();
+    }
+}

--- a/src/ExtensionStandIn/ExtensionStandIn.csproj
+++ b/src/ExtensionStandIn/ExtensionStandIn.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <!-- GH-601: like TestRunnerStandIn, the point of this project is its assembly NAME. It stands in
+             for a Critter Stack extension that calls services.AddJasperFx() on the application's behalf,
+             which is what UseWolverine() and AddMarten() both do. -->
+        <AssemblyName>Wolverine.StackWalkStandIn</AssemblyName>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\JasperFx\JasperFx.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -241,7 +241,7 @@ public class JasperFxOptions : SystemPartBase
             }
 
             if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft") ||
-                IsTestRunnerAssembly(assemblyName))
+                IsTestRunnerAssembly(assemblyName) || IsCritterStackAssembly(assemblyName))
             {
                 continue;
             }
@@ -271,6 +271,57 @@ public class JasperFxOptions : SystemPartBase
                || assemblyName.StartsWith("ReSharperTestRunner", StringComparison.OrdinalIgnoreCase)
                || assemblyName.StartsWith("JetBrains.", StringComparison.OrdinalIgnoreCase)
                || assemblyName.StartsWith("NCrunch.", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // GH-601: a Critter Stack extension registers JasperFx on the application's behalf --
+    // UseWolverine() and AddMarten() both call services.AddJasperFx() from inside their own assembly --
+    // so the first frame outside JasperFx belongs to the EXTENSION, not the app. RegistrationCallingAssembly
+    // then stopped meaning what its name says, and checkForDivergentApplicationAssembly compared the
+    // extension against the (correctly resolved) application assembly and warned on healthy hosts. That
+    // inverts the warning's whole value: it trains readers to ignore it, and its absence stops being
+    // evidence -- on JasperFx/wolverine#3776 "zero occurrences of the warning" was explicitly recorded as
+    // grounds for ruling out an application-assembly problem, which was exactly the bug.
+    //
+    // Matched as an exact name or a dotted prefix rather than a bare StartsWith, so an application named
+    // "MartenPlayground" or "WolverineDemo" is left alone.
+    private static readonly string[] _critterStackAssemblies =
+    [
+        "JasperFx",
+        "Wolverine",
+        "WolverineFx",
+        "Marten",
+        "Weasel",
+        "Polecat",
+        "CritterWatch",
+        "Oakton"
+    ];
+
+    internal static bool IsCritterStackAssembly(string assemblyName)
+    {
+        // The test assemblies inside the Critter Stack repos themselves -- Wolverine.RabbitMQ.Tests,
+        // Marten.Testing and friends -- ARE the application as far as discovery is concerned, because the
+        // handlers and documents under test live in them. Skipping those would reintroduce GH-600's defect
+        // from the other direction.
+        if (assemblyName.EndsWith("Tests", StringComparison.OrdinalIgnoreCase)
+            || assemblyName.EndsWith("Testing", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        foreach (var name in _critterStackAssemblies)
+        {
+            if (assemblyName.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (assemblyName.StartsWith(name + ".", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #601.

> **Stacked on #602.** Both change the same walk, so this PR targets `gh600/skip-test-runner-assemblies` rather than `main`. Review #602 first; this diff is the second commit only. Retarget to `main` once #602 merges.

## The defect

Follow-up to #600 — same function, different failure mode. Where #600 was about the walk landing on a *test runner*, this is about it landing on an *intermediate Critter Stack assembly*.

`UseWolverine()` and `AddMarten()` both call `services.AddJasperFx()` from inside their own assembly (`Wolverine/HostBuilderExtensions.cs:109`, `Marten/MartenServiceCollectionExtensions.cs:210,331`), so the first frame outside JasperFx belongs to the **extension**, not the application.

## Reproduced, not taken on faith

The issue measured Wolverine's twin of this logic and noted JasperFx's own walk had not been instrumented directly. It has now. A stand-in extension assembly that calls `AddJasperFx()` on the app's behalf, in a real host:

```
RegistrationCallingAssembly = Wolverine.StackWalkStandIn   <- the extension
ApplicationAssembly         = CoreTests                    <- correct
Warning                     = FIRED                        <- on a host where nothing is wrong
```

That inverts the warning's whole value. It trains readers to ignore it, and its **absence** stops being evidence — on JasperFx/wolverine#3776, "zero occurrences of the warning in the failing logs" was explicitly recorded as grounds for ruling out an application-assembly problem, and that was exactly the bug.

## It is more than warning noise

The same stack walk seeds the process-wide `RememberedApplicationAssembly` in `AddJasperFx`. Where `IHostEnvironment.ApplicationName` is empty, `establishApplicationAssembly` falls through to that pin — so the **extension assembly became the assembly type discovery scans**. Measured on a bare `ServiceCollection`:

```
RegistrationCallingAssembly=Widgets1 | Remembered=Widgets1 | ApplicationAssembly=Widgets1 | Warning=none
```

Note `Warning=none` there: registered and adopted agree, because both are wrong the same way. The divergence check is silent in exactly the case where it is most needed.

## The fix

Skip Critter Stack framework assemblies in the walk, alongside the runners:

```csharp
if (assemblyName.StartsWith("System") || assemblyName.StartsWith("Microsoft") ||
    IsTestRunnerAssembly(assemblyName) || IsCritterStackAssembly(assemblyName))
{
    continue;
}
```

Two guards against the risk the issue flags — *"it must not skip a legitimate application assembly that happens to be named for a product"*:

1. **Exact name or dotted prefix**, never a bare `StartsWith`. `Wolverine` and `Wolverine.SqlServer` match; `WolverineDemo`, `MartenPlayground` and `JasperFxSamples` do not.
2. **Never a `*.Tests` / `*.Testing` assembly.** `Wolverine.RabbitMQ.Tests` and `Marten.Testing` ARE the application as far as discovery is concerned — their handlers and documents are the types under test. Skipping those would reintroduce #600 from the other direction.

List: `JasperFx` · `Wolverine` · `WolverineFx` · `Marten` · `Weasel` · `Polecat` · `CritterWatch` · `Oakton`.

## Tests

`src/ExtensionStandIn` is a project whose only purpose is its assembly name — `Wolverine.StackWalkStandIn` — with an extension method that calls `AddJasperFx()` on the caller's behalf. Same trick as `TestRunnerStandIn` in #602.

- `registration_is_attributed_to_the_app_not_the_extension_that_registered_for_it` — real host; asserts `RegistrationCallingAssembly` is the test assembly **and** that the divergence warning stays quiet.
- `an_extension_registration_does_not_pin_the_extension_as_the_application_assembly` — the no-`ApplicationName` path; asserts neither `ApplicationAssembly` nor the process-wide pin becomes the extension.
- Predicate theories covering the framework names, the look-alike application names, and the in-repo test suites.

Both behaviour tests **fail** without the fix and pass with it. Full `CoreTests` green (539 passed, 1 skipped).

## Not done here

The issue's option 2 — capturing the registering assembly at the outermost public entry point instead of re-deriving it from a stack walk — is the structurally better answer and is unaffected by this change. This is the version that needs no downstream work in Wolverine or Marten to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)