### PR TITLE
Compliance wave 4: the portable-today suites (2.38.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.38.0</JasperFxVersion>
+        <JasperFxVersion>2.38.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -64,6 +64,19 @@ public sealed class ComplianceStoreConfig
     /// </remarks>
     public bool EnableCorrelationTracking { get; set; }
 
+    /// <summary>
+    /// Persist per-event header dictionaries. Off by default in both products and spelled
+    /// differently in each — Marten's <c>Events.MetadataConfig.HeadersEnabled</c>, Polecat's
+    /// <c>Events.EnableHeaders</c> — so the fixture resolves it, exactly like
+    /// <see cref="EnableCorrelationTracking"/>.
+    /// </summary>
+    /// <remarks>
+    /// Setting the headers themselves needs nothing from the fixture: <see cref="IEvent.SetHeader"/>
+    /// and <see cref="IEvent.GetHeader"/> are on the shared event interface, so a suite builds an
+    /// envelope with <c>BuildEvent</c>, stamps it and appends it.
+    /// </remarks>
+    public bool EnableHeaders { get; set; }
+
     public List<Type> EventTypes { get; } = new();
 
     public List<(Type Tag, string Suffix, Type? Aggregate)> TagTypes { get; } = new();

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -52,3 +52,45 @@ public class dcb_tag_query_and_consistency_compliance
 Where a store genuinely cannot support a behavior, override the `virtual bool Supports...` flags on
 the fixture; the affected tests skip rather than fail. Gates are meant to be temporary and tracked —
 a suite failing on your store is usually a product bug, not a test to soften.
+
+## Local dev loop
+
+Both current consumers accept a `ComplianceSourceDir` property that swaps the published suites for a
+working copy, so a new wave can be validated against a real store before the JasperFx release:
+
+```bash
+dotnet test src/EventSourcingTests/EventSourcingTests.csproj -f net9.0 \
+    -p:ComplianceSourceDir=/path/to/jasperfx/src/JasperFx.Events.ComplianceTests
+```
+
+## What is in scope
+
+The library asserts behavior that every `JasperFx.Events` store owes its users, reached through the
+shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`, `IEventStore`,
+`IProjectionDaemon`). Covered today:
+
+| Area | Suite |
+|---|---|
+| Self-aggregating `EvolveAsync` conventions | `SelfAggregatingEvolveCompliance` |
+| DCB tag queries and consistency | `DcbTagQueryAndConsistencyCompliance` |
+| `AssignTagWhere` | `AssignTagWhereCompliance` |
+| Async daemon smoke + rebuild | `AsyncDaemonCompliance` |
+| Aggregate type auto-discovery | `AutoDiscoveredAggregateCompliance` |
+| `EventProjection` registration and enrichment | `EventProjectionRegistrationCompliance`, `EventProjectionEnrichmentCompliance` |
+| Rebuild concurrency cap resolution | `RebuildConcurrencyCapCompliance` |
+| Session correlation / causation from `Activity` | `ActivityCorrelationCompliance` |
+| String stream identity | `StringIdentitySingleStreamCompliance` |
+| Write handles and stream concurrency | `FetchForWritingCompliance` |
+| Stream reads, time travel, stream state | `StreamReadCompliance` |
+| The `IEvent` envelope contract | `EventMetadataCompliance` |
+| Live aggregation, including last-known | `LiveAggregationCompliance` |
+
+## What is deliberately out of scope
+
+Storage layout and DDL, table partitioning, node distribution / HotCold, high-water detection
+internals, and anything on the document-db side (LINQ, patching, session semantics) — the last
+because no shared document store contract exists yet. If a behavior only makes sense in terms of one
+engine's storage, it belongs in that product's own test suite, not here.
+
+New cross-store event sourcing behavior should land as a compliance suite first, and only then be
+enrolled by each product.

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventMetadataCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventMetadataCompliance.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Metadata events
+
+public record ShipmentBooked(string Reference);
+
+public record ShipmentDispatched(DateTimeOffset When);
+
+#endregion
+
+/// <summary>
+/// The <see cref="IEvent"/> contract itself — the envelope every store hands back around a user's
+/// event body: identity, per-stream version, store-global sequence, server timestamp, type naming,
+/// tenant, and the header dictionary.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the surface most likely to drift quietly between implementations, because none of it is
+/// what a test is usually looking at — it is what a test takes for granted. Two independently
+/// written event stores can easily disagree on whether <c>Sequence</c> is per-stream or global, or
+/// whether <c>Timestamp</c> comes from the client or the server, and nothing fails until someone
+/// builds tooling on top.
+/// </para>
+/// <para>
+/// Headers need <see cref="ComplianceStoreConfig.EnableHeaders"/> (off by default in both products),
+/// but stamping them needs no fixture member — <see cref="IEvent.SetHeader"/> is shared, so the
+/// suite builds an envelope with <c>BuildEvent</c> and appends it.
+/// </para>
+/// </remarks>
+public abstract class EventMetadataCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_event_metadata";
+        config.EnableHeaders = true;
+        config.AddEventType<ShipmentBooked>();
+        config.AddEventType<ShipmentDispatched>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task the_envelope_is_fully_populated_after_a_round_trip()
+    {
+        var streamId = Guid.NewGuid();
+        var before = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ShipmentBooked("SHP-1"));
+        await SaveChangesAsync(session);
+
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+        var @event = events.Single();
+
+        @event.Id.ShouldNotBe(Guid.Empty);
+        @event.StreamId.ShouldBe(streamId);
+        @event.Version.ShouldBe(1);
+        @event.Sequence.ShouldBeGreaterThan(0);
+        @event.Data.ShouldBeOfType<ShipmentBooked>();
+        @event.EventType.ShouldBe(typeof(ShipmentBooked));
+        @event.EventTypeName.ShouldBe(EventTypeNameFor<ShipmentBooked>());
+        @event.DotNetTypeName.ShouldNotBeNullOrEmpty();
+        @event.IsArchived.ShouldBeFalse();
+
+        // Server-assigned, so all the suite can assert portably is that it is real and recent.
+        @event.Timestamp.ShouldBeGreaterThan(before);
+    }
+
+    [Fact]
+    public async Task version_is_per_stream_and_one_based()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(first, new ShipmentBooked("A-1"), new ShipmentBooked("A-2"));
+        EventsFor(session).StartStream(second, new ShipmentBooked("B-1"));
+        await SaveChangesAsync(session);
+
+        var firstEvents = await EventsFor(session).FetchStreamAsync(first, token: Cancellation);
+        var secondEvents = await EventsFor(session).FetchStreamAsync(second, token: Cancellation);
+
+        firstEvents.Select(x => x.Version).ShouldBe(new long[] { 1, 2 });
+
+        // Restarts at 1 for a different stream -- Version is not the global counter.
+        secondEvents.Single().Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task sequence_is_store_global_and_monotonic_across_streams()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(first, new ShipmentBooked("A-1"));
+        await SaveChangesAsync(session);
+
+        EventsFor(session).StartStream(second, new ShipmentBooked("B-1"));
+        await SaveChangesAsync(session);
+
+        var firstEvents = await EventsFor(session).FetchStreamAsync(first, token: Cancellation);
+        var secondEvents = await EventsFor(session).FetchStreamAsync(second, token: Cancellation);
+
+        secondEvents.Single().Sequence.ShouldBeGreaterThan(firstEvents.Single().Sequence);
+    }
+
+    [Fact]
+    public async Task timestamps_advance_with_the_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ShipmentBooked("SHP-1"));
+        await SaveChangesAsync(session);
+
+        await Task.Delay(50, Cancellation);
+
+        EventsFor(session).Append(streamId, new ShipmentDispatched(DateTimeOffset.UtcNow));
+        await SaveChangesAsync(session);
+
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+
+        events[1].Timestamp.ShouldBeGreaterThan(events[0].Timestamp);
+
+        // Ordering by timestamp agrees with ordering by sequence within one stream.
+        events.OrderBy(x => x.Timestamp).Select(x => x.Sequence)
+            .ShouldBe(events.OrderBy(x => x.Sequence).Select(x => x.Sequence));
+    }
+
+    [Fact]
+    public async Task event_type_name_matches_the_registry()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ShipmentBooked("SHP-1"), new ShipmentDispatched(DateTimeOffset.UtcNow));
+        await SaveChangesAsync(session);
+
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+
+        // Asserted through the shared registry surface rather than any store-internal generic, so
+        // this stays a zero-InternalsVisibleTo suite.
+        events[0].EventTypeName.ShouldBe(EventTypeNameFor<ShipmentBooked>());
+        events[1].EventTypeName.ShouldBe(EventTypeNameFor<ShipmentDispatched>());
+        events[0].EventTypeName.ShouldNotBe(events[1].EventTypeName);
+    }
+
+    [Fact]
+    public async Task headers_survive_the_round_trip()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var events = EventsFor(session);
+
+        var wrapped = events.BuildEvent(new ShipmentBooked("SHP-1"));
+        wrapped.SetHeader("origin", "compliance");
+        wrapped.SetHeader("attempt", 3);
+        events.StartStream(streamId, wrapped);
+        await SaveChangesAsync(session);
+
+        var stored = (await events.FetchStreamAsync(streamId, token: Cancellation)).Single();
+
+        stored.GetHeader("origin").ShouldNotBeNull();
+        stored.GetHeader("origin").ToString().ShouldBe("compliance");
+        stored.GetHeader("attempt").ShouldNotBeNull();
+        stored.GetHeader("attempt").ToString().ShouldBe("3");
+    }
+
+    [Fact]
+    public async Task an_event_without_headers_reports_no_header_rather_than_throwing()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ShipmentBooked("SHP-1"));
+        await SaveChangesAsync(session);
+
+        var stored = (await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation)).Single();
+
+        stored.GetHeader("nope").ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task events_carry_the_default_tenant_in_a_single_tenant_store()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ShipmentBooked("SHP-1"));
+        await SaveChangesAsync(session);
+
+        var stored = (await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation)).Single();
+
+        stored.TenantId.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task the_typed_event_wrapper_exposes_the_same_metadata()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ShipmentBooked("SHP-1"));
+        await SaveChangesAsync(session);
+
+        var stored = (await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation)).Single();
+        var typed = await EventsFor(session).LoadAsync<ShipmentBooked>(stored.Id, Cancellation);
+
+        typed.ShouldNotBeNull();
+        typed.Id.ShouldBe(stored.Id);
+        typed.Version.ShouldBe(stored.Version);
+        typed.Sequence.ShouldBe(stored.Sequence);
+        typed.StreamId.ShouldBe(stored.StreamId);
+        typed.Data.Reference.ShouldBe("SHP-1");
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/FetchForWritingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/FetchForWritingCompliance.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Fetch-for-writing events and aggregate
+
+public record AccountOpened(string Owner);
+
+public record MoneyDeposited(decimal Amount);
+
+public record MoneyWithdrawn(decimal Amount);
+
+/// <summary>
+/// A deliberately plain self-aggregating type. The point of this suite is the write handle and its
+/// concurrency semantics, not the aggregation conventions, which
+/// <see cref="SelfAggregatingEvolveCompliance{TFixture,TOperations,TQuerySession}"/> already covers.
+/// </summary>
+public partial class ComplianceAccount
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+
+    public static ComplianceAccount Create(AccountOpened e) => new() { Owner = e.Owner };
+
+    public void Apply(MoneyDeposited e) => Balance += e.Amount;
+
+    public void Apply(MoneyWithdrawn e) => Balance -= e.Amount;
+}
+
+#endregion
+
+/// <summary>
+/// The write handle contract — <c>FetchForWriting</c>, <c>FetchForExclusiveWriting</c>,
+/// <c>WriteToAggregate</c>, <c>AppendOptimistic</c>/<c>AppendExclusive</c> and version-checked
+/// <c>Append</c> — plus the concurrency failures all of them share.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every entry point here is declared on <see cref="IEventStoreOperations"/>, and the failure type is
+/// shared too: <see cref="EventStreamUnexpectedMaxEventIdException"/> derives from JasperFx's
+/// <see cref="ConcurrencyException"/> and both products throw it. So the suite needs no fixture
+/// member of its own, and no exception abstraction.
+/// </para>
+/// <para>
+/// The concurrency assertions deliberately wrap the whole fetch-append-save sequence and assert the
+/// shared <see cref="ConcurrencyException"/> base rather than the exact derived type or the exact
+/// call that throws. A store is free to detect the conflict eagerly at fetch time or late at commit
+/// time — that is an implementation choice, not a behavioral contract, and pinning it would encode
+/// one product's timing as the standard.
+/// </para>
+/// <para>
+/// Guid stream identity only: stream identity is a store-level setting, so the string-keyed
+/// equivalents live in
+/// <see cref="StringIdentitySingleStreamCompliance{TFixture,TOperations,TQuerySession}"/>.
+/// </para>
+/// </remarks>
+public abstract class FetchForWritingCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_fetch_writing";
+        config.Snapshot<ComplianceAccount>(SnapshotLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private async Task<Guid> anOpenAccountAsync(params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var all = new List<object> { new AccountOpened("Hilda") };
+        all.AddRange(events);
+        EventsFor(session).StartStream<ComplianceAccount>(streamId, all);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_a_stream_that_does_not_exist_yet()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceAccount>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldBeNull();
+        stream.Id.ShouldBe(streamId);
+
+        // Zero, not null. Both products report a not-yet-existing stream as version 0, and the
+        // XML docs on IEventStream<T> used to claim null -- this suite is what caught that.
+        stream.StartingVersion.ShouldBe(0);
+        stream.CurrentVersion.ShouldBe(0);
+
+        stream.AppendOne(new AccountOpened("Hilda"));
+        await SaveChangesAsync(session);
+
+        var account = await LoadDocumentAsync<ComplianceAccount>(session, streamId);
+        account.ShouldNotBeNull();
+        account.Owner.ShouldBe("Hilda");
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_an_existing_stream_returns_current_state_and_version()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100), new MoneyDeposited(50));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceAccount>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(150);
+        stream.StartingVersion.ShouldBe(3);
+        stream.CurrentVersion.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task appending_to_the_handle_advances_current_version_but_not_starting_version()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceAccount>(streamId, Cancellation);
+
+        stream.AppendOne(new MoneyDeposited(25));
+        stream.AppendMany(new MoneyWithdrawn(5), new MoneyWithdrawn(10));
+
+        stream.StartingVersion.ShouldBe(2);
+        stream.CurrentVersion.ShouldBe(5);
+        stream.Events.Count.ShouldBe(3);
+
+        await SaveChangesAsync(session);
+
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_with_a_matching_expected_version_commits()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceAccount>(streamId, 2, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(100);
+
+        stream.AppendOne(new MoneyDeposited(1));
+        await SaveChangesAsync(session);
+
+        var account = await LoadDocumentAsync<ComplianceAccount>(session, streamId);
+        account.ShouldNotBeNull();
+        account.Balance.ShouldBe(101);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_with_a_stale_expected_version_fails()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100), new MoneyDeposited(50));
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+
+            // The stream is at version 3, so 2 is a stale read. Whether the store rejects this at
+            // fetch time or at commit time is deliberately not pinned.
+            var stream = await EventsFor(session).FetchForWriting<ComplianceAccount>(streamId, 2, Cancellation);
+            stream.AppendOne(new MoneyDeposited(1));
+            await SaveChangesAsync(session);
+        });
+    }
+
+    [Fact]
+    public async Task appending_with_a_stale_expected_version_fails()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            EventsFor(session).Append(streamId, 99, new MoneyDeposited(1));
+            await SaveChangesAsync(session);
+        });
+    }
+
+    [Fact]
+    public async Task two_writers_racing_on_the_same_starting_version_lose_the_second_write()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var first = OpenSession();
+        await using var second = OpenSession();
+
+        var firstStream = await EventsFor(first).FetchForWriting<ComplianceAccount>(streamId, 2, Cancellation);
+        var secondStream = await EventsFor(second).FetchForWriting<ComplianceAccount>(streamId, 2, Cancellation);
+
+        firstStream.AppendOne(new MoneyDeposited(10));
+        await SaveChangesAsync(first);
+
+        secondStream.AppendOne(new MoneyDeposited(20));
+        await ShouldFailWithAsync<ConcurrencyException>(() => SaveChangesAsync(second));
+
+        // The winner's write stands, the loser's does not.
+        await using var reader = OpenSession();
+        var account = await LoadDocumentAsync<ComplianceAccount>(reader, streamId);
+        account.ShouldNotBeNull();
+        account.Balance.ShouldBe(110);
+    }
+
+    [Fact]
+    public async Task fetch_for_exclusive_writing_returns_the_same_state_and_commits()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session)
+            .FetchForExclusiveWriting<ComplianceAccount>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(100);
+
+        stream.AppendOne(new MoneyDeposited(5));
+        await SaveChangesAsync(session);
+
+        var account = await LoadDocumentAsync<ComplianceAccount>(session, streamId);
+        account.ShouldNotBeNull();
+        account.Balance.ShouldBe(105);
+    }
+
+    [Fact]
+    public async Task write_to_aggregate_with_the_action_overload()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        await EventsFor(session).WriteToAggregate<ComplianceAccount>(streamId,
+            stream =>
+            {
+                stream.Aggregate.ShouldNotBeNull();
+                stream.Aggregate.Balance.ShouldBe(100);
+                stream.AppendOne(new MoneyWithdrawn(40));
+            }, Cancellation);
+
+        await using var reader = OpenSession();
+        var account = await LoadDocumentAsync<ComplianceAccount>(reader, streamId);
+        account.ShouldNotBeNull();
+        account.Balance.ShouldBe(60);
+    }
+
+    [Fact]
+    public async Task write_to_aggregate_with_the_async_overload()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        await EventsFor(session).WriteToAggregate<ComplianceAccount>(streamId,
+            async stream =>
+            {
+                await Task.Yield();
+                stream.AppendOne(new MoneyDeposited(11));
+            }, Cancellation);
+
+        await using var reader = OpenSession();
+        var account = await LoadDocumentAsync<ComplianceAccount>(reader, streamId);
+        account.ShouldNotBeNull();
+        account.Balance.ShouldBe(111);
+    }
+
+    [Fact]
+    public async Task write_to_aggregate_with_a_stale_expected_version_fails()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            await EventsFor(session).WriteToAggregate<ComplianceAccount>(streamId, 99,
+                stream => stream.AppendOne(new MoneyDeposited(1)), Cancellation);
+        });
+    }
+
+    [Fact]
+    public async Task append_optimistic_against_an_existing_stream()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        await EventsFor(session).AppendOptimistic(streamId, Cancellation, new MoneyDeposited(7));
+        await SaveChangesAsync(session);
+
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task append_exclusive_against_an_existing_stream()
+    {
+        var streamId = await anOpenAccountAsync(new MoneyDeposited(100));
+
+        await using var session = OpenSession();
+        await EventsFor(session).AppendExclusive(streamId, Cancellation, new MoneyDeposited(3));
+        await SaveChangesAsync(session);
+
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(3);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/LiveAggregationCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/LiveAggregationCompliance.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Live aggregation events and aggregate
+
+public record TrailStarted(string Name);
+
+public record MilesWalked(int Miles);
+
+public record TrailAbandoned;
+
+/// <summary>
+/// Folded on read only — never registered as a snapshot, so the suite exercises the store's live
+/// aggregation path rather than a persisted document.
+/// </summary>
+/// <remarks>
+/// <c>Apply(TrailAbandoned)</c> returns null, which is how both products spell "this aggregate is
+/// deleted as of this event". That is what gives
+/// <c>AggregateStreamToLastKnownAsync</c> something to walk back from.
+/// </remarks>
+public partial class ComplianceTrail
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Miles { get; set; }
+
+    public static ComplianceTrail Create(TrailStarted e) => new() { Name = e.Name };
+
+    public void Apply(MilesWalked e) => Miles += e.Miles;
+
+    public ComplianceTrail? Apply(TrailAbandoned _) => null;
+}
+
+#endregion
+
+/// <summary>
+/// Live aggregation — folding a stream on read with nothing persisted — through
+/// <c>AggregateStreamAsync</c> and <c>AggregateStreamToLastKnownAsync</c>, including the version and
+/// timestamp bounds both accept.
+/// </summary>
+/// <remarks>
+/// Nothing is registered here on purpose. Polecat derives live aggregators automatically and rejects
+/// explicit registration (<see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsLiveAggregationRegistration"/>
+/// is false there), so a suite that leans on <c>LiveAggregation&lt;T&gt;()</c> would need a gate it
+/// does not actually need. Folding an unregistered type is the common ground.
+/// </remarks>
+public abstract class LiveAggregationCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_live_aggregation";
+        config.AddEventType<TrailStarted>();
+        config.AddEventType<MilesWalked>();
+        config.AddEventType<TrailAbandoned>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private async Task<Guid> aTrailAsync(params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceTrail>(streamId, events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task aggregate_stream_folds_every_event()
+    {
+        var streamId = await aTrailAsync(
+            new TrailStarted("Pennine Way"),
+            new MilesWalked(12),
+            new MilesWalked(9));
+
+        await using var session = OpenSession();
+        var trail = await EventsFor(session).AggregateStreamAsync<ComplianceTrail>(streamId, token: Cancellation);
+
+        trail.ShouldNotBeNull();
+        trail.Name.ShouldBe("Pennine Way");
+        trail.Miles.ShouldBe(21);
+    }
+
+    [Fact]
+    public async Task aggregate_stream_bounded_by_version()
+    {
+        var streamId = await aTrailAsync(
+            new TrailStarted("Pennine Way"),
+            new MilesWalked(12),
+            new MilesWalked(9));
+
+        await using var session = OpenSession();
+        var trail = await EventsFor(session)
+            .AggregateStreamAsync<ComplianceTrail>(streamId, 2, token: Cancellation);
+
+        trail.ShouldNotBeNull();
+        trail.Miles.ShouldBe(12);
+    }
+
+    [Fact]
+    public async Task aggregate_stream_bounded_by_timestamp()
+    {
+        var streamId = await aTrailAsync(new TrailStarted("Pennine Way"), new MilesWalked(12));
+
+        await Task.Delay(50, Cancellation);
+
+        await using var writer = OpenSession();
+        EventsFor(writer).Append(streamId, new MilesWalked(9));
+        await SaveChangesAsync(writer);
+
+        await using var session = OpenSession();
+        var all = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+        var cutoff = all[1].Timestamp + (all[2].Timestamp - all[1].Timestamp) / 2;
+
+        var trail = await EventsFor(session)
+            .AggregateStreamAsync<ComplianceTrail>(streamId, timestamp: cutoff, token: Cancellation);
+
+        trail.ShouldNotBeNull();
+        trail.Miles.ShouldBe(12);
+    }
+
+    [Fact]
+    public async Task aggregate_stream_for_an_unknown_stream_is_null()
+    {
+        await using var session = OpenSession();
+        var trail = await EventsFor(session)
+            .AggregateStreamAsync<ComplianceTrail>(Guid.NewGuid(), token: Cancellation);
+
+        trail.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task aggregate_stream_is_null_once_the_fold_deletes_the_aggregate()
+    {
+        var streamId = await aTrailAsync(
+            new TrailStarted("Pennine Way"),
+            new MilesWalked(12),
+            new TrailAbandoned());
+
+        await using var session = OpenSession();
+        var trail = await EventsFor(session).AggregateStreamAsync<ComplianceTrail>(streamId, token: Cancellation);
+
+        trail.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task aggregate_stream_to_last_known_walks_back_past_the_deletion()
+    {
+        var streamId = await aTrailAsync(
+            new TrailStarted("Pennine Way"),
+            new MilesWalked(12),
+            new TrailAbandoned());
+
+        await using var session = OpenSession();
+        var trail = await EventsFor(session)
+            .AggregateStreamToLastKnownAsync<ComplianceTrail>(streamId, token: Cancellation);
+
+        // The whole point of the method: the current fold is null, so the store hands back the last
+        // version that was not.
+        trail.ShouldNotBeNull();
+        trail.Name.ShouldBe("Pennine Way");
+        trail.Miles.ShouldBe(12);
+    }
+
+    [Fact]
+    public async Task aggregate_stream_to_last_known_matches_aggregate_stream_when_nothing_is_deleted()
+    {
+        var streamId = await aTrailAsync(new TrailStarted("Pennine Way"), new MilesWalked(12));
+
+        await using var session = OpenSession();
+        var lastKnown = await EventsFor(session)
+            .AggregateStreamToLastKnownAsync<ComplianceTrail>(streamId, token: Cancellation);
+        var plain = await EventsFor(session)
+            .AggregateStreamAsync<ComplianceTrail>(streamId, token: Cancellation);
+
+        lastKnown.ShouldNotBeNull();
+        plain.ShouldNotBeNull();
+        lastKnown.Miles.ShouldBe(plain.Miles);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamReadCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamReadCompliance.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Stream read events
+
+public record ExpeditionPlanned(string Destination);
+
+public record SuppliesLoaded(int Crates);
+
+public record CampMade(string Place);
+
+public record ExpeditionFinished;
+
+#endregion
+
+/// <summary>
+/// The read side of the event store — <c>FetchStreamAsync</c> with its version, <c>fromVersion</c>
+/// and timestamp bounds, <c>FetchStreamStateAsync</c>, and single-event <c>LoadAsync</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything here is on <see cref="IQueryEventStore"/>, so no fixture member is needed. The
+/// aggregate-folding overloads (<c>AggregateStreamAsync</c>) are deliberately left to the live
+/// aggregation suite; this one is about the raw event and stream metadata a store hands back.
+/// </para>
+/// <para>
+/// The time-travel test derives its cut-off from the *stored* event timestamps rather than the test
+/// host's clock — the two live on different machines in CI, and a store is free to stamp events
+/// server-side. It also picks a point strictly between two events, so the suite does not
+/// accidentally pin whether a store's timestamp filter is inclusive or exclusive.
+/// </para>
+/// </remarks>
+public abstract class StreamReadCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_stream_reads";
+        config.AddEventType<ExpeditionPlanned>();
+        config.AddEventType<SuppliesLoaded>();
+        config.AddEventType<CampMade>();
+        config.AddEventType<ExpeditionFinished>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private async Task<Guid> aStreamOfFourAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId,
+            new ExpeditionPlanned("The North"),
+            new SuppliesLoaded(12),
+            new CampMade("Base Camp"),
+            new ExpeditionFinished());
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task fetch_stream_returns_every_event_in_order()
+    {
+        var streamId = await aStreamOfFourAsync();
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(4);
+        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
+        events.Select(x => x.Data.GetType()).ShouldBe(new[]
+        {
+            typeof(ExpeditionPlanned), typeof(SuppliesLoaded), typeof(CampMade), typeof(ExpeditionFinished)
+        });
+
+        foreach (var @event in events)
+        {
+            @event.StreamId.ShouldBe(streamId);
+        }
+
+        // Sequence is store-global and monotonic, unlike the per-stream Version.
+        events.Select(x => x.Sequence).ShouldBeInOrder();
+        events[0].EventTypeName.ShouldBe(EventTypeNameFor<ExpeditionPlanned>());
+    }
+
+    [Fact]
+    public async Task fetch_stream_bounded_by_version()
+    {
+        var streamId = await aStreamOfFourAsync();
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, 2, token: Cancellation);
+
+        events.Count.ShouldBe(2);
+        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task fetch_stream_from_a_starting_version()
+    {
+        var streamId = await aStreamOfFourAsync();
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, fromVersion: 3, token: Cancellation);
+
+        events.Select(x => x.Version).ShouldBe(new long[] { 3, 4 });
+    }
+
+    [Fact]
+    public async Task fetch_stream_within_a_version_window()
+    {
+        var streamId = await aStreamOfFourAsync();
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, 3, fromVersion: 2, token: Cancellation);
+
+        events.Select(x => x.Version).ShouldBe(new long[] { 2, 3 });
+    }
+
+    [Fact]
+    public async Task fetch_stream_as_of_a_timestamp()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new ExpeditionPlanned("The North"), new SuppliesLoaded(12));
+        await SaveChangesAsync(session);
+
+        // A real gap so the two commits cannot land on the same server tick.
+        await Task.Delay(50, Cancellation);
+
+        EventsFor(session).Append(streamId, new CampMade("Base Camp"), new ExpeditionFinished());
+        await SaveChangesAsync(session);
+
+        var all = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+        all.Count.ShouldBe(4);
+
+        var lastOfFirstCommit = all[1].Timestamp;
+        var firstOfSecondCommit = all[2].Timestamp;
+        firstOfSecondCommit.ShouldBeGreaterThan(lastOfFirstCommit);
+
+        // Strictly between the two commits, so inclusive-vs-exclusive filtering is not pinned here.
+        var cutoff = lastOfFirstCommit + (firstOfSecondCommit - lastOfFirstCommit) / 2;
+
+        var asOf = await EventsFor(session).FetchStreamAsync(streamId, timestamp: cutoff, token: Cancellation);
+
+        asOf.Select(x => x.Version).ShouldBe(new long[] { 1, 2 });
+    }
+
+    [Fact]
+    public async Task fetch_stream_for_an_unknown_stream_is_empty()
+    {
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(Guid.NewGuid(), token: Cancellation);
+
+        events.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_reports_version_and_timestamps()
+    {
+        var streamId = await aStreamOfFourAsync();
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(4);
+        state.Created.ShouldNotBe(default);
+        state.LastTimestamp.ShouldNotBe(default);
+        state.LastTimestamp.ShouldBeGreaterThanOrEqualTo(state.Created);
+    }
+
+    [Fact]
+    public async Task fetch_stream_state_for_an_unknown_stream_is_null()
+    {
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(Guid.NewGuid(), Cancellation);
+
+        state.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task stream_state_carries_the_aggregate_type_when_the_stream_was_typed()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceAccount>(streamId, new AccountOpened("Hilda"));
+        await SaveChangesAsync(session);
+
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.AggregateType.ShouldBe(typeof(ComplianceAccount));
+    }
+
+    [Fact]
+    public async Task load_a_single_event_typed_and_untyped()
+    {
+        var streamId = await aStreamOfFourAsync();
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+        var second = events[1];
+
+        var typed = await EventsFor(session).LoadAsync<SuppliesLoaded>(second.Id, Cancellation);
+        typed.ShouldNotBeNull();
+        typed.Data.Crates.ShouldBe(12);
+        typed.Version.ShouldBe(2);
+        typed.StreamId.ShouldBe(streamId);
+
+        var untyped = await EventsFor(session).LoadAsync(second.Id, Cancellation);
+        untyped.ShouldNotBeNull();
+        untyped.Id.ShouldBe(second.Id);
+        untyped.Data.ShouldBeOfType<SuppliesLoaded>();
+    }
+
+    [Fact]
+    public async Task load_an_unknown_event_returns_null()
+    {
+        await using var session = OpenSession();
+
+        var untyped = await EventsFor(session).LoadAsync(Guid.NewGuid(), Cancellation);
+        untyped.ShouldBeNull();
+    }
+}

--- a/src/JasperFx.Events/IEventStream.cs
+++ b/src/JasperFx.Events/IEventStream.cs
@@ -27,15 +27,20 @@ public interface IEventStream<out T> where T : notnull
     T? Aggregate { get; }
 
     /// <summary>
-    /// The version of the stream at the moment it was fetched. Null when the stream
-    /// did not exist at fetch time.
+    /// The version of the stream at the moment it was fetched, and <c>0</c> when the stream did
+    /// not exist at fetch time.
     /// </summary>
+    /// <remarks>
+    /// Nullable for historical reasons only — a fetch of a missing stream reports 0, not null, on
+    /// every implementation. Verified across stores by
+    /// <c>FetchForWritingCompliance.fetch_for_writing_a_stream_that_does_not_exist_yet</c>; this
+    /// doc previously claimed null.
+    /// </remarks>
     long? StartingVersion { get; }
 
     /// <summary>
     /// The expected version after the events queued on this handle are persisted —
     /// equivalent to <see cref="StartingVersion"/> + the count of pending events.
-    /// Null when <see cref="StartingVersion"/> is null.
     /// </summary>
     long? CurrentVersion { get; }
 


### PR DESCRIPTION
Compliance wave 4 — the whole "portable today" group from the wave backlog (marten#5118). Four suites, **40 tests, library 65 → 105**, and not one of them needed a new fixture member: every entry point was already declared on the shared JasperFx surfaces.

| Suite | Tests | Covers | marten issue |
|---|---|---|---|
| `FetchForWritingCompliance` | 13 | `FetchForWriting` / `FetchForExclusiveWriting` / `WriteToAggregate` / `WriteExclusivelyToAggregate` / `AppendOptimistic` / `AppendExclusive` / version-checked `Append`, and the concurrency failures | marten#5137 |
| `StreamReadCompliance` | 11 | `FetchStreamAsync` with version, `fromVersion` and timestamp bounds; `FetchStreamStateAsync`; single-event `LoadAsync` | marten#5139 |
| `EventMetadataCompliance` | 9 | the `IEvent` envelope — per-stream `Version`, store-global `Sequence`, server `Timestamp`, type naming via the registry, tenant, headers | marten#5143 |
| `LiveAggregationCompliance` | 7 | `AggregateStreamAsync` and `AggregateStreamToLastKnownAsync`, including walking back past a fold that deletes the aggregate | marten#5141 |

## Verified on both stores before opening this

Not "should port cleanly" — actually run, against working copies wired through the `ComplianceSourceDir` dev loop:

- **Marten** 105/105 compliance, and 1667/0/7 for the whole EventSourcingTests suite
- **Polecat** 105/105 compliance

Zero capability gates on either store.

## Two things worth reading closely

**No exception abstraction was needed for concurrency.** `EventStreamUnexpectedMaxEventIdException` derives from JasperFx's own `ConcurrencyException`, and both products throw it — this was the one thing that looked like it would need a seam member and did not. The suite asserts the shared base rather than the exact derived type, and wraps the whole fetch-append-save sequence rather than a single call, because whether a store detects the conflict eagerly at fetch or late at commit is an implementation choice. Pinning it would encode one product's timing as the standard.

**A compliance test corrected an upstream contract doc, which is a first.** `IEventStream<T>.StartingVersion` was documented as null when the stream does not exist. Both products report `0`. The doc is what was wrong, so it is fixed here, with a pointer to the test that establishes it.

## Also included

- `ComplianceStoreConfig.EnableHeaders`, following the `EnableCorrelationTracking` precedent — the flag is spelled differently in each product (Marten `Events.MetadataConfig.HeadersEnabled`, Polecat `Events.EnableHeaders`) so the fixture resolves it. Stamping the headers needs nothing new: `IEvent.SetHeader` is already shared.
- README gains a coverage inventory, an explicit out-of-scope boundary, and the `ComplianceSourceDir` dev loop both consumers already support. That is part of what marten#5155 asks for.
- `JasperFxVersion` 2.38.0 → **2.38.1**, in this PR, per the `--skip-duplicate` publish trap.

## Notes on the time-based tests

Two tests need a real timestamp gap. Both derive the cut-off from the *stored* event timestamps rather than the test host's clock (the two are different machines in CI, and stores stamp server-side), and both pick a point strictly between two commits so the suite does not accidentally pin whether a store's timestamp filter is inclusive or exclusive.

## After this merges

Consumers adopt on 2.38.1 — Marten enrollments plus the `EnableHeaders` fixture wiring are ready on a branch and gated only on the publish; Polecat's are the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
