### PR TITLE
Add JasperFx.Events.ComplianceTests source-only package (2.37.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.37.0</JasperFxVersion>
+        <JasperFxVersion>2.37.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,6 +97,12 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <!--
+      The extensibility core only, for JasperFx.Events.ComplianceTests: a shared library must never
+      reference xunit.v3 itself, which forces OutputType=Exe onto every consuming project.
+    -->
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
   </ItemGroup>
 
 </Project>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -207,6 +207,7 @@ partial class Build : NukeBuild
                 Solution.JasperFx,
                 Solution.JasperFx_RuntimeCompiler,
                 Solution.JasperFx_Events,
+                Solution.JasperFx_Events_ComplianceTests,
                 Solution.src.JasperFx_Events_SourceGenerator,
                 Solution.src.JasperFx_SourceGenerator,
                 Solution.src.JasperFx_Aspire

--- a/jasperfx.slnx
+++ b/jasperfx.slnx
@@ -53,6 +53,7 @@
   <Project Path="src/ExtensionCommands/ExtensionCommands.csproj" />
   <Project Path="src/FakeApp/FakeApp.csproj" />
   <Project Path="src/FakeTool/FakeTool.csproj" />
+  <Project Path="src/JasperFx.Events.ComplianceTests/JasperFx.Events.ComplianceTests.csproj" />
   <Project Path="src/JasperFx.Events/JasperFx.Events.csproj" />
   <Project Path="src/JasperFx.RuntimeCompiler/JasperFx.RuntimeCompiler.csproj" />
   <Project Path="src/JasperFx/JasperFx.csproj" />

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Store-neutral description of the event store configuration a compliance suite needs.
+/// A suite fills one of these in; the fixture replays it against its store through
+/// <see cref="IComplianceStoreRegistrar"/>.
+/// </summary>
+/// <remarks>
+/// The public lists exist so a fixture can inspect what was asked for (for example, to decide
+/// whether the schema needs event tag tables). The actual registration runs through the recorded
+/// generic closures in <see cref="ApplyTo"/>, in declaration order.
+/// </remarks>
+public sealed class ComplianceStoreConfig
+{
+    private readonly List<Action<IComplianceStoreRegistrar>> _registrations = new();
+
+    /// <summary>
+    /// Optional schema/namespace override. When null the fixture picks its own.
+    /// </summary>
+    public string? SchemaName { get; set; }
+
+    public List<Type> EventTypes { get; } = new();
+
+    public List<(Type Tag, string Suffix, Type? Aggregate)> TagTypes { get; } = new();
+
+    public List<(Type Doc, SnapshotLifecycle Lifecycle)> Snapshots { get; } = new();
+
+    public List<Type> LiveAggregations { get; } = new();
+
+    public ComplianceStoreConfig AddEventType<T>()
+    {
+        EventTypes.Add(typeof(T));
+        _registrations.Add(registrar => registrar.AddEventType(typeof(T)));
+        return this;
+    }
+
+    public ComplianceStoreConfig RegisterTagType<TTag>(string tableSuffix, Type? aggregateType = null)
+        where TTag : notnull
+    {
+        TagTypes.Add((typeof(TTag), tableSuffix, aggregateType));
+        _registrations.Add(registrar =>
+        {
+            var registration = registrar.RegisterTagType<TTag>(tableSuffix);
+            if (aggregateType != null)
+            {
+                registration.ForAggregate(aggregateType);
+            }
+        });
+
+        return this;
+    }
+
+    public ComplianceStoreConfig Snapshot<TDoc>(SnapshotLifecycle lifecycle) where TDoc : notnull
+    {
+        Snapshots.Add((typeof(TDoc), lifecycle));
+        _registrations.Add(registrar => registrar.Snapshot<TDoc>(lifecycle));
+        return this;
+    }
+
+    public ComplianceStoreConfig LiveAggregation<TDoc>() where TDoc : notnull
+    {
+        LiveAggregations.Add(typeof(TDoc));
+        _registrations.Add(registrar => registrar.LiveAggregation<TDoc>());
+        return this;
+    }
+
+    public void ApplyTo(IComplianceStoreRegistrar registrar)
+    {
+        foreach (var registration in _registrations)
+        {
+            registration(registrar);
+        }
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The seam between the shared event sourcing compliance suites and a concrete event store.
+/// Every portable operation in the suites flows through the shared JasperFx surfaces
+/// (<see cref="IEventStoreOperations"/>, <see cref="IEventRegistry"/>, <see cref="IProjectionDaemon"/>);
+/// this type only exists to absorb the handful of things no shared interface declares —
+/// store construction, session acquisition, SaveChanges, document load-back, batched DCB queries,
+/// and teardown.
+/// </summary>
+/// <typeparam name="TOperations">
+/// The store's writable session type — Marten <c>IDocumentOperations</c>, Polecat <c>IDocumentSession</c>.
+/// </typeparam>
+/// <typeparam name="TQuerySession">The store's read-only session type.</typeparam>
+/// <remarks>
+/// The generic closure mirrors JasperFx's own <c>IEventStore&lt;TOperations, TQuerySession&gt;</c>.
+/// The products deliberately close it differently and convergence is a non-goal, so the compliance
+/// library is generic over the same pair rather than trying to unify them.
+/// </remarks>
+public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : IAsyncLifetime
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private Action<ComplianceStoreConfig>? _lastConfiguration;
+
+    /// <summary>
+    /// Cancellation token handed to every store call the suites make. Overridable rather than
+    /// hard-coded so a consumer can swap in its own budget.
+    /// </summary>
+    public virtual CancellationToken Cancellation => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    /// Build (or rebuild) the store for the supplied configuration.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately keyed on the identity of the <paramref name="configure"/> delegate: suites hold
+    /// their standard configuration in a static field, so repeated calls across the test methods of
+    /// one class are free, while a test that deliberately passes a different delegate gets a real
+    /// rebuild. Async because some stores (Polecat) must apply schema changes explicitly.
+    /// </remarks>
+    public async Task ConfigureAsync(Action<ComplianceStoreConfig> configure)
+    {
+        if (ReferenceEquals(_lastConfiguration, configure))
+        {
+            return;
+        }
+
+        var config = new ComplianceStoreConfig();
+        configure(config);
+
+        await BuildStoreAsync(config).ConfigureAwait(false);
+
+        _lastConfiguration = configure;
+    }
+
+    /// <summary>
+    /// Construct the store from the store-neutral configuration, replaying it through an
+    /// <see cref="IComplianceStoreRegistrar"/>, and make sure its schema exists.
+    /// </summary>
+    protected abstract Task BuildStoreAsync(ComplianceStoreConfig config);
+
+    /// <summary>
+    /// Open a writable session. Callers dispose it — <see cref="IStorageOperations"/> is
+    /// <see cref="IAsyncDisposable"/> on both stores.
+    /// </summary>
+    public abstract TOperations OpenSession();
+
+    public abstract Task SaveChangesAsync(TOperations session, CancellationToken token);
+
+    /// <summary>
+    /// Load a persisted document by id. Distinct from re-folding a stream: this is what proves an
+    /// inline snapshot projection actually wrote something.
+    /// </summary>
+    public abstract Task<T?> LoadDocumentAsync<T>(TQuerySession session, object id, CancellationToken token)
+        where T : class;
+
+    /// <summary>
+    /// The payoff member — everything portable in the suites runs off the shared JasperFx surface.
+    /// </summary>
+    public abstract IEventStoreOperations EventsFor(TOperations session);
+
+    public abstract IComplianceBatch CreateBatch(TQuerySession session);
+
+    /// <summary>
+    /// The store's event registry, reached through the shared interface so assertions can use
+    /// <c>EventMappingFor(Type)</c> → <see cref="IEventType"/> with no InternalsVisibleTo.
+    /// </summary>
+    public abstract IEventRegistry Registry { get; }
+
+    /// <summary>
+    /// Per-test isolation: remove all event (and projected document) data without dropping schema.
+    /// </summary>
+    public abstract Task CleanEventDataAsync();
+
+    public abstract Task<IProjectionDaemon> StartDaemonAsync();
+
+    public abstract Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout);
+
+    /// <summary>
+    /// False in stores that build live aggregators automatically and reject explicit registration.
+    /// </summary>
+    public virtual bool SupportsLiveAggregationRegistration => true;
+
+    /// <summary>
+    /// False where the store cannot run the async projection daemon in the test environment.
+    /// </summary>
+    public virtual bool SupportsAsyncDaemon => true;
+
+    public virtual ValueTask InitializeAsync() => default;
+
+    public virtual ValueTask DisposeAsync() => default;
+}

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Tags;
+using Shouldly;
 using Xunit;
 
 namespace JasperFx.Events.ComplianceTests;
@@ -61,6 +63,35 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
 
     protected Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
         => theFixture.WaitForNonStaleProjectionDataAsync(timeout);
+
+    /// <summary>
+    /// Assert that an operation fails with <typeparamref name="TException"/>, whether the store
+    /// throws it directly or wrapped in an <see cref="AggregateException"/>.
+    /// </summary>
+    /// <remarks>
+    /// A real cross-store divergence rather than test convenience: Marten surfaces
+    /// DcbConcurrencyException straight out of SaveChangesAsync, while Polecat runs its unit of work
+    /// in parallel and aggregates. The failure semantics are identical, so the suites assert the
+    /// semantics and let the exception shape vary.
+    /// </remarks>
+    protected static async Task ShouldFailWithAsync<TException>(Func<Task> action) where TException : Exception
+    {
+        var exception = await Should.ThrowAsync<Exception>(action).ConfigureAwait(false);
+
+        if (exception is TException)
+        {
+            return;
+        }
+
+        if (exception is AggregateException aggregate &&
+            aggregate.Flatten().InnerExceptions.Any(x => x is TException))
+        {
+            return;
+        }
+
+        throw new ShouldAssertException(
+            $"Expected {typeof(TException).Name}, directly or aggregated, but got {exception.GetType().FullName}: {exception.Message}");
+    }
 
     /// <summary>
     /// Convenience for the DCB suites: build an event envelope, stamp tags on it, append it and save.

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Tags;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Base class for every shared compliance suite. Owns the fixture lifecycle and forwards the seam
+/// members so the [Fact] bodies read like ordinary event store tests.
+/// </summary>
+/// <typeparam name="TFixture">The store's concrete fixture.</typeparam>
+/// <typeparam name="TOperations">The store's writable session type.</typeparam>
+/// <typeparam name="TQuerySession">The store's read-only session type.</typeparam>
+/// <remarks>
+/// A consuming store enrolls a suite with a single empty subclass closing the three generics.
+/// </remarks>
+public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySession> : IAsyncLifetime
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    protected readonly TFixture theFixture = new();
+
+    /// <summary>
+    /// The suite's standard store configuration. Implementations MUST return the same delegate
+    /// instance every time (hold it in a static field) so the fixture can skip redundant rebuilds.
+    /// </summary>
+    protected abstract Action<ComplianceStoreConfig> Configuration { get; }
+
+    public virtual async ValueTask InitializeAsync()
+    {
+        await theFixture.InitializeAsync().ConfigureAwait(false);
+        await theFixture.ConfigureAsync(Configuration).ConfigureAwait(false);
+        await theFixture.CleanEventDataAsync().ConfigureAwait(false);
+    }
+
+    public virtual ValueTask DisposeAsync() => theFixture.DisposeAsync();
+
+    protected CancellationToken Cancellation => theFixture.Cancellation;
+
+    protected TOperations OpenSession() => theFixture.OpenSession();
+
+    protected IEventStoreOperations EventsFor(TOperations session) => theFixture.EventsFor(session);
+
+    protected Task SaveChangesAsync(TOperations session) => theFixture.SaveChangesAsync(session, Cancellation);
+
+    protected Task<T?> LoadDocumentAsync<T>(TQuerySession session, object id) where T : class
+        => theFixture.LoadDocumentAsync<T>(session, id, Cancellation);
+
+    protected IComplianceBatch CreateBatch(TQuerySession session) => theFixture.CreateBatch(session);
+
+    /// <summary>
+    /// The event type name the store persists for <typeparamref name="T"/>, resolved through the
+    /// shared registry surface (never a store-internal generic).
+    /// </summary>
+    protected string EventTypeNameFor<T>() => theFixture.Registry.EventMappingFor(typeof(T)).EventTypeName;
+
+    protected Task<IProjectionDaemon> StartDaemonAsync() => theFixture.StartDaemonAsync();
+
+    protected Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
+        => theFixture.WaitForNonStaleProjectionDataAsync(timeout);
+
+    /// <summary>
+    /// Convenience for the DCB suites: build an event envelope, stamp tags on it, append it and save.
+    /// </summary>
+    protected async Task AppendTaggedEventAsync(TOperations session, Guid streamId, object eventData,
+        params object[] tags)
+    {
+        var events = EventsFor(session);
+        var wrapped = events.BuildEvent(eventData);
+        wrapped.WithTag(tags);
+        events.Append(streamId, wrapped);
+        await SaveChangesAsync(session).ConfigureAwait(false);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/IComplianceBatch.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceBatch.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The batched DCB query surface, which is the one part of the seed suites with no JasperFx
+/// abstraction today: Marten exposes it as <c>batch.Events.EventsExist(query)</c> through an
+/// <c>IBatchEvents</c> sub-object, Polecat flat on its own batch type. Method names and signatures
+/// already match exactly — only the accessor path differs.
+/// </summary>
+/// <remarks>
+/// As with the products' own batched queries, the tasks returned here do not complete until
+/// <see cref="Execute"/> has run.
+/// </remarks>
+public interface IComplianceBatch
+{
+    Task<bool> EventsExist(EventTagQuery query);
+
+    Task<IEventBoundary<T>> FetchForWritingByTags<T>(EventTagQuery query) where T : class;
+
+    Task Execute(CancellationToken token = default);
+}

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -1,0 +1,40 @@
+using System;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Tags;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The narrow, store-neutral configuration surface that a <see cref="ComplianceStoreConfig"/>
+/// is replayed against. Each event store implements this once inside its concrete
+/// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}"/> — it is the only place
+/// where store-specific option types (Marten's <c>StoreOptions</c>, Polecat's equivalent) leak in.
+/// </summary>
+/// <remarks>
+/// Registration is expressed through generic methods rather than <see cref="Type"/> arguments so
+/// that nothing in the compliance library needs reflection: the suites capture the closed generic
+/// at the call site and the registrar re-opens it here.
+/// </remarks>
+public interface IComplianceStoreRegistrar
+{
+    /// <summary>
+    /// Pre-register an event type. Maps to the shared <c>IEventRegistry.AddEventType(Type)</c>.
+    /// </summary>
+    void AddEventType(Type eventType);
+
+    /// <summary>
+    /// Register a strong-typed identifier as a DCB tag type with an explicit table suffix.
+    /// </summary>
+    ITagTypeRegistration RegisterTagType<TTag>(string tableSuffix) where TTag : notnull;
+
+    /// <summary>
+    /// Register a single stream snapshot projection for a self-aggregating type.
+    /// </summary>
+    void Snapshot<TDoc>(SnapshotLifecycle lifecycle) where TDoc : notnull;
+
+    /// <summary>
+    /// Register a live aggregation for a self-aggregating type. A no-op in stores that
+    /// build live aggregators automatically.
+    /// </summary>
+    void LiveAggregation<TDoc>() where TDoc : notnull;
+}

--- a/src/JasperFx.Events.ComplianceTests/JasperFx.Events.ComplianceTests.csproj
+++ b/src/JasperFx.Events.ComplianceTests/JasperFx.Events.ComplianceTests.csproj
@@ -1,0 +1,50 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Shared behavioral compliance test suites for Critter Stack event stores. Ships as C# source, not a compiled assembly.</Description>
+        <PackageId>JasperFx.Events.ComplianceTests</PackageId>
+        <Version>$(JasperFxVersion)</Version>
+        <PackageTags>eventsourcing;testing;compliance;critterstack</PackageTags>
+
+        <!--
+          Source-only package, and that is forced rather than preferred.
+
+          JasperFx.Events.SourceGenerator emits aggregate dispatchers per *consuming assembly* and
+          binds each product's own session type (it matches the session parameter of
+          EvolveAsync by type name). Aggregates compiled into one shared DLL could never dispatch for
+          both Marten and Polecat. Compiling in the consumer also sidesteps JasperFx/Weasel version
+          skew between the repos and their LangVersion/ImplicitUsings differences; these sources are
+          authored to the C# 13 / explicit-usings floor.
+        -->
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+
+        <!-- Authored to the floor the consumers share, not to this repo's conveniences. -->
+        <ImplicitUsings>false</ImplicitUsings>
+        <LangVersion>13</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\JasperFx.Events\JasperFx.Events.csproj" />
+
+        <!--
+          Never reference xunit.v3 itself from a shared library, since it forces OutputType=Exe onto
+          consumers. The extensibility core carries [Fact], IAsyncLifetime, TestContext and Assert.
+        -->
+        <PackageReference Include="xunit.v3.extensibility.core" />
+        <PackageReference Include="xunit.v3.assert" />
+        <PackageReference Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- The payload: every compliance source, compiled inside the consumer. -->
+        <Content Include="**\*.cs"
+                 Exclude="bin\**\*.cs;obj\**\*.cs;Local\**\*.cs"
+                 Pack="true"
+                 BuildAction="Compile"
+                 PackagePath="contentFiles\cs\any\JasperFx.Events.ComplianceTests\" />
+    </ItemGroup>
+
+</Project>

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceQuerySessionPlaceholder.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceQuerySessionPlaceholder.cs
@@ -1,0 +1,17 @@
+// NOT PACKAGED. Everything under Local/ exists so this project type-checks the compliance sources
+// inside the JasperFx repo, where no concrete event store is available.
+//
+// The shared self-aggregating fixtures declare EvolveAsync(IEvent, ComplianceQuerySession) so that
+// one source file can bind to Marten's IQuerySession in Marten and Polecat's in Polecat -- JasperFx's
+// aggregate source generator resolves the parameter by type name, so a per-consumer global alias is
+// enough. Each consuming test project supplies its own:
+//
+//     global using ComplianceQuerySession = Marten.IQuerySession;
+//
+// This placeholder stands in for that alias here and never leaves the repo.
+
+global using ComplianceQuerySession = JasperFx.Events.ComplianceTests.Local.IPlaceholderQuerySession;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+public interface IPlaceholderQuerySession;

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -1,0 +1,43 @@
+# JasperFx.Events.ComplianceTests
+
+Shared behavioral compliance test suites for Critter Stack event stores — the same event sourcing
+expectations asserted against [Marten](https://martendb.io) (PostgreSQL), Polecat (SQL Server), and
+any future store built on `JasperFx.Events`.
+
+This package ships **C# source, not a compiled assembly**. That is forced, not a preference:
+`JasperFx.Events.SourceGenerator` emits aggregate dispatchers per consuming assembly and binds each
+product's own session type, so the shared aggregates have to be compiled inside each consumer.
+Compiling in the consumer also sidesteps package-version skew and `LangVersion`/`ImplicitUsings`
+differences between the repos.
+
+## Using it
+
+Reference the package from a test project that already has xunit v3 and Shouldly, then supply two
+things.
+
+**1. A global alias naming your store's read session.** The shared self-aggregating fixtures declare
+`EvolveAsync(IEvent, ComplianceQuerySession)`; the source generator resolves the parameter by type
+name, so an alias is enough:
+
+```csharp
+global using ComplianceQuerySession = Marten.IQuerySession;
+```
+
+**2. A concrete fixture** closing `EventStoreComplianceFixture<TOperations, TQuerySession>` over your
+store's session pair. Everything portable in the suites runs through the shared JasperFx surfaces
+(`IEventStoreOperations`, `IEventRegistry`, `IProjectionDaemon`); the fixture only has to supply what
+no shared interface declares — store construction from a `ComplianceStoreConfig`, session
+acquisition, `SaveChangesAsync`, document load-back, batched DCB queries, and teardown.
+
+Then enroll each suite with an empty subclass:
+
+```csharp
+public class dcb_tag_query_and_consistency_compliance
+    : DcbTagQueryAndConsistencyCompliance<MyComplianceFixture, IDocumentOperations, IQuerySession>;
+```
+
+## Capability gates
+
+Where a store genuinely cannot support a behavior, override the `virtual bool Supports...` flags on
+the fixture; the affected tests skip rather than fail. Gates are meant to be temporary and tracked —
+a suite failing on your store is usually a product bug, not a test to soften.

--- a/src/JasperFx.Events.ComplianceTests/Suites/AssignTagWhereCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AssignTagWhereCompliance.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record RegionId(Guid Value);
+
+/// <summary>
+/// A tag type that is deliberately never registered with the store.
+/// </summary>
+public record UnregisteredTagId(Guid Value);
+
+public record OrderPlaced(string OrderNumber, decimal Amount);
+
+public record OrderShipped(string OrderNumber);
+
+public record OrderCancelled(string OrderNumber, string Reason);
+
+/// <summary>
+/// Retroactive tagging: AssignTagWhere applies a DCB tag to already-persisted events matching a
+/// predicate over the event metadata.
+/// </summary>
+public abstract class AssignTagWhereCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_assign_tag";
+
+        config.AddEventType<OrderPlaced>();
+        config.AddEventType<OrderShipped>();
+        config.AddEventType<OrderCancelled>();
+
+        config.RegisterTagType<RegionId>("region");
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private readonly RegionId _eastRegion = new(Guid.NewGuid());
+    private readonly RegionId _westRegion = new(Guid.NewGuid());
+
+    [Fact]
+    public async Task assign_tag_where_by_event_type_name()
+    {
+        var stream1 = Guid.NewGuid();
+
+        await using var session1 = OpenSession();
+        EventsFor(session1).Append(stream1, new OrderPlaced("ORD-1", 100m), new OrderShipped("ORD-1"));
+        await SaveChangesAsync(session1);
+
+        // Retroactively tag every OrderPlaced event with a region
+        await using var session2 = OpenSession();
+        var orderPlacedTypeName = EventTypeNameFor<OrderPlaced>();
+        EventsFor(session2).AssignTagWhere(e => e.EventTypeName == orderPlacedTypeName, _eastRegion);
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await EventsFor(session3).QueryByTagsAsync(query, Cancellation);
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<OrderPlaced>().OrderNumber.ShouldBe("ORD-1");
+    }
+
+    [Fact]
+    public async Task assign_tag_where_by_stream_id()
+    {
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        await using var session1 = OpenSession();
+        EventsFor(session1).Append(stream1, new OrderPlaced("ORD-1", 100m), new OrderShipped("ORD-1"));
+        EventsFor(session1).Append(stream2, new OrderPlaced("ORD-2", 200m));
+        await SaveChangesAsync(session1);
+
+        await using var session2 = OpenSession();
+        EventsFor(session2).AssignTagWhere(e => e.StreamId == stream1, _eastRegion);
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await EventsFor(session3).QueryByTagsAsync(query, Cancellation);
+
+        events.Count.ShouldBe(2);
+        events.ShouldAllBe(e => e.StreamId == stream1);
+    }
+
+    [Fact]
+    public async Task assign_tag_where_with_compound_predicate()
+    {
+        var stream1 = Guid.NewGuid();
+
+        await using var session1 = OpenSession();
+        EventsFor(session1).Append(stream1,
+            new OrderPlaced("ORD-1", 100m),
+            new OrderShipped("ORD-1"),
+            new OrderCancelled("ORD-1", "changed mind"));
+        await SaveChangesAsync(session1);
+
+        await using var session2 = OpenSession();
+        var placedType = EventTypeNameFor<OrderPlaced>();
+        var cancelledType = EventTypeNameFor<OrderCancelled>();
+
+        EventsFor(session2).AssignTagWhere(
+            e => e.EventTypeName == placedType || e.EventTypeName == cancelledType,
+            _eastRegion);
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await EventsFor(session3).QueryByTagsAsync(query, Cancellation);
+
+        events.Count.ShouldBe(2);
+        events.Select(e => e.Data.GetType()).ShouldContain(typeof(OrderPlaced));
+        events.Select(e => e.Data.GetType()).ShouldContain(typeof(OrderCancelled));
+        events.Select(e => e.Data.GetType()).ShouldNotContain(typeof(OrderShipped));
+    }
+
+    [Fact]
+    public async Task assign_tag_where_is_idempotent()
+    {
+        var stream1 = Guid.NewGuid();
+
+        await using var session1 = OpenSession();
+        EventsFor(session1).Append(stream1, new OrderPlaced("ORD-1", 100m));
+        await SaveChangesAsync(session1);
+
+        var placedType = EventTypeNameFor<OrderPlaced>();
+
+        await using var session2 = OpenSession();
+        EventsFor(session2).AssignTagWhere(e => e.EventTypeName == placedType, _eastRegion);
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        EventsFor(session3).AssignTagWhere(e => e.EventTypeName == placedType, _eastRegion);
+        await SaveChangesAsync(session3);
+
+        await using var session4 = OpenSession();
+        var query = new EventTagQuery().Or<RegionId>(_eastRegion);
+        var events = await EventsFor(session4).QueryByTagsAsync(query, Cancellation);
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task assign_tag_where_does_not_affect_unmatched_events()
+    {
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        await using var session1 = OpenSession();
+        EventsFor(session1).Append(stream1, new OrderPlaced("ORD-1", 100m));
+        EventsFor(session1).Append(stream2, new OrderPlaced("ORD-2", 200m));
+        await SaveChangesAsync(session1);
+
+        await using var session2 = OpenSession();
+        EventsFor(session2).AssignTagWhere(e => e.StreamId == stream1, _eastRegion);
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        EventsFor(session3).AssignTagWhere(e => e.StreamId == stream2, _westRegion);
+        await SaveChangesAsync(session3);
+
+        await using var session4 = OpenSession();
+        var eastEvents = await EventsFor(session4)
+            .QueryByTagsAsync(new EventTagQuery().Or<RegionId>(_eastRegion), Cancellation);
+        eastEvents.Count.ShouldBe(1);
+        eastEvents[0].StreamId.ShouldBe(stream1);
+
+        var westEvents = await EventsFor(session4)
+            .QueryByTagsAsync(new EventTagQuery().Or<RegionId>(_westRegion), Cancellation);
+        westEvents.Count.ShouldBe(1);
+        westEvents[0].StreamId.ShouldBe(stream2);
+    }
+
+    [Fact]
+    public async Task assign_tag_where_throws_for_unregistered_tag_type()
+    {
+        await using var session = OpenSession();
+
+        var unregisteredTag = new UnregisteredTagId(Guid.NewGuid());
+
+        Should.Throw<InvalidOperationException>(() =>
+            EventsFor(session).AssignTagWhere(e => e.Sequence > 0, unregisteredTag));
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/AsyncDaemonCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AsyncDaemonCompliance.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record ItemAdded(string Name);
+
+public record ItemRemoved(string Name);
+
+/// <summary>
+/// A deliberately plain self-aggregating snapshot type for the async daemon suite.
+/// </summary>
+public partial class DaemonItemTally
+{
+    public Guid Id { get; set; }
+    public int AddedCount { get; set; }
+    public int RemovedCount { get; set; }
+
+    public void Apply(ItemAdded e) => AddedCount++;
+
+    public void Apply(ItemRemoved e) => RemovedCount++;
+}
+
+/// <summary>
+/// Proves the fixture's daemon plumbing end to end: an async snapshot projection registered through
+/// <see cref="ComplianceStoreConfig"/>, driven by a started <see cref="Daemon.IProjectionDaemon"/>,
+/// waited on through the store's non-stale hook, asserted against the *persisted* document, and
+/// rebuilt once from the event stream.
+/// </summary>
+/// <remarks>
+/// Deliberately small and single-tenant. Multi-node, HotCold and distribution behavior is
+/// product-specific and stays out of compliance scope.
+/// </remarks>
+public abstract class AsyncDaemonCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_daemon";
+
+        config.AddEventType<ItemAdded>();
+        config.AddEventType<ItemRemoved>();
+
+        config.Snapshot<DaemonItemTally>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Capability gate. xunit v3's declarative SkipUnless needs a *static* property, which cannot
+    /// consult a per-store fixture instance, so the gate runs as a dynamic skip instead.
+    /// </summary>
+    private void SkipUnlessDaemonIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+    }
+
+    [Fact]
+    public async Task async_projection_catches_up_and_persists_the_document()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<DaemonItemTally>(streamId, new ItemAdded("one"), new ItemAdded("two"),
+                new ItemRemoved("one"));
+            await SaveChangesAsync(session);
+        }
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+        var tally = await LoadDocumentAsync<DaemonItemTally>(query, streamId);
+        tally.ShouldNotBeNull();
+        tally.AddedCount.ShouldBe(2);
+        tally.RemovedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task rebuild_the_projection_from_the_event_stream()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<DaemonItemTally>(streamId, new ItemAdded("one"), new ItemAdded("two"));
+            await SaveChangesAsync(session);
+        }
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.RebuildProjectionAsync<DaemonItemTally>(Cancellation);
+
+        await using var query = OpenSession();
+        var tally = await LoadDocumentAsync<DaemonItemTally>(query, streamId);
+        tally.ShouldNotBeNull();
+        tally.AddedCount.ShouldBe(2);
+        tally.RemovedCount.ShouldBe(0);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/DcbTagQueryAndConsistencyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DcbTagQueryAndConsistencyCompliance.cs
@@ -1,0 +1,727 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region sample_compliance_dcb_tag_type_definitions
+
+// Strong-typed tag identifiers
+public record StudentId(Guid Value);
+
+public record CourseId(Guid Value);
+
+#endregion
+
+#region sample_compliance_dcb_domain_events
+
+public record StudentEnrolled(string StudentName, string CourseName);
+
+public record AssignmentSubmitted(string AssignmentName, int Score);
+
+public record StudentDropped(string Reason);
+
+#endregion
+
+/// <summary>
+/// Event carrying tag-typed properties, so the store can infer its tags without WithTag()
+/// </summary>
+public record StudentGraded(StudentId StudentId, CourseId CourseId, int Grade);
+
+/// <summary>
+/// Event with NO tag-typed properties -- tag inference must fail loudly
+/// </summary>
+public record SystemNotification(string Message);
+
+#region sample_compliance_dcb_aggregate
+
+public partial class StudentCourseEnrollment
+{
+    public Guid Id { get; set; }
+    public string StudentName { get; set; } = "";
+    public string CourseName { get; set; } = "";
+    public List<string> Assignments { get; set; } = new();
+    public bool IsDropped { get; set; }
+
+    public void Apply(StudentEnrolled e)
+    {
+        StudentName = e.StudentName;
+        CourseName = e.CourseName;
+    }
+
+    public void Apply(AssignmentSubmitted e)
+    {
+        Assignments.Add(e.AssignmentName);
+    }
+
+    public void Apply(StudentDropped e)
+    {
+        IsDropped = true;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Dynamic Consistency Boundary behavior: tagging events, querying and aggregating across streams
+/// by tag, and the FetchForWritingByTags optimistic consistency check -- direct and batched.
+/// </summary>
+public abstract class DcbTagQueryAndConsistencyCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    #region sample_compliance_dcb_registering_tag_types
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_dcb";
+
+        config.AddEventType<StudentEnrolled>();
+        config.AddEventType<AssignmentSubmitted>();
+        config.AddEventType<StudentDropped>();
+        config.AddEventType<StudentGraded>();
+
+        // Each tag type gets its own table, and is associated with the aggregate it bounds
+        config.RegisterTagType<StudentId>("student", typeof(StudentCourseEnrollment));
+        config.RegisterTagType<CourseId>("course", typeof(StudentCourseEnrollment));
+
+        config.LiveAggregation<StudentCourseEnrollment>();
+    };
+
+    #endregion
+
+    /// <summary>
+    /// Same as the standard configuration except CourseId is registered with no aggregate
+    /// association, so events tagged only with a course have nowhere to route.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _unroutedCourseTagConfiguration = config =>
+    {
+        config.SchemaName = "compliance_dcb";
+
+        config.AddEventType<StudentEnrolled>();
+        config.AddEventType<StudentGraded>();
+
+        config.RegisterTagType<StudentId>("student", typeof(StudentCourseEnrollment));
+        config.RegisterTagType<CourseId>("course");
+
+        config.LiveAggregation<StudentCourseEnrollment>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task can_query_events_by_single_tag()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        #region sample_compliance_dcb_tagging_events
+
+        var enrolled = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+        EventsFor(session).Append(streamId, enrolled);
+        await SaveChangesAsync(session);
+
+        #endregion
+
+        #region sample_compliance_dcb_query_by_single_tag
+
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+
+        #endregion
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task can_query_events_by_multiple_tags_with_or()
+    {
+        var student1 = new StudentId(Guid.NewGuid());
+        var student2 = new StudentId(Guid.NewGuid());
+        var course = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        var e1 = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        e1.WithTag(student1, course);
+        EventsFor(session).Append(Guid.NewGuid(), e1);
+
+        var e2 = EventsFor(session).BuildEvent(new StudentEnrolled("Bob", "Math"));
+        e2.WithTag(student2, course);
+        EventsFor(session).Append(Guid.NewGuid(), e2);
+
+        await SaveChangesAsync(session);
+
+        #region sample_compliance_dcb_query_multiple_tags_or
+
+        var query = new EventTagQuery()
+            .Or<StudentId>(student1)
+            .Or<StudentId>(student2);
+
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+
+        #endregion
+
+        events.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task can_query_events_across_distinct_tag_types_with_or()
+    {
+        // The core DCB boundary case: events on different streams carry DIFFERENT single tags and the
+        // query OR-combines distinct tag types. Each matching event carries only one of the queried
+        // tag types -- a regression guard against an INNER JOIN that would require every event to
+        // carry all queried tag types, collapsing this query to zero rows.
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        var enrolled = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId);
+        EventsFor(session).Append(Guid.NewGuid(), enrolled);
+
+        var submitted = EventsFor(session).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(courseId);
+        EventsFor(session).Append(Guid.NewGuid(), submitted);
+
+        await SaveChangesAsync(session);
+
+        var query = new EventTagQuery()
+            .Or<StudentId>(studentId)
+            .Or<CourseId>(courseId);
+
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+        events.Count.ShouldBe(2);
+        events.ShouldContain(e => e.Data is StudentEnrolled);
+        events.ShouldContain(e => e.Data is AssignmentSubmitted);
+    }
+
+    [Fact]
+    public async Task can_query_events_by_tag_with_event_type_filter()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        var enrolled = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+
+        var submitted = EventsFor(session).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(studentId, courseId);
+
+        EventsFor(session).Append(streamId, enrolled, submitted);
+        await SaveChangesAsync(session);
+
+        #region sample_compliance_dcb_query_by_event_type
+
+        var query = new EventTagQuery()
+            .Or<AssignmentSubmitted, StudentId>(studentId);
+
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+
+        #endregion
+
+        events.Count.ShouldBe(1);
+        events[0].Data.ShouldBeOfType<AssignmentSubmitted>().AssignmentName.ShouldBe("HW1");
+    }
+
+    [Fact]
+    public async Task query_returns_empty_when_no_matching_tags()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var otherStudentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId,
+            courseId);
+
+        var query = new EventTagQuery().Or<StudentId>(otherStudentId);
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+        events.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task can_aggregate_events_by_tags()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        var enrolled = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+
+        var submitted = EventsFor(session).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(studentId, courseId);
+
+        EventsFor(session).Append(streamId, enrolled, submitted);
+        await SaveChangesAsync(session);
+
+        #region sample_compliance_dcb_aggregate_by_tags
+
+        var query = new EventTagQuery()
+            .Or<StudentId>(studentId)
+            .Or<CourseId>(courseId);
+
+        var aggregate = await EventsFor(session).AggregateByTagsAsync<StudentCourseEnrollment>(query, Cancellation);
+
+        #endregion
+
+        aggregate.ShouldNotBeNull();
+        aggregate.StudentName.ShouldBe("Alice");
+        aggregate.CourseName.ShouldBe("Math");
+        aggregate.Assignments.ShouldContain("HW1");
+    }
+
+    [Fact]
+    public async Task aggregate_by_tags_returns_null_when_no_events()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var aggregate = await EventsFor(session).AggregateByTagsAsync<StudentCourseEnrollment>(query, Cancellation);
+        aggregate.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task can_fetch_for_writing_by_tags_happy_path()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session1 = OpenSession();
+        await AppendTaggedEventAsync(session1, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId,
+            courseId);
+
+        #region sample_compliance_dcb_fetch_for_writing_by_tags
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        // Current state -- Aggregate may be null when no events matched yet
+        var aggregate = boundary.Aggregate;
+        var lastSequence = boundary.LastSeenSequence;
+
+        var assignment = EventsFor(session2).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        assignment.WithTag(studentId, courseId);
+        boundary.AppendOne(assignment);
+
+        // Throws DcbConcurrencyException if another session appended matching events since the read
+        await SaveChangesAsync(session2);
+
+        #endregion
+
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate!.StudentName.ShouldBe("Alice");
+        boundary.Events.Count.ShouldBe(1);
+        lastSequence.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_appends_to_existing_tag_derived_stream_without_collision()
+    {
+        // Seed the student's stream using the tag value as the stream id, so the boundary's
+        // tag-derived routing targets a PRE-EXISTING stream on save. A boundary that unconditionally
+        // starts a new stream here throws an existing-stream-collision error.
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using var session1 = OpenSession();
+        await AppendTaggedEventAsync(session1, studentId.Value, new StudentEnrolled("Alice", "Math"), studentId);
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        var submitted = EventsFor(session2).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(studentId);
+        boundary.AppendOne(submitted);
+
+        await Should.NotThrowAsync(async () => await SaveChangesAsync(session2));
+
+        await using var session3 = OpenSession();
+        var events = await EventsFor(session3)
+            .QueryByTagsAsync(new EventTagQuery().Or<StudentId>(studentId), Cancellation);
+        events.ShouldContain(e => e.Data is AssignmentSubmitted);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_by_tags_detects_concurrency_violation()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, streamId, new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session1 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session1).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        // Another session appends a matching event BEFORE session 1 saves
+        await using var session2 = OpenSession();
+        await AppendTaggedEventAsync(session2, streamId, new AssignmentSubmitted("HW-conflict", 50), studentId,
+            courseId);
+
+        var assignment = EventsFor(session1).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        assignment.WithTag(studentId, courseId);
+        boundary.AppendOne(assignment);
+
+        await Should.ThrowAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_by_tags_no_violation_when_unrelated_events_appended()
+    {
+        var student1 = new StudentId(Guid.NewGuid());
+        var student2 = new StudentId(Guid.NewGuid());
+        var course = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), student1, course);
+
+        await using var session1 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(student1);
+        var boundary = await EventsFor(session1).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        // A different student's event must NOT conflict
+        await using var session2 = OpenSession();
+        await AppendTaggedEventAsync(session2, Guid.NewGuid(), new StudentEnrolled("Bob", "Math"), student2, course);
+
+        var assignment = EventsFor(session1).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        assignment.WithTag(student1, course);
+        boundary.AppendOne(assignment);
+
+        await Should.NotThrowAsync(async () => await SaveChangesAsync(session1));
+    }
+
+    [Fact]
+    public async Task events_across_multiple_streams_can_be_queried_by_tag()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var course1 = new CourseId(Guid.NewGuid());
+        var course2 = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        var enrolled1 = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled1.WithTag(studentId, course1);
+        EventsFor(session).Append(Guid.NewGuid(), enrolled1);
+
+        var enrolled2 = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Science"));
+        enrolled2.WithTag(studentId, course2);
+        EventsFor(session).Append(Guid.NewGuid(), enrolled2);
+
+        await SaveChangesAsync(session);
+
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+
+        events.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task query_events_ordered_by_sequence()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        var enrolled = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+
+        var hw1 = EventsFor(session).BuildEvent(new AssignmentSubmitted("HW1", 90));
+        hw1.WithTag(studentId, courseId);
+
+        var hw2 = EventsFor(session).BuildEvent(new AssignmentSubmitted("HW2", 85));
+        hw2.WithTag(studentId, courseId);
+
+        EventsFor(session).Append(streamId, enrolled, hw1, hw2);
+        await SaveChangesAsync(session);
+
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var events = await EventsFor(session).QueryByTagsAsync(query, Cancellation);
+
+        events.Count.ShouldBe(3);
+        events[0].Sequence.ShouldBeLessThan(events[1].Sequence);
+        events[1].Sequence.ShouldBeLessThan(events[2].Sequence);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_with_empty_result_still_enforces_consistency()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session1 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session1).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        boundary.Aggregate.ShouldBeNull();
+        boundary.Events.Count.ShouldBe(0);
+        boundary.LastSeenSequence.ShouldBe(0);
+
+        await using var session2 = OpenSession();
+        await AppendTaggedEventAsync(session2, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId,
+            courseId);
+
+        var e = EventsFor(session1).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        e.WithTag(studentId, courseId);
+        boundary.AppendOne(e);
+
+        await Should.ThrowAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
+    }
+
+    [Fact]
+    public async Task can_fetch_for_writing_by_tags_via_batch_query()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session2 = OpenSession();
+        var batch = CreateBatch(session2);
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundaryTask = batch.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        await batch.Execute(Cancellation);
+
+        var boundary = await boundaryTask;
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate!.StudentName.ShouldBe("Alice");
+        boundary.Events.Count.ShouldBe(1);
+        boundary.LastSeenSequence.ShouldBeGreaterThan(0);
+
+        var assignment = EventsFor(session2).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        assignment.WithTag(studentId, courseId);
+        boundary.AppendOne(assignment);
+        await SaveChangesAsync(session2);
+    }
+
+    [Fact]
+    public async Task batch_query_fetch_for_writing_by_tags_detects_concurrency_violation()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, streamId, new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session1 = OpenSession();
+        var batch = CreateBatch(session1);
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundaryTask = batch.FetchForWritingByTags<StudentCourseEnrollment>(query);
+        await batch.Execute(Cancellation);
+        var boundary = await boundaryTask;
+
+        await using var session2 = OpenSession();
+        await AppendTaggedEventAsync(session2, streamId, new AssignmentSubmitted("HW-conflict", 50), studentId,
+            courseId);
+
+        var assignment = EventsFor(session1).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        assignment.WithTag(studentId, courseId);
+        boundary.AppendOne(assignment);
+
+        await Should.ThrowAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
+    }
+
+    #region sample_compliance_dcb_events_exist_async
+
+    [Fact]
+    public async Task events_exist_returns_true_when_matching_events_found()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId,
+            courseId);
+
+        // Existence check -- no event loading
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var exists = await EventsFor(session).EventsExistAsync(query, Cancellation);
+        exists.ShouldBeTrue();
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task events_exist_returns_false_when_no_matching_events()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var exists = await EventsFor(session).EventsExistAsync(query, Cancellation);
+        exists.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task events_exist_with_event_type_filter()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId,
+            courseId);
+
+        var query1 = new EventTagQuery().Or<StudentEnrolled, StudentId>(studentId);
+        (await EventsFor(session).EventsExistAsync(query1, Cancellation)).ShouldBeTrue();
+
+        // No AssignmentSubmitted was appended
+        var query2 = new EventTagQuery().Or<AssignmentSubmitted, StudentId>(studentId);
+        (await EventsFor(session).EventsExistAsync(query2, Cancellation)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task events_exist_via_batch_query_positive()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session2 = OpenSession();
+        var batch = CreateBatch(session2);
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var existsTask = batch.EventsExist(query);
+        await batch.Execute(Cancellation);
+
+        (await existsTask).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task events_exist_via_batch_query_negative()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        var batch = CreateBatch(session);
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var existsTask = batch.EventsExist(query);
+        await batch.Execute(Cancellation);
+
+        (await existsTask).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_by_tags_throws_on_empty_query()
+    {
+        await using var session = OpenSession();
+
+        var query = new EventTagQuery();
+        await Should.ThrowAsync<ArgumentException>(async () =>
+        {
+            await EventsFor(session).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+        });
+    }
+
+    [Fact]
+    public async Task append_event_with_inferred_tags_from_properties()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        // Raw event carrying StudentId and CourseId properties -- tags are inferred
+        boundary.AppendOne(new StudentGraded(studentId, courseId, 95));
+
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        var events = await EventsFor(session3)
+            .QueryByTagsAsync(new EventTagQuery().Or<StudentId>(studentId), Cancellation);
+        events.Count.ShouldBe(2);
+        events[1].Data.ShouldBeOfType<StudentGraded>().Grade.ShouldBe(95);
+    }
+
+    [Fact]
+    public async Task append_event_with_no_tags_and_no_inferable_properties_throws()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        Should.Throw<InvalidOperationException>(() => boundary.AppendOne(new SystemNotification("test")));
+    }
+
+    [Fact]
+    public async Task append_already_wrapped_event_with_explicit_tags_works()
+    {
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        var graded = EventsFor(session2).BuildEvent(new StudentGraded(studentId, courseId, 88));
+        graded.WithTag(studentId, courseId);
+        boundary.AppendOne(graded);
+
+        await Should.NotThrowAsync(async () => await SaveChangesAsync(session2));
+    }
+
+    [Fact]
+    public async Task append_event_with_tag_having_no_aggregate_type_creates_new_stream()
+    {
+        await theFixture.ConfigureAsync(_unroutedCourseTagConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var seed = OpenSession();
+        await AppendTaggedEventAsync(seed, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId, courseId);
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<StudentCourseEnrollment>(query, Cancellation);
+
+        // CourseId has no AggregateType -- the unrouted tag creates a new stream per event
+        var graded = EventsFor(session2).BuildEvent(new StudentGraded(studentId, courseId, 90));
+        graded.WithTag(courseId);
+        boundary.AppendOne(graded);
+
+        await Should.NotThrowAsync(async () => await SaveChangesAsync(session2));
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/DcbTagQueryAndConsistencyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DcbTagQueryAndConsistencyCompliance.cs
@@ -385,7 +385,7 @@ public abstract class DcbTagQueryAndConsistencyCompliance<TFixture, TOperations,
         assignment.WithTag(studentId, courseId);
         boundary.AppendOne(assignment);
 
-        await Should.ThrowAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
+        await ShouldFailWithAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
     }
 
     [Fact]
@@ -489,7 +489,7 @@ public abstract class DcbTagQueryAndConsistencyCompliance<TFixture, TOperations,
         e.WithTag(studentId, courseId);
         boundary.AppendOne(e);
 
-        await Should.ThrowAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
+        await ShouldFailWithAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
     }
 
     [Fact]
@@ -544,7 +544,7 @@ public abstract class DcbTagQueryAndConsistencyCompliance<TFixture, TOperations,
         assignment.WithTag(studentId, courseId);
         boundary.AppendOne(assignment);
 
-        await Should.ThrowAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
+        await ShouldFailWithAsync<DcbConcurrencyException>(async () => await SaveChangesAsync(session1));
     }
 
     #region sample_compliance_dcb_events_exist_async

--- a/src/JasperFx.Events.ComplianceTests/Suites/SelfAggregatingEvolveCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/SelfAggregatingEvolveCompliance.cs
@@ -1,0 +1,318 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region sample_compliance_evolve_aggregates
+
+public record EvolveAEvent;
+
+public record EvolveBEvent;
+
+public record EvolveCEvent;
+
+/// <summary>
+/// Mutable aggregate using void Evolve(IEvent e) -- switches on the IEvent envelope
+/// </summary>
+public partial class MutableIEventEvolveAggregate
+{
+    public Guid Id { get; set; }
+    public int ACount { get; set; }
+    public int BCount { get; set; }
+    public int CCount { get; set; }
+
+    public void Evolve(IEvent e)
+    {
+        switch (e)
+        {
+            case IEvent<EvolveAEvent>:
+                ACount++;
+                break;
+            case IEvent<EvolveBEvent>:
+                BCount++;
+                break;
+            case IEvent<EvolveCEvent>:
+                CCount++;
+                break;
+        }
+    }
+}
+
+/// <summary>
+/// Mutable aggregate using void Evolve(object o) -- switches on the event data
+/// </summary>
+public partial class MutableObjectEvolveAggregate
+{
+    public Guid Id { get; set; }
+    public int ACount { get; set; }
+    public int BCount { get; set; }
+    public int CCount { get; set; }
+
+    public void Evolve(object o)
+    {
+        switch (o)
+        {
+            case EvolveAEvent:
+                ACount++;
+                break;
+            case EvolveBEvent:
+                BCount++;
+                break;
+            case EvolveCEvent:
+                CCount++;
+                break;
+        }
+    }
+}
+
+/// <summary>
+/// Immutable aggregate using TDoc Evolve(IEvent e) -- returns a new instance
+/// </summary>
+public partial record ImmutableIEventEvolveAggregate(Guid Id, int ACount = 0, int BCount = 0, int CCount = 0)
+{
+    public ImmutableIEventEvolveAggregate(): this(Guid.Empty) { }
+
+    public ImmutableIEventEvolveAggregate Evolve(IEvent e)
+    {
+        return e switch
+        {
+            IEvent<EvolveAEvent> => this with { ACount = ACount + 1 },
+            IEvent<EvolveBEvent> => this with { BCount = BCount + 1 },
+            IEvent<EvolveCEvent> => this with { CCount = CCount + 1 },
+            _ => this
+        };
+    }
+}
+
+/// <summary>
+/// Immutable aggregate using TDoc Evolve(object o) -- returns a new instance
+/// </summary>
+public partial record ImmutableObjectEvolveAggregate(Guid Id, int ACount = 0, int BCount = 0, int CCount = 0)
+{
+    public ImmutableObjectEvolveAggregate(): this(Guid.Empty) { }
+
+    public ImmutableObjectEvolveAggregate Evolve(object o)
+    {
+        return o switch
+        {
+            EvolveAEvent => this with { ACount = ACount + 1 },
+            EvolveBEvent => this with { BCount = BCount + 1 },
+            EvolveCEvent => this with { CCount = CCount + 1 },
+            _ => this
+        };
+    }
+}
+
+/// <summary>
+/// Mutable aggregate using async Task EvolveAsync(IEvent e, IQuerySession session).
+/// The session parameter is written against the consumer-supplied
+/// <c>ComplianceQuerySession</c> global alias so this one shared source file binds to
+/// Marten's IQuerySession in Marten and Polecat's in Polecat.
+/// </summary>
+public partial class AsyncEvolveAggregate
+{
+    public Guid Id { get; set; }
+    public int ACount { get; set; }
+    public int BCount { get; set; }
+
+    public Task EvolveAsync(IEvent e, ComplianceQuerySession session)
+    {
+        switch (e)
+        {
+            case IEvent<EvolveAEvent>:
+                ACount++;
+                break;
+            case IEvent<EvolveBEvent>:
+                BCount++;
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Immutable aggregate using async ValueTask&lt;TDoc&gt; EvolveAsync(IEvent e, IQuerySession session)
+/// </summary>
+public partial record ImmutableAsyncEvolveAggregate(Guid Id, int ACount = 0, int BCount = 0)
+{
+    public ImmutableAsyncEvolveAggregate(): this(Guid.Empty) { }
+
+    public ValueTask<ImmutableAsyncEvolveAggregate> EvolveAsync(IEvent e, ComplianceQuerySession session)
+    {
+        var result = e switch
+        {
+            IEvent<EvolveAEvent> => this with { ACount = ACount + 1 },
+            IEvent<EvolveBEvent> => this with { BCount = BCount + 1 },
+            _ => this
+        };
+
+        return new ValueTask<ImmutableAsyncEvolveAggregate>(result);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Behavior of self-aggregating types that use Evolve/EvolveAsync conventions instead of
+/// Apply/Create. The store's source generator emits an IGeneratedSyncEvolver /
+/// IGeneratedAsyncEvolver that delegates to the user's method.
+/// </summary>
+/// <remarks>
+/// Every inline case asserts the *persisted* document via LoadDocumentAsync rather than re-folding
+/// the stream: re-folding would pass even if the inline projection never wrote anything.
+/// </remarks>
+public abstract class SelfAggregatingEvolveCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_evolve";
+
+        config.Snapshot<MutableIEventEvolveAggregate>(SnapshotLifecycle.Inline);
+        config.Snapshot<MutableObjectEvolveAggregate>(SnapshotLifecycle.Inline);
+        config.Snapshot<ImmutableIEventEvolveAggregate>(SnapshotLifecycle.Inline);
+        config.Snapshot<ImmutableObjectEvolveAggregate>(SnapshotLifecycle.Inline);
+        config.Snapshot<AsyncEvolveAggregate>(SnapshotLifecycle.Inline);
+        config.Snapshot<ImmutableAsyncEvolveAggregate>(SnapshotLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task mutable_ievent_evolve_inline()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveBEvent(), new EvolveAEvent(),
+            new EvolveCEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<MutableIEventEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(2);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task mutable_object_evolve_inline()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveBEvent(), new EvolveCEvent(),
+            new EvolveCEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<MutableObjectEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(1);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task immutable_ievent_evolve_inline()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveAEvent(), new EvolveBEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<ImmutableIEventEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(2);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task immutable_object_evolve_inline()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveBEvent(), new EvolveCEvent(), new EvolveAEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<ImmutableObjectEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(1);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task async_evolve_inline()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveAEvent(), new EvolveBEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<AsyncEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(2);
+        aggregate.BCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task immutable_async_evolve_inline()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveBEvent(), new EvolveAEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<ImmutableAsyncEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(2);
+        aggregate.BCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task mutable_ievent_evolve_with_append_to_existing_stream()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveBEvent());
+        await SaveChangesAsync(session);
+
+        EventsFor(session).Append(streamId, new EvolveAEvent(), new EvolveCEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate = await LoadDocumentAsync<MutableIEventEvolveAggregate>(session, streamId);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(2);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task live_aggregation_with_evolve()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveBEvent(), new EvolveCEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate =
+            await EventsFor(session).AggregateStreamAsync<MutableIEventEvolveAggregate>(streamId, token: Cancellation);
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(1);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(1);
+    }
+}


### PR DESCRIPTION
Companion to [marten#5116](https://github.com/JasperFx/marten/issues/5116); part of the test-harness standardization program ([marten#5119](https://github.com/JasperFx/marten/issues/5119), epic [marten#5110](https://github.com/JasperFx/marten/issues/5110)).

## What

A new packable project, `JasperFx.Events.ComplianceTests`, giving the Critter Stack event stores one shared set of behavioral event sourcing tests instead of hand-mirrored copies that drift. Marten (PostgreSQL) and Polecat (SQL Server) both consume it in this same wave; the planned Sqlite minimal store becomes the third consumer and the first real proof the seam carries no PostgreSQL/SQL Server residue.

## Why source-only

The package ships C# sources as `contentFiles`, no compiled assembly. That is forced rather than preferred:

- `JasperFx.Events.SourceGenerator` emits aggregate dispatchers **per consuming assembly** and binds each product's own session type (it matches the `EvolveAsync` session parameter by type name). Shared aggregates living in one DLL could never dispatch correctly for both products.
- Compiling in the consumer also sidesteps package-version skew between the repos and their `LangVersion` / `ImplicitUsings` differences.

## Contents

- `EventStoreComplianceFixture<TOperations, TQuerySession>` — the seam, generic over the same pair `IEventStore<,>` closes over. Everything portable flows through `IEventStoreOperations` / `IEventRegistry` / `IProjectionDaemon`; the fixture only absorbs what no shared interface declares (store construction, session acquisition, `SaveChangesAsync`, document load-back, batched DCB queries, daemon plumbing, teardown).
- `ComplianceStoreConfig` + `IComplianceStoreRegistrar` — store-neutral configuration replayed through recorded generic closures, so nothing needs reflection.
- `IComplianceBatch` — absorbs the batched-DCB accessor divergence (`batch.Events.EventsExist` vs `batch.EventsExist`).
- `EventStoreComplianceSuite` — owns the fixture lifecycle, so enrolling a suite is a one-line empty subclass.
- Four suites, 42 tests: `SelfAggregatingEvolveCompliance`, `DcbTagQueryAndConsistencyCompliance`, `AssignTagWhereCompliance`, `AsyncDaemonCompliance`.

## Packaging constraints, deliberately

- References `xunit.v3.extensibility.core` — **never** `xunit.v3`, which would force `OutputType=Exe` onto every consumer — plus `xunit.v3.assert` for dynamic skip.
- Authored to the floor the consumers share: `LangVersion 13`, `ImplicitUsings` off, explicit usings.
- Requires **zero** `InternalsVisibleTo` from any consumer; event type names are asserted through `IEventRegistry.EventMappingFor(Type)`.
- `Local/` holds a placeholder session alias so this repo type-checks the sources without a concrete store; it is excluded from the package.

Version bumped to 2.37.1 so the whole JasperFx line ships together.

## Verified

Packed locally and consumed by both stores before this went up:

- Marten `EventSourcingTests` net9.0: **1613 passed, 0 failed**, 42/42 compliance. Also builds clean on net10.0.
- Polecat `Polecat.Tests` net9.0: **1629 passed, 0 failed**, 42/42 compliance. Also builds clean on net10.0.

Adoption immediately earned its keep — it surfaced a real Polecat bug (`QueryByTagsAsync` never mapped `stream_id` onto the event envelope, so every DCB tag query returned `StreamId == Guid.Empty`), caught because the shared suite kept Marten's stronger assertion where the Polecat mirror had been weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)