### PR TITLE
Compliance wave 5 part 2: flat tables, string identity, multi-stream, snapshot lifecycle (2.40.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.39.5</JasperFxVersion>
+        <JasperFxVersion>2.40.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -146,6 +146,34 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     public abstract Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout);
 
     /// <summary>
+    /// Read every row of a flat-table projection's table, as case-insensitive column/value maps.
+    /// </summary>
+    /// <param name="tableName">Unqualified table name. The fixture resolves the schema.</param>
+    /// <remarks>
+    /// <para>
+    /// The only raw data-access member on this seam, and deliberately the narrowest one that works:
+    /// a table name in, every row out. No predicates, no ordering, no SQL from the suite. A flat
+    /// table is by definition not a document, so there is no supported read path for its rows on
+    /// either product — asserting the result of a flat-table projection means reading the table, and
+    /// that is dialect-specific in a way nothing shared can absorb (schema resolution, identifier
+    /// quoting, parameter syntax).
+    /// </para>
+    /// <para>
+    /// Keeping it predicate-free is the point. Suites filter in memory on the identity they appended
+    /// under, so this never becomes a general query escape hatch — the moment it grows a where
+    /// clause it starts encoding one dialect's expression syntax and stops being portable.
+    /// </para>
+    /// <para>
+    /// Column keys must compare case-insensitively: PostgreSQL folds undelimited identifiers to
+    /// lower case while SQL Server preserves the declared casing, so a suite that asked for
+    /// <c>row["member_count"]</c> would otherwise pass on one store and fail on the other for
+    /// reasons that have nothing to do with the projection.
+    /// </para>
+    /// </remarks>
+    public abstract Task<IReadOnlyList<IReadOnlyDictionary<string, object?>>> QueryTableAsync(
+        string tableName, CancellationToken token);
+
+    /// <summary>
     /// False in stores that build live aggregators automatically and reject explicit registration.
     /// </summary>
     public virtual bool SupportsLiveAggregationRegistration => true;
@@ -160,6 +188,26 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// (<c>GetRecentStreamsAsync</c>, <c>GetStreamMetadataAsync</c>) at all.
     /// </summary>
     public virtual bool SupportsExplorerSurface => true;
+
+    /// <summary>
+    /// False in a store that has no flat-table event projection — an <c>EventProjection</c> writing
+    /// into a plain relational table rather than a document.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Unlike the other gates this one exists for a store that is still being built: a new consumer
+    /// can enroll <c>FlatTableProjectionCompliance</c> from day one, leave this false, and flip it
+    /// when the behavior lands, using the suite as the specification it is implementing against.
+    /// Both current consumers leave it true.
+    /// </para>
+    /// <para>
+    /// It gates <em>behavior</em>, not compilation. These suites compile inside the consumer, and
+    /// the shared projection's constructor shim has to name a real flat-table base class, so a store
+    /// still needs the type and its mapping API to exist before it can enroll at all. That ordering
+    /// is deliberate: declare the surface, gate off, then make the assertions pass one at a time.
+    /// </para>
+    /// </remarks>
+    public virtual bool SupportsFlatTableProjections => true;
 
 
     public virtual ValueTask InitializeAsync() => default;

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,6 +76,14 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
 
     protected Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
         => theFixture.WaitForNonStaleProjectionDataAsync(timeout);
+
+    /// <summary>
+    /// Every row of a flat-table projection's table. See
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.QueryTableAsync"/> for why
+    /// this is deliberately predicate-free.
+    /// </summary>
+    protected Task<IReadOnlyList<IReadOnlyDictionary<string, object?>>> QueryTableAsync(string tableName)
+        => theFixture.QueryTableAsync(tableName, Cancellation);
 
     /// <summary>
     /// Assert that an operation fails with <typeparamref name="TException"/>, whether the store

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceFlatTableProjectionPlaceholder.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceFlatTableProjectionPlaceholder.cs
@@ -1,0 +1,81 @@
+// NOT PACKAGED. See ComplianceQuerySessionPlaceholder.cs for why Local/ exists.
+//
+// FlatTableProjectionCompliance is the one suite whose shared type cannot be reached by an alias.
+// Every product's flat-table projection base takes constructor arguments describing where the table
+// lives and those signatures genuinely differ (Marten a SchemaNameSource enum, Polecat a literal
+// schema name), so no single base(...) call satisfies both. Each consumer therefore supplies a
+// partial carrying the constructor and the primary key column:
+//
+//     public partial class ComplianceFlatTableProjection : FlatTableProjection
+//     {
+//         public ComplianceFlatTableProjection() : base(TableName, SchemaNameSource.DocumentSchema)
+//         {
+//             Table.AddColumn<Guid>("id").AsPrimaryKey();
+//             ConfigureMappings();
+//         }
+//     }
+//
+// This is that partial, for the JasperFx repo. It is also the closest thing the library has to a
+// written-down statement of the surface a flat-table base must expose, so a new consumer can read
+// it as the contract to implement -- everything below is called by ConfigureMappings.
+//
+// Return types are deliberately void here. Both products return their own dialect's
+// Table.ColumnExpression (two unrelated nested types with no shared base), and the shared suite
+// never names or chains off the result, so the placeholder does not invent a common one.
+
+using System;
+using System.Linq.Expressions;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+/// <summary>
+/// Stand-in for each product's flat-table projection base. Members exist only where
+/// <c>ComplianceFlatTableProjection.ConfigureMappings</c> actually calls them.
+/// </summary>
+public abstract class PlaceholderFlatTableProjection: ProjectionBase
+{
+    public void Project<TEvent>(Action<PlaceholderStatementMap<TEvent>> configure,
+        Expression<Func<TEvent, object>>? primaryKeySource = null)
+    {
+    }
+
+    public void Delete<TEvent>(Expression<Func<TEvent, object>>? primaryKeySource = null)
+    {
+    }
+}
+
+/// <summary>
+/// Stand-in for each product's <c>StatementMap&lt;TEvent&gt;</c>. The two are signature-identical
+/// today; only the declaring namespace and the <c>Table.ColumnExpression</c> return type differ.
+/// </summary>
+public class PlaceholderStatementMap<TEvent>
+{
+    public void Map<TValue>(Expression<Func<TEvent, TValue>> members, string? columnName = null)
+    {
+    }
+
+    public void Increment<TValue>(Expression<Func<TEvent, TValue>> members, string? columnName = null)
+    {
+    }
+
+    public void Increment(string columnName)
+    {
+    }
+
+    public void Decrement<TValue>(Expression<Func<TEvent, TValue>> members, string? columnName = null)
+    {
+    }
+
+    public void Decrement(string columnName)
+    {
+    }
+
+    public void SetValue(string columnName, string value)
+    {
+    }
+
+    public void SetValue(string columnName, int value)
+    {
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceFlatTableProjectionShim.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceFlatTableProjectionShim.cs
@@ -1,0 +1,7 @@
+// NOT PACKAGED. The JasperFx repo's own copy of the per-consumer partial that
+// FlatTableProjectionCompliance requires -- see ComplianceFlatTableProjectionPlaceholder.cs for the
+// surface it binds to, and for why this suite needs a partial rather than a global alias.
+
+namespace JasperFx.Events.ComplianceTests;
+
+public partial class ComplianceFlatTableProjection: Local.PlaceholderFlatTableProjection;

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceMultiStreamProjectionPlaceholder.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceMultiStreamProjectionPlaceholder.cs
@@ -1,0 +1,26 @@
+// NOT PACKAGED. See ComplianceQuerySessionPlaceholder.cs for why Local/ exists.
+//
+// MultiStreamProjectionCompliance declares its projection at file scope, so it cannot reach the
+// <TOperations, TQuerySession> pair its suite class is generic over -- the same gap
+// ComplianceStringPartyProjectionBase closes for the string identity suite. The alias names a
+// *closed* generic here too, because the multi stream base is generic over both the document and
+// its identity:
+//
+//     global using ComplianceMultiStreamProjectionBase =
+//         Marten.Events.Projections.MultiStreamProjection<
+//             JasperFx.Events.ComplianceTests.ComplianceDepartment, string>;
+//
+// Unlike the flat-table suite this needs no constructor shim in the consumer: both products'
+// MultiStreamProjection<TDoc, TId> are parameterless subclasses of JasperFxMultiStreamProjectionBase,
+// and every grouping construct the suite uses -- Identity, Identities, FanOut -- is declared on that
+// shared base rather than on either product's subclass.
+
+global using ComplianceMultiStreamProjectionBase =
+    JasperFx.Events.ComplianceTests.Local.PlaceholderDepartmentProjection;
+
+using JasperFx.Events.Aggregation;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+public abstract class PlaceholderDepartmentProjection: JasperFxMultiStreamProjectionBase<ComplianceDepartment,
+    string, IPlaceholderOperations, IPlaceholderQuerySession>;

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -118,6 +118,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Flat-table event projections | `FlatTableProjectionCompliance` |
 | String stream identity, read and write surface | `StringStreamIdentityCompliance` |
 | Multi-stream projection grouping and fan-out | `MultiStreamProjectionCompliance` |
+| Snapshot lifecycle equivalence (Inline / Async / Live) | `SnapshotLifecycleCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -112,6 +112,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Archiving a stream and its consequences | `StreamArchivingCompliance` |
 | The event store explorer surface | `EventStoreExplorerCompliance` |
 | Flat-table event projections | `FlatTableProjectionCompliance` |
+| String stream identity, read and write surface | `StringStreamIdentityCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -40,6 +40,30 @@ store's session pair. Everything portable in the suites runs through the shared 
 no shared interface declares — store construction from a `ComplianceStoreConfig`, session
 acquisition, `SaveChangesAsync`, document load-back, batched DCB queries, and teardown.
 
+**3. One partial class, for the flat-table suite only.** `FlatTableProjectionCompliance` is the one
+suite whose shared type cannot be reached by an alias: every product's flat-table projection base
+takes constructor arguments describing where the table lives, and those signatures genuinely differ,
+so no single `base(...)` call satisfies all of them. Declaring the primary key column is per-product
+for the same reason — that API hangs off each dialect's own `Table` type. The library owns the table
+name, the projection name and every event mapping; a consumer supplies the rest:
+
+```csharp
+namespace JasperFx.Events.ComplianceTests;
+
+public partial class ComplianceFlatTableProjection : FlatTableProjection
+{
+    public ComplianceFlatTableProjection() : base(TableName, SchemaNameSource.DocumentSchema)
+    {
+        Table.AddColumn<Guid>("id").AsPrimaryKey();   // your dialect's column API
+        ConfigureMappings();                          // everything portable
+    }
+}
+```
+
+If your base takes a literal schema name rather than resolving the store's, pass
+`ComplianceFlatTableProjection.SchemaName` — the suite configures its store with the same constant,
+and the two have to agree or the projection writes into a table the suite is not reading.
+
 Then enroll each suite with an empty subclass:
 
 ```csharp
@@ -84,6 +108,10 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Stream reads, time travel, stream state | `StreamReadCompliance` |
 | The `IEvent` envelope contract | `EventMetadataCompliance` |
 | Live aggregation, including last-known | `LiveAggregationCompliance` |
+| `FetchLatest` / `ProjectLatest` across lifecycles | `FetchLatestCompliance` |
+| Archiving a stream and its consequences | `StreamArchivingCompliance` |
+| The event store explorer surface | `EventStoreExplorerCompliance` |
+| Flat-table event projections | `FlatTableProjectionCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -12,10 +12,10 @@ differences between the repos.
 
 ## Using it
 
-Reference the package from a test project that already has xunit v3 and Shouldly, then supply two
+Reference the package from a test project that already has xunit v3 and Shouldly, then supply three
 things.
 
-**1. Four global aliases naming your store's own types.** The shared suites declare aggregates and
+**1. Five global aliases naming your store's own types.** The shared suites declare aggregates and
 projections at file scope, so they cannot reach the `<TOperations, TQuerySession>` pair the suite
 classes are generic over. The source generator resolves these by type name, so aliases are enough:
 
@@ -26,13 +26,17 @@ global using ComplianceEventProjection = Marten.Events.Projections.EventProjecti
 global using ComplianceStringPartyProjectionBase =
     Marten.Events.Aggregation.SingleStreamProjection<
         JasperFx.Events.ComplianceTests.StringQuestParty, string>;
+global using ComplianceMultiStreamProjectionBase =
+    Marten.Events.Projections.MultiStreamProjection<
+        JasperFx.Events.ComplianceTests.ComplianceDepartment, string>;
 ```
 
 `ComplianceQuerySession` binds the `EvolveAsync(IEvent, …)` convention on the self-aggregating
 fixtures; the next two bind the EventProjection suites to your product's own projection base and
-writable session. The last one is a *closed* generic, because the single stream projection base is
-generic over both the document and its identity — it binds the string-identity suite's custom
-projection to your product's `SingleStreamProjection<TDoc, TId>`.
+writable session. The last two are *closed* generics, because the single stream and multi stream
+projection bases are generic over both the document and its identity — they bind the string-identity
+and multi-stream suites' custom projections to your product's `SingleStreamProjection<TDoc, TId>`
+and `MultiStreamProjection<TDoc, TId>`.
 
 **2. A concrete fixture** closing `EventStoreComplianceFixture<TOperations, TQuerySession>` over your
 store's session pair. Everything portable in the suites runs through the shared JasperFx surfaces
@@ -103,7 +107,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | `EventProjection` registration and enrichment | `EventProjectionRegistrationCompliance`, `EventProjectionEnrichmentCompliance` |
 | Rebuild concurrency cap resolution | `RebuildConcurrencyCapCompliance` |
 | Session correlation / causation from `Activity` | `ActivityCorrelationCompliance` |
-| String stream identity | `StringIdentitySingleStreamCompliance` |
+| String stream identity, single stream projections | `StringIdentitySingleStreamCompliance` |
 | Write handles and stream concurrency | `FetchForWritingCompliance` |
 | Stream reads, time travel, stream state | `StreamReadCompliance` |
 | The `IEvent` envelope contract | `EventMetadataCompliance` |
@@ -113,6 +117,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | The event store explorer surface | `EventStoreExplorerCompliance` |
 | Flat-table event projections | `FlatTableProjectionCompliance` |
 | String stream identity, read and write surface | `StringStreamIdentityCompliance` |
+| Multi-stream projection grouping and fan-out | `MultiStreamProjectionCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/FetchForWritingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/FetchForWritingCompliance.cs
@@ -57,7 +57,7 @@ public partial class ComplianceAccount
 /// <para>
 /// Guid stream identity only: stream identity is a store-level setting, so the string-keyed
 /// equivalents live in
-/// <see cref="StringIdentitySingleStreamCompliance{TFixture,TOperations,TQuerySession}"/>.
+/// <see cref="StringStreamIdentityCompliance{TFixture,TOperations,TQuerySession}"/>.
 /// </para>
 /// </remarks>
 public abstract class FetchForWritingCompliance<TFixture, TOperations, TQuerySession>

--- a/src/JasperFx.Events.ComplianceTests/Suites/FlatTableProjectionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/FlatTableProjectionCompliance.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Flat table events
+
+public record FlatValuesSet(int A, int B, int C, int D, int MemberCount);
+
+public record FlatValuesAdded(int A, int B, int C, int D);
+
+public record FlatValuesSubtracted(int A, int B, int C, int D);
+
+public record FlatValuesDeleted;
+
+#endregion
+
+/// <summary>
+/// The flat-table projection under compliance: one table keyed on the stream id, written by three
+/// mapping event types and emptied by a fourth.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the first shared type in the library whose base class cannot be reached by an alias
+/// alone. Every product's flat-table projection base takes constructor arguments describing where
+/// the table lives, and those signatures genuinely differ (Marten resolves the schema through a
+/// <c>SchemaNameSource</c> enum; Polecat takes a literal schema name), so no single
+/// <c>base(...)</c> call satisfies both. Declaring the primary key is likewise per-product, because
+/// the column-declaration API hangs off each dialect's own <c>Table</c> type.
+/// </para>
+/// <para>
+/// So the shape is split: everything portable — the table name, the projection name, and every
+/// event mapping — lives here, and each consumer supplies a small partial carrying the constructor
+/// and the primary key column. That shim is the honest cost of this suite, and it is deliberately
+/// visible rather than hidden behind more seam surface. Lifting the flat-table projection shape
+/// onto a shared base in JasperFx.Events would retire it (see marten#5147), but doing that with
+/// only two dialects in hand risks designing the abstraction around exactly those two.
+/// </para>
+/// <para>
+/// The library stays free of any Weasel reference on purpose. <c>Weasel.Core.ITable</c> does now
+/// offer a dialect-neutral column surface — <c>AddColumn(name, Type)</c> and
+/// <c>AddPrimaryKeyColumn(name, Type)</c>, routed through a per-dialect type resolver — which would
+/// let the primary key move into this file. It is not used here because these sources compile
+/// inside every consumer, so a Weasel dependency in one suite becomes a Weasel dependency for the
+/// whole package, and a JasperFx.Events store is not obliged to be built on Weasel.
+/// </para>
+/// </remarks>
+public partial class ComplianceFlatTableProjection
+{
+    /// <summary>
+    /// Unqualified name of the projected table. Consumers pass this to their base constructor and
+    /// suites hand it to <c>QueryTableAsync</c>.
+    /// </summary>
+    public const string TableName = "compliance_flat_values";
+
+    /// <summary>
+    /// Schema the suite's stores are built in. A consumer whose flat-table base takes a literal
+    /// schema name needs this; one that resolves the store's schema at runtime can ignore it.
+    /// </summary>
+    /// <remarks>
+    /// Lower case because at least one consumer normalizes schema names to lower case when building
+    /// the store, and the two have to agree or the projection writes somewhere the suite is not
+    /// looking.
+    /// </remarks>
+    public const string SchemaName = "compliance_flat_table";
+
+    /// <summary>
+    /// The daemon-facing projection name, pinned rather than defaulted.
+    /// </summary>
+    /// <remarks>
+    /// Products disagree on the default: one uses the projection's short type name, another its
+    /// full name. Rebuild is addressed by name, so the suite sets it explicitly instead of encoding
+    /// either default.
+    /// </remarks>
+    public const string ProjectionName = "ComplianceFlatTable";
+
+    /// <summary>
+    /// Every portable part of the projection definition. A consumer's constructor declares the
+    /// primary key column and then calls this.
+    /// </summary>
+    protected void ConfigureMappings()
+    {
+        Name = ProjectionName;
+
+        Project<FlatValuesSet>(map =>
+        {
+            // No explicit column names: deriving the column from the event member is part of the
+            // contract, and both single-word (A) and multi-word (MemberCount) members are covered.
+            map.Map(x => x.A);
+            map.Map(x => x.B);
+            map.Map(x => x.C);
+            map.Map(x => x.D);
+            map.Map(x => x.MemberCount);
+
+            map.SetValue("status", "new");
+            map.SetValue("revision", 1);
+        });
+
+        Project<FlatValuesAdded>(map =>
+        {
+            map.Increment(x => x.A);
+            map.Increment(x => x.B);
+            map.Increment(x => x.C);
+            map.Increment(x => x.D);
+
+            map.Increment("revision");
+
+            map.SetValue("status", "old");
+        });
+
+        Project<FlatValuesSubtracted>(map =>
+        {
+            map.Decrement(x => x.A);
+            map.Decrement(x => x.B);
+            map.Decrement(x => x.C);
+            map.Decrement(x => x.D);
+
+            map.Decrement("revision");
+
+            map.SetValue("status", "old");
+        });
+
+        Delete<FlatValuesDeleted>();
+    }
+}
+
+/// <summary>
+/// Flat-table event projections — an <c>EventProjection</c> that writes into a plain relational
+/// table keyed on the stream id, rather than into a document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Worth pinning across stores because the implementations underneath are genuinely different
+/// mechanisms for the same promised semantics: one product generates per-event upsert functions,
+/// another emits <c>MERGE</c> statements. Both claim insert-or-update, increment, decrement and
+/// delete; whether they agree at the edges — a second event updating rather than duplicating a row,
+/// an increment landing on a row that does not exist yet, a rebuild replaying increments exactly
+/// once — is exactly what two independent implementations get wrong in different ways.
+/// </para>
+/// <para>
+/// Table *shape* is asserted only through the columns that come back with a row. The generated DDL,
+/// the upsert mechanism, index layout and identifier quoting are all storage layout and stay in
+/// each product's own tests.
+/// </para>
+/// </remarks>
+public abstract class FlatTableProjectionCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = ComplianceFlatTableProjection.SchemaName;
+
+        config.AddEventType<FlatValuesSet>();
+        config.AddEventType<FlatValuesAdded>();
+        config.AddEventType<FlatValuesSubtracted>();
+        config.AddEventType<FlatValuesDeleted>();
+
+        config.AddProjection(new ComplianceFlatTableProjection(), ProjectionLifecycle.Inline);
+    };
+
+    /// <summary>
+    /// The same projection registered <see cref="ProjectionLifecycle.Async"/>, in the same schema so
+    /// the table is the one the inline tests already proved out.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _asyncConfiguration = config =>
+    {
+        config.SchemaName = ComplianceFlatTableProjection.SchemaName;
+
+        config.AddEventType<FlatValuesSet>();
+        config.AddEventType<FlatValuesAdded>();
+        config.AddEventType<FlatValuesSubtracted>();
+        config.AddEventType<FlatValuesDeleted>();
+
+        config.AddProjection(new ComplianceFlatTableProjection(), ProjectionLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Capability gate. xunit v3's declarative SkipUnless needs a *static* property, which cannot
+    /// consult a per-store fixture instance, so the gate runs as a dynamic skip instead.
+    /// </summary>
+    private void SkipUnlessFlatTablesAreSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsFlatTableProjections,
+            "This event store does not implement flat table event projections");
+    }
+
+    private void SkipUnlessDaemonIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+    }
+
+    private async Task appendAsync(Guid streamId, params object[] events)
+    {
+        await using var session = OpenSession();
+        EventsFor(session).Append(streamId, events);
+        await SaveChangesAsync(session);
+    }
+
+    /// <summary>
+    /// The single row this test appended under, or null when the projection deleted it.
+    /// </summary>
+    /// <remarks>
+    /// Filtering happens here, in memory, rather than in the query: see
+    /// <c>QueryTableAsync</c> for why that member stays predicate-free. Tests use a fresh stream id
+    /// so rows left by sibling tests in the same table are simply not theirs.
+    /// </remarks>
+    private async Task<IReadOnlyDictionary<string, object?>?> rowAsync(Guid streamId)
+    {
+        var rows = await QueryTableAsync(ComplianceFlatTableProjection.TableName);
+
+        var mine = rows.Where(x => Equals(x["id"], streamId)).ToList();
+
+        mine.Count.ShouldBeLessThanOrEqualTo(1,
+            $"The flat table holds {mine.Count} rows for stream {streamId}; the projection should upsert a single row per identity");
+
+        return mine.SingleOrDefault();
+    }
+
+    private static int intValue(IReadOnlyDictionary<string, object?> row, string column)
+    {
+        var raw = row[column];
+        raw.ShouldNotBeNull($"Column '{column}' came back null");
+
+        // Stores are free to widen a numeric column (int vs bigint vs numeric); the contract is the
+        // value, not the width it was stored at.
+        return Convert.ToInt32(raw);
+    }
+
+    [Fact]
+    public async Task the_projected_table_carries_the_mapped_columns()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId, new FlatValuesSet(1, 2, 3, 4, 5));
+
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull();
+
+        // The primary key plus every column the mappings named or derived.
+        foreach (var column in new[] { "id", "a", "b", "c", "d", "member_count", "status", "revision" })
+        {
+            row.ContainsKey(column).ShouldBeTrue(
+                $"Expected the flat table to have a '{column}' column, but it has: {string.Join(", ", row.Keys)}");
+        }
+    }
+
+    [Fact]
+    public async Task mapping_an_event_writes_a_new_row()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId, new FlatValuesSet(3, 4, 5, 6, 7));
+
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull();
+
+        intValue(row, "a").ShouldBe(3);
+        intValue(row, "b").ShouldBe(4);
+        intValue(row, "c").ShouldBe(5);
+        intValue(row, "d").ShouldBe(6);
+
+        row["status"].ShouldBe("new");
+        intValue(row, "revision").ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task column_names_are_derived_from_the_event_members()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId, new FlatValuesSet(1, 2, 3, 4, 11));
+
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull();
+
+        // A single-word member maps to its lower-cased name, a multi-word member to snake case.
+        intValue(row, "a").ShouldBe(1);
+        intValue(row, "member_count").ShouldBe(11);
+    }
+
+    [Fact]
+    public async Task a_later_event_updates_the_row_rather_than_inserting_a_second_one()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId, new FlatValuesSet(1, 2, 3, 4, 5));
+        await appendAsync(streamId, new FlatValuesAdded(10, 10, 10, 10));
+
+        // rowAsync fails if the store inserted a second row for the same identity.
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull();
+
+        intValue(row, "a").ShouldBe(11);
+        intValue(row, "b").ShouldBe(12);
+        intValue(row, "c").ShouldBe(13);
+        intValue(row, "d").ShouldBe(14);
+
+        row["status"].ShouldBe("old");
+        intValue(row, "revision").ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task increment_and_decrement_move_the_column_in_both_directions()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId,
+            new FlatValuesSet(10, 20, 30, 40, 1),
+            new FlatValuesAdded(5, 5, 5, 5),
+            new FlatValuesSubtracted(2, 2, 2, 2));
+
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull();
+
+        intValue(row, "a").ShouldBe(13);
+        intValue(row, "b").ShouldBe(23);
+        intValue(row, "c").ShouldBe(33);
+        intValue(row, "d").ShouldBe(43);
+
+        // Set to 1, incremented once, decremented once.
+        intValue(row, "revision").ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_delete_event_removes_the_row()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId, new FlatValuesSet(1, 2, 3, 4, 5));
+
+        (await rowAsync(streamId)).ShouldNotBeNull();
+
+        await appendAsync(streamId, new FlatValuesDeleted());
+
+        (await rowAsync(streamId)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task an_async_projection_produces_the_same_row_as_an_inline_one()
+    {
+        SkipUnlessFlatTablesAreSupported();
+        SkipUnlessDaemonIsSupported();
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var streamId = Guid.NewGuid();
+        await appendAsync(streamId,
+            new FlatValuesSet(3, 4, 5, 6, 7),
+            new FlatValuesAdded(1, 1, 1, 1));
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull();
+
+        // Byte for byte what the inline lifecycle produces from the same two events.
+        intValue(row, "a").ShouldBe(4);
+        intValue(row, "b").ShouldBe(5);
+        intValue(row, "c").ShouldBe(6);
+        intValue(row, "d").ShouldBe(7);
+
+        row["status"].ShouldBe("old");
+        intValue(row, "revision").ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_rebuild_empties_the_table_before_replaying_it()
+    {
+        SkipUnlessFlatTablesAreSupported();
+        SkipUnlessDaemonIsSupported();
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        // Two rows: one whose events the rebuild will still see, and one whose events it will not.
+        // The second is what makes this test discriminating at all. Because Map overwrites rather
+        // than accumulates, a rebuild that replayed straight onto surviving rows would land on
+        // exactly the same values as one that emptied the table first, so the only observable
+        // difference is whether a row the replay cannot recreate is still there afterwards.
+        var archived = Guid.NewGuid();
+        await appendAsync(archived, new FlatValuesSet(9, 9, 9, 9, 9));
+
+        var replayed = Guid.NewGuid();
+        await appendAsync(replayed,
+            new FlatValuesSet(1, 1, 1, 1, 1),
+            new FlatValuesAdded(2, 2, 2, 2));
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        (await rowAsync(archived)).ShouldNotBeNull();
+
+        // Archiving is how the suite takes events away from the replay without touching the table
+        // directly. Deleting event data is not usable here: at least one store's cleaning also
+        // erases flat-table rows, which would make this assertion pass for the wrong reason.
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).ArchiveStream(archived);
+            await SaveChangesAsync(session);
+        }
+
+        await daemon.RebuildProjectionAsync(ComplianceFlatTableProjection.ProjectionName, Cancellation);
+
+        (await rowAsync(archived)).ShouldBeNull(
+            "A rebuild should start the flat table from empty, so a row the replay cannot recreate should not survive it");
+
+        var after = await rowAsync(replayed);
+        after.ShouldNotBeNull();
+
+        // And the replay itself applies each event exactly once.
+        intValue(after, "a").ShouldBe(3);
+        intValue(after, "revision").ShouldBe(2);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/MultiStreamProjectionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/MultiStreamProjectionCompliance.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Multi-stream projection events and aggregate
+
+public record EmployeeHired(string Department, string Name);
+
+public record EmployeeDeparted(string Department, string Name);
+
+/// <summary>
+/// Carries several identities in one event, for <c>Identities&lt;T&gt;</c>.
+/// </summary>
+public record DepartmentsAudited(string[] Departments);
+
+/// <summary>
+/// The child item a <c>TeamOnboarded</c> fans out into. It carries no identity of its own on
+/// purpose: a fanned-out child is applied within the slice its parent was grouped into.
+/// </summary>
+public record TeamMemberOnboarded(string Name);
+
+public record TeamOnboarded(string Department, TeamMemberOnboarded[] Members);
+
+public class ComplianceDepartment
+{
+    public string Id { get; set; } = string.Empty;
+    public int HeadCount { get; set; }
+    public List<string> Names { get; set; } = new();
+    public int AuditCount { get; set; }
+}
+
+/// <summary>
+/// The multi-stream projection under compliance. Every grouping construct it uses —
+/// <c>Identity</c>, <c>Identities</c>, <c>FanOut</c> — is declared on JasperFx's shared
+/// <c>JasperFxMultiStreamProjectionBase</c>; only the concrete base class name is per-product, and
+/// that arrives through the <c>ComplianceMultiStreamProjectionBase</c> global alias.
+/// </summary>
+public partial class ComplianceDepartmentProjection: ComplianceMultiStreamProjectionBase
+{
+    public ComplianceDepartmentProjection()
+    {
+        Identity<EmployeeHired>(x => x.Department);
+        Identity<EmployeeDeparted>(x => x.Department);
+        Identities<DepartmentsAudited>(x => x.Departments);
+
+        // One event explodes into a child per member. Grouping comes from the parent -- the child is
+        // applied inside whatever slice TeamOnboarded landed in -- so the child needs no identity.
+        Identity<TeamOnboarded>(x => x.Department);
+        FanOut<TeamOnboarded, TeamMemberOnboarded>(x => x.Members);
+    }
+
+    public void Apply(EmployeeHired e, ComplianceDepartment doc)
+    {
+        doc.HeadCount++;
+        doc.Names.Add(e.Name);
+    }
+
+    public void Apply(EmployeeDeparted e, ComplianceDepartment doc)
+    {
+        doc.HeadCount--;
+        doc.Names.Remove(e.Name);
+    }
+
+    public void Apply(DepartmentsAudited e, ComplianceDepartment doc) => doc.AuditCount++;
+
+    public void Apply(TeamMemberOnboarded e, ComplianceDepartment doc)
+    {
+        doc.HeadCount++;
+        doc.Names.Add(e.Name);
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Multi-stream projections — the grouping half of the projection model, where a projection decides
+/// which aggregate each event belongs to rather than inheriting that from the stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The most valuable projection surface to pin cross-store, because slicing is where two
+/// implementations have the most freedom to disagree: which shard sees which event, whether one
+/// event can reach several aggregates, and whether a fanned-out child is routed by its own identity
+/// or its parent's. Single-stream aggregation has none of those degrees of freedom.
+/// </para>
+/// <para>
+/// Everything here runs through <c>JasperFxMultiStreamProjectionBase</c>, so the only per-consumer
+/// cost is the <c>ComplianceMultiStreamProjectionBase</c> alias — the same mechanism the string
+/// identity suite already uses, and unlike the flat-table suite no constructor shim is needed
+/// because both products' multi-stream bases are parameterless.
+/// </para>
+/// <para>
+/// Grouping is asserted through the *persisted* document, never by re-folding, so a projection that
+/// sliced correctly but never wrote fails.
+/// </para>
+/// </remarks>
+public abstract class MultiStreamProjectionCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_multi_stream";
+
+        config.AddEventType<EmployeeHired>();
+        config.AddEventType<EmployeeDeparted>();
+        config.AddEventType<DepartmentsAudited>();
+        config.AddEventType<TeamOnboarded>();
+
+        config.AddProjection(new ComplianceDepartmentProjection(), ProjectionLifecycle.Inline);
+    };
+
+    /// <summary>
+    /// The same projection registered <see cref="ProjectionLifecycle.Async"/>, in the same schema.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _asyncConfiguration = config =>
+    {
+        config.SchemaName = "compliance_multi_stream";
+
+        config.AddEventType<EmployeeHired>();
+        config.AddEventType<EmployeeDeparted>();
+        config.AddEventType<DepartmentsAudited>();
+        config.AddEventType<TeamOnboarded>();
+
+        config.AddProjection(new ComplianceDepartmentProjection(), ProjectionLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Departments are suffixed per test so sibling tests sharing the schema cannot collide.
+    /// </summary>
+    private static string department(string name) => $"{name}-{Guid.NewGuid():N}";
+
+    private async Task appendAsync(params object[] events)
+    {
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(Guid.NewGuid(), events);
+        await SaveChangesAsync(session);
+    }
+
+    private async Task<ComplianceDepartment?> departmentAsync(string id)
+    {
+        await using var query = OpenSession();
+        return await LoadDocumentAsync<ComplianceDepartment>(query, id);
+    }
+
+    [Fact]
+    public async Task events_from_separate_streams_land_on_one_aggregate()
+    {
+        var dept = department("engineering");
+
+        // Three separate streams, one aggregate -- the whole point of a multi-stream projection.
+        await appendAsync(new EmployeeHired(dept, "Ada"));
+        await appendAsync(new EmployeeHired(dept, "Grace"));
+        await appendAsync(new EmployeeHired(dept, "Edsger"));
+
+        var doc = await departmentAsync(dept);
+
+        doc.ShouldNotBeNull();
+        doc.Id.ShouldBe(dept);
+        doc.HeadCount.ShouldBe(3);
+        doc.Names.OrderBy(x => x).ToArray().ShouldBe(new[] { "Ada", "Edsger", "Grace" });
+    }
+
+    [Fact]
+    public async Task events_within_one_stream_are_grouped_by_their_identity()
+    {
+        var left = department("sales");
+        var right = department("support");
+
+        // A single stream carrying events for two different aggregates.
+        await appendAsync(
+            new EmployeeHired(left, "Ada"),
+            new EmployeeHired(right, "Grace"),
+            new EmployeeHired(left, "Edsger"));
+
+        (await departmentAsync(left))!.HeadCount.ShouldBe(2);
+        (await departmentAsync(right))!.HeadCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task separate_identities_stay_independent()
+    {
+        var left = department("alpha");
+        var right = department("beta");
+
+        await appendAsync(new EmployeeHired(left, "Ada"), new EmployeeHired(right, "Grace"));
+        await appendAsync(new EmployeeDeparted(left, "Ada"));
+
+        (await departmentAsync(left))!.HeadCount.ShouldBe(0);
+
+        var other = await departmentAsync(right);
+        other!.HeadCount.ShouldBe(1);
+        other.Names.ShouldBe(new[] { "Grace" });
+    }
+
+    [Fact]
+    public async Task an_event_can_update_an_aggregate_built_by_an_earlier_commit()
+    {
+        var dept = department("platform");
+
+        await appendAsync(new EmployeeHired(dept, "Ada"), new EmployeeHired(dept, "Grace"));
+        await appendAsync(new EmployeeDeparted(dept, "Ada"));
+
+        var doc = await departmentAsync(dept);
+
+        doc!.HeadCount.ShouldBe(1);
+        doc.Names.ShouldBe(new[] { "Grace" });
+    }
+
+    [Fact]
+    public async Task one_event_reaches_every_identity_it_names()
+    {
+        var left = department("finance");
+        var right = department("legal");
+
+        await appendAsync(new EmployeeHired(left, "Ada"), new EmployeeHired(right, "Grace"));
+
+        // Identities<T> -- a single event applied to two different aggregates.
+        await appendAsync(new DepartmentsAudited([left, right]));
+
+        (await departmentAsync(left))!.AuditCount.ShouldBe(1);
+        (await departmentAsync(right))!.AuditCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_fanned_out_event_applies_each_child_inside_its_parents_identity()
+    {
+        var left = department("research");
+        var right = department("design");
+
+        // One event per department, each exploding into a child per member. Each child is applied
+        // as if it were its own event, but inside the slice its parent was grouped into.
+        await appendAsync(
+            new TeamOnboarded(left, [new TeamMemberOnboarded("Ada"), new TeamMemberOnboarded("Grace")]),
+            new TeamOnboarded(right, [new TeamMemberOnboarded("Edsger")]));
+
+        var first = await departmentAsync(left);
+        first.ShouldNotBeNull();
+        first.HeadCount.ShouldBe(2);
+        first.Names.OrderBy(x => x).ToArray().ShouldBe(new[] { "Ada", "Grace" });
+
+        var second = await departmentAsync(right);
+        second.ShouldNotBeNull();
+        second.HeadCount.ShouldBe(1);
+        second.Names.ShouldBe(new[] { "Edsger" });
+    }
+
+    [Fact]
+    public async Task a_fanned_out_child_composes_with_ordinary_events_on_the_same_aggregate()
+    {
+        var dept = department("mixed");
+
+        await appendAsync(new EmployeeHired(dept, "Ada"));
+        await appendAsync(new TeamOnboarded(dept, [new TeamMemberOnboarded("Grace")]));
+        await appendAsync(new EmployeeDeparted(dept, "Ada"));
+
+        var doc = await departmentAsync(dept);
+
+        doc.ShouldNotBeNull();
+        doc.HeadCount.ShouldBe(1);
+        doc.Names.ShouldBe(new[] { "Grace" });
+    }
+
+    [Fact]
+    public async Task an_identity_that_no_event_names_has_no_aggregate()
+    {
+        await appendAsync(new EmployeeHired(department("ops"), "Ada"));
+
+        (await departmentAsync(department("never-referenced"))).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task the_async_lifecycle_produces_the_same_aggregate_as_inline()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var dept = department("async-eng");
+
+        await appendAsync(new EmployeeHired(dept, "Ada"));
+        await appendAsync(new EmployeeHired(dept, "Grace"), new EmployeeDeparted(dept, "Ada"));
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        var doc = await departmentAsync(dept);
+
+        doc.ShouldNotBeNull();
+        doc.HeadCount.ShouldBe(1);
+        doc.Names.ShouldBe(new[] { "Grace" });
+    }
+
+    [Fact]
+    public async Task a_rebuild_reproduces_the_grouping()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var left = department("rebuild-a");
+        var right = department("rebuild-b");
+
+        await appendAsync(new EmployeeHired(left, "Ada"), new EmployeeHired(right, "Grace"));
+        await appendAsync(new TeamOnboarded(left, [new TeamMemberOnboarded("Edsger")]));
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        (await departmentAsync(left))!.HeadCount.ShouldBe(2);
+
+        await daemon.RebuildProjectionAsync<ComplianceDepartment>(Cancellation);
+
+        // Exactly once, not twice -- a rebuild that replayed onto the surviving document rather than
+        // starting from empty would double every count here.
+        var rebuilt = await departmentAsync(left);
+        rebuilt.ShouldNotBeNull();
+        rebuilt.HeadCount.ShouldBe(2);
+        rebuilt.Names.OrderBy(x => x).ToArray().ShouldBe(new[] { "Ada", "Edsger" });
+
+        (await departmentAsync(right))!.HeadCount.ShouldBe(1);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/SnapshotLifecycleCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/SnapshotLifecycleCompliance.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Snapshot lifecycle events and aggregate
+
+public record ParcelShipped(string Destination);
+
+public record ParcelScanned(string Location);
+
+public record ParcelDelivered;
+
+/// <summary>
+/// One aggregate, folded the same way whichever lifecycle persists it.
+/// </summary>
+public partial class ParcelSnapshot
+{
+    public Guid Id { get; set; }
+    public string Destination { get; set; } = string.Empty;
+    public List<string> Scans { get; set; } = new();
+    public bool Delivered { get; set; }
+
+    public static ParcelSnapshot Create(ParcelShipped e) => new() { Destination = e.Destination };
+
+    public void Apply(ParcelScanned e) => Scans.Add(e.Location);
+
+    public void Apply(ParcelDelivered e) => Delivered = true;
+}
+
+#endregion
+
+/// <summary>
+/// Equivalence across <see cref="SnapshotLifecycle"/> — the same aggregate registered
+/// <c>Inline</c> or <c>Async</c>, or folded live, must produce the same state. Only *when* the state
+/// becomes visible is allowed to differ.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The individual lifecycles are already exercised elsewhere: <c>SelfAggregatingEvolveCompliance</c>
+/// and <c>FetchForWritingCompliance</c> use inline snapshots, <c>AsyncDaemonCompliance</c> drives an
+/// async one, <c>LiveAggregationCompliance</c> folds without registration. What none of them assert
+/// is that the three agree, which is the property users actually rely on when they move a projection
+/// from inline to async to keep writes cheap.
+/// </para>
+/// <para>
+/// The timing half is asserted as deliberately as the equivalence half. An inline snapshot is
+/// readable the moment its transaction commits; an async one is not readable until the daemon has
+/// caught up. That difference is the entire reason to choose between them, so a store that quietly
+/// persisted an async projection inline would be wrong in a way no equivalence assertion catches.
+/// </para>
+/// </remarks>
+public abstract class SnapshotLifecycleCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_snapshot_lifecycle";
+
+        config.AddEventType<ParcelShipped>();
+        config.AddEventType<ParcelScanned>();
+        config.AddEventType<ParcelDelivered>();
+
+        config.Snapshot<ParcelSnapshot>(SnapshotLifecycle.Inline);
+    };
+
+    /// <summary>
+    /// The same aggregate, same schema, registered async instead.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _asyncConfiguration = config =>
+    {
+        config.SchemaName = "compliance_snapshot_lifecycle";
+
+        config.AddEventType<ParcelShipped>();
+        config.AddEventType<ParcelScanned>();
+        config.AddEventType<ParcelDelivered>();
+
+        config.Snapshot<ParcelSnapshot>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    private static readonly object[] _story =
+    [
+        new ParcelShipped("Rivendell"),
+        new ParcelScanned("Bree"),
+        new ParcelScanned("Weathertop"),
+        new ParcelDelivered()
+    ];
+
+    private async Task<Guid> aParcelAsync(params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ParcelSnapshot>(streamId, events.Length == 0 ? _story : events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private static void shouldMatchTheStory(ParcelSnapshot? snapshot, Guid streamId)
+    {
+        snapshot.ShouldNotBeNull();
+        snapshot.Id.ShouldBe(streamId);
+        snapshot.Destination.ShouldBe("Rivendell");
+        snapshot.Scans.ToArray().ShouldBe(new[] { "Bree", "Weathertop" });
+        snapshot.Delivered.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task an_inline_snapshot_matches_the_live_fold()
+    {
+        var streamId = await aParcelAsync();
+
+        await using var query = OpenSession();
+
+        var persisted = await LoadDocumentAsync<ParcelSnapshot>(query, streamId);
+        shouldMatchTheStory(persisted, streamId);
+
+        // Same events, folded on demand rather than read back.
+        var live = await EventsFor(query).AggregateStreamAsync<ParcelSnapshot>(streamId, token: Cancellation);
+        shouldMatchTheStory(live, streamId);
+
+        persisted!.Scans.ToArray().ShouldBe(live!.Scans.ToArray());
+        persisted.Delivered.ShouldBe(live.Delivered);
+        persisted.Destination.ShouldBe(live.Destination);
+    }
+
+    [Fact]
+    public async Task an_inline_snapshot_is_readable_as_soon_as_it_commits()
+    {
+        var streamId = await aParcelAsync();
+
+        // No daemon, no waiting -- that is what inline means.
+        await using var query = OpenSession();
+        (await LoadDocumentAsync<ParcelSnapshot>(query, streamId)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task an_async_snapshot_matches_the_live_fold_once_the_daemon_catches_up()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var streamId = await aParcelAsync();
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+
+        var persisted = await LoadDocumentAsync<ParcelSnapshot>(query, streamId);
+        shouldMatchTheStory(persisted, streamId);
+
+        var live = await EventsFor(query).AggregateStreamAsync<ParcelSnapshot>(streamId, token: Cancellation);
+        shouldMatchTheStory(live, streamId);
+    }
+
+    [Fact]
+    public async Task an_async_snapshot_is_not_written_by_the_committing_transaction()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var streamId = await aParcelAsync();
+
+        // The whole point of choosing async over inline: the write path does not pay for the
+        // projection. No daemon has been started, so nothing should have been persisted yet.
+        await using var query = OpenSession();
+        (await LoadDocumentAsync<ParcelSnapshot>(query, streamId)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task both_lifecycles_reach_the_same_state_from_the_same_events()
+    {
+        // Inline first, on the suite's standard configuration.
+        var inlineStream = await aParcelAsync();
+
+        ParcelSnapshot inline;
+        await using (var query = OpenSession())
+        {
+            inline = (await LoadDocumentAsync<ParcelSnapshot>(query, inlineStream))!;
+        }
+
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        // Then the identical story through the async lifecycle.
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var asyncStream = await aParcelAsync();
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var asyncQuery = OpenSession();
+        var async = (await LoadDocumentAsync<ParcelSnapshot>(asyncQuery, asyncStream))!;
+
+        // Everything except the identity, which is the stream's.
+        async.Destination.ShouldBe(inline.Destination);
+        async.Scans.ToArray().ShouldBe(inline.Scans.ToArray());
+        async.Delivered.ShouldBe(inline.Delivered);
+    }
+
+    [Fact]
+    public async Task a_snapshot_keeps_up_with_events_appended_after_it_was_created()
+    {
+        var streamId = await aParcelAsync(new ParcelShipped("Rivendell"), new ParcelScanned("Bree"));
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new ParcelScanned("Weathertop"), new ParcelDelivered());
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        shouldMatchTheStory(await LoadDocumentAsync<ParcelSnapshot>(query, streamId), streamId);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StringStreamIdentityCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StringStreamIdentityCompliance.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region String-keyed stream events and aggregate
+
+public record StringLedgerOpened(string Owner);
+
+public record StringLedgerEntryPosted(decimal Amount);
+
+public record StringLedgerAudited(string Auditor);
+
+/// <summary>
+/// A plain self-aggregating type keyed by the stream's string key. The subject of this suite is the
+/// stream identity, not the aggregation conventions, so the folding is as dull as possible.
+/// </summary>
+public partial class StringLedger
+{
+    public string Id { get; set; } = string.Empty;
+    public string Owner { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+    public int EntryCount { get; set; }
+
+    public static StringLedger Create(StringLedgerOpened e) => new() { Owner = e.Owner };
+
+    public void Apply(StringLedgerEntryPosted e)
+    {
+        Balance += e.Amount;
+        EntryCount++;
+    }
+}
+
+#endregion
+
+/// <summary>
+/// The event store operations surface against <see cref="StreamIdentity.AsString"/> streams — the
+/// string-keyed counterpart to <c>StreamReadCompliance</c>, <c>FetchForWritingCompliance</c> and
+/// <c>StreamArchivingCompliance</c>, all of which are Guid-only and say so.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Stream identity is a store-level setting, so string-keyed behavior cannot be folded into those
+/// suites — it needs its own store, and therefore its own suite. Until this existed, the only shared
+/// coverage of string identity was
+/// <see cref="StringIdentitySingleStreamCompliance{TFixture,TOperations,TQuerySession}"/>, which
+/// exercises single stream *projections* and nothing on the read/write surface underneath them.
+/// </para>
+/// <para>
+/// This is the seam where a store is most likely to have implemented one identity well and the other
+/// by analogy. Every operation here has a <c>string</c> overload declared right next to the
+/// <c>Guid</c> one on <see cref="IEventStoreOperations"/> or <c>IQueryEventStore</c>, so nothing here
+/// needs a fixture member — which is exactly why an untested gap can sit in a store for a long time
+/// without anyone noticing.
+/// </para>
+/// <para>
+/// No capability gates. A store that declares <see cref="StreamIdentity.AsString"/> owes the same
+/// contract on the same methods as it does for Guids; the only thing that changes is which column
+/// carries the identity.
+/// </para>
+/// </remarks>
+public abstract class StringStreamIdentityCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_string_streams";
+        config.StreamIdentity = StreamIdentity.AsString;
+
+        config.AddEventType<StringLedgerOpened>();
+        config.AddEventType<StringLedgerEntryPosted>();
+        config.AddEventType<StringLedgerAudited>();
+
+        config.Snapshot<StringLedger>(SnapshotLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// Keys deliberately carry a slash and a dash. Both are legal in a stream key and neither is
+    /// special to a store, but an implementation that ever interpolates a key into SQL rather than
+    /// parameterizing it tends to fall over on punctuation first.
+    /// </summary>
+    private static string streamKey() => $"ledger/{Guid.NewGuid():N}-01";
+
+    private async Task<string> aLedgerAsync(params object[] events)
+    {
+        var key = streamKey();
+
+        await using var session = OpenSession();
+        var all = new List<object> { new StringLedgerOpened("Hilda") };
+        all.AddRange(events);
+        EventsFor(session).StartStream<StringLedger>(key, all);
+        await SaveChangesAsync(session);
+
+        return key;
+    }
+
+    [Fact]
+    public async Task start_stream_and_read_it_back_by_key()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(25), new StringLedgerEntryPosted(75));
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(key, token: Cancellation);
+
+        events.Count.ShouldBe(3);
+        events.Select(x => x.Version).ToArray().ShouldBe(new[] { 1L, 2L, 3L });
+        events[0].Data.ShouldBeOfType<StringLedgerOpened>();
+    }
+
+    [Fact]
+    public async Task appending_to_an_existing_string_keyed_stream_continues_its_versions()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(10));
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(key, new StringLedgerEntryPosted(5));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(key, token: Cancellation);
+
+        events.Count.ShouldBe(3);
+        events.Last().Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task events_on_a_string_keyed_stream_carry_the_key()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(1));
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(key, token: Cancellation);
+
+        events.ShouldAllBe(x => x.StreamKey == key);
+
+        // The negative half of the contract, which neither product asserted anywhere before this
+        // suite: on a string-keyed stream the Guid slot is left at its default rather than being
+        // filled with a synthesized value. Consumers that branch on identity (CritterWatch reads
+        // these envelopes cross-store) need to be able to tell which slot is authoritative.
+        events.ShouldAllBe(x => x.StreamId == Guid.Empty);
+    }
+
+    [Fact]
+    public async Task stream_state_reports_the_key_and_version()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(1), new StringLedgerEntryPosted(2));
+
+        await using var query = OpenSession();
+        var state = await EventsFor(query).FetchStreamStateAsync(key, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.Key.ShouldBe(key);
+        state.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task stream_state_for_an_unknown_key_is_null()
+    {
+        await using var query = OpenSession();
+        var state = await EventsFor(query).FetchStreamStateAsync(streamKey(), Cancellation);
+
+        state.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task fetch_stream_bounded_by_version_on_a_string_key()
+    {
+        var key = await aLedgerAsync(
+            new StringLedgerEntryPosted(10),
+            new StringLedgerEntryPosted(20),
+            new StringLedgerEntryPosted(30));
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(key, 2, token: Cancellation);
+
+        events.Count.ShouldBe(2);
+        events.Last().Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task fetch_stream_from_a_starting_version_on_a_string_key()
+    {
+        var key = await aLedgerAsync(
+            new StringLedgerEntryPosted(10),
+            new StringLedgerEntryPosted(20),
+            new StringLedgerEntryPosted(30));
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(key, fromVersion: 3, token: Cancellation);
+
+        events.ShouldAllBe(x => x.Version >= 3);
+        events.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task aggregate_a_string_keyed_stream_live()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(40), new StringLedgerEntryPosted(2));
+
+        await using var query = OpenSession();
+        var ledger = await EventsFor(query).AggregateStreamAsync<StringLedger>(key, token: Cancellation);
+
+        ledger.ShouldNotBeNull();
+        ledger.Owner.ShouldBe("Hilda");
+        ledger.Balance.ShouldBe(42);
+        ledger.EntryCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task aggregate_a_string_keyed_stream_at_an_earlier_version()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(40), new StringLedgerEntryPosted(2));
+
+        await using var query = OpenSession();
+        var ledger = await EventsFor(query).AggregateStreamAsync<StringLedger>(key, 2, token: Cancellation);
+
+        ledger.ShouldNotBeNull();
+        ledger.Balance.ShouldBe(40);
+        ledger.EntryCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task aggregate_an_unknown_string_key_is_null()
+    {
+        await using var query = OpenSession();
+        var ledger = await EventsFor(query).AggregateStreamAsync<StringLedger>(streamKey(), token: Cancellation);
+
+        ledger.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_a_string_keyed_stream_that_does_not_exist_yet()
+    {
+        var key = streamKey();
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<StringLedger>(key, Cancellation);
+
+        stream.Aggregate.ShouldBeNull();
+        stream.Key.ShouldBe(key);
+        stream.StartingVersion.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_an_existing_string_keyed_stream()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(15));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<StringLedger>(key, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(15);
+        stream.Key.ShouldBe(key);
+        stream.StartingVersion.ShouldBe(2);
+
+        stream.AppendOne(new StringLedgerEntryPosted(5));
+        await SaveChangesAsync(session);
+
+        await using var query = OpenSession();
+        var ledger = await EventsFor(query).AggregateStreamAsync<StringLedger>(key, token: Cancellation);
+        ledger!.Balance.ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task fetch_for_writing_a_string_key_with_a_stale_expected_version_fails()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(15));
+
+        // As in the Guid suite: wrap the whole fetch-append-save sequence and assert the shared
+        // ConcurrencyException base, so a store is free to detect the conflict eagerly or at commit.
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            var stream = await EventsFor(session).FetchForWriting<StringLedger>(key, 1, Cancellation);
+            stream.AppendOne(new StringLedgerEntryPosted(1));
+            await SaveChangesAsync(session);
+        });
+    }
+
+    [Fact]
+    public async Task fetch_for_exclusive_writing_a_string_keyed_stream()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(15));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForExclusiveWriting<StringLedger>(key, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(15);
+        stream.Key.ShouldBe(key);
+
+        stream.AppendOne(new StringLedgerEntryPosted(7));
+        await SaveChangesAsync(session);
+
+        await using var query = OpenSession();
+        var ledger = await EventsFor(query).AggregateStreamAsync<StringLedger>(key, token: Cancellation);
+        ledger!.Balance.ShouldBe(22);
+    }
+
+    [Fact]
+    public async Task write_to_aggregate_by_string_key()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(100));
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).WriteToAggregate<StringLedger>(key, stream =>
+            {
+                stream.Aggregate.ShouldNotBeNull();
+                stream.Aggregate.Balance.ShouldBe(100);
+                stream.AppendOne(new StringLedgerEntryPosted(-40));
+            }, Cancellation);
+        }
+
+        await using var query = OpenSession();
+        var ledger = await EventsFor(query).AggregateStreamAsync<StringLedger>(key, token: Cancellation);
+        ledger!.Balance.ShouldBe(60);
+    }
+
+    [Fact]
+    public async Task append_optimistic_against_an_existing_string_keyed_stream()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(10));
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).AppendOptimistic(key, new StringLedgerEntryPosted(5));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var state = await EventsFor(query).FetchStreamStateAsync(key, Cancellation);
+        state!.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task append_exclusive_against_an_existing_string_keyed_stream()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(10));
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).AppendExclusive(key, new StringLedgerEntryPosted(5));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var state = await EventsFor(query).FetchStreamStateAsync(key, Cancellation);
+        state!.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task fetch_latest_by_string_key()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(11), new StringLedgerEntryPosted(31));
+
+        await using var session = OpenSession();
+        var ledger = await EventsFor(session).FetchLatest<StringLedger>(key, Cancellation);
+
+        ledger.ShouldNotBeNull();
+        ledger.Balance.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task archive_a_string_keyed_stream()
+    {
+        var key = await aLedgerAsync(new StringLedgerEntryPosted(1));
+
+        await using (var reader = OpenSession())
+        {
+            var before = await EventsFor(reader).FetchStreamStateAsync(key, Cancellation);
+            before!.IsArchived.ShouldBeFalse();
+        }
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).ArchiveStream(key);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var after = await EventsFor(query).FetchStreamStateAsync(key, Cancellation);
+
+        after.ShouldNotBeNull();
+        after.Key.ShouldBe(key);
+        after.IsArchived.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Four suites, **library 124 → 169 tests (17 → 21 suites)**, both consumers green, no capability gates in use. Tracks marten#5147, marten#5191, marten#5145, marten#5142.

Validated against both stores through the `ComplianceSourceDir` dev loop before this PR: **Marten 169/169** (full EventSourcingTests green), **Polecat 169/169** once polecat#415 lands.

## `FlatTableProjectionCompliance` — 8 tests (marten#5147)

An `EventProjection` writing into a plain relational table rather than a document. Worth pinning cross-store because the implementations are genuinely *different mechanisms for the same promised semantics*: Marten generates per-event upsert functions, Polecat emits `MERGE`.

Two seam additions:

- **`QueryTableAsync(tableName, ct)`** — the only raw data-access member on the fixture, and deliberately the narrowest one that works. Table name in, every row out; no predicates, no ordering, no SQL from the suite. Suites filter in memory, so it cannot drift into a general query escape hatch. Keys compare case-insensitively because PostgreSQL folds undelimited identifiers to lower case while SQL Server preserves declared casing.
- **`SupportsFlatTableProjections`** — the first gate aimed at a store still being *built* rather than one that cannot support a behavior. It gates behavior, not compilation.

`ComplianceFlatTableProjection` is the first shared type whose base cannot be reached by an alias — every product's flat-table base takes constructor arguments describing where the table lives, and those signatures genuinely differ. The library owns the table name, projection name and every mapping; each consumer supplies a ~5-line partial. Rationale for not using `Weasel.Core.ITable`'s dialect-neutral column API (which would remove the shim) is recorded in the file: these sources compile inside every consumer, so a Weasel reference in one suite becomes one for the whole package.

**Found a real Polecat bug** — polecat#415, rebuild does not empty the flat table. Root cause was a shared JasperFx contract with one consumer: `AsyncOptions.CleanUps` had references only in Marten.

## `StringStreamIdentityCompliance` — 19 tests (marten#5191)

The event store read/write surface under `StreamIdentity.AsString`. `StringIdentitySingleStreamCompliance` covered string-keyed *projections* only, and the Guid suites already claimed otherwise — `FetchForWritingCompliance` carried a cross-reference promising the string equivalents lived in the projection suite, which was never true. Now points here.

No seam addition, no gates. Covers StartStream/Append, FetchStream (plain / version-bounded / `fromVersion`), FetchStreamState, AggregateStream (live / at-version / unknown), FetchForWriting (incl. stale expected version), FetchForExclusiveWriting, WriteToAggregate, AppendOptimistic, AppendExclusive, FetchLatest, ArchiveStream.

Pins one contract neither product asserted anywhere: **`IEvent.StreamId` stays `Guid.Empty`** on a string-keyed stream rather than carrying a synthesized value. Out-of-repo consumers reading envelopes cross-store need to know which identity slot is authoritative.

Closed ~10 real coverage gaps on the Polecat side (no `ArchiveStream`, `AppendOptimistic`/`Exclusive`, `WriteToAggregate` or time travel by key anywhere) — all of which passed first run. A useful negative result: those overloads were not built by analogy and left to rot.

## `MultiStreamProjectionCompliance` — 10 tests (marten#5145)

The grouping half of the projection model — the surface with the most freedom to disagree, since slicing decides which shard sees which event. Costs one global alias; no constructor shim, because both products' `MultiStreamProjection<TDoc, TId>` are parameterless subclasses of the shared `JasperFxMultiStreamProjectionBase`.

Covers `Identity` (cross-stream grouping, intra-stream splitting, independence), `Identities` (one event reaching several aggregates), `FanOut` (children applied inside the parent's slice, composing with ordinary events), async-vs-inline agreement, and rebuild reproducing the grouping exactly once.

## `SnapshotLifecycleCompliance` — 6 tests (marten#5142)

The same aggregate registered `Inline` or `Async`, or folded live, must reach the same state. No seam addition. The individual lifecycles were each already exercised elsewhere, but nothing asserted that they *agree* — which is the property users rely on when moving a projection from inline to async to keep writes cheap.

The timing half is asserted as deliberately as the equivalence half: an inline snapshot is readable the moment its transaction commits, an async one is not until the daemon catches up. That difference is the entire reason to choose between them, so a store that quietly persisted an async projection inline would be wrong in a way no equivalence assertion catches.

## Notes for reviewers

**The rebuild assertions needed care to be non-vacuous.** `Map` overwrites rather than accumulates, so a rebuild that replayed onto surviving rows lands on the same values as one that emptied the table first — only a row the replay *cannot* recreate discriminates. The first draft created one by deleting event data, which passed **vacuously on Polecat** because its `Clean` also erases flat-table rows. The suite archives the stream instead, and says why at the assertion.

**`FanOut` does not route by the child's identity** — the parent carries it and the child applies inside the parent's slice. An earlier draft modelled it the other way and produced no aggregate at all. Commented at the registration site.

`Directory.Build.props` bumped 2.39.4 → **2.40.0** in this PR per jasperfx#614. Minor rather than patch: `QueryTableAsync` is a new abstract member, so an existing consumer must implement one member to move up.

README refreshed — the coverage table had drifted (the three wave 5 part 1 suites were missing), the alias count is now five, and "two things" became three.