### PR TITLE
Discover EventProjection published types semantically, not syntactically

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.37.2</JasperFxVersion>
+        <JasperFxVersion>2.37.3</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -1411,4 +1411,113 @@ public partial class CartProjection : SingleStreamProjection<Cart, Guid>
         allGenerated.ShouldContain("return s.Apply(data);");
         allGenerated.ShouldNotContain("GetUninitializedObject(typeof(global::Test.Cart)).Apply(");
     }
+
+    // Published-type discovery from an explicit ApplyAsync override (marten#4166). The document type
+    // is read off the bound method symbol, so the explicit and inferred spellings of the same call
+    // must produce the same registration -- see the remarks on
+    // AggregateAnalyzer.DiscoverDocumentTypesFromMethodBodies.
+    private const string EventProjectionPreamble = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public interface ITestQuerySession { }
+
+public interface ITestOperations : ITestQuerySession, IStorageOperations
+{
+    void Store<T>(T entity) where T : notnull;
+}
+
+public abstract class TestEventProjection : JasperFxEventProjectionBase<ITestOperations, ITestQuerySession>
+{
+    protected override void storeEntity<T>(ITestOperations ops, T entity) => ops.Store(entity);
+}
+
+public class AuditRecord { public Guid Id { get; set; } }
+public class AuditableEvent { }
+";
+
+    [Fact]
+    public void registers_published_type_from_an_explicit_store_type_argument()
+    {
+        var (_, generatedSources) = RunGenerator(EventProjectionPreamble + @"
+public partial class ExplicitStoreProjection : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store<AuditRecord>(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        string.Join("\n", generatedSources)
+            .ShouldContain("RegisterPublishedType(typeof(global::Test.AuditRecord));");
+    }
+
+    [Fact]
+    public void registers_published_type_when_the_store_type_argument_is_inferred()
+    {
+        // The trap this closes: discovery used to be syntactic, so this spelling compiled and
+        // registered nothing at all, while the explicit one above worked.
+        var (_, generatedSources) = RunGenerator(EventProjectionPreamble + @"
+public partial class InferredStoreProjection : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        string.Join("\n", generatedSources)
+            .ShouldContain("RegisterPublishedType(typeof(global::Test.AuditRecord));");
+    }
+
+    [Fact]
+    public void reports_a_diagnostic_when_the_document_type_cannot_be_registered()
+    {
+        var (diagnostics, generatedSources) = RunGenerator(EventProjectionPreamble + @"
+public partial class ObjectStoreProjection : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store<object>(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        diagnostics.ShouldContain(d => d.Id == "JFXEVT005");
+        string.Join("\n", generatedSources).ShouldNotContain("RegisterPublishedType");
+    }
+
+    [Fact]
+    public void ignores_a_store_call_that_is_not_on_the_projection_session()
+    {
+        // A same-named method on an unrelated object is not a document operation, and must produce
+        // neither a registration nor a diagnostic.
+        var (diagnostics, generatedSources) = RunGenerator(EventProjectionPreamble + @"
+public class SomethingElse { public void Store<T>(T thing) { } }
+
+public partial class UnrelatedStoreProjection : TestEventProjection
+{
+    private readonly SomethingElse _other = new();
+
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        _other.Store(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        diagnostics.ShouldNotContain(d => d.Id == "JFXEVT005");
+        string.Join("\n", generatedSources).ShouldNotContain("RegisterPublishedType");
+    }
 }

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -120,10 +120,35 @@ internal sealed class CandidateInfo
     /// See https://github.com/JasperFx/marten/issues/4166
     /// </summary>
     public List<ITypeSymbol> DiscoveredPublishedTypes { get; set; } = new();
+
+    /// <summary>
+    /// Document operations that bound to the projection's own session but whose document type is
+    /// not registrable (object, dynamic, an open type parameter). Reported as JFXEVT005 rather than
+    /// silently skipped, because nothing at the call site tells the user it was skipped.
+    /// </summary>
+    public List<UnresolvedDocumentOperation> UnresolvedDocumentOperations { get; set; } = new();
     // SelfAggregatingEvolve-specific
     public EvolveMethodInfo? EvolveMethod { get; set; }
     // Natural key discovery
     public bool HasNaturalKey { get; set; }
+}
+
+/// <summary>
+/// A document operation that bound to an EventProjection's own session but whose document type
+/// could not be turned into a published-type registration.
+/// </summary>
+internal sealed class UnresolvedDocumentOperation
+{
+    public UnresolvedDocumentOperation(string methodName, string documentTypeDisplay, Location location)
+    {
+        MethodName = methodName;
+        DocumentTypeDisplay = documentTypeDisplay;
+        Location = location;
+    }
+
+    public string MethodName { get; }
+    public string DocumentTypeDisplay { get; }
+    public Location Location { get; }
 }
 
 internal static class AggregateAnalyzer
@@ -161,7 +186,8 @@ internal static class AggregateAnalyzer
         var eventProjBaseInfo = FindEventProjectionBase(classSymbol);
         if (eventProjBaseInfo != null)
         {
-            return AnalyzeEventProjectionSubclass(classDecl, classSymbol, eventProjBaseInfo.Value, ct);
+            return AnalyzeEventProjectionSubclass(classDecl, classSymbol, eventProjBaseInfo.Value,
+                context.SemanticModel, ct);
         }
 
         // Not a projection subclass - check if self-aggregating
@@ -895,6 +921,7 @@ internal static class AggregateAnalyzer
         TypeDeclarationSyntax classDecl,
         INamedTypeSymbol classSymbol,
         (INamedTypeSymbol operationsType, INamedTypeSymbol querySessionType) baseInfo,
+        SemanticModel? semanticModel,
         CancellationToken ct)
     {
         var isPartial = classDecl.Modifiers.Any(SyntaxKind.PartialKeyword);
@@ -907,8 +934,12 @@ internal static class AggregateAnalyzer
             // See https://github.com/JasperFx/marten/issues/4166
             if (!isPartial) return null;
 
-            var discoveredTypes = DiscoverDocumentTypesFromMethodBodies(classDecl, classSymbol);
-            if (discoveredTypes.Count == 0) return null;
+            var unresolved = new List<UnresolvedDocumentOperation>();
+            var discoveredTypes = DiscoverDocumentTypesFromMethodBodies(classDecl, classSymbol,
+                baseInfo.operationsType, semanticModel, unresolved);
+
+            // A class with nothing registrable AND nothing to warn about is not a candidate at all.
+            if (discoveredTypes.Count == 0 && unresolved.Count == 0) return null;
 
             return new CandidateInfo
             {
@@ -919,6 +950,7 @@ internal static class AggregateAnalyzer
                 OperationsType = baseInfo.operationsType,
                 QuerySessionType = baseInfo.querySessionType,
                 DiscoveredPublishedTypes = discoveredTypes,
+                UnresolvedDocumentOperations = unresolved,
                 HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol)
             };
         }
@@ -945,65 +977,176 @@ internal static class AggregateAnalyzer
     }
 
     /// <summary>
+    /// Operation methods on a document session that carry the document type as their single
+    /// generic argument, whether it was written explicitly or inferred from the argument.
+    /// </summary>
+    private static readonly HashSet<string> DocumentOperationMethodNames = new()
+        { "Store", "Insert", "Delete", "Update", "HardDelete" };
+
+    /// <summary>
     /// Scans method bodies in an EventProjection class for calls to Store&lt;T&gt;, Insert&lt;T&gt;,
     /// Delete&lt;T&gt;, Update&lt;T&gt; on document operations to discover published document types.
     /// This handles the case where users override ApplyAsync directly and call operations
     /// methods with document types that are not otherwise registered.
     /// See https://github.com/JasperFx/marten/issues/4166
     /// </summary>
+    /// <remarks>
+    /// Resolution is SEMANTIC, deliberately. This used to match only <c>GenericNameSyntax</c>, which
+    /// meant <c>ops.Store&lt;Doc&gt;(x)</c> registered the published type and the equally valid
+    /// <c>ops.Store(x)</c> compiled and registered nothing at all — a silent trap, since the store
+    /// then provisions that document's storage on demand and only the schema-ahead-of-time and
+    /// known-document-type surfaces come up short. Binding the invocation gives the same answer for
+    /// both spellings, because the type argument is on the symbol whether or not it was written down.
+    /// The syntactic path stays as a fallback for code that does not bind (mid-edit, broken trees).
+    /// </remarks>
     private static List<ITypeSymbol> DiscoverDocumentTypesFromMethodBodies(
         TypeDeclarationSyntax classDecl,
-        INamedTypeSymbol classSymbol)
+        INamedTypeSymbol classSymbol,
+        INamedTypeSymbol operationsType,
+        SemanticModel? semanticModel,
+        List<UnresolvedDocumentOperation>? unresolved = null)
     {
         var documentTypes = new List<ITypeSymbol>();
         var typeNames = new HashSet<string>();
+        var seen = new HashSet<string>();
 
-        // Operation methods that accept a document type as a generic argument
-        var operationMethodNames = new HashSet<string>
-            { "Store", "Insert", "Delete", "Update", "HardDelete" };
-
-        // Scan all method bodies in the class for generic invocations
         foreach (var node in classDecl.DescendantNodes())
         {
-            if (node is InvocationExpressionSyntax invocation)
-            {
-                // Look for patterns like: operations.Store<T>(...) or ops.Insert<T>(...)
-                var methodName = invocation.Expression switch
-                {
-                    MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
-                    _ => null
-                };
+            if (node is not InvocationExpressionSyntax invocation) continue;
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) continue;
 
-                if (methodName is GenericNameSyntax genericName &&
-                    operationMethodNames.Contains(genericName.Identifier.ValueText) &&
-                    genericName.TypeArgumentList.Arguments.Count == 1)
+            var simpleName = memberAccess.Name;
+            if (!DocumentOperationMethodNames.Contains(simpleName.Identifier.ValueText)) continue;
+
+            if (semanticModel != null &&
+                TryResolveDocumentOperation(semanticModel, invocation, memberAccess, operationsType,
+                    out var resolvedType, out var isOnOperations))
+            {
+                if (IsRegistrableDocumentType(resolvedType))
                 {
-                    var typeArg = genericName.TypeArgumentList.Arguments[0];
-                    var typeName = ExtractTypeNameFromTypeSyntax(typeArg);
-                    if (typeName != null)
+                    if (seen.Add(resolvedType!.ToDisplayString()))
                     {
-                        typeNames.Add(typeName);
+                        documentTypes.Add(resolvedType);
                     }
                 }
+                else if (isOnOperations && unresolved != null)
+                {
+                    // Bound to the operations session but the document type is not something we can
+                    // register -- object, dynamic, an open type parameter. Nothing to emit, and the
+                    // user cannot tell from the call site, so it is worth a diagnostic.
+                    unresolved.Add(new UnresolvedDocumentOperation(
+                        simpleName.Identifier.ValueText,
+                        resolvedType?.ToDisplayString() ?? "?",
+                        simpleName.GetLocation()));
+                }
+
+                continue;
             }
 
-            // Also detect: new SomeType(...) passed to operations.Insert(new SomeType(...))
-            // This is handled by looking for non-generic overloads like Insert(entity) where
-            // the entity is a new expression. But this is harder to detect without semantic analysis.
-            // For now, focus on the generic overload pattern which is the most common.
+            // Fallback: unbindable code. Only the explicit spelling is recoverable from syntax alone.
+            if (simpleName is GenericNameSyntax genericName &&
+                genericName.TypeArgumentList.Arguments.Count == 1)
+            {
+                var typeName = ExtractTypeNameFromTypeSyntax(genericName.TypeArgumentList.Arguments[0]);
+                if (typeName != null)
+                {
+                    typeNames.Add(typeName);
+                }
+            }
         }
 
-        // Resolve type names to symbols
         foreach (var tn in typeNames)
         {
             var resolved = FindTypeByName(tn, classSymbol);
-            if (resolved != null && !IsFrameworkType(resolved))
+            if (resolved != null && !IsFrameworkType(resolved) && seen.Add(resolved.ToDisplayString()))
             {
                 documentTypes.Add(resolved);
             }
         }
 
         return documentTypes;
+    }
+
+    /// <summary>
+    /// Bind a candidate document operation call and pull the document type off the method symbol.
+    /// </summary>
+    /// <param name="isOnOperations">
+    /// True when the receiver really is the projection's operations session, which is what separates
+    /// "we could not register this document type" from "this was somebody else's Store method".
+    /// </param>
+    private static bool TryResolveDocumentOperation(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocation,
+        MemberAccessExpressionSyntax memberAccess,
+        INamedTypeSymbol operationsType,
+        out ITypeSymbol? documentType,
+        out bool isOnOperations)
+    {
+        documentType = null;
+        isOnOperations = false;
+
+        var symbol = semanticModel.GetSymbolInfo(invocation).Symbol
+                     ?? semanticModel.GetSymbolInfo(invocation).CandidateSymbols.FirstOrDefault();
+
+        if (symbol is not IMethodSymbol method) return false;
+
+        var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+        isOnOperations = receiverType != null && IsOrImplements(receiverType, operationsType);
+
+        // Extension methods hang the session off the first parameter rather than the receiver.
+        if (!isOnOperations && method.IsExtensionMethod && method.ReducedFrom == null &&
+            method.Parameters.Length > 0)
+        {
+            isOnOperations = IsOrImplements(method.Parameters[0].Type, operationsType);
+        }
+
+        if (!isOnOperations) return true;
+
+        if (method.TypeArguments.Length == 1)
+        {
+            var candidate = method.TypeArguments[0];
+            // Kept even when it is not registrable, so the diagnostic can name what was written.
+            documentType = candidate;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Can this type be named in a <c>RegisterPublishedType(typeof(...))</c> call and mean something?
+    /// </summary>
+    /// <remarks>
+    /// <c>SpecialType</c> is the check that matters and <see cref="IsFrameworkType"/> cannot stand in
+    /// for it: <c>object</c> and <c>string</c> render through <c>ToDisplayString()</c> as their C#
+    /// keywords, not as <c>System.Object</c> / <c>System.String</c>, so a name-prefix test lets them
+    /// through and the projection ends up registering <c>object</c> as a published document type.
+    /// </remarks>
+    private static bool IsRegistrableDocumentType(ITypeSymbol? type)
+    {
+        if (type == null) return false;
+        if (type.TypeKind is TypeKind.TypeParameter or TypeKind.Dynamic or TypeKind.Error) return false;
+        if (type.SpecialType != SpecialType.None) return false;
+
+        return !IsFrameworkType(type);
+    }
+
+    private static bool IsOrImplements(ITypeSymbol type, INamedTypeSymbol target)
+    {
+        if (SymbolEqualityComparer.Default.Equals(type, target)) return true;
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(iface, target)) return true;
+        }
+
+        var baseType = type.BaseType;
+        while (baseType != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(baseType, target)) return true;
+            baseType = baseType.BaseType;
+        }
+
+        return false;
     }
 
     private static List<ConventionalMethodInfo> DiscoverEventProjectionMethods(

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -482,6 +482,16 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
 
     private static void EmitEventProjectionTypeRegistration(SourceProductionContext context, CandidateInfo info)
     {
+        foreach (var unresolved in info.UnresolvedDocumentOperations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.UnregistrableDocumentOperation,
+                unresolved.Location,
+                info.ClassSymbol.Name,
+                unresolved.MethodName,
+                unresolved.DocumentTypeDisplay));
+        }
+
         if (info.DiscoveredPublishedTypes.Count == 0) return;
 
         var source = EvolverCodeEmitter.EmitEventProjectionTypeRegistrationPartial(info);

--- a/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
+++ b/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
@@ -28,6 +28,21 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// An EventProjection's explicit ApplyAsync writes a document whose type the generator cannot
+    /// name, so no published-type registration is emitted for it. Silent otherwise: the store will
+    /// still provision that document's storage on demand, and only the ahead-of-time surfaces
+    /// (schema creation, known document types, rebuild teardown) come up short.
+    /// </summary>
+    public static readonly DiagnosticDescriptor UnregistrableDocumentOperation = new(
+        id: "JFXEVT005",
+        title: "Document type cannot be registered from this operation",
+        messageFormat:
+            "'{0}' calls {1} on its session with document type '{2}', which cannot be registered as a published type; call it with a concrete document type so the projection registers it",
+        category: "JasperFx.Events",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
     public static readonly DiagnosticDescriptor HasLambdaRegistrations = new(
         id: "JFXEVT004",
         title: "Has lambda registrations",


### PR DESCRIPTION
Closes the trap that cost compliance wave 2 (#608) a red test. It is far worse for users than it was for suite authors.

## The trap

`AggregateAnalyzer.DiscoverDocumentTypesFromMethodBodies` matched only `GenericNameSyntax`. So an explicit `ApplyAsync` override that wrote

```csharp
operations.Store<AuditRecord>(record);   // registers AuditRecord
operations.Store(record);                // registers NOTHING
```

behaved completely differently for two spellings of the same call — and nothing tells you. It compiles, and it does not fail at runtime either: the store provisions that document's storage on demand, so only the ahead-of-time surfaces come up short (schema creation, known document types, rebuild teardown). Original context in marten#4166.

## The fix

Bind the invocation. The type argument is on the method symbol whether or not it was written down, so both spellings give the same answer. The syntactic path stays as a fallback for trees that do not bind (mid-edit, broken code), so nothing regresses when the semantic model has nothing to say.

Receiver identification is deliberate rather than name-based: the call must bind to the projection's own `TOperations` — directly, through an interface, or as an extension method's first parameter — so an unrelated `Store` method on some other object produces neither a registration nor a diagnostic. There is a test for exactly that.

## A hole the semantic path made visible

`IsFrameworkType` cannot decide whether a type is registrable. `object` and `string` render through `ToDisplayString()` as their **C# keywords**, not as `System.Object` / `System.String`, so a name-prefix test lets them straight through — `Store<object>(...)` was registering `object` as a published document type. Registrability is now a `SpecialType` / `TypeKind` question, with `IsFrameworkType` only as the last check.

## New diagnostic: JFXEVT005 (Info)

Covers what is left after the fix — a call that binds to the projection's own session but whose document type cannot be named: `object`, `dynamic`, an open type parameter.

**Info rather than Warning, on purpose.** Registration is not always required — the type may be registered through store options, and storage is provisioned on demand regardless — so this must not break a `TreatWarningsAsErrors` build over a perfectly legitimate call.

## Verification

- `JasperFx.Events.SourceGenerator.Tests` **30/30**, with four new cases: explicit spelling, inferred spelling, the unregistrable case, and the unrelated-receiver case.
- `EventTests` **657 / 0 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde