### PR TITLE
fix: composed block chains (PushUpstream) report the whole chain's Count and drain all the way down

### DIFF
--- a/src/CoreTests/Blocks/BlockSetCompositionTests.cs
+++ b/src/CoreTests/Blocks/BlockSetCompositionTests.cs
@@ -1,0 +1,107 @@
+using JasperFx.Blocks;
+using Shouldly;
+
+namespace CoreTests.Blocks;
+
+/// <summary>
+/// A BlockSet produced by PushUpstream must account for the WHOLE chain. Wolverine reads
+/// BufferedReceiver.QueueCount straight off this Count to decide back-pressure latching and,
+/// critically, when to RESUME a latched listener — a Count that misses the downstream backlog
+/// (or double-counts the top stage) makes those decisions against the wrong number.
+/// </summary>
+public class BlockSetCompositionTests
+{
+    private static async Task WaitUntil(Func<bool> condition, string description)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException($"Timed out waiting for: {description}");
+            }
+
+            await Task.Delay(25);
+        }
+    }
+
+    [Fact]
+    public async Task count_reflects_downstream_backlog()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processed = 0;
+
+        await using var downstream = new Block<string>(async (_, _) =>
+        {
+            await gate.Task;
+            Interlocked.Increment(ref processed);
+        });
+
+        var set = downstream.PushUpstream<int>(i => i.ToString());
+
+        for (var i = 0; i < 10; i++)
+        {
+            set.Post(i);
+        }
+
+        // Let the transform stage push everything into the (blocked) downstream block
+        await WaitUntil(() => downstream.Count == 10, "downstream block holds all 10 items");
+
+        // The backlog is sitting in the downstream block; the set must report it
+        set.Count.ShouldBe(10u);
+
+        gate.SetResult();
+        await WaitUntil(() => set.Count == 0, "chain fully drained");
+        processed.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task count_does_not_double_count_the_top_stage()
+    {
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var downstream = new Block<string>((_, _) => Task.CompletedTask);
+
+        var set = downstream.PushUpstream<int>(async (i, _) =>
+        {
+            await gate.Task;
+            return i.ToString();
+        });
+
+        for (var i = 0; i < 10; i++)
+        {
+            set.Post(i);
+        }
+
+        // All 10 items are held in the (blocked) top transform stage. The set holds exactly
+        // 10 items total — not 20.
+        set.Count.ShouldBe(10u);
+
+        gate.SetResult();
+        await WaitUntil(() => set.Count == 0, "chain fully drained");
+    }
+
+    [Fact]
+    public async Task wait_for_completion_drains_the_downstream_block_too()
+    {
+        var processed = 0;
+
+        await using var downstream = new Block<string>(async (_, _) =>
+        {
+            await Task.Delay(30);
+            Interlocked.Increment(ref processed);
+        });
+
+        var set = downstream.PushUpstream<int>(i => i.ToString());
+
+        for (var i = 0; i < 10; i++)
+        {
+            await set.PostAsync(i);
+        }
+
+        await set.WaitForCompletionAsync();
+
+        // Completion of the set means the whole chain finished, not just the top stage
+        processed.ShouldBe(10);
+    }
+}

--- a/src/JasperFx/Blocks/BatchingChannel.cs
+++ b/src/JasperFx/Blocks/BatchingChannel.cs
@@ -37,7 +37,10 @@ public class BatchingChannel<T> : BlockBase<T>
         }, null, Timeout.Infinite, Timeout.Infinite);
     }
 
-    public override uint Count => (uint)_current.Count + _inner.Count;
+    // The downstream block is part of this chain: an item that has left the batching stage but is
+    // still buffered downstream is work-not-yet-finished, and consumers of Count (back-pressure,
+    // drain decisions) need to see it. Mirrors the same accounting fix in BlockSet.Count.
+    public override uint Count => (uint)_current.Count + _inner.Count + _downstream.Count;
 
     public override Action<T, Exception> OnError
     {

--- a/src/JasperFx/Blocks/Block.cs
+++ b/src/JasperFx/Blocks/Block.cs
@@ -287,14 +287,27 @@ public class Block<T> : BlockBase<T>
         }
     }
 
-    public override ValueTask PostAsync(T item)
+    public override async ValueTask PostAsync(T item)
     {
         assertNotFaulted();
 
-        if (_latched) return ValueTask.CompletedTask;
+        if (_latched) return;
 
         Interlocked.Increment(ref _count);
-        return _channel.Writer.WriteAsync(item, _cancellation.Token);
+
+        try
+        {
+            await _channel.Writer.WriteAsync(item, _cancellation.Token);
+        }
+        catch
+        {
+            // A failed write (closed/faulted channel, shutdown cancellation) never enqueued the item,
+            // so it must not be counted — a leaked increment permanently inflates Count, which
+            // consumers read as "work still pending" (e.g. a back-pressured listener deciding whether
+            // it may resume). The sync Post() has always decremented on failure; this is its async twin.
+            Interlocked.Decrement(ref _count);
+            throw;
+        }
     }
 
     public override uint Count => _count;

--- a/src/JasperFx/Blocks/BlockBase.cs
+++ b/src/JasperFx/Blocks/BlockBase.cs
@@ -27,7 +27,7 @@ public abstract class BlockBase<T> : IBlock<T>
             }
         });
 
-        return new BlockSet<TBefore>(top, []);
+        return new BlockSet<TBefore>(top, [this]);
     }
 
     public IBlock<TBefore> PushUpstream<TBefore>(int parallelCount, Func<TBefore, CancellationToken, Task<T>> transformation)
@@ -41,7 +41,7 @@ public abstract class BlockBase<T> : IBlock<T>
             }
         });
 
-        return new BlockSet<TBefore>(top, []);
+        return new BlockSet<TBefore>(top, [this]);
     }
 
     public IBlock<TBefore> PushUpstream<TBefore>(Func<TBefore, T> transformation)
@@ -55,7 +55,7 @@ public abstract class BlockBase<T> : IBlock<T>
             }
         });
 
-        return new BlockSet<TBefore>(top, []);
+        return new BlockSet<TBefore>(top, [this]);
     }
 
     public IBlock<TBefore> PushUpstream<TBefore>(int parallelCount, Func<TBefore, T> transformation)
@@ -69,7 +69,7 @@ public abstract class BlockBase<T> : IBlock<T>
             }
         });
 
-        return new BlockSet<TBefore>(top, []);
+        return new BlockSet<TBefore>(top, [this]);
     }
 
     public abstract uint Count { get; }

--- a/src/JasperFx/Blocks/BlockSet.cs
+++ b/src/JasperFx/Blocks/BlockSet.cs
@@ -11,16 +11,24 @@ public class BlockSet<T> : IBlock<T>
 
     public BlockSet(IBlock<T> top, List<IBlock> previous)
     {
-        previous.Insert(0, top);
-        _blocks = previous;
+        // Copy rather than mutate: the caller may be an existing BlockSet handing over its own
+        // _blocks list, and inserting into that shared list would corrupt the original set.
+        _blocks = new List<IBlock>(previous.Count + 1) { top };
+        _blocks.AddRange(previous);
         _top = top;
     }
 
+    /// <summary>
+    /// The total number of items buffered or in flight across the WHOLE chain — the top stage plus
+    /// every downstream block. Consumers (e.g. Wolverine's back-pressure agent reading a listener's
+    /// QueueCount) treat this as "work not yet finished", so an item that has moved from the top
+    /// stage into a downstream block must still be counted.
+    /// </summary>
     public uint Count
     {
         get
         {
-            return _top.Count + (uint)_blocks.Sum(x => x.Count);
+            return (uint)_blocks.Sum(x => (long)x.Count);
         }
     }
 


### PR DESCRIPTION
## The bug

`BlockBase.PushUpstream` built its `BlockSet` with an empty `previous` list. The downstream block — the one actually executing the work — was therefore invisible to the set:

- `Count` returned `_top.Count + _blocks.Sum(...)` where `_blocks = [top]`: it **double-counted the top transform stage** and reported **zero** for any backlog sitting in the downstream block.
- `WaitForCompletionAsync` / `DisposeAsync` only touched the top stage, so "completion" of the set did not mean the chain had finished.
- The `BlockSet` ctor also mutated the caller's list (`previous.Insert(0, top)`), which corrupts the source set when chaining `PushUpstream` off an existing `BlockSet`.

## Why it matters

Wolverine composes exactly this shape for every listener endpoint using `PartitionProcessingByGroupId`: `ShardedExecutionBlock.DeserializeFirst` wraps the sharded slots behind a `PushUpstream` deserialize stage, for both `BufferedReceiver` and `DurableReceiver`, and `ListeningAgent.QueueCount` reads the composed `Count` directly. Consequences in the field:

- **Back-pressure latches against the wrong number.** The sharded slot channels can hold up to 10,000 messages *per slot* that `BufferingLimits.Maximum` never sees; the listener only latches once the *deserialize stage* backs up (i.e. once a slot channel is already full).
- **Resume decisions read the same wrong number.** `BackPressureAgent` restarts a `TooBusy` listener when `QueueCount <= Restart` — computed from a Count that both double-counts one stage and misses the real backlog.

Found while chasing a permanently-latched console ingest listener at JasperFx/CritterWatch#922 (single back-pressure event, no resume ever, queue to 288k).

## The fix

- `BlockSet`: every block of the chain counted exactly once; ctor copies rather than mutates.
- `BlockBase.PushUpstream` (all four overloads): pass `[this]` so the downstream block joins the set.
- `BatchingChannel.Count`: include `_downstream.Count` for the same reason.
- `Block.PostAsync`: decrement `_count` when the channel write faults — the sync `Post()` has always done this; the async path leaked the increment, permanently inflating `Count`.

## Tests

`BlockSetCompositionTests` pins all three behaviors (downstream backlog visible, no double-count, completion drains the chain); all three fail on main. CoreTests 558/558, EventTests 730/730, EventStoreTests 72/72 on net9.0 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v2Aijyo8MX2AdPUZL5VtG