### PR TITLE
Lift the ProjectionScenario test harness into JasperFx.Events

### DIFF
--- a/src/EventTests/TestSupport/projection_scenario_tests.cs
+++ b/src/EventTests/TestSupport/projection_scenario_tests.cs
@@ -1,0 +1,261 @@
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.TestSupport;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace EventTests.TestSupport;
+
+public class projection_scenario_tests
+{
+    private readonly FakeProjectionScenario theScenario = new();
+
+    [Fact]
+    public async Task deletes_existing_data_by_default()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.Cleaned.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task can_opt_out_of_deleting_existing_data()
+    {
+        theScenario.DeleteExistingData = false;
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.Cleaned.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task actions_are_deferred_until_execution_and_flow_to_the_session_events()
+    {
+        var streamId = Guid.NewGuid();
+        var @event = new AEvent();
+
+        theScenario.Append(streamId, @event);
+        theScenario.Events.DidNotReceiveWithAnyArgs().Append(Guid.Empty, Array.Empty<object>());
+
+        await theScenario.ExecuteAsync();
+
+        theScenario.Events.Received().Append(streamId, Arg.Is<object[]>(x => x.Single() == @event));
+    }
+
+    [Fact]
+    public async Task start_stream_returns_the_generated_stream_id_used_by_the_queued_operation()
+    {
+        var @event = new AEvent();
+        var streamId = theScenario.StartStream<FakeAggregate>(@event);
+
+        streamId.ShouldNotBe(Guid.Empty);
+
+        await theScenario.ExecuteAsync();
+
+        theScenario.Events.Received().StartStream<FakeAggregate>(streamId,
+            Arg.Is<object[]>(x => x.Single() == @event));
+    }
+
+    [Fact]
+    public async Task flushes_before_each_assertion_and_once_at_the_end()
+    {
+        theScenario.Documents[1] = new FakeDocument();
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+
+        await theScenario.ExecuteAsync();
+
+        // Once before the assertion, once for the trailing append (see marten#5126)
+        theScenario.SaveCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task an_arrange_only_scenario_still_commits()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+
+        await theScenario.ExecuteAsync();
+
+        theScenario.SaveCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task failed_assertions_accumulate_and_surface_as_typed_assertion_exceptions()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.DocumentShouldExist<FakeDocument>(2);
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(() => theScenario.ExecuteAsync());
+
+        ex.InnerExceptions.Count.ShouldBe(2);
+        ex.InnerExceptions.ShouldAllBe(x => x is ProjectionScenarioAssertionException);
+        ex.Message.ShouldContain("FAILED");
+    }
+
+    [Fact]
+    public async Task document_should_not_exist_fails_when_the_document_is_there()
+    {
+        theScenario.Documents[1] = new FakeDocument();
+        theScenario.DocumentShouldNotExist<FakeDocument>(1);
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(() => theScenario.ExecuteAsync());
+
+        ex.InnerExceptions.Single().ShouldBeOfType<ProjectionScenarioAssertionException>();
+    }
+
+    [Fact]
+    public async Task document_should_exist_runs_the_optional_additional_assertions()
+    {
+        theScenario.Documents[1] = new FakeDocument { Name = "right" };
+        var observed = "";
+        theScenario.DocumentShouldExist<FakeDocument>(1, doc => observed = doc.Name);
+
+        await theScenario.ExecuteAsync();
+
+        observed.ShouldBe("right");
+    }
+
+    [Fact]
+    public async Task a_failed_action_stops_the_scenario_and_skips_the_remaining_steps()
+    {
+        theScenario.Documents[1] = new FakeDocument();
+
+        theScenario.AppendEvents("blows up", _ => throw new DivideByZeroException("boom"));
+        theScenario.DocumentShouldNotExist<FakeDocument>(2);
+        theScenario.DocumentShouldExist<FakeDocument>(3);
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(() => theScenario.ExecuteAsync());
+
+        ex.InnerExceptions.Single().ShouldBeOfType<DivideByZeroException>();
+        ex.Message.ShouldContain("Skipped the remaining 2 step(s)");
+
+        // No final flush either -- the session may hold a partially built unit of work
+        theScenario.SaveCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_scenario_cannot_be_executed_twice()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        await Should.ThrowAsync<InvalidOperationException>(() => theScenario.ExecuteAsync());
+    }
+
+    [Fact]
+    public async Task uses_no_daemon_when_there_are_no_async_projections()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        await theScenario.FakeDaemon.DidNotReceive().StartAllAsync();
+    }
+
+    [Fact]
+    public async Task starts_waits_on_and_stops_the_daemon_when_async_projections_exist()
+    {
+        theScenario.HasAsync = true;
+        theScenario.Timeout = 5.Seconds();
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        await theScenario.FakeDaemon.Received().StartAllAsync();
+        await theScenario.FakeDaemon.Received().WaitForNonStaleData(5.Seconds());
+        await theScenario.FakeDaemon.Received().StopAllAsync();
+    }
+
+    [Fact]
+    public async Task tenant_id_flows_to_the_session_and_daemon()
+    {
+        theScenario.HasAsync = true;
+        theScenario.TenantId = "purple";
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.OpenedTenant.ShouldBe("purple");
+        theScenario.DaemonTenant.ShouldBe("purple");
+    }
+
+    [Fact]
+    public async Task the_session_is_disposed_after_execution()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        await theScenario.Operations.Received().DisposeAsync();
+    }
+
+    public class AEvent;
+
+    public class FakeAggregate;
+
+    public class FakeDocument
+    {
+        public string Name { get; set; } = "";
+    }
+}
+
+public interface IFakeQuerySession;
+
+public interface IFakeOperations: IFakeQuerySession, IStorageOperations;
+
+/// <summary>
+/// Closes the scenario over throwaway session interfaces so the sequencing, flushing, and
+/// failure-handling logic can be exercised without a running store.
+/// </summary>
+public class FakeProjectionScenario: ProjectionScenario<IFakeOperations, IFakeQuerySession>
+{
+    public IFakeOperations Operations { get; } = Substitute.For<IFakeOperations>();
+    public IEventOperations Events { get; } = Substitute.For<IEventOperations>();
+    public IProjectionDaemon FakeDaemon { get; } = Substitute.For<IProjectionDaemon>();
+
+    public Dictionary<object, object> Documents { get; } = new();
+
+    public bool HasAsync { get; set; }
+    public bool Cleaned { get; private set; }
+    public int SaveCount { get; private set; }
+    public string? OpenedTenant { get; private set; }
+    public string? DaemonTenant { get; private set; }
+
+    protected override Task DeleteExistingDataAsync(CancellationToken ct)
+    {
+        Cleaned = true;
+        return Task.CompletedTask;
+    }
+
+    protected override bool HasAnyAsyncProjections => HasAsync;
+
+    protected override ValueTask<IProjectionDaemon> BuildDaemonAsync(string? tenantId)
+    {
+        DaemonTenant = tenantId;
+        return new ValueTask<IProjectionDaemon>(FakeDaemon);
+    }
+
+    protected override IFakeOperations OpenSession(string? tenantId)
+    {
+        OpenedTenant = tenantId;
+        return Operations;
+    }
+
+    protected override Task SaveChangesAsync(IFakeOperations session, CancellationToken ct)
+    {
+        SaveCount++;
+        return Task.CompletedTask;
+    }
+
+    protected override IEventOperations EventsFor(IFakeOperations session) => Events;
+
+    protected override Task<T?> LoadDocumentAsync<T>(IFakeQuerySession session, object id, CancellationToken ct)
+        where T : class
+    {
+        return Task.FromResult(Documents.TryGetValue(id, out var doc) ? doc as T : null);
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ProjectionScenario.Assertions.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenario.Assertions.cs
@@ -1,0 +1,58 @@
+using JasperFx.Core.Reflection;
+
+namespace JasperFx.Events.TestSupport;
+
+public abstract partial class ProjectionScenario<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    /// <summary>
+    ///     General hook to make any assertion against the projected data with a query session
+    /// </summary>
+    /// <param name="description">Descriptive explanation of the assertion in case of failures</param>
+    /// <param name="assertions"></param>
+    public void AssertAgainstProjectedData(string description, Func<TQuerySession, CancellationToken, Task> assertions)
+    {
+        assertion(assertions).Description = description;
+    }
+
+    /// <summary>
+    ///     Verify that a document with the supplied id exists. The id can be a Guid, string,
+    ///     int, or long -- whatever identity type the document uses
+    /// </summary>
+    /// <param name="id">The identity of the document</param>
+    /// <param name="assertions">Optional lambda to make additional assertions about the document state</param>
+    /// <typeparam name="T">The document type</typeparam>
+    public void DocumentShouldExist<T>(object id, Action<T>? assertions = null) where T : class
+    {
+        assertion(async (session, ct) =>
+        {
+            var document = await LoadDocumentAsync<T>(session, id, ct).ConfigureAwait(false);
+            if (document == null)
+            {
+                throw new ProjectionScenarioAssertionException(
+                    $"Document {typeof(T).FullNameInCode()} with id '{id}' does not exist");
+            }
+
+            assertions?.Invoke(document);
+        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should exist";
+    }
+
+    /// <summary>
+    ///     Asserts that a document with a given id has been deleted or does not exist. The id
+    ///     can be a Guid, string, int, or long -- whatever identity type the document uses
+    /// </summary>
+    /// <param name="id">The identity of the document</param>
+    /// <typeparam name="T">The document type</typeparam>
+    public void DocumentShouldNotExist<T>(object id) where T : class
+    {
+        assertion(async (session, ct) =>
+        {
+            var document = await LoadDocumentAsync<T>(session, id, ct).ConfigureAwait(false);
+            if (document != null)
+            {
+                throw new ProjectionScenarioAssertionException(
+                    $"Document {typeof(T).FullNameInCode()} with id '{id}' exists, but should not.");
+            }
+        }).Description = $"Document {typeof(T).FullNameInCode()} with id '{id}' should not exist or be deleted";
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ProjectionScenario.EventOperations.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenario.EventOperations.cs
@@ -1,0 +1,315 @@
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+
+namespace JasperFx.Events.TestSupport;
+
+public abstract partial class ProjectionScenario<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static string describe(object[] events)
+    {
+        return events.Length > 3 ? "events" : events.Select(x => x.ToString()).Join(", ");
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream id</param>
+    /// <param name="events">The events to append</param>
+    public void Append(Guid stream, IEnumerable<object> events)
+    {
+        Append(stream, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream id</param>
+    /// <param name="events">The events to append</param>
+    public void Append(Guid stream, params object[] events)
+    {
+        action(e => e.Append(stream, events)).Description = $"Append({stream}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, IEnumerable<object> events)
+    {
+        Append(stream, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, params object[] events)
+    {
+        action(e => e.Append(stream, events)).Description = $"Append(\"{stream}\", {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream with an expected version
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream id</param>
+    /// <param name="expectedVersion">The expected stream version after appending</param>
+    /// <param name="events">The events to append</param>
+    public void Append(Guid stream, long expectedVersion, params object[] events)
+    {
+        action(e => e.Append(stream, expectedVersion, events)).Description =
+            $"Append({stream}, {expectedVersion}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream with an expected version
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="expectedVersion">The expected stream version after appending</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, long expectedVersion, IEnumerable<object> events)
+    {
+        Append(stream, expectedVersion, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue appending events to an existing event stream with an expected version
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="stream">The stream key</param>
+    /// <param name="expectedVersion">The expected stream version after appending</param>
+    /// <param name="events">The events to append</param>
+    public void Append(string stream, long expectedVersion, params object[] events)
+    {
+        action(e => e.Append(stream, expectedVersion, events)).Description =
+            $"Append(\"{stream}\", {expectedVersion}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    public void StartStream<TAggregate>(Guid id, params object[] events) where TAggregate : class
+    {
+        action(e => e.StartStream<TAggregate>(id, events)).Description =
+            $"StartStream<{typeof(TAggregate).FullNameInCode()}>({id}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, Guid id, IEnumerable<object> events)
+    {
+        StartStream(aggregateType, id, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, Guid id, params object[] events)
+    {
+        action(e => e.StartStream(aggregateType, id, events)).Description =
+            $"StartStream({aggregateType.FullNameInCode()}, {id}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    public void StartStream<TAggregate>(string streamKey, IEnumerable<object> events)
+        where TAggregate : class
+    {
+        StartStream<TAggregate>(streamKey, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    public void StartStream<TAggregate>(string streamKey, params object[] events) where TAggregate : class
+    {
+        action(e => e.StartStream<TAggregate>(streamKey, events)).Description =
+            $"StartStream<{typeof(TAggregate).FullNameInCode()}>(\"{streamKey}\", {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, string streamKey, IEnumerable<object> events)
+    {
+        StartStream(aggregateType, streamKey, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Type aggregateType, string streamKey, params object[] events)
+    {
+        action(e => e.StartStream(aggregateType, streamKey, events)).Description =
+            $"StartStream({aggregateType.FullNameInCode()}, \"{streamKey}\", {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Guid id, IEnumerable<object> events)
+    {
+        StartStream(id, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="id">The stream id</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(Guid id, params object[] events)
+    {
+        action(e => e.StartStream(id, events)).Description = $"StartStream({id}, {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(string streamKey, IEnumerable<object> events)
+    {
+        StartStream(streamKey, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream in the scenario sequence
+    /// </summary>
+    /// <param name="streamKey">The stream key</param>
+    /// <param name="events">The initial events</param>
+    public void StartStream(string streamKey, params object[] events)
+    {
+        action(e => e.StartStream(streamKey, events)).Description =
+            $"StartStream(\"{streamKey}\", {describe(events)})";
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream<TAggregate>(IEnumerable<object> events) where TAggregate : class
+    {
+        return StartStream<TAggregate>(events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <typeparam name="TAggregate">The aggregate type for the new stream</typeparam>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream<TAggregate>(params object[] events) where TAggregate : class
+    {
+        var streamId = Guid.NewGuid();
+        action(e => e.StartStream<TAggregate>(streamId, events)).Description =
+            $"StartStream<{typeof(TAggregate).FullNameInCode()}>({streamId}, {describe(events)})";
+
+        return streamId;
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(Type aggregateType, IEnumerable<object> events)
+    {
+        return StartStream(aggregateType, events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="aggregateType">The aggregate type for the new stream</param>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(Type aggregateType, params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+        action(e => e.StartStream(aggregateType, streamId, events)).Description =
+            $"StartStream({aggregateType.FullNameInCode()}, {streamId}, {describe(events)})";
+
+        return streamId;
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(IEnumerable<object> events)
+    {
+        return StartStream(events as object[] ?? events.ToArray());
+    }
+
+    /// <summary>
+    ///     Queue starting a new event stream with a newly generated stream id
+    ///     in the scenario sequence
+    /// </summary>
+    /// <param name="events">The initial events</param>
+    /// <returns>The generated id of the new stream</returns>
+    public Guid StartStream(params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+        action(e => e.StartStream(streamId, events)).Description =
+            $"StartStream({streamId}, {describe(events)})";
+
+        return streamId;
+    }
+
+    /// <summary>
+    ///     Make any number of append event operations in the scenario sequence
+    /// </summary>
+    /// <param name="description">Descriptive explanation of the action in case of failures</param>
+    /// <param name="appendAction"></param>
+    public void AppendEvents(string description, Action<IEventOperations> appendAction)
+    {
+        action(appendAction).Description = description;
+    }
+
+    /// <summary>
+    ///     Make any number of append event operations in the scenario sequence
+    /// </summary>
+    /// <param name="appendAction"></param>
+    public void AppendEvents(Action<IEventOperations> appendAction)
+    {
+        AppendEvents("Appending events...", appendAction);
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ProjectionScenario.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenario.cs
@@ -1,0 +1,242 @@
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+
+namespace JasperFx.Events.TestSupport;
+
+/// <summary>
+///     Store-agnostic test harness that scripts a sequence of event appends and document
+///     assertions against a running event store, then executes the whole sequence --
+///     including standing up a projection daemon when any asynchronous projections are
+///     registered. Concrete event stores (Marten, Polecat) subclass this to close the
+///     generic session pair and implement the small seam of store-specific operations.
+/// </summary>
+/// <typeparam name="TOperations">
+///     The store's writable session type -- Marten <c>IDocumentOperations</c>, Polecat
+///     <c>IDocumentSession</c>.
+/// </typeparam>
+/// <typeparam name="TQuerySession">The store's read-only session type.</typeparam>
+/// <remarks>
+///     The generic closure mirrors <c>IEventStore&lt;TOperations, TQuerySession&gt;</c> and
+///     <c>EventStoreComplianceFixture&lt;TOperations, TQuerySession&gt;</c>: the products
+///     deliberately close the pair differently and convergence is a non-goal.
+/// </remarks>
+public abstract partial class ProjectionScenario<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private readonly Queue<ScenarioStep<TOperations, TQuerySession>> _steps = new();
+    private TOperations? _session;
+    private bool _hasExecuted;
+
+    private IProjectionDaemon? Daemon { get; set; }
+
+    internal ScenarioStep<TOperations, TQuerySession>? NextStep => _steps.Count != 0 ? _steps.Peek() : null;
+
+    internal IEventOperations SessionEvents => EventsFor(_session!);
+
+    internal TQuerySession QuerySession => _session!;
+
+    internal Task CommitAsync(CancellationToken ct)
+    {
+        return SaveChangesAsync(_session!, ct);
+    }
+
+    internal Task AwaitNonStaleDataAsync(CancellationToken ct)
+    {
+        if (Daemon == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return Daemon.WaitForNonStaleData(Timeout).WaitAsync(ct);
+    }
+
+    /// <summary>
+    ///     The scenario deletes all existing event data plus the storage for every
+    ///     registered projection before running. Set this to false to run the
+    ///     scenario on top of whatever data already exists
+    /// </summary>
+    public bool DeleteExistingData { get; set; } = true;
+
+    /// <summary>
+    ///     Opt into applying this scenario to a specific tenant id in the
+    ///     case of using multi-tenancy of any kind
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
+    ///     Maximum time the scenario waits for any asynchronous projections to
+    ///     catch up after each batch of appended events. Default is 30 seconds
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = 30.Seconds();
+
+    /// <summary>
+    ///     Remove all event data plus the storage for every registered projection so the
+    ///     scenario starts from a clean slate. Only called when <see cref="DeleteExistingData" />
+    ///     is true (the default)
+    /// </summary>
+    protected abstract Task DeleteExistingDataAsync(CancellationToken ct);
+
+    /// <summary>
+    ///     Whether the store has any projections registered with an asynchronous lifecycle.
+    ///     When true, the scenario stands up a projection daemon for the duration of the run
+    /// </summary>
+    protected abstract bool HasAnyAsyncProjections { get; }
+
+    /// <summary>
+    ///     Build the store's projection daemon, optionally scoped to a tenant database
+    /// </summary>
+    protected abstract ValueTask<IProjectionDaemon> BuildDaemonAsync(string? tenantId);
+
+    /// <summary>
+    ///     Open a writable session, optionally scoped to a tenant. The scenario disposes it
+    /// </summary>
+    protected abstract TOperations OpenSession(string? tenantId);
+
+    /// <summary>
+    ///     Commit the session's pending work. No shared JasperFx interface declares
+    ///     SaveChanges, so each store supplies its own one-liner
+    /// </summary>
+    protected abstract Task SaveChangesAsync(TOperations session, CancellationToken ct);
+
+    /// <summary>
+    ///     The session's event operations, through the shared <see cref="IEventOperations" /> surface
+    /// </summary>
+    protected abstract IEventOperations EventsFor(TOperations session);
+
+    /// <summary>
+    ///     Load a persisted document by id, dispatching on the id's runtime type. This is what
+    ///     proves a projection actually wrote something
+    /// </summary>
+    protected abstract Task<T?> LoadDocumentAsync<T>(TQuerySession session, object id, CancellationToken ct)
+        where T : class;
+
+    private ScenarioStep<TOperations, TQuerySession> action(Action<IEventOperations> action)
+    {
+        var step = new ScenarioAction<TOperations, TQuerySession>(action);
+        _steps.Enqueue(step);
+
+        return step;
+    }
+
+    private ScenarioStep<TOperations, TQuerySession> assertion(Func<TQuerySession, CancellationToken, Task> check)
+    {
+        var step = new ScenarioAssertion<TOperations, TQuerySession>(check);
+        _steps.Enqueue(step);
+
+        return step;
+    }
+
+    /// <summary>
+    ///     Execute every queued step in order. Consecutive appends are batched into a single
+    ///     commit; the pending work is saved whenever the next step is an assertion, and once
+    ///     more at the end of the scenario. A scenario can only be executed once
+    /// </summary>
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        if (_hasExecuted)
+        {
+            throw new InvalidOperationException(
+                "This ProjectionScenario has already been executed and its steps have been consumed. Build and run a new scenario instead");
+        }
+
+        _hasExecuted = true;
+
+        if (DeleteExistingData)
+        {
+            await DeleteExistingDataAsync(ct).ConfigureAwait(false);
+        }
+
+        if (HasAnyAsyncProjections)
+        {
+            Daemon = await BuildDaemonAsync(TenantId).ConfigureAwait(false);
+            await Daemon.StartAllAsync().ConfigureAwait(false);
+        }
+
+        _session = OpenSession(TenantId);
+
+        try
+        {
+            var exceptions = new List<Exception>();
+            var number = 0;
+            var descriptions = new List<string>();
+            var actionFailed = false;
+
+            while (_steps.Count != 0)
+            {
+                number++;
+                var step = _steps.Dequeue();
+
+                try
+                {
+                    await step.Execute(this, ct).ConfigureAwait(false);
+                    descriptions.Add($"{number.ToString().PadLeft(3)}. {step.Description}");
+                }
+                catch (Exception e)
+                {
+                    descriptions.Add($"FAILED: {number.ToString().PadLeft(3)}. {step.Description}");
+                    descriptions.Add(e.ToString());
+                    exceptions.Add(e);
+
+                    // A failed action means every later step would run against a state nobody
+                    // intended, so stop right here instead of piling up cascading noise. Failed
+                    // assertions keep accumulating -- the state is still the intended one.
+                    if (step is ScenarioAction<TOperations, TQuerySession>)
+                    {
+                        actionFailed = true;
+                        if (_steps.Count != 0)
+                        {
+                            descriptions.Add(
+                                $"Skipped the remaining {_steps.Count} step(s) after the failed action");
+                            _steps.Clear();
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            // An action only flushes when the step AFTER it is an assertion, so whatever a
+            // trailing action queued is still sitting in the session -- and the finally below
+            // disposes that session without committing. An append with no assertion after it is
+            // still an append, and an arrange-only scenario should not be a silent no-op that
+            // passes. See marten#5126.
+            //
+            // Unconditional on purpose: SaveChanges is expected to return immediately when the
+            // unit of work is empty, and the non-stale wait is already a no-op when no daemon is
+            // running. Skipped when an action failed -- the session may hold a partially built
+            // unit of work at that point.
+            if (!actionFailed)
+            {
+                try
+                {
+                    await CommitAsync(ct).ConfigureAwait(false);
+                    await AwaitNonStaleDataAsync(ct).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    descriptions.Add("FAILED: committing the events queued by the final step");
+                    descriptions.Add(e.ToString());
+                    exceptions.Add(e);
+                }
+            }
+
+            if (exceptions.Count != 0)
+            {
+                throw new ProjectionScenarioException(descriptions, exceptions);
+            }
+        }
+        finally
+        {
+            if (Daemon != null)
+            {
+                await Daemon.StopAllAsync().ConfigureAwait(false);
+                Daemon.SafeDispose();
+            }
+
+            if (_session is not null)
+            {
+                await _session.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ProjectionScenarioAssertionException.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenarioAssertionException.cs
@@ -1,0 +1,13 @@
+namespace JasperFx.Events.TestSupport;
+
+/// <summary>
+///     Thrown when a single ProjectionScenario assertion fails, e.g. a document that should
+///     exist does not. Lets test code and tooling distinguish scenario assertion failures
+///     from infrastructure failures inside the aggregated ProjectionScenarioException
+/// </summary>
+public class ProjectionScenarioAssertionException: Exception
+{
+    public ProjectionScenarioAssertionException(string message): base(message)
+    {
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ProjectionScenarioException.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenarioException.cs
@@ -1,0 +1,16 @@
+using JasperFx.Core;
+
+namespace JasperFx.Events.TestSupport;
+
+/// <summary>
+///     Thrown when a ProjectionScenario fails. Aggregates every step failure, and the message
+///     lists each executed step with a FAILED marker on the ones that went wrong
+/// </summary>
+public class ProjectionScenarioException: AggregateException
+{
+    public ProjectionScenarioException(IReadOnlyList<string> descriptions, IEnumerable<Exception> exceptions): base(
+        $"Event Projection Scenario Failure{System.Environment.NewLine}{descriptions.Join(System.Environment.NewLine)}",
+        exceptions)
+    {
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ScenarioStep.cs
+++ b/src/JasperFx.Events/TestSupport/ScenarioStep.cs
@@ -1,0 +1,50 @@
+namespace JasperFx.Events.TestSupport;
+
+internal abstract class ScenarioStep<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    public string Description { get; set; } = string.Empty;
+
+    public abstract Task Execute(ProjectionScenario<TOperations, TQuerySession> scenario,
+        CancellationToken ct = default);
+}
+
+internal class ScenarioAction<TOperations, TQuerySession>: ScenarioStep<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private readonly Action<IEventOperations> _action;
+
+    public ScenarioAction(Action<IEventOperations> action)
+    {
+        _action = action;
+    }
+
+    public override async Task Execute(ProjectionScenario<TOperations, TQuerySession> scenario,
+        CancellationToken ct = default)
+    {
+        _action(scenario.SessionEvents);
+
+        if (scenario.NextStep is ScenarioAssertion<TOperations, TQuerySession>)
+        {
+            await scenario.CommitAsync(ct).ConfigureAwait(false);
+            await scenario.AwaitNonStaleDataAsync(ct).ConfigureAwait(false);
+        }
+    }
+}
+
+internal class ScenarioAssertion<TOperations, TQuerySession>: ScenarioStep<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private readonly Func<TQuerySession, CancellationToken, Task> _check;
+
+    public ScenarioAssertion(Func<TQuerySession, CancellationToken, Task> check)
+    {
+        _check = check;
+    }
+
+    public override Task Execute(ProjectionScenario<TOperations, TQuerySession> scenario,
+        CancellationToken ct = default)
+    {
+        return _check(scenario.QuerySession, ct);
+    }
+}


### PR DESCRIPTION
Cross-store lift of Marten's `EventProjectionScenario` test support, following the ergonomics/quality pass in JasperFx/marten#5127 (merged as marten#5132). Fixing the shape first was deliberate — the shared surface starts from the corrected API rather than inheriting the throwaway `StreamAction` returns and the copy-pasted assertion overloads.

This also closes the intent of JasperFx/polecat#404 without anyone hand-porting 15 overloads: Polecat subclasses the shared type instead of maintaining a parallel implementation.

## What's here

New `JasperFx.Events.TestSupport` namespace in the main library (it ships in the product assembly because users reach it through their store's `Advanced` surface):

- **`ProjectionScenario<TOperations, TQuerySession>`** — scripts a sequence of event appends (through the shared `IEventOperations` surface) and document assertions, then executes them in order. Consecutive appends batch into one commit; pending work is saved before each assertion and once more at the end, which is the marten#5126 trailing-append rule. A failed *action* stops the scenario and reports how many steps were skipped; failed *assertions* accumulate and report together. Scenarios are single-use — re-execution throws rather than silently doing nothing. When the store has any async projections the scenario stands up an `IProjectionDaemon` for the duration and waits for non-stale data after each batch, with a configurable `Timeout` (default 30s) that honors the caller's `CancellationToken`.
- **Seven abstract seam members** — `DeleteExistingDataAsync`, `HasAnyAsyncProjections`, `BuildDaemonAsync`, `OpenSession`, `SaveChangesAsync`, `EventsFor`, `LoadDocumentAsync<T>(session, object id, ct)`. Deliberately the same shape `EventStoreComplianceFixture<TOperations, TQuerySession>` already asks of each store, including the `object id` load dispatch — so a store that already has a compliance fixture has already written every one of these.
- **`DocumentShouldExist` / `DocumentShouldNotExist` take `object` ids** and dispatch through `LoadDocumentAsync`. That collapses what were four typed overloads per assertion into one, and typed call sites keep compiling since everything converts to `object`.
- **`StartStream` overloads that generate their own stream id return that `Guid`**; the rest of the append surface returns `void`, since these operations only queue closures and there is no meaningful result until execution.
- **`ProjectionScenarioException`** (aggregate, carries the step-by-step report) and **`ProjectionScenarioAssertionException`** (typed assertion failures, distinguishable from infrastructure errors inside the aggregate).

The generic closure mirrors `IEventStore<TOperations, TQuerySession>` and the compliance fixture — the products close the pair differently and convergence stays a non-goal.

## Tests

15 new unit tests in `EventTests/TestSupport` drive the harness against a fake store closure via NSubstitute, so the sequencing logic is covered with no database: deferred execution and step ordering, flush points (before each assertion, once at the end, including the arrange-only case), typed assertion failures and accumulation, action fail-fast with skip reporting and no final flush, the re-execution guard, daemon start/wait/stop plus the timeout value, tenant id flowing to both session and daemon, and session disposal. `EventTests` is 672/672 on net9.0.

## Consumer status

Marten's adoption branch (`feat/5127-scenario-lift`) is built and green against a local pack of this branch — `Marten.slnx` compiles clean and the full scenario suite is 15/15 on net9.0. Marten's `ProjectionScenario` becomes a ~70-line subclass; seven files and roughly 400 lines of duplicated harness delete. That PR opens once this is merged and published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)