### PR TITLE
Compliance wave 2: EventProjection, auto-discovery and rebuild-cap suites (2.37.2)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.37.1</JasperFxVersion>
+        <JasperFxVersion>2.37.2</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -23,6 +23,24 @@ public sealed class ComplianceStoreConfig
     /// </summary>
     public string? SchemaName { get; set; }
 
+    /// <summary>
+    /// Optional explicit value for the per-database rebuild concurrency cap. Null leaves the store
+    /// on its derived default; zero or negative disables the cap.
+    /// </summary>
+    /// <remarks>
+    /// Not routed through <see cref="IComplianceStoreRegistrar"/> because the products hang the knob
+    /// off different option objects (Marten <c>Projections</c>, Polecat <c>DaemonSettings</c>) and
+    /// the fixture is already the place that knows which.
+    /// </remarks>
+    public int? MaxConcurrentRebuildsPerDatabase { get; set; }
+
+    /// <summary>
+    /// Optional connection pool ceiling, folded into the connection string by the fixture. Exists so
+    /// the rebuild-cap suite can exercise the pool-size-derived default without caring whether the
+    /// store speaks Npgsql or SqlClient.
+    /// </summary>
+    public int? MaxPoolSize { get; set; }
+
     public List<Type> EventTypes { get; } = new();
 
     public List<(Type Tag, string Suffix, Type? Aggregate)> TagTypes { get; } = new();
@@ -30,6 +48,8 @@ public sealed class ComplianceStoreConfig
     public List<(Type Doc, SnapshotLifecycle Lifecycle)> Snapshots { get; } = new();
 
     public List<Type> LiveAggregations { get; } = new();
+
+    public List<(ProjectionBase Projection, ProjectionLifecycle Lifecycle)> Projections { get; } = new();
 
     public ComplianceStoreConfig AddEventType<T>()
     {
@@ -65,6 +85,18 @@ public sealed class ComplianceStoreConfig
     {
         LiveAggregations.Add(typeof(TDoc));
         _registrations.Add(registrar => registrar.LiveAggregation<TDoc>());
+        return this;
+    }
+
+    /// <summary>
+    /// Register an already-constructed projection instance. Used where the projection carries test
+    /// state (the enrichment suite's call-order recorder) or where the point of the test is what the
+    /// source generator emitted onto a concrete projection type.
+    /// </summary>
+    public ComplianceStoreConfig AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle)
+    {
+        Projections.Add((projection, lifecycle));
+        _registrations.Add(registrar => registrar.AddProjection(projection, lifecycle));
         return this;
     }
 

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
@@ -80,9 +81,32 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
         where T : class;
 
     /// <summary>
+    /// Store a plain document — not an event. Only needed where a suite has to seed state the event
+    /// store itself did not produce, such as the lookup document an enrichment projection reads.
+    /// </summary>
+    public abstract void StoreDocument<T>(TOperations session, T document) where T : notnull;
+
+    /// <summary>
     /// The payoff member — everything portable in the suites runs off the shared JasperFx surface.
     /// </summary>
     public abstract IEventStoreOperations EventsFor(TOperations session);
+
+    /// <summary>
+    /// The store itself, as the shared <see cref="IEventStore"/> surface. Suites reach for this on
+    /// store-level contracts — the rebuild concurrency cap, usage descriptors — never for anything
+    /// session-scoped.
+    /// </summary>
+    public abstract IEventStore EventStore { get; }
+
+    /// <summary>
+    /// Aggregate types the store knows about, including ones discovered from source-generated
+    /// evolvers rather than explicit registration.
+    /// </summary>
+    /// <remarks>
+    /// <c>ProjectionGraph.AllAggregateTypes()</c> is shared, but the graph hangs off each product's
+    /// own options type, so reaching it costs one line of fixture code.
+    /// </remarks>
+    public abstract IEnumerable<Type> AllAggregateTypes();
 
     public abstract IComplianceBatch CreateBatch(TQuerySession session);
 

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -51,6 +51,11 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
     protected Task<T?> LoadDocumentAsync<T>(TQuerySession session, object id) where T : class
         => theFixture.LoadDocumentAsync<T>(session, id, Cancellation);
 
