### PR TITLE
Register an EventProjection's published types as teardown targets (#626)

### DIFF
--- a/src/EventTests/Projections/EventProjectionTests.cs
+++ b/src/EventTests/Projections/EventProjectionTests.cs
@@ -113,3 +113,120 @@ public class EventProjection : JasperFxEventProjectionBase<FakeOperations, FakeS
         throw new NotImplementedException();
     }
 }
+/// <summary>
+/// jasperfx#626 — JasperFxEventProjectionBase's constructor never touched Options, so an
+/// EventProjection registered NO teardown targets: a rebuild deleted the progression row and then
+/// re-projected into a table still holding the previous run's documents, and the ProjectionScenario
+/// harness wipe (which reads Options.StorageTypes) did nothing after an event projection. Aggregation
+/// projections have always registered their single TDoc; nothing in the API surface signalled the
+/// difference, so every event projection author had to know it independently.
+/// </summary>
+public class EventProjectionTeardownTests
+{
+    private static Type[] cleanupTypes(ProjectionBase projection)
+        => projection.Options.CleanUps.OfType<DeleteDocuments>().Select(x => x.DocumentType).ToArray();
+
+    [Fact]
+    public void published_types_become_teardown_targets()
+    {
+        var projection = new CreatesDocumentsProjection();
+
+        // Nothing is registered until assembly -- the source generator emits its
+        // RegisterPublishedType calls into the subclass constructor, after the base one
+        projection.Options.CleanUps.ShouldBeEmpty();
+
+        projection.AssembleAndAssertValidity();
+
+        cleanupTypes(projection).ShouldBe([typeof(DocOne)]);
+        projection.Options.StorageTypes.ShouldContain(typeof(DocOne));
+    }
+
+    [Fact]
+    public void every_published_type_is_registered_not_just_the_first()
+    {
+        var projection = new CreatesTwoDocumentsProjection();
+        projection.AssembleAndAssertValidity();
+
+        cleanupTypes(projection).ShouldBe([typeof(DocOne), typeof(DocTwo)], ignoreOrder: true);
+    }
+
+    [Fact]
+    public void a_projection_that_publishes_nothing_registers_nothing()
+    {
+        var projection = new ConventionalEventProjection();
+        projection.AssembleAndAssertValidity();
+
+        projection.Options.CleanUps.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_opt_out_wins_over_the_default()
+    {
+        // For a projection writing into storage that must not be truncated on rebuild
+        var projection = new AppendOnlyProjection();
+        projection.AssembleAndAssertValidity();
+
+        projection.Options.CleanUps.ShouldBeEmpty();
+        projection.Options.StorageTypes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_hand_registered_type_is_not_duplicated()
+    {
+        var projection = new CreatesDocumentsProjection();
+        projection.Options.DeleteViewTypeOnTeardown<DocOne>();
+
+        projection.AssembleAndAssertValidity();
+
+        cleanupTypes(projection).ShouldBe([typeof(DocOne)]);
+    }
+
+    [Fact]
+    public void assembling_twice_does_not_duplicate_the_registrations()
+    {
+        // ProjectionGraph assembles on more than one path; a second pass must be a no-op
+        var projection = new CreatesDocumentsProjection();
+        projection.AssembleAndAssertValidity();
+        projection.AssembleAndAssertValidity();
+
+        cleanupTypes(projection).ShouldBe([typeof(DocOne)]);
+    }
+
+    [Fact]
+    public void an_explicitly_registered_type_survives_the_opt_out()
+    {
+        // The documented "some but not all" recipe: opt out, then declare what you do want wiped
+        var projection = new AppendOnlyProjection();
+        projection.Options.DeleteViewTypeOnTeardown<DocTwo>();
+
+        projection.AssembleAndAssertValidity();
+
+        cleanupTypes(projection).ShouldBe([typeof(DocTwo)]);
+    }
+}
+
+public class DocOne;
+
+public class DocTwo;
+
+public partial class CreatesDocumentsProjection : EventProjection
+{
+    public DocOne Create(AEvent e) => new();
+}
+
+public partial class CreatesTwoDocumentsProjection : EventProjection
+{
+    public DocOne Create(AEvent e) => new();
+
+    public DocTwo Create(BEvent e) => new();
+}
+
+public partial class AppendOnlyProjection : EventProjection
+{
+    public AppendOnlyProjection()
+    {
+        DeletePublishedTypesOnTeardown = false;
+    }
+
+    public DocOne Create(AEvent e) => new();
+}

--- a/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
+++ b/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
@@ -150,8 +150,45 @@ public abstract class JasperFxEventProjectionBase<TOperations, TQuerySession> :
 
     protected abstract void storeEntity<T>(TOperations ops, T entity) where T : notnull;
 
+    /// <summary>
+    /// jasperfx#626: whether the document types this projection publishes are automatically
+    /// registered as teardown targets (<see cref="AsyncOptions.DeleteViewTypeOnTeardown(Type)" />),
+    /// so a rebuild wipes the previous run's documents before re-projecting. True by default, which
+    /// matches what aggregation projections have always done for their single view type.
+    ///
+    /// <para>
+    /// Set to false when this projection writes into storage that must NOT be truncated on rebuild —
+    /// an append-only audit table, or documents another projection owns. With it off, nothing is
+    /// registered automatically and <see cref="ProjectionBase.Options" />'s teardown rules are
+    /// entirely yours to declare. It is all-or-nothing: to keep automatic registration for some
+    /// published types only, turn it off and call <c>Options.DeleteViewTypeOnTeardown&lt;T&gt;()</c>
+    /// for the ones you do want wiped.
+    /// </para>
+    /// </summary>
+    public bool DeletePublishedTypesOnTeardown { get; set; } = true;
+
+    // jasperfx#626: an EventProjection can publish several document types, so the base constructor
+    // cannot do what JasperFxAggregationProjectionBase does with its single TDoc -- and it could not
+    // do it there anyway, because the source generator emits its RegisterPublishedType calls into the
+    // subclass constructor, which runs AFTER this base one. Deferring to AssembleAndAssertValidity
+    // (registration time, via ProjectionGraph) sees the complete set and lets a subclass constructor
+    // turn the behavior off before it happens. Idempotent: a type the author already registered by
+    // hand, or a previous pass, is skipped rather than duplicated.
+    private void registerPublishedTypesForTeardown()
+    {
+        if (!DeletePublishedTypesOnTeardown) return;
+
+        foreach (var publishedType in PublishedTypes().ToArray())
+        {
+            if (Options.StorageTypes.Contains(publishedType)) continue;
+            Options.DeleteViewTypeOnTeardown(publishedType);
+        }
+    }
+
     public sealed override void AssembleAndAssertValidity()
     {
+        registerPublishedTypesForTeardown();
+
         var applyMethod = GetType()!.GetMethod(nameof(ApplyAsync))!;
         var isOverridden = applyMethod.DeclaringType!.Assembly != typeof(JasperFxEventProjectionBase<,>).Assembly;
         if (isOverridden)


### PR DESCRIPTION
Closes #626.

## The problem

`JasperFxEventProjectionBase`'s constructor never touched `Options`, so an `EventProjection` registered **no** teardown targets — `Options.CleanUps` and `Options.StorageTypes` stayed empty for the projection's whole lifetime unless the author hand-called `Options.DeleteViewTypeOnTeardown<T>()`. `JasperFxAggregationProjectionBase` has always done it for its single `TDoc`, and nothing in the API surface signalled that the two families differed.

Everything that derives "what does this projection own" from those lists therefore silently did nothing for event projections:

- **Rebuild teardown** — `Options.Teardown(session)` iterates `CleanUps`, so a rebuild deleted the progression row and then re-projected into a table still holding the previous run's documents.
- **Per-tenant progression deletion** — same path, per tenant.
- **The `ProjectionScenario` harness wipe** — `All.SelectMany(x => x.Options.StorageTypes)`, identical in Marten and Polecat, never wiped after an event projection.

It was already known and worked around by hand rather than fixed: a Marten test carries a comment explaining the gap followed by an explicit `Options.DeleteViewTypeOnTeardown<LegLog>()`.

## The fix

Published types now default to teardown targets — registered in `AssembleAndAssertValidity()`, not the constructor, for two reasons:

1. The source generator emits its `RegisterPublishedType(typeof(...))` calls into the **subclass** constructor, which runs *after* the base one, so a constructor-time pass can't see the complete set. Assembly time (via `ProjectionGraph`) sees everything.
2. Registering at assembly time lets a subclass constructor turn the behavior off before it happens.

Registration is idempotent — a type the author registered by hand, or a second assembly pass, is skipped rather than duplicated.

## Opt-out

```csharp
public bool DeletePublishedTypesOnTeardown { get; set; } = true;
```

For projections writing into storage that must not be truncated on rebuild — an append-only audit table, or documents another projection owns. All-or-nothing by design: turn it off and call `Options.DeleteViewTypeOnTeardown<T>()` for the types you *do* want wiped. That recipe has its own test.

## Behavior change

This is deliberate and is the point of the issue, but worth stating plainly: **rebuilding an event projection now truncates the document types it publishes.** Anyone currently relying on the silence — an event projection writing into storage it doesn't own — needs `DeletePublishedTypesOnTeardown = false`. The issue flagged the same coupling on `StorageTypes`: since `DeleteViewTypeOnTeardown` writes to both lists, the `ProjectionScenario` wipe starts working as a side effect. Desirable here, and now deliberate rather than incidental.

## Tests

`EventProjectionTeardownTests` in `src/EventTests/Projections/EventProjectionTests.cs` — published types become cleanups + storage types, every published type rather than just the first, a projection publishing nothing registers nothing, the opt-out wins, a hand-registered type isn't duplicated, assembling twice is a no-op, and an explicitly registered type survives the opt-out.

`EventTests` (724) and `EventStoreTests` (72) both pass.

## Scope note

The issue mentions marten#5169 — the same class of failure for composite projections — as where this was found. That's a separate case (a composite's `PublishedTypes()` delegates to its member stages) and isn't touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fuk1GybEEmohFmboJuM4Po