### PR TITLE
Compliance wave 5 part 1: explorer, archiving and FetchLatest suites (2.39.4)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.39.3</JasperFxVersion>
+        <JasperFxVersion>2.39.4</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -155,6 +155,33 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// </summary>
     public virtual bool SupportsAsyncDaemon => true;
 
+    /// <summary>
+    /// False in a store that has not implemented the event store explorer default-interface methods
+    /// (<c>GetRecentStreamsAsync</c>, <c>GetStreamMetadataAsync</c>) at all.
+    /// </summary>
+    public virtual bool SupportsExplorerSurface => true;
+
+    /// <summary>
+    /// False where <c>TryCreateUsage</c> returns a descriptor that does not enumerate the store's
+    /// registered event types.
+    /// </summary>
+    /// <remarks>
+    /// Split from <see cref="SupportsExplorerSurface"/> because a store can implement stream
+    /// browsing without the usage descriptor, and the two are consumed separately by tooling.
+    /// </remarks>
+    public virtual bool SupportsUsageEventTypeDescriptors => true;
+
+    /// <summary>
+    /// False where <c>GetStreamMetadataAsync</c> returns a null <c>Tags</c> dictionary.
+    /// </summary>
+    /// <remarks>
+    /// <c>StreamMetadata.Tags</c> is declared as a non-nullable
+    /// <c>IReadOnlyDictionary&lt;string, string&gt;</c>, so null is a contract violation rather than
+    /// a legitimate "no tags" answer — an empty dictionary is how that is spelled. This gate exists
+    /// so a store with the defect can enroll while it is fixed, not so the assertion can be dropped.
+    /// </remarks>
+    public virtual bool SupportsStreamMetadataTags => true;
+
     public virtual ValueTask InitializeAsync() => default;
 
     public virtual ValueTask DisposeAsync() => default;

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -161,26 +161,6 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// </summary>
     public virtual bool SupportsExplorerSurface => true;
 
-    /// <summary>
-    /// False where <c>TryCreateUsage</c> returns a descriptor that does not enumerate the store's
-    /// registered event types.
-    /// </summary>
-    /// <remarks>
-    /// Split from <see cref="SupportsExplorerSurface"/> because a store can implement stream
-    /// browsing without the usage descriptor, and the two are consumed separately by tooling.
-    /// </remarks>
-    public virtual bool SupportsUsageEventTypeDescriptors => true;
-
-    /// <summary>
-    /// False where <c>GetStreamMetadataAsync</c> returns a null <c>Tags</c> dictionary.
-    /// </summary>
-    /// <remarks>
-    /// <c>StreamMetadata.Tags</c> is declared as a non-nullable
-    /// <c>IReadOnlyDictionary&lt;string, string&gt;</c>, so null is a contract violation rather than
-    /// a legitimate "no tags" answer — an empty dictionary is how that is spelled. This gate exists
-    /// so a store with the defect can enroll while it is fixed, not so the assertion can be dropped.
-    /// </remarks>
-    public virtual bool SupportsStreamMetadataTags => true;
 
     public virtual ValueTask InitializeAsync() => default;
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
@@ -137,11 +137,9 @@ public abstract class EventStoreExplorerCompliance<TFixture, TOperations, TQuery
         metadata.IsArchived.ShouldBeFalse();
         metadata.CreatedAt.ShouldNotBe(default);
 
-        if (theFixture.SupportsStreamMetadataTags)
-        {
-            // Non-nullable in the record's declaration: "no tags" is an empty dictionary, not null.
-            metadata.Tags.ShouldNotBeNull();
-        }
+        // Non-nullable in the record's declaration: "no tags" is an empty dictionary, not null.
+        // Polecat returned null here until polecat#412; this assertion is what found it.
+        metadata.Tags.ShouldNotBeNull();
     }
 
     [Fact]
@@ -167,11 +165,6 @@ public abstract class EventStoreExplorerCompliance<TFixture, TOperations, TQuery
         if (usage == null)
         {
             return;
-        }
-
-        if (!theFixture.SupportsUsageEventTypeDescriptors)
-        {
-            Assert.Skip("This store's usage descriptor does not enumerate registered event types.");
         }
 
         var names = usage.Events.Select(x => x.EventTypeName).ToList();

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Explorer events
+
+public record VoyageBegun(string Ship);
+
+public record PortVisited(string Port);
+
+#endregion
+
+/// <summary>
+/// The event store explorer surface on <see cref="IEventStore"/> — <c>GetRecentStreamsAsync</c>,
+/// <c>GetStreamMetadataAsync</c> and <c>TryCreateUsage</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are default-interface methods that throw unless a store implements them, which makes them
+/// unusually easy to leave half-built: nothing fails at compile time, and each product has its own
+/// tests. They also have an out-of-repo consumer — this is the surface CritterWatch reads — so a
+/// cross-store contract test is the cheapest guard against a tooling regression on one store only.
+/// </para>
+/// <para>
+/// Per-tenant overloads are deliberately not exercised here; they belong with the conjoined tenancy
+/// suite, which owns the tenant-scoped session seam.
+/// </para>
+/// </remarks>
+public abstract class EventStoreExplorerCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_explorer";
+        config.AddEventType<VoyageBegun>();
+        config.AddEventType<PortVisited>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private bool SupportsExplorer => theFixture.SupportsExplorerSurface;
+
+    private async Task<Guid> aVoyageAsync(params object[] extra)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var events = new object[] { new VoyageBegun("Beagle") }.Concat(extra).ToArray();
+        EventsFor(session).StartStream(streamId, events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task recent_streams_reports_the_streams_that_exist()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        var first = await aVoyageAsync();
+        var second = await aVoyageAsync(new PortVisited("Plymouth"));
+
+        var streams = await EventStore.GetRecentStreamsAsync(10, Cancellation);
+
+        var ids = streams.Select(x => x.StreamId).ToList();
+        ids.ShouldContain(first.ToString());
+        ids.ShouldContain(second.ToString());
+
+        var summary = streams.Single(x => x.StreamId == second.ToString());
+        summary.Version.ShouldBe(2);
+        summary.CreatedAt.ShouldNotBe(default);
+        summary.LastUpdatedAt.ShouldNotBe(default);
+        summary.LastUpdatedAt.ShouldBeGreaterThanOrEqualTo(summary.CreatedAt);
+    }
+
+    [Fact]
+    public async Task recent_streams_honours_the_count_and_orders_newest_first()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        await aVoyageAsync();
+        await Task.Delay(20, Cancellation);
+        await aVoyageAsync();
+        await Task.Delay(20, Cancellation);
+        var newest = await aVoyageAsync();
+
+        var streams = await EventStore.GetRecentStreamsAsync(2, Cancellation);
+
+        streams.Count.ShouldBe(2);
+        streams[0].StreamId.ShouldBe(newest.ToString());
+        streams[0].LastUpdatedAt.ShouldBeGreaterThanOrEqualTo(streams[1].LastUpdatedAt);
+    }
+
+    [Fact]
+    public async Task asking_for_more_streams_than_exist_is_not_an_error()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        await aVoyageAsync();
+
+        var streams = await EventStore.GetRecentStreamsAsync(1000, Cancellation);
+
+        streams.Count.ShouldBeGreaterThanOrEqualTo(1);
+        streams.Count.ShouldBeLessThan(1000);
+    }
+
+    [Fact]
+    public async Task stream_metadata_for_a_known_stream()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        var streamId = await aVoyageAsync(new PortVisited("Plymouth"), new PortVisited("Bahia"));
+
+        var metadata = await EventStore.GetStreamMetadataAsync(streamId.ToString(), Cancellation);
+
+        metadata.ShouldNotBeNull();
+        metadata.StreamId.ShouldBe(streamId.ToString());
+        metadata.Version.ShouldBe(3);
+        metadata.IsArchived.ShouldBeFalse();
+        metadata.CreatedAt.ShouldNotBe(default);
+
+        if (theFixture.SupportsStreamMetadataTags)
+        {
+            // Non-nullable in the record's declaration: "no tags" is an empty dictionary, not null.
+            metadata.Tags.ShouldNotBeNull();
+        }
+    }
+
+    [Fact]
+    public async Task stream_metadata_for_an_unknown_stream_is_null()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        var metadata = await EventStore.GetStreamMetadataAsync(Guid.NewGuid().ToString(), Cancellation);
+
+        metadata.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task usage_describes_the_registered_event_types()
+    {
+        var usage = await EventStore.TryCreateUsage(Cancellation);
+
+        // TryCreateUsage is allowed to return null for a store that cannot describe itself, but a
+        // store that returns one must know the event types it was configured with.
+        if (usage == null)
+        {
+            return;
+        }
+
+        if (!theFixture.SupportsUsageEventTypeDescriptors)
+        {
+            Assert.Skip("This store's usage descriptor does not enumerate registered event types.");
+        }
+
+        var names = usage.Events.Select(x => x.EventTypeName).ToList();
+        names.ShouldContain(EventTypeNameFor<VoyageBegun>());
+        names.ShouldContain(EventTypeNameFor<PortVisited>());
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/FetchLatestCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/FetchLatestCompliance.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region FetchLatest events and aggregate
+
+public record TabOpened(string Customer);
+
+public record DrinkOrdered(decimal Price);
+
+public record TabClosed;
+
+/// <summary>
+/// Registered as an inline snapshot by the default configuration, and as nothing at all by the
+/// live configuration, so the same aggregate can be read back both ways.
+/// </summary>
+public partial class ComplianceTab
+{
+    public Guid Id { get; set; }
+    public string Customer { get; set; } = string.Empty;
+    public decimal Total { get; set; }
+    public bool Closed { get; set; }
+
+    public static ComplianceTab Create(TabOpened e) => new() { Customer = e.Customer };
+
+    public void Apply(DrinkOrdered e) => Total += e.Price;
+
+    public void Apply(TabClosed _) => Closed = true;
+}
+
+#endregion
+
+/// <summary>
+/// <c>FetchLatest</c> and <c>ProjectLatest</c> — the "give me the current aggregate, and do not
+/// make me care how it is stored" entry points.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The behaviour worth pinning is that the answer does not depend on the projection lifecycle. A
+/// caller that switches an aggregate from Live to Inline should see identical state; only the
+/// persistence timing changes. This suite asserts that directly by rebuilding the store with a
+/// second configuration mid-test — the fixture keys rebuilds on the configuration delegate's
+/// identity, so passing a different static delegate is the supported way to ask for a different
+/// store shape.
+/// </para>
+/// <para>
+/// The other half is that <c>FetchLatest</c> must fold events appended in the current, still
+/// uncommitted session on top of whatever is persisted. That is the property that makes it safe
+/// inside a command handler, and it is easy to lose when a store optimises the snapshot read.
+/// </para>
+/// </remarks>
+public abstract class FetchLatestCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _inlineConfiguration = config =>
+    {
+        config.SchemaName = "compliance_fetch_latest";
+        config.Snapshot<ComplianceTab>(SnapshotLifecycle.Inline);
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _liveConfiguration = config =>
+    {
+        config.SchemaName = "compliance_fetch_latest_live";
+        config.AddEventType<TabOpened>();
+        config.AddEventType<DrinkOrdered>();
+        config.AddEventType<TabClosed>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _inlineConfiguration;
+
+    private async Task<Guid> aTabAsync(params object[] extra)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var events = new object[] { new TabOpened("Ada") };
+        if (extra.Length > 0)
+        {
+            events = [.. events, .. extra];
+        }
+
+        EventsFor(session).StartStream<ComplianceTab>(streamId, events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task fetch_latest_returns_the_current_aggregate()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4), new DrinkOrdered(6));
+
+        await using var session = OpenSession();
+        var tab = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Customer.ShouldBe("Ada");
+        tab.Total.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task fetch_latest_for_an_unknown_stream_is_null()
+    {
+        await using var session = OpenSession();
+        var tab = await EventsFor(session).FetchLatest<ComplianceTab>(Guid.NewGuid(), Cancellation);
+
+        tab.ShouldBeNull();
+    }
+
+    /// <summary>
+    /// The documented command-handler shape: <c>FetchForWriting</c>, append to the handle, save,
+    /// then <c>FetchLatest</c> on the <em>same</em> session. Both products special-case this
+    /// sequence, and the risk it carries is a stale read — the aggregate loaded for writing is
+    /// still in the session, and returning that pre-append instance would be silently wrong.
+    /// </summary>
+    /// <remarks>
+    /// What this deliberately does NOT assert is visibility of <em>unsaved</em> events. Neither
+    /// product promises that, and neither delivers it: Marten's own test for this path saves before
+    /// reading back. Two earlier drafts of this test asserted the stronger claim — first through a
+    /// bare <c>Append</c>, then through the write handle — and both were wrong about the contract
+    /// rather than finding a bug. Recorded here so the next reader does not re-litigate it.
+    /// </remarks>
+    [Fact]
+    public async Task fetch_latest_after_fetch_for_writing_and_save_is_not_stale()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4));
+
+        await using var session = OpenSession();
+
+        var stream = await EventsFor(session).FetchForWriting<ComplianceTab>(streamId, Cancellation);
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Total.ShouldBe(4);
+
+        stream.AppendOne(new DrinkOrdered(6));
+        await SaveChangesAsync(session);
+
+        var tab = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Total.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task fetch_latest_agrees_with_a_live_fold_of_the_same_stream()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4), new DrinkOrdered(6));
+
+        await using var session = OpenSession();
+        var fetched = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+        var folded = await EventsFor(session).AggregateStreamAsync<ComplianceTab>(streamId, token: Cancellation);
+
+        fetched.ShouldNotBeNull();
+        folded.ShouldNotBeNull();
+        folded.Total.ShouldBe(fetched.Total);
+        folded.Customer.ShouldBe(fetched.Customer);
+    }
+
+    [Fact]
+    public async Task fetch_latest_reflects_a_later_append()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4));
+
+        await using (var writer = OpenSession())
+        {
+            EventsFor(writer).Append(streamId, new DrinkOrdered(6), new TabClosed());
+            await SaveChangesAsync(writer);
+        }
+
+        await using var session = OpenSession();
+        var tab = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Total.ShouldBe(10);
+        tab.Closed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task project_latest_agrees_with_fetch_latest()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4), new DrinkOrdered(6));
+
+        await using var session = OpenSession();
+        var fetched = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+        var projected = await EventsFor(session).ProjectLatest<ComplianceTab>(streamId, Cancellation);
+
+        fetched.ShouldNotBeNull();
+        projected.ShouldNotBeNull();
+        projected.Total.ShouldBe(fetched.Total);
+        projected.Closed.ShouldBe(fetched.Closed);
+    }
+
+    [Fact]
+    public async Task fetch_latest_gives_the_same_answer_with_no_snapshot_registered()
+    {
+        // Rebuild the store with the aggregate registered nowhere, so FetchLatest has to fold the
+        // stream rather than read a persisted document. Same events, same expected answer.
+        await theFixture.ConfigureAsync(_liveConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceTab>(streamId,
+            new TabOpened("Ada"), new DrinkOrdered(4), new DrinkOrdered(6));
+        await SaveChangesAsync(session);
+
+        var tab = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Customer.ShouldBe("Ada");
+        tab.Total.ShouldBe(10);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamArchivingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamArchivingCompliance.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Archiving events
+
+public record LedgerOpened(string Name);
+
+public record LedgerEntryPosted(decimal Amount);
+
+public record LedgerClosed;
+
+#endregion
+
+/// <summary>
+/// <c>ArchiveStream</c> and the consequences of archiving — what a store still reports about an
+/// archived stream, and what it stops reporting.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Archiving is a good compliance candidate precisely because the call itself is trivial and the
+/// <em>consequences</em> are where two implementations drift: whether stream state still answers,
+/// whether the events remain readable, whether the archived flag is visible, and whether appending
+/// to an archived stream is allowed.
+/// </para>
+/// <para>
+/// Physical partition movement (Marten's archived event partition and Polecat's equivalent) is
+/// explicitly out of scope — that is storage layout, and it stays in each product's own tests.
+/// </para>
+/// </remarks>
+public abstract class StreamArchivingCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_archiving";
+        config.AddEventType<LedgerOpened>();
+        config.AddEventType<LedgerEntryPosted>();
+        config.AddEventType<LedgerClosed>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private async Task<Guid> aLedgerAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId,
+            new LedgerOpened("Petty Cash"),
+            new LedgerEntryPosted(25),
+            new LedgerEntryPosted(75));
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task archiveAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        EventsFor(session).ArchiveStream(streamId);
+        await SaveChangesAsync(session);
+    }
+
+    [Fact]
+    public async Task archiving_marks_the_stream_archived_in_its_state()
+    {
+        var streamId = await aLedgerAsync();
+
+        await using (var reader = OpenSession())
+        {
+            var before = await EventsFor(reader).FetchStreamStateAsync(streamId, Cancellation);
+            before.ShouldNotBeNull();
+            before.IsArchived.ShouldBeFalse();
+        }
+
+        await archiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeTrue();
+
+        // Archiving is not truncation: the version the stream reached is still reported.
+        state.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task archiving_is_idempotent()
+    {
+        var streamId = await aLedgerAsync();
+
+        await archiveAsync(streamId);
+        await archiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeTrue();
+        state.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task archiving_one_stream_leaves_its_neighbours_alone()
+    {
+        var archived = await aLedgerAsync();
+        var untouched = await aLedgerAsync();
+
+        await archiveAsync(archived);
+
+        await using var session = OpenSession();
+
+        var archivedState = await EventsFor(session).FetchStreamStateAsync(archived, Cancellation);
+        archivedState.ShouldNotBeNull();
+        archivedState.IsArchived.ShouldBeTrue();
+
+        var untouchedState = await EventsFor(session).FetchStreamStateAsync(untouched, Cancellation);
+        untouchedState.ShouldNotBeNull();
+        untouchedState.IsArchived.ShouldBeFalse();
+
+        var events = await EventsFor(session).FetchStreamAsync(untouched, token: Cancellation);
+        events.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task events_of_an_archived_stream_report_themselves_as_archived()
+    {
+        var streamId = await aLedgerAsync();
+        await archiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+
+        // A store is free to exclude archived events from the default stream read or to return
+        // them flagged, but it must not return them silently claiming to be live.
+        if (events.Any())
+        {
+            events.ShouldAllBe(x => x.IsArchived);
+        }
+    }
+
+    [Fact]
+    public async Task archiving_a_stream_that_does_not_exist_is_not_an_error()
+    {
+        var unknown = Guid.NewGuid();
+
+        await archiveAsync(unknown);
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(unknown, Cancellation);
+
+        // Nothing was created by archiving a phantom.
+        state.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task an_archived_stream_can_still_be_aggregated_to_its_last_known_state()
+    {
+        var streamId = await aLedgerAsync();
+        await archiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        // Whatever the read semantics for archived events, the recorded version survives archiving
+        // -- that is what makes archiving reversible bookkeeping rather than deletion.
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(3);
+        state.IsArchived.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Compliance wave 5, part 1 — three more suites from the portable-today group of the backlog (marten#5118). **19 tests, library 105 → 124.**

| Suite | Tests | Covers | marten issue |
|---|---|---|---|
| `EventStoreExplorerCompliance` | 6 | `GetRecentStreamsAsync`, `GetStreamMetadataAsync`, `TryCreateUsage` | marten#5146 |
| `StreamArchivingCompliance` | 6 | `ArchiveStream` and its consequences | marten#5140 |
| `FetchLatestCompliance` | 7 | `FetchLatest` / `ProjectLatest` | marten#5138 |

Verified against working copies of both stores: **Marten 124/124**, **Polecat 124/124** plus its full suite at 1722/0/3. **Zero capability gates on either store.**

## What adoption found — two real Polecat defects, both now fixed

This is the payoff argument for the shared suite, so it's worth being concrete: neither of these was caught by either product's own tests.

- **polecat#411** — `EventStoreUsage` carries the event registry twice, as `Events` and `RegisteredEventTypes`. Marten fills both; Polecat filled only the latter, so `usage.Events` came back empty. This descriptor is read *out of repo* by CritterWatch, where an empty `Events` list reads as "this store has no event types configured" rather than "this store describes them under a different key".
- **polecat#412** — `GetStreamMetadataAsync` returned `Tags: null!`, but `StreamMetadata.Tags` is declared as a non-nullable `IReadOnlyDictionary<string, string>`. "No tags" is spelled with an empty dictionary; null forces every consumer that trusts the declaration into a `NullReferenceException`. The `null!` had silenced the compiler's warning rather than answering it.

Both are fixed in polecat#413, so the assertions here stand unmodified and **the two capability gates I added while diagnosing them have been removed again**. An unused gate is an invitation to soften an assertion later, so the second commit takes them back out. `SupportsExplorerSurface` stays — the explorer methods are throwing default-interface methods, so a genuinely minimal store may not implement them at all.

## A note on FetchLatest and pending events

Two drafts of `fetch_latest_after_fetch_for_writing_and_save_is_not_stale` asserted that `FetchLatest` sees *uncommitted* appends — first through a bare `Append`, then through the `FetchForWriting` handle. Both failed, and both times the claim was wrong rather than the store: neither product documents that behaviour, and Marten's own test for this path saves before reading back.

The suite now pins the documented sequence (fetch for writing → append → save → read back on the same session), which still guards the real risk in that path: a stale cached aggregate surviving the save. The dead end is recorded in the test's `<remarks>` so it isn't re-litigated.

## Scope notes

`StreamArchivingCompliance` deliberately stops at behaviour. Physical partition movement — Marten's archived event partition and Polecat's equivalent — is storage layout and stays in each product's own tests. Where the two stores could legitimately differ (whether archived events are excluded from a default stream read or returned flagged), the suite asserts the invariant they must share: an archived stream's events must never come back claiming to be live.

`JasperFxVersion` 2.39.3 → **2.39.4**, in this PR, per the `--skip-duplicate` publish trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
