### PR TITLE
Fail the publish when the line version is already on nuget.org

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -24,6 +24,7 @@
     "ExecutableTarget": {
       "type": "string",
       "enum": [
+        "AssertVersionIsUnpublished",
         "Clean",
         "Compile",
         "NugetPack",
@@ -113,6 +114,10 @@
   "allOf": [
     {
       "properties": {
+        "AllowRepublish": {
+          "type": "boolean",
+          "description": "Push even when the line version is already on nuget.org. Only for retrying a publish that failed partway"
+        },
         "Configuration": {
           "type": "string",
           "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Xml.Linq;
 using Nuke.Common;
 using Nuke.Common.CI;
 using Nuke.Common.Execution;
@@ -225,8 +229,79 @@ partial class Build : NukeBuild
     
     [Parameter("Nuget Api Key")] [Secret] readonly string NugetApiKey;
 
+    [Parameter(
+        "Push even when the line version is already on nuget.org. Only for retrying a publish that failed partway.")]
+    readonly bool AllowRepublish;
+
+    /// <summary>
+    /// Fail before pushing if $(JasperFxVersion) is already published.
+    /// </summary>
+    /// <remarks>
+    /// NugetPush uses --skip-duplicate, which is correct -- JasperFx.RuntimeCompiler is deliberately
+    /// pinned off the line and skips every time, and a publish that failed partway has to be safe to
+    /// retry. The cost is that running the workflow WITHOUT bumping the version skips all seven
+    /// packages and still exits 0, so a shippable merge can "release" nothing and report success. The
+    /// only signal is a consumer restore resolving the old version, a long way from the cause.
+    ///
+    /// Checks the JasperFx package alone: it carries the line version, whereas RuntimeCompiler
+    /// intentionally does not. A network failure warns rather than fails -- this is a safety net, and
+    /// an unreachable nuget.org should not block a release.
+    /// </remarks>
+    Target AssertVersionIsUnpublished => _ => _
+        .OnlyWhenDynamic(() => !AllowRepublish)
+        .Executes(() =>
+        {
+            var version = XDocument.Load(RootDirectory / "Directory.Build.props")
+                .Descendants("JasperFxVersion")
+                .Select(x => x.Value.Trim())
+                .FirstOrDefault();
+
+            if (string.IsNullOrEmpty(version))
+            {
+                throw new Exception("Could not read JasperFxVersion from Directory.Build.props");
+            }
+
+            string[] published;
+            try
+            {
+                using var client = new HttpClient();
+                var response = client
+                    .GetAsync("https://api.nuget.org/v3-flatcontainer/jasperfx/index.json")
+                    .GetAwaiter().GetResult();
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var json = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                published = JsonDocument.Parse(json).RootElement.GetProperty("versions")
+                    .EnumerateArray().Select(x => x.GetString()).ToArray();
+            }
+            catch (Exception e)
+            {
+                Serilog.Log.Warning(e,
+                    "Could not reach nuget.org to check whether {Version} is already published; pushing anyway",
+                    version);
+                return;
+            }
+
+            if (published.Contains(version, StringComparer.OrdinalIgnoreCase))
+            {
+                throw new Exception(
+                    $"JasperFx {version} is already published to nuget.org. Every package would be skipped as a "
+                    + "duplicate and this run would still report success. Bump JasperFxVersion in "
+                    + "Directory.Build.props, or pass --allow-republish to retry a publish that failed partway.");
+            }
+
+            Serilog.Log.Information("JasperFx {Version} is not yet published; proceeding", version);
+        });
+
     Target NugetPush => _ => _
         .DependsOn(NugetPack)
+        .DependsOn(AssertVersionIsUnpublished)
         .Requires(() => !string.IsNullOrEmpty(NugetApiKey))
         .Executes(() =>
         {


### PR DESCRIPTION
Closes #612

## The problem

`NugetPush` pushes with `--skip-duplicate`, so running the publish workflow **without** bumping `JasperFxVersion` skips all seven packages and still exits 0. The workflow goes green and nothing shipped. The only signal is a consumer restore resolving the old version, a long way from the cause.

It is easiest to hit right after a release, when `main` already sits at the just-published version and the next shippable merge is one forgotten line away from a silent no-op.

## What this does not do

`--skip-duplicate` stays. It is doing two legitimate jobs:

- `JasperFx.RuntimeCompiler` is deliberately pinned off the line at 5.0.0 and skips on **every** publish. That is correct and must keep working.
- A publish that failed partway has to be safe to retry.

So the guard checks the **line version**, not each package: it queries the `JasperFx` package alone, which carries the line version where RuntimeCompiler intentionally does not. It cannot be confused by the deliberate skip.

## What it does

`AssertVersionIsUnpublished`, a new dependency of `NugetPush`, reads `$(JasperFxVersion)` from `Directory.Build.props` and checks the flat-container index.

- **`--allow-republish` opts out.** This is required, not a nicety — retrying a publish that pushed three of seven packages before failing is exactly what `--skip-duplicate` exists for, and the guard must not stand in its way.
- **A network failure warns and proceeds.** This is a safety net; an unreachable nuget.org should not block a release.

## Verified locally, against the real feed

```
./build.sh AssertVersionIsUnpublished
  → Failed: "JasperFx 2.37.3 is already published to nuget.org. Every package would be skipped as a
     duplicate and this run would still report success. Bump JasperFxVersion in Directory.Build.props,
     or pass --allow-republish to retry a publish that failed partway."

./build.sh AssertVersionIsUnpublished --allow-republish
  → Skipped   // OnlyWhen: !AllowRepublish

(JasperFxVersion temporarily set to 2.99.9)
./build.sh AssertVersionIsUnpublished
  → "JasperFx 2.99.9 is not yet published; proceeding"   Succeeded
```

`.nuke/build.schema.json` is regenerated by Nuke for the new parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde