### PR TITLE
Fix the race in SideEffectGateTimeoutTests.a_timeout_that_did_not_reach_the_prior_mark_pauses_the_shard

### DIFF
--- a/src/EventTests/Daemon/SideEffectGateTimeoutTests.cs
+++ b/src/EventTests/Daemon/SideEffectGateTimeoutTests.cs
@@ -62,21 +62,26 @@ public class SideEffectGateTimeoutTests
         // The genuine failure. Side effects must NOT be enabled over history the prior version already
         // covered, so no continuous agent starts — but the shard is published as Paused rather than left
         // silently stopped, so it is visible to a supervisor and resumes from its persisted floor.
-        var paused = new List<ShardState>();
+        // ShardStateTracker publishes through a Block<ShardState>, so an observer runs on the block's
+        // consumer thread and is NOT guaranteed to have run by the time StartAgentAsync returns.
+        // Collecting into a List and asserting straight after the call is a race, and CI lost it: the
+        // list was empty at the assertion and held the state by the time Shouldly rendered the failure
+        // message, which is why that failure read "should have single item but had 1 items".
+        var paused = new TaskCompletionSource<ShardState>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var harness = new DaemonHarness(
             settings => settings.SideEffectGateTimeout = 250.Milliseconds(),
             progressReads: [0, PriorMark - 40],
             onShardState: state =>
             {
-                if (state.Action == ShardAction.Paused) paused.Add(state);
+                if (state.Action == ShardAction.Paused) paused.TrySetResult(state);
             });
 
         await harness.Daemon.StartAgentAsync("Trip:V2:All", CancellationToken.None);
 
         harness.Daemon.CurrentAgents().ShouldNotContain(x => x.Name.Identity == "Trip:V2:All");
 
-        var state = paused.ShouldHaveSingleItem();
+        var state = await paused.Task.WaitAsync(TestTimeout);
         state.ShardName.ShouldBe("Trip:V2:All");
         state.Sequence.ShouldBe(PriorMark - 40);
         state.PauseReason.ShouldContain("side-effect gate warm-up timed out");


### PR DESCRIPTION
Test-only. This test went red on net9 during #608 — a compliance-suite PR that touches nothing `EventTests` references — and passed on the rerun. It is a real race, not infrastructure noise.

## Diagnosis

`ShardStateTracker` publishes through a `Block<ShardState>`, so a subscribed observer runs on the block's consumer thread and is **not** guaranteed to have run by the time `StartAgentAsync` returns. The test collected `Paused` states into a `List<ShardState>` and asserted on it immediately.

What pins it down is the failure message, not a wrong count:

```
Shouldly.ShouldAssertException : [ShardName: Trip:V2:All, Sequence: 60, Action: Paused]
    should have single item but had
1
    items
```

A **one-element** collection reported as failing a single-item assertion is impossible unless the collection changed between the check and the message being rendered. The list was empty when `ShouldHaveSingleItem` ran, and held the state a moment later when Shouldly enumerated it again to build the message. So the shard did pause, correctly, with the right sequence — the test just looked too early.

## Fix

Wait for the publication through a `TaskCompletionSource`, bounded by the class's `TestTimeout` — which was declared at the top of the file for exactly this purpose and never used.

**One deliberate narrowing:** the exactly-one-publication assertion is gone. "Exactly one so far" cannot be asserted against an asynchronous publisher without an arbitrary sleep, and the test's subject — stated in its own comment — is that a supervisor *sees* the pause with the right sequence and reason, not the publication count.

## Verification

net9.0: the class 8/8 consecutive runs, `EventTests` 657 / 0 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde