### PR TITLE
fix: CallingAssembly.Find could adopt a test runner too (#600)

### DIFF
--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using Shouldly;
+using RunnerFrame = xunit.v3.stackwalk.standin.RunnerFrame;
 
 namespace CoreTests;
 
@@ -383,7 +384,7 @@ public class JasperFxOptionsTests
         // a runner-named frame between JasperFx and this test -- the layout an async test fixture produces
         // for real, where the frames above JasperFx belong to the runner rather than the test assembly.
         // Before the fix the walk stopped on that frame and adopted the runner.
-        var assembly = TestRunnerStandIn.RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
+        var assembly = RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
 
         assembly.ShouldBe(GetType().Assembly);
     }
@@ -391,7 +392,7 @@ public class JasperFxOptionsTests
     [Fact]
     public void never_adopts_a_test_runner_as_the_calling_assembly()
     {
-        var assembly = TestRunnerStandIn.RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
+        var assembly = RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
 
         assembly.ShouldNotBeNull();
         JasperFxOptions.IsTestRunnerAssembly(assembly.GetName().Name!).ShouldBeFalse();

--- a/src/CoreTests/TypeScanning/CallingAssemblyTests.cs
+++ b/src/CoreTests/TypeScanning/CallingAssemblyTests.cs
@@ -1,7 +1,10 @@
+using System.Reflection;
+using JasperFx;
 using JasperFx.Core.TypeScanning;
 using Shouldly;
 using Widgets1;
 using Widgets5;
+using RunnerFrame = xunit.v3.stackwalk.standin.RunnerFrame;
 
 namespace CoreTests.TypeScanning;
 
@@ -27,5 +30,37 @@ public class CallingAssemblyTests
         // Widget4 assembly should be ignored
         Widget5CallingWidget4Caller.Calling()
             .ShouldBe(typeof(Widget5CallingWidget4Caller).Assembly);
+    }
+
+    // GH-600: AssemblyScanner.TheCallingAssembly() resolves through here, so a scan configured from an
+    // async test could adopt the runner and then scan an assembly holding none of the suite's types --
+    // the same defect fixed in JasperFxOptions.DetermineCallingAssembly, on the other stack walk.
+
+    [Fact]
+    public void walks_past_a_test_runner_frame_out_to_the_calling_assembly()
+    {
+        RunnerFrame.Invoke(CallingAssembly.Find)
+            .ShouldBe(GetType().Assembly);
+    }
+
+    [Fact]
+    public void never_adopts_a_test_runner_as_the_calling_assembly()
+    {
+        var assembly = RunnerFrame.Invoke(CallingAssembly.Find);
+
+        assembly.ShouldNotBeNull();
+        JasperFxOptions.IsTestRunnerAssembly(assembly.GetName().Name!).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void find_is_safe_to_call_concurrently()
+    {
+        // The old implementation cached failed Assembly.Load attempts in a plain static List<string> that
+        // every caller mutated, so concurrent scans raced on it.
+        var results = new Assembly?[64];
+
+        Parallel.For(0, results.Length, i => results[i] = CallingAssembly.Find());
+
+        results.ShouldAllBe(x => x != null);
     }
 }

--- a/src/JasperFx/Core/TypeScanning/CallingAssembly.cs
+++ b/src/JasperFx/Core/TypeScanning/CallingAssembly.cs
@@ -1,49 +1,44 @@
-﻿using System.Globalization;
+using System.Diagnostics;
 using System.Reflection;
-using JasperFx.Core.TypeScanning;
 
 namespace JasperFx.Core.TypeScanning;
 
 /// <summary>
 ///     Use to walk up the execution stack and "find" the assembly
-///     that originates the call. Ignores system assemblies and any
-///     assembly marked with the [IgnoreOnScanning] attribute
+///     that originates the call. Ignores system assemblies, test runner
+///     assemblies, and any assembly marked with the [IgnoreAssembly] attribute
 /// </summary>
 public class CallingAssembly
 {
     private static readonly string[] _prefixesToIgnore = { "System.", "Microsoft." };
 
-    private static readonly IList<string> _misses = new List<string>();
-
-    /// <summary>
-    ///     Method is used to get the stack trace in english
-    /// </summary>
-    /// <returns>Stack trace in english</returns>
-    private static string GetStackTraceInEnglish()
-    {
-        var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
-        Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
-        var trace = System.Environment.StackTrace;
-        Thread.CurrentThread.CurrentUICulture = currentUiCulture;
-        return trace;
-    }
-
-
     public static Assembly? Find()
     {
-        var trace = GetStackTraceInEnglish();
+        // GH-600: this used to render the stack as TEXT (Environment.StackTrace) and then guess each
+        // frame's assembly by trying to Assembly.Load progressively shorter dotted prefixes of the method
+        // name. That could only ever resolve an assembly whose name lined up with its namespace, so it
+        // missed some frames outright and adopted others it should have skipped -- NUnit's NUnit.Framework
+        // namespace matches its nunit.framework assembly exactly, for instance, so a scan configured from
+        // an async test adopted the runner. Reading the assembly off the frame is exact, needs no
+        // speculative loads, and drops a static List<string> cache that was being mutated from every
+        // thread that ever called in here.
+        var frames = new StackTrace().GetFrames();
 
-
-        var parts = trace.Split('\n');
-
-        for (var i = 0; i < parts.Length; i++)
+        foreach (var frame in frames)
         {
-            var line = parts[i];
-            var assembly = findAssembly(line);
-            if (assembly != null && !isSystemAssembly(assembly))
+            var assembly = frame.GetMethod()?.DeclaringType?.Assembly;
+
+            if (assembly is null)
             {
-                return assembly;
+                continue;
             }
+
+            if (isSystemAssembly(assembly))
+            {
+                continue;
+            }
+
+            return assembly;
         }
 
         return Assembly.GetEntryAssembly();
@@ -63,47 +58,17 @@ public class CallingAssembly
 
         var assemblyName = assembly.GetName().Name;
 
-        return isSystemAssembly(assemblyName!);
+        return assemblyName != null && isSystemAssembly(assemblyName);
     }
 
     private static bool isSystemAssembly(string assemblyName)
     {
-        return _prefixesToIgnore.Any(x => assemblyName.StartsWith(x));
-    }
-
-    private static Assembly? findAssembly(string stacktraceLine)
-    {
-        var candidate = stacktraceLine.Trim().Substring(3);
-
-        // Short circuit this
-        if (isSystemAssembly(candidate))
-        {
-            return null;
-        }
-
-        Assembly? assembly = null;
-        var names = candidate.Split('.');
-        for (var i = names.Length - 2; i > 0; i--)
-        {
-            var possibility = string.Join(".", names.Take(i).ToArray());
-
-            if (_misses.Contains(possibility))
-            {
-                continue;
-            }
-
-            try
-            {
-                assembly = Assembly.Load(new AssemblyName(possibility));
-                break;
-            }
-            catch
-            {
-                _misses.Add(possibility);
-            }
-        }
-
-        return assembly;
+        // GH-600: the frames between JasperFx and the code that configured the scan belong to the test
+        // runner under an async fixture, and adopting one means scanning an assembly that holds none of
+        // the application's types. Shares JasperFxOptions' list so the two stack walks agree on what a
+        // runner is.
+        return _prefixesToIgnore.Any(x => assemblyName.StartsWith(x, StringComparison.Ordinal))
+               || JasperFxOptions.IsTestRunnerAssembly(assemblyName);
     }
 
     /// <summary>

--- a/src/TestRunnerStandIn/RunnerFrame.cs
+++ b/src/TestRunnerStandIn/RunnerFrame.cs
@@ -1,11 +1,21 @@
 using System.Runtime.CompilerServices;
 
-namespace TestRunnerStandIn;
+// The namespace deliberately matches this project's AssemblyName. The two stack walks this stands in for
+// identify an assembly differently: JasperFxOptions.DetermineCallingAssembly reads the real assembly off the
+// frame, while CallingAssembly.Find parses the stack trace as TEXT and guesses the assembly by trying to
+// load dotted prefixes of the method name. The second one can only ever resolve an assembly whose name
+// lines up with its namespace, so the stand-in has to line up too in order to reproduce it.
+//
+// That alignment is not a contrivance. xUnit's Xunit.v3 namespace does not match its xunit.v3.core
+// assembly, but NUnit's NUnit.Framework namespace matches its nunit.framework assembly exactly -- so NUnit
+// is a real, affected case for the text-based walk.
+namespace xunit.v3.stackwalk.standin;
 
 /// <summary>
 /// Stands in for a real test runner (xUnit, NUnit, ...) in the one respect that matters to
-/// <c>JasperFxOptions.DetermineCallingAssembly</c>: it puts a frame from a runner-named assembly between
-/// JasperFx and the test assembly, the way an async test fixture's runner frames do. See GH-600.
+/// <c>JasperFxOptions.DetermineCallingAssembly</c> and <c>CallingAssembly.Find</c>: it puts a frame from a
+/// runner-named assembly between JasperFx and the test assembly, the way an async test fixture's runner
+/// frames do. See GH-600.
 /// </summary>
 public static class RunnerFrame
 {


### PR DESCRIPTION
Follow-up to #602 / #604, on the *other* stack walk. Noted as out of scope on #602; picking it up now.

> **Stacked on #604** (which is stacked on #602). Review those first; this diff is the last commit only. Retarget to `main` once they merge.

## The defect

`AssemblyScanner.TheCallingAssembly()` resolves through `CallingAssembly.Find()`, which ignored only `System.` and `Microsoft.` prefixes. Same exposure as #600: a scan configured from an async test can adopt the runner and then scan an assembly holding none of the suite's types.

But the implementation made it stranger than that. `Find()` rendered the stack as **text** (`Environment.StackTrace`) and guessed each frame's assembly by trying to `Assembly.Load` progressively shorter dotted prefixes of the method name:

```csharp
var names = candidate.Split('.');
for (var i = names.Length - 2; i > 0; i--)
{
    var possibility = string.Join(".", names.Take(i).ToArray());
    try { assembly = Assembly.Load(new AssemblyName(possibility)); break; }
    catch { _misses.Add(possibility); }
}
```

That can only ever resolve an assembly whose **name lines up with its namespace**, which made it blind and wrong in different places:

- it silently missed frames where they differ — xUnit's `Xunit.v3` namespace vs its `xunit.v3.core` assembly;
- it faithfully resolved, and adopted, ones that do line up — **NUnit's `NUnit.Framework` namespace matches its `nunit.framework` assembly exactly**.

So this is a real case, not a theoretical one, and which runner you use decides whether you hit it.

Three further problems in the same method:

- `_misses` is a plain `static List<string>` mutated by every caller with no synchronisation — concurrent scans race on it.
- `stacktraceLine.Trim().Substring(3)` throws `ArgumentOutOfRangeException` on any line shorter than three characters.
- Every miss costs a throwing `Assembly.Load`.

## The fix

Read the assembly off the frame, the way `JasperFxOptions.DetermineCallingAssembly` already does:

```csharp
var frames = new StackTrace().GetFrames();

foreach (var frame in frames)
{
    var assembly = frame.GetMethod()?.DeclaringType?.Assembly;
    if (assembly is null || isSystemAssembly(assembly)) continue;
    return assembly;
}

return Assembly.GetEntryAssembly();
```

Exact, no speculative loads, no shared mutable state, and `isSystemAssembly` now shares `JasperFxOptions.IsTestRunnerAssembly` so the two walks agree on what a runner is.

## Behaviour preserved

`[IgnoreAssembly]` is still honoured — that is precisely why `Find()` skips JasperFx's own frames, since JasperFx carries `[assembly: IgnoreAssembly]` (`AssemblyScanner.cs:8`). The three existing tests pin the "innermost non-ignored caller" semantics and are unchanged:

- `use_current_assembly` → the test assembly
- `from_another_assembly` → `Widgets1`
- `skip_ignore_assembly` → `Widgets5`, skipping `[IgnoreAssembly]`-marked `Widgets4`

I did **not** add the #601 Critter Stack skip here. `Find()`'s contract is the immediate caller, `[IgnoreAssembly]` is the established opt-out for this API, and neither Wolverine nor Marten calls `TheCallingAssembly()` — so a name list would be redundant where an attribute already does the job better.

## Tests

`TestRunnerStandIn`'s namespace now matches its assembly name. That is required, not cosmetic: the text-based walk keys on namespace, so with a mismatched one the stand-in cannot reproduce the defect at all. The comment in the file explains it, and notes that the alignment mirrors NUnit rather than being a contrivance.

- `walks_past_a_test_runner_frame_out_to_the_calling_assembly` / `never_adopts_a_test_runner_as_the_calling_assembly` — both **fail** against the old implementation (it returns `xunit.v3.stackwalk.standin`) and pass against the new one.
- `find_is_safe_to_call_concurrently` — guards the `_misses` race.

Verified in **Release** as well as Debug, since these tests depend on frames the JIT is free to inline away and CI builds Release. All five suites green: CoreTests 542, EventTests 657, CommandLineTests 295, CodegenTests 419, EventStoreTests 72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)