### PR TITLE
Compliance wave 3: activity correlation and string stream identity suites

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -41,6 +41,29 @@ public sealed class ComplianceStoreConfig
     /// </summary>
     public int? MaxPoolSize { get; set; }
 
+    /// <summary>
+    /// Optional stream identity style. Null leaves the store on its own default, which is
+    /// <see cref="Events.StreamIdentity.AsGuid"/> in both products.
+    /// </summary>
+    /// <remarks>
+    /// A plain property rather than an <see cref="IComplianceStoreRegistrar"/> call for the same
+    /// reason as <see cref="MaxConcurrentRebuildsPerDatabase"/>: the value is the shared
+    /// <see cref="Events.StreamIdentity"/> enum, but the options object it hangs off is the product's
+    /// own event graph, and the fixture is already the place that knows which.
+    /// </remarks>
+    public StreamIdentity? StreamIdentity { get; set; }
+
+    /// <summary>
+    /// Persist correlation and causation metadata onto appended events. Off by default in both
+    /// products, and spelled differently in each — Marten's <c>Events.MetadataConfig</c>, Polecat's
+    /// <c>Events.EnableCorrelationId</c>/<c>EnableCausationId</c>.
+    /// </summary>
+    /// <remarks>
+    /// One flag rather than two because no suite needs correlation without causation, and the pair
+    /// is what distributed tracing actually populates.
+    /// </remarks>
+    public bool EnableCorrelationTracking { get; set; }
+
     public List<Type> EventTypes { get; } = new();
 
     public List<(Type Tag, string Suffix, Type? Aggregate)> TagTypes { get; } = new();

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -92,6 +92,26 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     public abstract IEventStoreOperations EventsFor(TOperations session);
 
     /// <summary>
+    /// The session's correlation id, which both products seed from <c>Activity.Current.RootId</c>
+    /// when the session opens.
+    /// </summary>
+    /// <remarks>
+    /// Session-scoped correlation/causation is one of the few genuinely shared behaviors that no
+    /// shared interface declares: both products hang the pair off their own query session type, and
+    /// <see cref="IStorageOperations"/> deliberately stays narrow. Three fixture members are cheaper
+    /// than widening that contract. The <em>event</em> side of the same behavior needs nothing here,
+    /// because <see cref="IEvent.CorrelationId"/> is already shared.
+    /// </remarks>
+    public abstract string? CorrelationIdFor(TOperations session);
+
+    public abstract string? CausationIdFor(TOperations session);
+
+    /// <summary>
+    /// Assign the correlation id explicitly, which must beat whatever the ambient activity seeded.
+    /// </summary>
+    public abstract void SetCorrelationId(TOperations session, string? correlationId);
+
+    /// <summary>
     /// The store itself, as the shared <see cref="IEventStore"/> surface. Suites reach for this on
     /// store-level contracts — the rebuild concurrency cap, usage descriptors — never for anything
     /// session-scoped.

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -46,6 +46,13 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
 
     protected IEventStoreOperations EventsFor(TOperations session) => theFixture.EventsFor(session);
 
+    protected string? CorrelationIdFor(TOperations session) => theFixture.CorrelationIdFor(session);
+
+    protected string? CausationIdFor(TOperations session) => theFixture.CausationIdFor(session);
+
+    protected void SetCorrelationId(TOperations session, string? correlationId)
+        => theFixture.SetCorrelationId(session, correlationId);
+
     protected Task SaveChangesAsync(TOperations session) => theFixture.SaveChangesAsync(session, Cancellation);
 
     protected Task<T?> LoadDocumentAsync<T>(TQuerySession session, object id) where T : class

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceSingleStreamProjectionPlaceholder.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceSingleStreamProjectionPlaceholder.cs
@@ -1,0 +1,24 @@
+// NOT PACKAGED. See ComplianceQuerySessionPlaceholder.cs for why Local/ exists.
+//
+// StringIdentitySingleStreamCompliance declares a custom single stream projection at file scope, so
+// it cannot reach the <TOperations, TQuerySession> pair its suite class is generic over -- the same
+// gap ComplianceEventProjection closes for the EventProjection suites. Here the alias has to name a
+// *closed* generic, because the projection base is generic over both the document and its identity:
+//
+//     global using ComplianceStringPartyProjectionBase =
+//         Marten.Events.Aggregation.SingleStreamProjection<
+//             JasperFx.Events.ComplianceTests.StringQuestParty, string>;
+//
+// An alias rather than a shared base class for the same reason as the others: each product's
+// SingleStreamProjection<TDoc, TId> carries store-specific members, and the shared source wants the
+// product's own type whatever it is.
+
+global using ComplianceStringPartyProjectionBase =
+    JasperFx.Events.ComplianceTests.Local.PlaceholderStringPartyProjection;
+
+using JasperFx.Events.Aggregation;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+public class PlaceholderStringPartyProjection: JasperFxSingleStreamProjectionBase<StringQuestParty, string,
+    IPlaceholderOperations, IPlaceholderQuerySession>;

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -15,7 +15,7 @@ differences between the repos.
 Reference the package from a test project that already has xunit v3 and Shouldly, then supply two
 things.
 
-**1. Three global aliases naming your store's own types.** The shared suites declare aggregates and
+**1. Four global aliases naming your store's own types.** The shared suites declare aggregates and
 projections at file scope, so they cannot reach the `<TOperations, TQuerySession>` pair the suite
 classes are generic over. The source generator resolves these by type name, so aliases are enough:
 
@@ -23,11 +23,16 @@ classes are generic over. The source generator resolves these by type name, so a
 global using ComplianceQuerySession = Marten.IQuerySession;
 global using ComplianceOperations = Marten.IDocumentOperations;
 global using ComplianceEventProjection = Marten.Events.Projections.EventProjection;
+global using ComplianceStringPartyProjectionBase =
+    Marten.Events.Aggregation.SingleStreamProjection<
+        JasperFx.Events.ComplianceTests.StringQuestParty, string>;
 ```
 
 `ComplianceQuerySession` binds the `EvolveAsync(IEvent, …)` convention on the self-aggregating
-fixtures; the other two bind the EventProjection suites to your product's own projection base and
-writable session.
+fixtures; the next two bind the EventProjection suites to your product's own projection base and
+writable session. The last one is a *closed* generic, because the single stream projection base is
+generic over both the document and its identity — it binds the string-identity suite's custom
+projection to your product's `SingleStreamProjection<TDoc, TId>`.
 
 **2. A concrete fixture** closing `EventStoreComplianceFixture<TOperations, TQuerySession>` over your
 store's session pair. Everything portable in the suites runs through the shared JasperFx surfaces

--- a/src/JasperFx.Events.ComplianceTests/Suites/ActivityCorrelationCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ActivityCorrelationCompliance.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record ActivityQuestStarted(string Name);
+
+/// <summary>
+/// Opening a session seeds <c>CorrelationId</c> from <c>Activity.Current.RootId</c> and
+/// <c>CausationId</c> from <c>Activity.Current.ParentId</c>, so distributed tracing context reaches
+/// appended events with no application code. An explicit caller assignment still wins.
+/// </summary>
+/// <remarks>
+/// The seeding happens at session construction, which is why every test here opens its session
+/// inside the activity scope rather than in a fixture. Both stores read the ambient
+/// <see cref="Activity"/> the same way; the only thing that differs is which options object carries
+/// the "persist this metadata" switch, and that is what
+/// <see cref="ComplianceStoreConfig.EnableCorrelationTracking"/> absorbs.
+/// </remarks>
+public abstract class ActivityCorrelationCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_activity";
+
+        // Only the second test needs the metadata actually persisted onto events, but turning it on
+        // for the whole suite costs nothing: the session-level seeding under test is independent of
+        // whether the store writes the columns.
+        config.EnableCorrelationTracking = true;
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// A started activity nested inside another, so <c>ParentId</c> is non-null and distinguishable
+    /// from <c>RootId</c>.
+    /// </summary>
+    private static (Activity Parent, Activity Child) startActivityScope()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        var parent = new Activity("compliance-parent").Start();
+        var child = new Activity("compliance-child").Start();
+
+        return (parent, child);
+    }
+
+    [Fact]
+    public async Task session_seeds_correlation_and_causation_from_activity()
+    {
+        var (parent, child) = startActivityScope();
+
+        try
+        {
+            await using var session = OpenSession();
+
+            CorrelationIdFor(session).ShouldBe(child.RootId);
+            CausationIdFor(session).ShouldBe(child.ParentId);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task events_appended_in_activity_scope_carry_root_and_parent_ids()
+    {
+        var (parent, child) = startActivityScope();
+        var streamId = Guid.NewGuid();
+
+        try
+        {
+            await using var session = OpenSession();
+            EventsFor(session).StartStream(streamId, new ActivityQuestStarted("Traced Quest"));
+            await SaveChangesAsync(session);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(1);
+        events[0].CorrelationId.ShouldBe(child.RootId);
+        events[0].CausationId.ShouldBe(child.ParentId);
+    }
+
+    [Fact]
+    public async Task explicit_caller_value_wins_over_activity()
+    {
+        var (parent, child) = startActivityScope();
+
+        try
+        {
+            await using var session = OpenSession();
+            SetCorrelationId(session, "explicit-corr");
+
+            CorrelationIdFor(session).ShouldBe("explicit-corr");
+            CorrelationIdFor(session).ShouldNotBe(child.RootId);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task no_activity_leaves_correlation_null()
+    {
+        var ambient = Activity.Current;
+        Activity.Current = null;
+
+        try
+        {
+            await using var session = OpenSession();
+
+            CorrelationIdFor(session).ShouldBeNull();
+            CausationIdFor(session).ShouldBeNull();
+        }
+        finally
+        {
+            Activity.Current = ambient;
+        }
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StringIdentitySingleStreamCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StringIdentitySingleStreamCompliance.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region String identity events and aggregates
+
+public record StringQuestStarted(string Name);
+
+public record StringMembersJoined(int Day, string Location, string[] Members);
+
+public record StringMembersDeparted(string[] Members);
+
+public record StringArrivedAtLocation(string Location, int Day);
+
+public record StringMonsterSlain(string Name);
+
+public record StringQuestEnded(string Name);
+
+/// <summary>
+/// Aggregate keyed by the stream's string key rather than a Guid.
+/// </summary>
+public partial class StringQuestParty
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<string> Members { get; set; } = new();
+    public string? Location { get; set; }
+    public List<string> MonstersSlain { get; set; } = new();
+}
+
+/// <summary>
+/// The same aggregate shape, but self-aggregating, so it can be registered with plain
+/// <c>Snapshot&lt;T&gt;()</c> and the store has to derive <c>string</c> as the identity type from the
+/// document itself.
+/// </summary>
+public partial class SelfAggregatingStringQuest
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public List<string> Members { get; set; } = new();
+
+    public static SelfAggregatingStringQuest Create(StringQuestStarted e) => new() { Name = e.Name };
+
+    public void Apply(StringMembersJoined e) => Members.AddRange(e.Members);
+}
+
+/// <summary>
+/// A custom single stream projection closed over <c>string</c>. The base type comes from the
+/// consumer-supplied <c>ComplianceStringPartyProjectionBase</c> global alias, because each product
+/// declares its own <c>SingleStreamProjection&lt;TDoc, TId&gt;</c> subclass of
+/// <c>JasperFxSingleStreamProjectionBase</c> and this file cannot reach the suite's generics.
+/// </summary>
+public partial class StringQuestPartyProjection: ComplianceStringPartyProjectionBase
+{
+    public static StringQuestParty Create(IEvent<StringQuestStarted> @event) =>
+        new() { Id = @event.StreamKey!, Name = @event.Data.Name };
+
+    public void Apply(StringMembersJoined e, StringQuestParty party)
+    {
+        party.Members.AddRange(e.Members);
+        party.Location = e.Location;
+    }
+
+    public void Apply(StringMembersDeparted e, StringQuestParty party)
+    {
+        foreach (var member in e.Members)
+        {
+            party.Members.Remove(member);
+        }
+    }
+
+    public void Apply(StringArrivedAtLocation e, StringQuestParty party) => party.Location = e.Location;
+
+    public void Apply(StringMonsterSlain e, StringQuestParty party) => party.MonstersSlain.Add(e.Name);
+
+    public bool ShouldDelete(StringQuestEnded e) => true;
+}
+
+#endregion
+
+/// <summary>
+/// Single stream aggregation against string-keyed streams — <c>StreamIdentity.AsString</c> — through
+/// both routes a store offers: an explicit <c>SingleStreamProjection&lt;TDoc, string&gt;</c> subclass
+/// and a self-aggregating type registered with <c>Snapshot&lt;T&gt;()</c>.
+/// </summary>
+/// <remarks>
+/// The assertions all load the persisted document rather than re-folding the stream, so a projection
+/// that never wrote anything fails. Deletion is covered too: <c>ShouldDelete</c> has to remove the
+/// aggregate row, not merely stop updating it.
+/// </remarks>
+public abstract class StringIdentitySingleStreamCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_string_id";
+        config.StreamIdentity = StreamIdentity.AsString;
+
+        config.AddProjection(new StringQuestPartyProjection(), ProjectionLifecycle.Inline);
+        config.Snapshot<SelfAggregatingStringQuest>(SnapshotLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static string streamKey() => "quest-" + Guid.NewGuid();
+
+    [Fact]
+    public async Task custom_projection_creates_aggregate_on_start_stream()
+    {
+        var key = streamKey();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key, new StringQuestStarted("Destroy the Ring"));
+        await SaveChangesAsync(session);
+
+        var party = await LoadDocumentAsync<StringQuestParty>(session, key);
+
+        party.ShouldNotBeNull();
+        party.Id.ShouldBe(key);
+        party.Name.ShouldBe("Destroy the Ring");
+    }
+
+    [Fact]
+    public async Task custom_projection_applies_multiple_events()
+    {
+        var key = streamKey();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key,
+            new StringQuestStarted("Fellowship"),
+            new StringMembersJoined(1, "Rivendell", ["Aragorn", "Legolas", "Gimli"]));
+        await SaveChangesAsync(session);
+
+        var party = await LoadDocumentAsync<StringQuestParty>(session, key);
+
+        party.ShouldNotBeNull();
+        party.Name.ShouldBe("Fellowship");
+        party.Members.ShouldBe(new List<string> { "Aragorn", "Legolas", "Gimli" });
+        party.Location.ShouldBe("Rivendell");
+    }
+
+    [Fact]
+    public async Task custom_projection_updates_on_append()
+    {
+        var key = streamKey();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key,
+            new StringQuestStarted("Adventure"),
+            new StringMembersJoined(1, "Start", ["Hero"]));
+        await SaveChangesAsync(session);
+
+        EventsFor(session).Append(key,
+            new StringArrivedAtLocation("Dungeon", 2),
+            new StringMonsterSlain("Goblin"));
+        await SaveChangesAsync(session);
+
+        var party = await LoadDocumentAsync<StringQuestParty>(session, key);
+
+        party.ShouldNotBeNull();
+        party.Location.ShouldBe("Dungeon");
+        party.MonstersSlain.ShouldContain("Goblin");
+    }
+
+    [Fact]
+    public async Task custom_projection_should_delete_removes_aggregate()
+    {
+        var key = streamKey();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key,
+            new StringQuestStarted("Doomed Quest"),
+            new StringMembersJoined(1, "Start", ["Hero"]));
+        await SaveChangesAsync(session);
+
+        EventsFor(session).Append(key, new StringQuestEnded("Doomed Quest"));
+        await SaveChangesAsync(session);
+
+        var party = await LoadDocumentAsync<StringQuestParty>(session, key);
+        party.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task multiple_string_keyed_streams_projected_independently()
+    {
+        var first = streamKey();
+        var second = streamKey();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(first,
+            new StringQuestStarted("Quest 1"),
+            new StringMembersJoined(1, "Town A", ["Alpha"]));
+        EventsFor(session).StartStream(second,
+            new StringQuestStarted("Quest 2"),
+            new StringMembersJoined(1, "Town B", ["Beta", "Gamma"]));
+        await SaveChangesAsync(session);
+
+        var partyOne = await LoadDocumentAsync<StringQuestParty>(session, first);
+        var partyTwo = await LoadDocumentAsync<StringQuestParty>(session, second);
+
+        partyOne.ShouldNotBeNull();
+        partyOne.Name.ShouldBe("Quest 1");
+        partyOne.Members.ShouldBe(new List<string> { "Alpha" });
+
+        partyTwo.ShouldNotBeNull();
+        partyTwo.Name.ShouldBe("Quest 2");
+        partyTwo.Members.ShouldBe(new List<string> { "Beta", "Gamma" });
+    }
+
+    [Fact]
+    public async Task self_aggregating_snapshot_with_string_identity()
+    {
+        var key = "snap-" + Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key,
+            new StringQuestStarted("Snapshot Quest"),
+            new StringMembersJoined(1, "Castle", ["Knight"]));
+        await SaveChangesAsync(session);
+
+        var quest = await LoadDocumentAsync<SelfAggregatingStringQuest>(session, key);
+
+        quest.ShouldNotBeNull();
+        quest.Id.ShouldBe(key);
+        quest.Name.ShouldBe("Snapshot Quest");
+        quest.Members.ShouldBe(new List<string> { "Knight" });
+    }
+}


### PR DESCRIPTION
Companion to polecat#399 (epic marten#5110, marten#5118). Adds the two shared suites that retire
Polecat's last two event sourcing test files claiming to be Marten ports.

## New suites

**`ActivityCorrelationCompliance`** — opening a session seeds `CorrelationId` from
`Activity.Current.RootId` and `CausationId` from `Activity.Current.ParentId`; events appended inside
the scope carry both; an explicit assignment beats the ambient activity; no ambient activity leaves
both null. Marten does this in `DocumentStore.cs`, Polecat in `DocumentStore.EventStore.cs`, and
nothing asserted it in one place.

**`StringIdentitySingleStreamCompliance`** — single stream aggregation over `StreamIdentity.AsString`
through both registration routes: an explicit `SingleStreamProjection<TDoc, string>` subclass with
`Create`/`Apply`/`ShouldDelete`, and a self-aggregating type registered with `Snapshot<T>()`, which
forces the store to derive `string` as the identity type from the document. Every assertion loads the
persisted document rather than re-folding the stream, so a projection that never wrote anything
fails.

## Seam changes

- `ComplianceStoreConfig.StreamIdentity` and `.EnableCorrelationTracking`. Plain properties applied by
  the fixture rather than `IComplianceStoreRegistrar` calls, following the
  `MaxConcurrentRebuildsPerDatabase` precedent: the values are shared, but the options object each
  hangs off is the product's own event graph (Marten's `MetadataConfig`, Polecat's
  `EnableCorrelationId`/`EnableCausationId`).
- Three abstract fixture members — `CorrelationIdFor`, `CausationIdFor`, `SetCorrelationId`.
  Session-scoped correlation is a genuinely shared behavior that no shared interface declares, and
  `IStorageOperations` deliberately stays narrow. The event side needed nothing, since
  `IEvent.CorrelationId` is already shared.
- A fourth global alias, `ComplianceStringPartyProjectionBase`. Unlike the existing three it names a
  *closed* generic, because the single stream projection base is generic over both the document and
  its identity. `Local/` gains the matching placeholder so the library still type-checks inside this
  repo, and the README documents the alias.

**Consumers must update their fixtures** for the three new abstract members — the same shape of
break waves 1 and 2 made. Polecat's side is written and green (65/65 in its compliance namespace, up
from 55).

## Verification

`JasperFx.Events.ComplianceTests` builds clean. The suites were validated end-to-end against Polecat
by compiling this working copy into `Polecat.Tests` — 10 new tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8tN8ApXiKhyVzia4iwmof