### PR TITLE
Stop writing a periodic per-shard heartbeat nobody reads (#622)

### DIFF
--- a/src/EventTests/Daemon/ExtendedProgressionHeartbeatIntervalTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionHeartbeatIntervalTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using EventTests.Projections;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+/// <summary>
+/// jasperfx#622 — the periodic per-shard extended progression heartbeat had no reader anywhere and
+/// cost one pooled connection + one transaction per database per node every 5 seconds, with no
+/// configuration path at all (the interval was private on the daemon and no DaemonSettings knob
+/// reached it). It is off by default now, and DaemonSettings.ExtendedProgressionHeartbeatInterval is
+/// the compatibility hatch.
+/// </summary>
+public class ExtendedProgressionHeartbeatIntervalTests : IDisposable
+{
+    private readonly ShardStateTracker theTracker = new(new NulloLogger());
+    private readonly RecordingDatabase theDatabase;
+
+    private readonly List<JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>>
+        theDaemons = [];
+
+    public ExtendedProgressionHeartbeatIntervalTests()
+    {
+        theDatabase = new RecordingDatabase(theTracker);
+    }
+
+    public void Dispose()
+    {
+        foreach (var daemon in theDaemons) daemon.Dispose();
+    }
+
+    private async Task<JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>>
+        startedDaemon(TimeSpan? heartbeatInterval)
+    {
+        var store = Substitute.For<IEventStore<FakeOperations, FakeSession>>();
+        store.Meter.Returns(new Meter("tests"));
+        store.TimeProvider.Returns(TimeProvider.System);
+        store.ExtendedProgressionEnabled.Returns(true);
+        store.AutoCreateSchemaObjects.Returns(AutoCreate.None);
+
+        var graph = new FakeGraph { ExtendedProgressionHeartbeatInterval = heartbeatInterval };
+
+        var daemon = new JasperFxAsyncDaemon<FakeOperations, FakeSession, IJasperFxProjection<FakeOperations>>(
+            store, theDatabase, new NulloLogger(), new StubDetector(), graph);
+
+        theDaemons.Add(daemon);
+        await daemon.StartHighWaterDetectionAsync();
+        return daemon;
+    }
+
+    private static ShardState heartbeat() => new("Trip:All", 5)
+    {
+        Action = ShardAction.Updated, AgentStatus = "Running", LastHeartbeat = DateTimeOffset.UtcNow
+    };
+
+    private static ShardState transition() => new("Trip:All", 5)
+    {
+        Action = ShardAction.Paused, AgentStatus = "Paused", PauseReason = "boom"
+    };
+
+    private async Task<int> writeCountAfterPublishing(ShardState state, int expected)
+    {
+        await theTracker.PublishAsync(state);
+
+        for (var i = 0; i < 100 && theDatabase.Writes < expected; i++)
+        {
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+        }
+
+        if (expected == 0)
+        {
+            await Task.Delay(250, TestContext.Current.CancellationToken);
+        }
+
+        return theDatabase.Writes;
+    }
+
+    [Fact]
+    public async Task no_periodic_heartbeat_write_by_default()
+    {
+        await startedDaemon(null);
+
+        (await writeCountAfterPublishing(heartbeat(), 0)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task transitions_are_still_persisted_by_default()
+    {
+        await startedDaemon(null);
+
+        (await writeCountAfterPublishing(transition(), 1)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_configured_interval_restores_the_periodic_beat()
+    {
+        await startedDaemon(TimeSpan.FromSeconds(5));
+
+        (await writeCountAfterPublishing(heartbeat(), 1)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_non_positive_configured_interval_is_off()
+    {
+        await startedDaemon(TimeSpan.Zero);
+
+        (await writeCountAfterPublishing(heartbeat(), 0)).ShouldBe(0);
+    }
+
+    private sealed class RecordingDatabase : IEventDatabase
+    {
+        private int _writes;
+
+        public RecordingDatabase(ShardStateTracker tracker) => Tracker = tracker;
+
+        public int Writes => Volatile.Read(ref _writes);
+
+        public Task WriteExtendedProgressionAsync(IReadOnlyList<ShardState> states, CancellationToken token = default)
+        {
+            Interlocked.Increment(ref _writes);
+            return Task.CompletedTask;
+        }
+
+        public Task WriteExtendedProgressionAsync(ShardState state, CancellationToken token = default)
+        {
+            Interlocked.Increment(ref _writes);
+            return Task.CompletedTask;
+        }
+
+        public ShardStateTracker Tracker { get; }
+        public string Identifier => "db1";
+        public Uri DatabaseUri { get; } = new("fake://db1");
+        public string StorageIdentifier => "db1";
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent, CancellationToken token)
+            => Task.CompletedTask;
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token) => Task.CompletedTask;
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout) => Task.CompletedTask;
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => Task.FromResult(0L);
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => Task.FromResult<long?>(null);
+
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token) => Task.FromResult(0L);
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => Task.FromResult<IReadOnlyList<ShardState>>([]);
+    }
+
+    private sealed class StubDetector : IHighWaterDetector
+    {
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics());
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+    }
+
+    private sealed class FakeGraph : ProjectionGraph<IJasperFxProjection<FakeOperations>, FakeOperations, FakeSession>
+    {
+        public FakeGraph() : base(Substitute.For<IEventRegistry>(), "tests")
+        {
+        }
+
+        protected override void onAddProjection(object projection)
+        {
+            // Nothing
+        }
+    }
+}

--- a/src/EventTests/Daemon/ExtendedProgressionSubscriptionLifecycleTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionSubscriptionLifecycleTests.cs
@@ -55,8 +55,13 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
         return daemon;
     }
 
-    private static ShardState heartbeat(string shardName) =>
-        new(shardName, 5) { AgentStatus = "Running", LastHeartbeat = DateTimeOffset.UtcNow };
+    // jasperfx#622: only status transitions are persisted by default, so the probe publication that
+    // proves "this daemon is writing" has to be one
+    private static ShardState startedState(string shardName) =>
+        new(shardName, 5)
+        {
+            Action = ShardAction.Started, AgentStatus = "Running", LastHeartbeat = DateTimeOffset.UtcNow
+        };
 
     // Publications are delivered asynchronously through the tracker's block, so both the positive and
     // the negative assertion have to be given the same chance to happen
@@ -84,7 +89,7 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
         // every 15 seconds purely to read CurrentAgents()
         var daemon = buildDaemon();
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 0)).ShouldBe(0);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 0)).ShouldBe(0);
     }
 
     [Fact]
@@ -95,7 +100,7 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
             buildDaemon();
         }
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 0)).ShouldBe(0);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 0)).ShouldBe(0);
     }
 
     [Fact]
@@ -104,7 +109,7 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
         var daemon = buildDaemon();
         await daemon.StartHighWaterDetectionAsync();
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 1)).ShouldBe(1);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 1)).ShouldBe(1);
     }
 
     [Fact]
@@ -119,7 +124,7 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
 
         await owner.StartHighWaterDetectionAsync();
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 1)).ShouldBe(1);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 1)).ShouldBe(1);
     }
 
     [Fact]
@@ -129,7 +134,7 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
         await daemon.StartHighWaterDetectionAsync();
         await daemon.StartHighWaterDetectionAsync();
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 1)).ShouldBe(1);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 1)).ShouldBe(1);
     }
 
     [Fact]
@@ -137,11 +142,11 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
     {
         var daemon = buildDaemon();
         await daemon.StartHighWaterDetectionAsync();
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 1)).ShouldBe(1);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 1)).ShouldBe(1);
 
         await daemon.StopAllAsync();
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 2)).ShouldBe(1);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 2)).ShouldBe(1);
     }
 
     [Fact]
@@ -154,7 +159,7 @@ public class ExtendedProgressionSubscriptionLifecycleTests : IDisposable
         await daemon.StopAllAsync();
         await daemon.StartHighWaterDetectionAsync();
 
-        (await writeCountAfterPublishing(heartbeat("Trip:All"), 1)).ShouldBe(1);
+        (await writeCountAfterPublishing(startedState("Trip:All"), 1)).ShouldBe(1);
     }
 
     [Fact]

--- a/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
+++ b/src/EventTests/Daemon/ExtendedProgressionWriterTests.cs
@@ -21,6 +21,14 @@ public class ExtendedProgressionWriterTests
         theWriter = new ExtendedProgressionWriter(theStore, theDatabase, theTime, NullLogger.Instance);
     }
 
+    // jasperfx#622: the periodic per-shard beat is OFF by default now. The machinery is unchanged and
+    // still shipped behind DaemonSettings.ExtendedProgressionHeartbeatInterval, so the tests that pin
+    // its coalescing/flush behavior opt into it explicitly.
+    private void enablePeriodicHeartbeats()
+    {
+        theWriter.HeartbeatWriteInterval = TimeSpan.FromSeconds(5);
+    }
+
     private static ShardState transition(ShardAction action, string status, string? pauseReason = null,
         string shardName = "Counters:All")
     {
@@ -100,6 +108,8 @@ public class ExtendedProgressionWriterTests
     [Fact]
     public async Task coalesces_heartbeats_into_one_batched_write_per_flush_interval()
     {
+        enablePeriodicHeartbeats();
+
         // The very first heartbeat flushes immediately (nothing to wait for)
         theWriter.OnNext(heartbeat(sequence: 1));
         var writes = await theDatabase.WaitForWrites(1);
@@ -127,6 +137,8 @@ public class ExtendedProgressionWriterTests
     [Fact]
     public async Task a_transition_flushes_immediately_and_carries_the_pending_heartbeats_along()
     {
+        enablePeriodicHeartbeats();
+
         // Seed a flush so the interval throttle is active
         theWriter.OnNext(heartbeat(sequence: 1));
         await theDatabase.WaitForWrites(1);
@@ -148,6 +160,8 @@ public class ExtendedProgressionWriterTests
     [Fact]
     public async Task a_transition_replaces_a_pending_heartbeat_for_the_same_shard()
     {
+        enablePeriodicHeartbeats();
+
         theWriter.OnNext(heartbeat(sequence: 1));
         await theDatabase.WaitForWrites(1);
 
@@ -205,6 +219,8 @@ public class ExtendedProgressionWriterTests
     [Fact]
     public async Task disposing_flushes_the_pending_batch()
     {
+        enablePeriodicHeartbeats();
+
         theWriter.OnNext(heartbeat(sequence: 1));
         await theDatabase.WaitForWrites(1);
 
@@ -240,6 +256,54 @@ public class ExtendedProgressionWriterTests
 
         var writes = await theDatabase.WaitForWrites(1);
         writes[0].AgentStatus.ShouldBe("Stopped");
+    }
+
+    // jasperfx#622
+    [Fact]
+    public async Task no_periodic_heartbeat_write_by_default()
+    {
+        // The whole point: a heartbeat nobody reads costs a connection + a transaction per database
+        // per node per interval (marten#5167). Off unless asked for.
+        theWriter.PeriodicHeartbeatsEnabled.ShouldBeFalse();
+
+        theWriter.OnNext(heartbeat(sequence: 1));
+        theWriter.OnNext(heartbeat(sequence: 2));
+        theWriter.OnNext(heartbeat("Others:All", sequence: 7));
+        theTime.Advance(TimeSpan.FromMinutes(5));
+        theWriter.OnNext(heartbeat(sequence: 3));
+
+        await theDatabase.AssertNoWrites();
+    }
+
+    // jasperfx#622: the transitional columns are exactly what survives -- rare writes, and the data
+    // the "durable across a crash" story was actually about
+    [Fact]
+    public async Task transitions_are_still_written_with_the_periodic_beat_off()
+    {
+        theWriter.OnNext(heartbeat(sequence: 1));
+        theWriter.OnNext(transition(ShardAction.Paused, "Paused", "boom"));
+
+        var writes = await theDatabase.WaitForWrites(1);
+        var batches = await theDatabase.Batches();
+
+        // ...and the dropped heartbeat does NOT ride along on the transition's write
+        batches.Count.ShouldBe(1);
+        batches[0].Length.ShouldBe(1);
+        writes[0].AgentStatus.ShouldBe("Paused");
+        writes[0].PauseReason.ShouldBe("boom");
+    }
+
+    // jasperfx#622: the compatibility hatch the interval never had
+    [Fact]
+    public async Task a_positive_interval_restores_the_periodic_beat()
+    {
+        enablePeriodicHeartbeats();
+        theWriter.PeriodicHeartbeatsEnabled.ShouldBeTrue();
+
+        theWriter.OnNext(heartbeat(sequence: 1));
+
+        var writes = await theDatabase.WaitForWrites(1);
+        writes[0].Sequence.ShouldBe(1);
     }
 
     [Fact]

--- a/src/JasperFx.Events/Daemon/DaemonSettings.cs
+++ b/src/JasperFx.Events/Daemon/DaemonSettings.cs
@@ -41,6 +41,18 @@ public interface IReadOnlyDaemonSettings
     TimeSpan HighWaterStalenessThreshold { get; }
 
     /// <summary>
+    ///     jasperfx#622: cadence of the PERIODIC per-shard extended progression heartbeat write.
+    ///     Null (the default) or any non-positive value means no periodic write at all — only agent
+    ///     status transitions (Started/Paused/Stopped) are persisted, which is what the extended
+    ///     columns are actually read for. A positive value restores the pre-#622 behavior at that
+    ///     cadence and is a compatibility hatch, not the recommended shape: the periodic beat costs
+    ///     one pooled connection and one transaction per database per node per interval, and nothing
+    ///     in JasperFx, Marten or CritterWatch reads the persisted heartbeat (marten#5167).
+    ///     Only consulted when <c>IEventStore.ExtendedProgressionEnabled</c> is on.
+    /// </summary>
+    TimeSpan? ExtendedProgressionHeartbeatInterval { get; }
+
+    /// <summary>
     ///     How long the daemon will wait for a single subscription or projection shard to gracefully
     ///     finish its in-flight page and flush its progression when that agent is stopped. Exceeding
     ///     this bound cancels the drain mid-flight, which abandons the progression flush. The default
@@ -110,6 +122,15 @@ public class DaemonSettings: IReadOnlyDaemonSettings
     ///     if the daemon detects low activity. The default is 1 second.
     /// </summary>
     public TimeSpan SlowPollingTime { get; set; } = 1.Seconds();
+
+    /// <summary>
+    ///     jasperfx#622: cadence of the PERIODIC per-shard extended progression heartbeat write. Null
+    ///     (the default) or any non-positive value means no periodic write at all — only agent status
+    ///     transitions are persisted. A positive value restores the pre-#622 5 second beat at that
+    ///     cadence; see <see cref="IReadOnlyDaemonSettings.ExtendedProgressionHeartbeatInterval" />
+    ///     for why that is a compatibility hatch rather than a recommendation.
+    /// </summary>
+    public TimeSpan? ExtendedProgressionHeartbeatInterval { get; set; }
 
     /// <summary>
     ///     Polling time between looking for a new high water sequence mark

--- a/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
+++ b/src/JasperFx.Events/Daemon/ExtendedProgressionWriter.cs
@@ -17,16 +17,28 @@ namespace JasperFx.Events.Daemon;
 /// <list type="bullet">
 /// <item>Gated on <see cref="IEventStore.ExtendedProgressionEnabled"/>, read live per publication —
 /// nothing is written (or even queued) for stores that have not opted in.</item>
-/// <item>Heartbeat/telemetry publications (<see cref="ShardAction.Updated"/> — the ~10s heartbeat
-/// timer ticks and the per-batch commit publications) are coalesced per shard (latest state wins)
-/// and flushed as ONE batched database write per <see cref="HeartbeatWriteInterval"/> for the whole
+/// <item>jasperfx#622: heartbeat/telemetry publications (<see cref="ShardAction.Updated"/>) are
+/// DROPPED by default. The periodic per-shard beat had no reader anywhere — not in JasperFx, not
+/// in Marten, and not in CritterWatch, which reads agent status and heartbeats off in-memory
+/// objects and drops the persisted columns on the floor — while costing one pooled connection and
+/// one transaction per database per node every 5 seconds. On a 512-shard-database deployment that
+/// was ~37 connection acquisitions/sec/node to keep 6-12 rows current, and it made a production web
+/// app unresponsive (marten#5167). Liveness is a node property and is tracked as one per node
+/// upstream; <c>last_updated</c> plus the agent assignment grid reconstructs what any consumer
+/// actually renders. Set <see cref="HeartbeatWriteInterval"/> (or
+/// <c>DaemonSettings.ExtendedProgressionHeartbeatInterval</c>) to a positive value to restore the
+/// old behavior — that is the compatibility hatch, not the recommended shape.</item>
+/// <item>When periodic beats ARE enabled, they are coalesced per shard (latest state wins) and
+/// flushed as ONE batched database write per <see cref="HeartbeatWriteInterval"/> for the whole
 /// database. The write rate is therefore constant per database instead of O(shards): under
 /// per-tenant agent fan-out (agents = projections × tenants) the previous
 /// one-connection-rent-per-shard-per-interval write path drove a sharded multi-tenant deployment
 /// to its database server's connection ceiling (jasperfx#553).</item>
 /// <item>Agent status transitions (<see cref="ShardAction.Started"/>, <see cref="ShardAction.Paused"/>,
 /// <see cref="ShardAction.Stopped"/>) flush immediately — a paused/stopped shard is exactly when the
-/// persisted status matters most. The pending heartbeat batch rides along in the same write.</item>
+/// persisted status matters most, and these writes are rare, so they keep the "durable across a
+/// crash" story for the data where it means something. The pending heartbeat batch, if periodic
+/// beats are enabled, rides along in the same write.</item>
 /// <item>Writes are best-effort and serialized on a background block: a failed write is logged at
 /// debug and can never fail or stall the shard, and a slow database can never back up the
 /// tracker's publication loop.</item>
@@ -64,11 +76,24 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
     /// <summary>
     /// Spacing between two batched heartbeat/telemetry flushes for the database. All shard states
     /// that arrive within the interval are coalesced (latest state per shard) into the next flush,
-    /// so no heartbeat is ever more than one interval stale. Status transitions flush immediately,
-    /// carrying any pending batch with them. Defaults to 5 seconds so every tick of the agents'
-    /// 10 second heartbeat timer lands.
+    /// so no heartbeat is ever more than one interval stale. Status transitions always flush
+    /// immediately, carrying any pending batch with them.
+    ///
+    /// <para>
+    /// jasperfx#622: defaults to <see cref="TimeSpan.Zero"/> — periodic heartbeat writes are OFF, and
+    /// only status transitions are persisted. Zero or negative disables them; any positive value
+    /// restores the periodic beat at that cadence. Before #622 this was hardcoded to 5 seconds with
+    /// no configuration path at all (the field was private on the daemon, reachable from no
+    /// <c>DaemonSettings</c> knob), which is what made the cost impossible to opt out of.
+    /// </para>
     /// </summary>
-    public TimeSpan HeartbeatWriteInterval { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan HeartbeatWriteInterval { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Whether this writer persists the periodic per-shard heartbeat at all. False by default; see
+    /// <see cref="HeartbeatWriteInterval"/>.
+    /// </summary>
+    public bool PeriodicHeartbeatsEnabled => HeartbeatWriteInterval > TimeSpan.Zero;
 
     public void OnNext(ShardState value)
     {
@@ -79,6 +104,13 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
 
         // Plain progress publications (e.g. rebuild range completions) carry no agent telemetry
         if (value.AgentStatus == null && value.LastHeartbeat == null) return;
+
+        var isTransition = value.Action is ShardAction.Started or ShardAction.Paused or ShardAction.Stopped;
+
+        // jasperfx#622: with the periodic beat off, a non-transition publication is dropped outright
+        // rather than queued -- there is no later flush to carry it, and letting it ride along on the
+        // next transition would write a stale heartbeat nobody reads.
+        if (!isTransition && !PeriodicHeartbeatsEnabled) return;
 
         // Carry the assigned node through to the persisted running_on_node column when a
         // distribution layer (e.g. Wolverine-managed subscription distribution) stamped it
@@ -91,7 +123,6 @@ public sealed class ExtendedProgressionWriter : IObserver<ShardState>, IAsyncDis
         // simply replaces it
         _pending[value.ShardName] = value;
 
-        var isTransition = value.Action is ShardAction.Started or ShardAction.Paused or ShardAction.Stopped;
         var now = _timeProvider.GetUtcNow();
 
         if (isTransition || now - _lastFlush >= HeartbeatWriteInterval)

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -256,7 +256,14 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // StopAllAsync drained it, exactly as it rebuilds the dead-letter block (jasperfx#557).
     private ExtendedProgressionWriter buildExtendedProgressionWriter()
         => new(_store, Database, _store.TimeProvider,
-            _loggerFactory?.CreateLogger<ExtendedProgressionWriter>() ?? Logger);
+            _loggerFactory?.CreateLogger<ExtendedProgressionWriter>() ?? Logger)
+        {
+            // jasperfx#622: off unless the application asks for it. This is the configuration path
+            // the interval never had -- before #622 it was a hardcoded 5 seconds that no
+            // DaemonSettings knob could reach.
+            HeartbeatWriteInterval =
+                _projections.ExtendedProgressionHeartbeatInterval ?? TimeSpan.Zero
+        };
 
     /// <summary>
     /// jasperfx#621: arm the extended progression writer. Called from every path that actually starts
@@ -1189,10 +1196,15 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             await _tenantHighWater.PollAndRouteAsync(CurrentAgents(), _cancellation.Token).ConfigureAwait(false);
 
             // jasperfx#539: publish the per-cycle liveness heartbeat for Path B. The coordinator has already
-            // stamped its in-memory LastPolledAt; this surfaces the same beat on the live Tracker (and the
-            // ExtendedProgression columns) so remote consumers can tell "no new events" from "the tenant
-            // high-water poll died". Carries the store-global mark unchanged, so it never advances it and,
-            // by the OnNext guard above, never re-triggers a poll.
+            // stamped its in-memory LastPolledAt; this surfaces the same beat on the live Tracker so
+            // in-process consumers can tell "no new events" from "the tenant high-water poll died".
+            // Carries the store-global mark unchanged, so it never advances it and, by the OnNext guard
+            // above, never re-triggers a poll.
+            //
+            // jasperfx#622: this beat does NOT reach the ExtendedProgression columns, and never did --
+            // ExtendedProgressionWriter.OnNext drops HighWaterMark and AllProjections states outright
+            // (pinned by skips_high_water_mark_and_all_projections_states). The live Tracker is the only
+            // place it shows up.
             await publishHighWaterStatusAsync(ShardAction.Updated, "Running").ConfigureAwait(false);
         }
         catch (Exception e)


### PR DESCRIPTION
Closes #622. Rebased onto `main` now that #625 (the writer-accumulation fix) has merged — #621 is the bug that multiplied this cost without bound; this is the cost model that remains after it.

## What the audit found

`EnableExtendedProgressionTracking` cost one pooled connection and one transaction per database per node every 5 seconds — ~37 connection acquisitions/sec/node on a 512-shard-database deployment, to keep 6–12 rows per database current, writing into the same rows the progress writer updates. It made a production web app unresponsive (marten#5167).

And nothing reads it. Not JasperFx — the only read of `LastHeartbeat` anywhere is the writer checking its own input before writing it, and the CLI daemon status grid renders sequence and high-water only. Not CritterWatch, the sole intended consumer, which obtains agent status and heartbeats by reflecting off **in-memory** objects (`CurrentAgents()`, the tracker's `ShardState`) and drops the extended columns it already receives over the wire. Its `AgentDown` alert fires at `heartbeatAge > 60s`, on a 30s tick, fed by a 15s poll — a 5s write is a 12× oversample of something nothing downstream can observe below 15s resolution.

## The change

Proposal items 1–3 from the issue.

**1. Stop the periodic beat.** `ExtendedProgressionWriter` drops non-transition publications by default — outright, rather than queueing them, so a stale beat can't ride along on the next transition write either.

**2. Keep the transitional columns.** `Started`/`Paused`/`Stopped` writes are untouched: rare, and the data the "durable across a crash" story was actually about.

**3. Make the interval configurable.** `HeartbeatWriteInterval` now defaults to `TimeSpan.Zero` (off) and is reachable from application code through the new `DaemonSettings.ExtendedProgressionHeartbeatInterval`. Before this it was a hardcoded 5 seconds that no `DaemonSettings` knob could reach — the field was private on the daemon, exposed by no property, and the only code that set it was the class's own unit test. A positive value restores the old behavior at that cadence; that is the compatibility hatch, not the recommended shape.

The coalescing/batching machinery is unchanged and still fully tested — it just has to be asked for now.

## Also

Corrects the comment at the Path B tenant high-water heartbeat (`JasperFxAsyncDaemon.cs`), which claimed the beat "surfaces the same beat on the live Tracker (and the ExtendedProgression columns)". It never reached the columns — `OnNext` drops `HighWaterMark` and `AllProjections` states, as `skips_high_water_mark_and_all_projections_states` pins. The issue asked for this regardless of the outcome.

## What is deliberately not done

- **Per-node liveness rows.** The issue's replacement for the per-shard beat already exists on the consuming side (CritterWatch's `NodeHeartbeat`, #837). Nothing to add here.
- **Folding idle-shard liveness into the progress writer's transaction.** That's the "if per-shard liveness is wanted despite the above" alternative; it's a larger change and should follow evidence that someone wants the signal.
- **The permanently-NULL columns** (`pause_reason`, `running_on_node`). Left alone — they're free now that they're only written on transition.

## Tests

- `ExtendedProgressionWriterTests`: new coverage for the default (no periodic write even after 5 minutes of publications), transitions still written with the beat off and *not* carrying a dropped heartbeat along, and a positive interval restoring the beat. The existing periodic-beat tests now opt in explicitly, which is the honest statement of where that behavior lives.
- `ExtendedProgressionHeartbeatIntervalTests`: end-to-end through a real daemon + shared tracker, proving `DaemonSettings.ExtendedProgressionHeartbeatInterval` reaches the writer — null and `TimeSpan.Zero` are off, a positive value is on, transitions persist regardless.

Full `EventTests` suite passes (693).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fuk1GybEEmohFmboJuM4Po
