### PR TITLE
Lift CompactStreamAsync<T> and IEventDataMasking into JasperFx.Events (2.41.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.40.0</JasperFxVersion>
+        <JasperFxVersion>2.41.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events/IEventStoreOperations.cs
+++ b/src/JasperFx.Events/IEventStoreOperations.cs
@@ -96,6 +96,42 @@ public interface IEventStoreOperations : IEventOperations, IQueryEventStore
     void ArchiveStream(string streamKey);
 
     /// <summary>
+    /// Compact a stream by replacing its earlier events with a single <c>Compacted&lt;T&gt;</c> event
+    /// establishing the snapshot. Use when older stream data no longer matters but database size and
+    /// replay cost do.
+    /// </summary>
+    /// <param name="streamId">Identity of the stream to compact.</param>
+    /// <param name="configure">
+    /// Configure the request. The default compacts at the latest point in the stream.
+    /// </param>
+    /// <remarks>
+    /// A default-implemented member rather than an abstract one, so a store that has not implemented
+    /// compacting stays source-compatible -- the same treatment the event store explorer surface gets
+    /// on <see cref="IEventStore"/>. <see cref="Protected.StreamCompactingRequest{T}"/> already lived
+    /// here; only the declaration was duplicated per product (marten#5153).
+    /// </remarks>
+    Task CompactStreamAsync<T>(Guid streamId, Action<Protected.StreamCompactingRequest<T>>? configure = null)
+        where T : class
+        => throw new NotSupportedException(
+            "Stream compacting is not implemented on this event store. Use Marten or Polecat.");
+
+    /// <summary>
+    /// Compact a stream by replacing its earlier events with a single <c>Compacted&lt;T&gt;</c> event
+    /// establishing the snapshot. Use when older stream data no longer matters but database size and
+    /// replay cost do.
+    /// </summary>
+    /// <param name="streamKey">String identity of the stream to compact.</param>
+    /// <param name="configure">
+    /// Configure the request. The default compacts at the latest point in the stream.
+    /// </param>
+    /// <inheritdoc cref="CompactStreamAsync{T}(Guid, Action{Protected.StreamCompactingRequest{T}})"
+    ///     path="/remarks"/>
+    Task CompactStreamAsync<T>(string streamKey, Action<Protected.StreamCompactingRequest<T>>? configure = null)
+        where T : class
+        => throw new NotSupportedException(
+            "Stream compacting is not implemented on this event store. Use Marten or Polecat.");
+
+    /// <summary>
     /// Fetch the projected aggregate T by id with built-in optimistic concurrency checks
     /// starting at the point the aggregate was fetched.
     /// </summary>

--- a/src/JasperFx.Events/Protected/IEventDataMasking.cs
+++ b/src/JasperFx.Events/Protected/IEventDataMasking.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq.Expressions;
+
+namespace JasperFx.Events.Protected;
+
+/// <summary>
+/// Fluent builder for applying data-protection masking to already-stored events — rewriting
+/// protected information in place for GDPR-style erasure, without rewriting the stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lifted here because both Critter Stack event stores declared this interface member-for-member
+/// identically in parallel namespaces (marten#5154). It sits beside
+/// <see cref="StreamCompactingRequest{T}"/> for the same reason: the *shape* of the request is a
+/// database-agnostic description of intent, while executing it is unavoidably store-specific — each
+/// product resolves its own session, query surface and update path.
+/// </para>
+/// <para>
+/// A store exposes this through its own advanced-operations surface (both current products spell it
+/// <c>Advanced.ApplyEventDataMasking(Action&lt;IEventDataMasking&gt;, CancellationToken)</c>) and
+/// supplies the implementation. Masking rules themselves are registered per event type on the store's
+/// event options, not here.
+/// </para>
+/// </remarks>
+public interface IEventDataMasking
+{
+    /// <summary>
+    /// Isolate the event masking to a specific tenant if using multi-tenancy.
+    /// </summary>
+    IEventDataMasking ForTenant(string tenantId);
+
+    /// <summary>
+    /// Apply data protection masking to every event in this stream.
+    /// </summary>
+    IEventDataMasking IncludeStream(Guid streamId);
+
+    /// <summary>
+    /// Apply data protection masking to every event in this stream.
+    /// </summary>
+    IEventDataMasking IncludeStream(string streamKey);
+
+    /// <summary>
+    /// Apply data protection masking to the events within this stream that match the filter.
+    /// </summary>
+    IEventDataMasking IncludeStream(Guid streamId, Func<IEvent, bool> filter);
+
+    /// <summary>
+    /// Apply data protection masking to the events within this stream that match the filter.
+    /// </summary>
+    IEventDataMasking IncludeStream(string streamKey, Func<IEvent, bool> filter);
+
+    /// <summary>
+    /// Apply data protection masking to every event matching this criteria.
+    /// </summary>
+    IEventDataMasking IncludeEvents(Expression<Func<IEvent, bool>> filter);
+
+    /// <summary>
+    /// Add a header value to the metadata of any event masked as part of this batch. Applies only to
+    /// event types that have a matching masking rule.
+    /// </summary>
+    IEventDataMasking AddHeader(string key, object value);
+}


### PR DESCRIPTION
Two duplicated shapes, same argument for both: each product declares an identical member or interface over types that **already live here**, so the declaration was the only thing not shared. Tracks marten#5153 and marten#5154.

Both changes are additive to JasperFx. Neither is usable until the consumers adopt — but see the warning at the bottom, because for #5153 adoption cannot lag the bump.

## #5153 — `CompactStreamAsync<T>` onto `IEventStoreOperations`

`StreamCompactingRequest<T>` was already in `JasperFx.Events/Protected/`. Only the two overloads that take it were duplicated, character for character:

| | Declaration |
|---|---|
| Marten | `Marten/Events/IEventOperations.cs:30,36` |
| Polecat | `Polecat/Events/IEventOperations.cs:61,67` |

```csharp
Task CompactStreamAsync<T>(Guid streamId, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
Task CompactStreamAsync<T>(string streamKey, Action<StreamCompactingRequest<T>>? configure = null) where T : class;
```

Added as **default-implemented members that throw**, not abstract ones, so a store that has not implemented compacting stays source-compatible. Same treatment the event store explorer surface already gets on `IEventStore` — and it matters for the Sqlite consumer (marten#5156), which will not have compacting on day one.

## #5154 — `IEventDataMasking` into `JasperFx.Events/Protected/`

The two copies are **member-for-member identical** — `ForTenant`, four `IncludeStream` overloads, `IncludeEvents(Expression<Func<IEvent,bool>>)`, `AddHeader`. Same order, same signatures.

| | |
|---|---|
| Marten | `Marten/Events/Protected/EventDataMasking.cs:111` |
| Polecat | `Polecat/Events/Protected/EventDataMasking.cs:11` |

It belongs beside `StreamCompactingRequest<T>` for exactly the same reason: the request shape is a database-agnostic description of intent, while executing it is unavoidably store-specific — each product resolves its own session, query surface and update path. Only the shape moves.

## ⚠️ Consumer adoption is not optional for #5153

Both products' operations interfaces already inherit `JasperFx.Events.IEventStoreOperations`:

- `Marten.Events.IEventStoreOperations : JasperFx.Events.IEventStoreOperations, IEventOperations, IQueryEventStore`
- `Polecat.Events.IEventOperations : JasperFx.Events.IEventStoreOperations, IQueryEventStore`

…while *also* declaring `CompactStreamAsync<T>` themselves. On bumping to 2.41.0 the same signature becomes reachable through two paths and call sites go ambiguous (**CS0121**).

Adopting means **deleting the per-product declarations**, which is the entire point of the lift — it just cannot lag the bump. Polecat already carries the same diamond on `FetchLatest` and collapses it with `new`, so the shape is familiar there if a softer landing is wanted.

Adoption PRs (and the two compliance suites these lifts unblock — stream compacting and event data masking) follow once 2.41.0 is published.

`Directory.Build.props` bumped 2.40.0 → **2.41.0** in this PR per jasperfx#614. Minor, not patch: new members on a public interface.