+    protected void StoreDocument<T>(TOperations session, T document) where T : notnull
+        => theFixture.StoreDocument(session, document);
+
+    protected IEventStore EventStore => theFixture.EventStore;
+
     protected IComplianceBatch CreateBatch(TQuerySession session) => theFixture.CreateBatch(session);
 
     /// <summary>

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -37,4 +37,16 @@ public interface IComplianceStoreRegistrar
     /// build live aggregators automatically.
     /// </summary>
     void LiveAggregation<TDoc>() where TDoc : notnull;
+
+    /// <summary>
+    /// Register an already-constructed projection instance.
+    /// </summary>
+    /// <remarks>
+    /// Typed as the shared <see cref="ProjectionBase"/> rather than
+    /// <c>IProjectionSource&lt;TOperations, TQuerySession&gt;</c> because this interface is not
+    /// generic over the session pair; the implementing fixture casts down to its own closure. Every
+    /// projection a suite can build derives from the product's own EventProjection base, so the cast
+    /// is total in practice.
+    /// </remarks>
+    void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle);
 }

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceProjectionPlaceholders.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceProjectionPlaceholders.cs
@@ -1,0 +1,35 @@
+// NOT PACKAGED. See ComplianceQuerySessionPlaceholder.cs for why Local/ exists.
+//
+// The EventProjection suites declare projection types at file scope, so they cannot reach the
+// <TOperations, TQuerySession> pair that the suite classes are generic over. Two more per-consumer
+// global aliases close that gap, exactly like ComplianceQuerySession does for the self-aggregating
+// fixtures:
+//
+//     global using ComplianceOperations = Marten.IDocumentOperations;
+//     global using ComplianceEventProjection = Marten.Events.Projections.EventProjection;
+//
+// Aliases (rather than generic base classes) because both products' EventProjection base carries
+// store-specific members -- Marten's IProjectionSchemaSource/IMartenRegistrable, Polecat's sealed
+// storeEntity override -- so the shared sources want the product's own base type, whatever it is.
+
+global using ComplianceOperations = JasperFx.Events.ComplianceTests.Local.IPlaceholderOperations;
+global using ComplianceEventProjection = JasperFx.Events.ComplianceTests.Local.PlaceholderEventProjection;
+
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+public interface IPlaceholderOperations: IPlaceholderQuerySession, IStorageOperations
+{
+    /// <summary>
+    /// Called by the registration suite's explicit <c>ApplyAsync</c> override, which is the whole
+    /// point of that test -- the source generator has to see the <c>Store&lt;T&gt;</c> call.
+    /// </summary>
+    void Store<T>(T entity) where T : notnull;
+}
+
+public abstract class PlaceholderEventProjection: JasperFxEventProjectionBase<IPlaceholderOperations,
+    IPlaceholderQuerySession>
+{
+    protected override void storeEntity<T>(IPlaceholderOperations ops, T entity) => ops.Store(entity);
+}

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceQuerySessionPlaceholder.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceQuerySessionPlaceholder.cs
@@ -8,10 +8,24 @@
 //
 //     global using ComplianceQuerySession = Marten.IQuerySession;
 //
-// This placeholder stands in for that alias here and never leaves the repo.
+// This placeholder stands in for that alias here and never leaves the repo. Members are declared
+// only where a shared suite actually calls them, and their shapes are the intersection of what
+// Marten and Polecat already expose -- binding against the real session types in the consumers is
+// what validates them for real.
 
 global using ComplianceQuerySession = JasperFx.Events.ComplianceTests.Local.IPlaceholderQuerySession;
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace JasperFx.Events.ComplianceTests.Local;
 
-public interface IPlaceholderQuerySession;
+public interface IPlaceholderQuerySession
+{
+    /// <summary>
+    /// Called by the enrichment suite's database-lookup projection, which reads a document from
+    /// inside <c>EnrichEventsAsync</c>.
+    /// </summary>
+    Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : class;
+}

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -15,13 +15,19 @@ differences between the repos.
 Reference the package from a test project that already has xunit v3 and Shouldly, then supply two
 things.
 
-**1. A global alias naming your store's read session.** The shared self-aggregating fixtures declare
-`EvolveAsync(IEvent, ComplianceQuerySession)`; the source generator resolves the parameter by type
-name, so an alias is enough:
+**1. Three global aliases naming your store's own types.** The shared suites declare aggregates and
+projections at file scope, so they cannot reach the `<TOperations, TQuerySession>` pair the suite
+classes are generic over. The source generator resolves these by type name, so aliases are enough:
 
 ```csharp
 global using ComplianceQuerySession = Marten.IQuerySession;
+global using ComplianceOperations = Marten.IDocumentOperations;
+global using ComplianceEventProjection = Marten.Events.Projections.EventProjection;
 ```
+
+`ComplianceQuerySession` binds the `EvolveAsync(IEvent, …)` convention on the self-aggregating
+fixtures; the other two bind the EventProjection suites to your product's own projection base and
+writable session.
 
 **2. A concrete fixture** closing `EventStoreComplianceFixture<TOperations, TQuerySession>` over your
 store's session pair. Everything portable in the suites runs through the shared JasperFx surfaces

--- a/src/JasperFx.Events.ComplianceTests/Suites/AutoDiscoveredAggregateCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AutoDiscoveredAggregateCompliance.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Self-aggregating types whose evolvers were emitted by the source generator have to be usable
+/// without ever being registered — no <c>Snapshot&lt;T&gt;()</c>, no explicit projection. The store
+/// finds them by walking loaded assemblies for <c>[GeneratedEvolver]</c> at construction time.
+/// </summary>
+/// <remarks>
+/// Deliberately configures a store with nothing registered at all, which is what separates this from
+/// <see cref="SelfAggregatingEvolveCompliance{TFixture,TOperations,TQuerySession}"/> — there the same
+/// aggregates are registered as inline snapshots, so discovery is never exercised.
+/// </remarks>
+public abstract class AutoDiscoveredAggregateCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_auto_discover";
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public void self_aggregating_types_are_auto_discovered()
+    {
+        var aggregateTypes = theFixture.AllAggregateTypes().ToArray();
+
+        aggregateTypes.ShouldContain(typeof(MutableIEventEvolveAggregate),
+            "MutableIEventEvolveAggregate has a source-generated evolver and was never registered, " +
+            "so it can only be here by assembly discovery");
+    }
+
+    [Fact]
+    public async Task auto_discovered_type_works_for_live_aggregation()
+    {
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EvolveAEvent(), new EvolveBEvent(), new EvolveCEvent());
+        await SaveChangesAsync(session);
+
+        var aggregate =
+            await EventsFor(session).AggregateStreamAsync<MutableIEventEvolveAggregate>(streamId, token: Cancellation);
+
+        aggregate.ShouldNotBeNull();
+        aggregate.ACount.ShouldBe(1);
+        aggregate.BCount.ShouldBe(1);
+        aggregate.CCount.ShouldBe(1);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventProjectionEnrichmentCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventProjectionEnrichmentCompliance.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Enrichment events and documents
+
+public class EnrichmentTaskAssigned
+{
+    public Guid TaskId { get; set; }
+    public Guid UserId { get; set; }
+    public string? UserName { get; set; }
+}
+
+public class EnrichmentLookupAssigned
+{
+    public Guid TaskId { get; set; }
+    public Guid UserId { get; set; }
+    public string? UserName { get; set; }
+}
+
+public class EnrichmentPing
+{
+    public Guid TaskId { get; set; }
+}
+
+public class EnrichmentTaskSummary
+{
+    public Guid Id { get; set; }
+    public string? AssignedUserName { get; set; }
+}
+
+public class EnrichmentLookupSummary
+{
+    public Guid Id { get; set; }
+    public string? AssignedUserName { get; set; }
+}
+
+public class EnrichmentUser
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+#endregion
+
+#region Enrichment projections
+
+/// <summary>
+/// Enrichment with no external reads — mutates the event data in place before the projection sees
+/// it, which is the minimum contract: <c>Project</c> observes the enriched value, not the raw one.
+/// </summary>
+public partial class SimpleEnrichmentProjection: ComplianceEventProjection
+{
+    public void Project(EnrichmentTaskAssigned e, ComplianceOperations ops)
+    {
+        ops.Store(new EnrichmentTaskSummary { Id = e.TaskId, AssignedUserName = e.UserName });
+    }
+
+    public override Task EnrichEventsAsync(ComplianceQuerySession querySession,
+        IReadOnlyList<IEvent> events, CancellationToken cancellation)
+    {
+        foreach (var e in events.OfType<IEvent<EnrichmentTaskAssigned>>())
+        {
+            e.Data.UserName = "Enriched User";
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// The reason enrichment takes a query session at all: the hook can read persisted documents before
+/// the projection runs.
+/// </summary>
+public partial class DbLookupEnrichmentProjection: ComplianceEventProjection
+{
+    public void Project(EnrichmentLookupAssigned e, ComplianceOperations ops)
+    {
+        ops.Store(new EnrichmentLookupSummary { Id = e.TaskId, AssignedUserName = e.UserName });
+    }
+
+    public override async Task EnrichEventsAsync(ComplianceQuerySession querySession,
+        IReadOnlyList<IEvent> events, CancellationToken cancellation)
+    {
+        var assigned = events.OfType<IEvent<EnrichmentLookupAssigned>>().ToArray();
+        if (assigned.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var userId in assigned.Select(x => x.Data.UserId).Distinct())
+        {
+            var user = await querySession.LoadAsync<EnrichmentUser>(userId, cancellation).ConfigureAwait(false);
+            if (user == null)
+            {
+                continue;
+            }
+
+            foreach (var e in assigned.Where(x => x.Data.UserId == userId))
+            {
+                e.Data.UserName = user.Name;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Records the order in which the store calls enrichment versus projection.
+/// </summary>
+/// <remarks>
+/// The recording list is static because the suite's store configuration lives in a static delegate
+/// (that is what lets the fixture skip redundant rebuilds), so the projection instance is not
+/// reachable from a test method. Tests clear it before appending.
+/// </remarks>
+public partial class EnrichmentCallOrderProjection: ComplianceEventProjection
+{
+    public static readonly List<string> CallOrder = new();
+
+    public void Project(EnrichmentPing e, ComplianceOperations ops)
+    {
+        CallOrder.Add($"Apply:{nameof(EnrichmentPing)}");
+    }
+
+    public override Task EnrichEventsAsync(ComplianceQuerySession querySession,
+        IReadOnlyList<IEvent> events, CancellationToken cancellation)
+    {
+        if (events.OfType<IEvent<EnrichmentPing>>().Any())
+        {
+            CallOrder.Add(nameof(EnrichEventsAsync));
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// <c>IEventEnrichment.EnrichEventsAsync</c> runs before an inline EventProjection applies the same
+/// batch, and can read from the store while it does.
+/// </summary>
+/// <remarks>
+/// Each projection owns its own event and document type on purpose: all three are registered against
+/// one store, and two projections writing a summary for the same id would just overwrite each other.
+/// </remarks>
+public abstract class EventProjectionEnrichmentCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_enrichment";
+
+        config.AddProjection(new SimpleEnrichmentProjection(), ProjectionLifecycle.Inline);
+        config.AddProjection(new DbLookupEnrichmentProjection(), ProjectionLifecycle.Inline);
+        config.AddProjection(new EnrichmentCallOrderProjection(), ProjectionLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task enrichment_sets_data_before_apply_inline()
+    {
+        await using var session = OpenSession();
+
+        var taskId = Guid.NewGuid();
+        EventsFor(session).StartStream(taskId,
+            new EnrichmentTaskAssigned { TaskId = taskId, UserId = Guid.NewGuid() });
+        await SaveChangesAsync(session);
+
+        var summary = await LoadDocumentAsync<EnrichmentTaskSummary>(session, taskId);
+
+        summary.ShouldNotBeNull();
+
+        // The raw event carries a null UserName. Anything else means enrichment ran first.
+        summary.AssignedUserName.ShouldBe("Enriched User");
+    }
+
+    [Fact]
+    public async Task enrichment_can_read_documents_from_the_store()
+    {
+        var userId = Guid.NewGuid();
+
+        await using (var seeding = OpenSession())
+        {
+            StoreDocument(seeding, new EnrichmentUser { Id = userId, Name = "Alice Smith" });
+            await SaveChangesAsync(seeding);
+        }
+
+        await using var session = OpenSession();
+
+        var taskId = Guid.NewGuid();
+        EventsFor(session).StartStream(taskId,
+            new EnrichmentLookupAssigned { TaskId = taskId, UserId = userId });
+        await SaveChangesAsync(session);
+
+        var summary = await LoadDocumentAsync<EnrichmentLookupSummary>(session, taskId);
+
+        summary.ShouldNotBeNull();
+        summary.AssignedUserName.ShouldBe("Alice Smith");
+    }
+
+    [Fact]
+    public async Task enrichment_is_called_before_apply()
+    {
+        EnrichmentCallOrderProjection.CallOrder.Clear();
+
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new EnrichmentPing { TaskId = streamId });
+        await SaveChangesAsync(session);
+
+        EnrichmentCallOrderProjection.CallOrder
+            .ShouldBe(new[] { "EnrichEventsAsync", $"Apply:{nameof(EnrichmentPing)}" });
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventProjectionRegistrationCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventProjectionRegistrationCompliance.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Document type written by an EventProjection but never registered with the store. See
+/// https://github.com/JasperFx/marten/issues/4166.
+/// </summary>
+public class AuditRecord
+{
+    public Guid Id { get; set; }
+    public Guid StreamId { get; set; }
+    public string EventType { get; set; } = string.Empty;
+    public DateTimeOffset Timestamp { get; set; }
+}
+
+public class AuditableEvent
+{
+    public string Description { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// An EventProjection with an explicit <c>ApplyAsync</c> override that writes a document through
+/// <c>operations.Store&lt;T&gt;()</c>. The source generator has to see that call and emit a
+/// constructor registering <see cref="AuditRecord"/> as a published type — nothing else in the
+/// configuration mentions it.
+/// </summary>
+/// <remarks>
+/// The record id is the stream id rather than a fresh Guid so the end-to-end test can load it back.
+/// </remarks>
+public partial class AuditRecordProjection: ComplianceEventProjection
+{
+    public override ValueTask ApplyAsync(ComplianceOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        switch (e.Data)
+        {
+            case AuditableEvent:
+                // The explicit type argument is load-bearing: the generator's scan of ApplyAsync
+                // bodies is syntactic, so it only sees Store<T>/Insert<T>/Update<T> written with one.
+                operations.Store<AuditRecord>(new AuditRecord
+                {
+                    Id = e.StreamId,
+                    StreamId = e.StreamId,
+                    EventType = e.Data.GetType().Name,
+                    Timestamp = e.Timestamp
+                });
+                break;
+        }
+
+        return new ValueTask();
+    }
+}
+
+/// <summary>
+/// The conventional route to the same registration: a <c>Create</c> method whose return type is the
+/// published document type.
+/// </summary>
+public partial class AuditRecordCreatorProjection: ComplianceEventProjection
+{
+    public AuditRecord Create(AuditableEvent e) => new()
+    {
+        Id = Guid.NewGuid(), EventType = nameof(AuditableEvent)
+    };
+}
+
+/// <summary>
+/// Document types used by an EventProjection are discovered and registered without the user
+/// declaring them — whether they show up as a <c>Store&lt;T&gt;</c> call inside an explicit
+/// <c>ApplyAsync</c> override or as the return type of a conventional <c>Create</c> method.
+/// </summary>
+public abstract class EventProjectionRegistrationCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_projection_registration";
+
+        // Only the ApplyAsync projection is registered: the Create-convention one is asserted as a
+        // bare object, and registering both would have two projections racing to write an
+        // AuditRecord for the same event.
+        config.AddProjection(new AuditRecordProjection(), ProjectionLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public void explicit_apply_async_projection_publishes_the_stored_document_type()
+    {
+        var projection = new AuditRecordProjection();
+
+        projection.PublishedTypes().ShouldContain(typeof(AuditRecord),
+            "AuditRecord should be discovered from the operations.Store<AuditRecord>() call in ApplyAsync");
+    }
+
+    [Fact]
+    public void conventional_create_projection_publishes_its_return_type()
+    {
+        var projection = new AuditRecordCreatorProjection();
+
+        projection.PublishedTypes().ShouldContain(typeof(AuditRecord),
+            "AuditRecord should be discovered from the Create method's return type");
+    }
+
+    [Fact]
+    public async Task unregistered_document_type_is_persisted_end_to_end()
+    {
+        // The assertion the registration checks above are a proxy for: if discovery worked, the
+        // store has real storage for AuditRecord and the inline projection can write to it.
+        await using var session = OpenSession();
+
+        var streamId = Guid.NewGuid();
+        EventsFor(session).StartStream(streamId, new AuditableEvent { Description = "created" });
+        await SaveChangesAsync(session);
+
+        var record = await LoadDocumentAsync<AuditRecord>(session, streamId);
+
+        record.ShouldNotBeNull();
+        record.StreamId.ShouldBe(streamId);
+        record.EventType.ShouldBe(nameof(AuditableEvent));
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/RebuildConcurrencyCapCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/RebuildConcurrencyCapCompliance.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Resolution of the per-database rebuild concurrency cap that stores surface through
+/// <see cref="IEventStore.MaxConcurrentRebuildsPerDatabase"/> — jasperfx#420 / marten#4710. An
+/// explicit setting wins; a non-positive setting disables the cap; otherwise the store derives one
+/// from its connection pool ceiling, an eighth of the pool with a floor of one.
+/// </summary>
+/// <remarks>
+/// Every test configures its own store, so this suite skips the standard build in
+/// <see cref="InitializeAsync"/> rather than paying for a store nothing uses. Pool sizes are
+/// expressed store-neutrally through <see cref="ComplianceStoreConfig.MaxPoolSize"/> — the fixture
+/// owns the connection string and knows whether it speaks Npgsql or SqlClient.
+/// </remarks>
+public abstract class RebuildConcurrencyCapCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private const string Schema = "compliance_rebuild_cap";
+
+    private static readonly Action<ComplianceStoreConfig> _capOfThree = config =>
+    {
+        config.SchemaName = Schema;
+        config.MaxConcurrentRebuildsPerDatabase = 3;
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _capOfZero = config =>
+    {
+        config.SchemaName = Schema;
+        config.MaxConcurrentRebuildsPerDatabase = 0;
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _capOfSix = config =>
+    {
+        config.SchemaName = Schema;
+        config.MaxConcurrentRebuildsPerDatabase = 6;
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _largePool = config =>
+    {
+        config.SchemaName = Schema;
+        config.MaxPoolSize = 64;
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _tinyPool = config =>
+    {
+        config.SchemaName = Schema;
+        config.MaxPoolSize = 5;
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _capOfThree;
+
+    /// <summary>
+    /// Skips the base class's standard build and per-test data cleanup: each test below builds the
+    /// store it needs and none of them write events.
+    /// </summary>
+    public override ValueTask InitializeAsync() => theFixture.InitializeAsync();
+
+    [Fact]
+    public async Task configured_value_wins_over_derived_default()
+    {
+        await theFixture.ConfigureAsync(_capOfThree);
+
+        EventStore.MaxConcurrentRebuildsPerDatabase.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task non_positive_configured_value_disables_the_cap()
+    {
+        await theFixture.ConfigureAsync(_capOfZero);
+
+        EventStore.MaxConcurrentRebuildsPerDatabase.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task derived_default_is_pool_size_over_eight()
+    {
+        await theFixture.ConfigureAsync(_largePool);
+
+        EventStore.MaxConcurrentRebuildsPerDatabase.ShouldBe(8);
+    }
+
+    [Fact]
+    public async Task derived_default_floors_at_one_for_tiny_pools()
+    {
+        await theFixture.ConfigureAsync(_tinyPool);
+
+        EventStore.MaxConcurrentRebuildsPerDatabase.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task usage_descriptor_carries_the_effective_cap()
+    {
+        // jasperfx#434: CritterWatch's rebuild dispatcher reads the effective cap off the
+        // EventStoreUsage descriptor rather than guessing at it.
+        await theFixture.ConfigureAsync(_capOfSix);
+
+        var usage = await EventStore.TryCreateUsage(Cancellation);
+
+        usage.ShouldNotBeNull();
+        usage.MaxConcurrentRebuildsPerDatabase.ShouldBe(6);
+    }
+}


### PR DESCRIPTION
Companion to [marten#5118](https://github.com/JasperFx/marten/issues/5118) (epic marten#5110, program marten#5119), and the follow-on to #607. Four more suites lifted out of the hand-mirrored Marten/Polecat pairs — 13 tests, taking the shared library from 42 to 55.

## Suites added

| Suite | What it pins down |
|---|---|
| `AutoDiscoveredAggregateCompliance` | A self-aggregating type with a generated evolver works with **nothing** registered. Distinct from `SelfAggregatingEvolveCompliance`, where the same aggregates are registered as inline snapshots and discovery is never exercised. |
| `EventProjectionRegistrationCompliance` | Document types discovered from a `Store<T>` call inside an explicit `ApplyAsync` override (marten#4166) and from a conventional `Create` return type, plus an end-to-end write proving the store really provisioned storage for a type nobody registered. |
| `EventProjectionEnrichmentCompliance` | `EnrichEventsAsync` runs before an inline EventProjection applies the same batch, and can read documents from the store while it does. |
| `RebuildConcurrencyCapCompliance` | Resolution of `IEventStore.MaxConcurrentRebuildsPerDatabase` (jasperfx#420 / marten#4710): explicit setting wins, non-positive disables, otherwise pool size over eight with a floor of one, and the usage descriptor carries the effective value. |

Strongest-assertion-wins in action: Marten's registration test only checked the store's known document types, Polecat's only checked `PublishedTypes()`. The shared suite does both **and** adds the round trip.

## Seam additions

Each one exists because a suite needed it, not on speculation:

- `EventStoreComplianceFixture.StoreDocument` — seeding a lookup document the event store did not produce.
- `EventStoreComplianceFixture.EventStore` — store-level contracts (`MaxConcurrentRebuildsPerDatabase`, `TryCreateUsage`).
- `EventStoreComplianceFixture.AllAggregateTypes` — `ProjectionGraph.AllAggregateTypes()` is shared, but the graph hangs off each product's own options type.
- `ComplianceStoreConfig.AddProjection` + `IComplianceStoreRegistrar.AddProjection`.
- `ComplianceStoreConfig.MaxConcurrentRebuildsPerDatabase` / `MaxPoolSize`. These bypass the registrar deliberately: the products hang the cap off different objects (Marten `Projections`, Polecat `DaemonSettings`), and `MaxPoolSize` has to reach the connection string, which only the fixture owns.

## Consumer-visible change

Consumers now supply **three** global aliases instead of one. The EventProjection suites declare projection types at file scope, so they cannot reach the `<TOperations, TQuerySession>` pair the suite classes are generic over:

```csharp
global using ComplianceQuerySession = Marten.IQuerySession;
global using ComplianceOperations = Marten.IDocumentOperations;      // new
global using ComplianceEventProjection = Marten.Events.Projections.EventProjection;  // new
```

Aliases rather than a shared generic base, because both products' `EventProjection` carries store-specific members (Marten's `IProjectionSchemaSource`/`IMartenRegistrable`, Polecat's sealed `storeEntity`). README updated.

## Landmine worth knowing

The generator's scan of `ApplyAsync` bodies for published types (`AggregateAnalyzer.DiscoverDocumentTypesFromMethodBodies`) is **syntactic**, so `Store<T>` must be written with an explicit type argument. `Store(entity)` compiles and silently registers nothing — that is a real trap for users, and it cost this PR one red test before the comment went in.

## Verification

Both stores against the packed package: **Marten 55/55, Polecat 55/55**, still zero capability gates on either.

Consumer PRs: [marten#5123](https://github.com/JasperFx/marten/pull/5123), polecat#TBD — both blocked on the 2.37.2 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde