### PR TITLE
fix(generator): register published types via a PublishedTypes() override (marten#5192)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.42.0</JasperFxVersion>
+        <JasperFxVersion>2.42.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -1456,7 +1456,7 @@ public partial class ExplicitStoreProjection : TestEventProjection
 ");
 
         string.Join("\n", generatedSources)
-            .ShouldContain("RegisterPublishedType(typeof(global::Test.AuditRecord));");
+            .ShouldContain("typeof(global::Test.AuditRecord)");
     }
 
     [Fact]
@@ -1476,7 +1476,7 @@ public partial class InferredStoreProjection : TestEventProjection
 ");
 
         string.Join("\n", generatedSources)
-            .ShouldContain("RegisterPublishedType(typeof(global::Test.AuditRecord));");
+            .ShouldContain("typeof(global::Test.AuditRecord)");
     }
 
     [Fact]
@@ -1494,7 +1494,7 @@ public partial class ObjectStoreProjection : TestEventProjection
 ");
 
         diagnostics.ShouldContain(d => d.Id == "JFXEVT005");
-        string.Join("\n", generatedSources).ShouldNotContain("RegisterPublishedType");
+        string.Join("\n", generatedSources).ShouldNotContain("typeof(global::Test.AuditRecord)");
     }
 
     [Fact]
@@ -1518,6 +1518,115 @@ public partial class UnrelatedStoreProjection : TestEventProjection
 ");
 
         diagnostics.ShouldNotContain(d => d.Id == "JFXEVT005");
-        string.Join("\n", generatedSources).ShouldNotContain("RegisterPublishedType");
+        string.Join("\n", generatedSources).ShouldNotContain("typeof(global::Test.AuditRecord)");
+    }
+
+    [Fact]
+    public void registers_published_types_on_a_projection_with_a_primary_constructor()
+    {
+        // marten#5192: registration used to be emitted as a parameterless constructor, which is
+        // illegal on a type declaring a primary constructor -- C# requires every other constructor
+        // to chain through it -- so the generated file failed the whole build with CS8862.
+        var source = EventProjectionPreamble + @"
+public class Recorder { }
+
+public partial class PrimaryCtorProjection(Recorder recorder) : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store(new AuditRecord());
+        return default;
+    }
+}
+";
+
+        CompileWithGenerator(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ShouldBeEmpty();
+
+        var (_, generatedSources) = RunGenerator(source);
+        string.Join("\n", generatedSources).ShouldContain("typeof(global::Test.AuditRecord)");
+    }
+
+    [Fact]
+    public void registers_published_types_on_a_projection_built_by_a_container()
+    {
+        // marten#5192: a projection taking dependencies has to be registered through Marten's
+        // AddProjectionWithServices, so the container calls the dependency-taking constructor. The
+        // old generated parameterless constructor compiled here but never ran, and the published
+        // types went silently unregistered. An override does not care how the instance was built.
+        var (_, generatedSources) = RunGenerator(EventProjectionPreamble + @"
+public class Recorder { }
+
+public partial class InjectedProjection : TestEventProjection
+{
+    private readonly Recorder _recorder;
+
+    public InjectedProjection(Recorder recorder) => _recorder = recorder;
+
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        var generated = string.Join("\n", generatedSources);
+        generated.ShouldContain(
+            "public override global::System.Collections.Generic.IEnumerable<global::System.Type> PublishedTypes()");
+        generated.ShouldContain("typeof(global::Test.AuditRecord)");
+        generated.ShouldNotContain("public InjectedProjection()");
+    }
+
+    [Fact]
+    public void defers_to_a_hand_written_published_types_override()
+    {
+        // The author took control of PublishedTypes(); a generated second override would be CS0111.
+        var source = EventProjectionPreamble + @"
+public partial class HandWrittenProjection : TestEventProjection
+{
+    public override System.Collections.Generic.IEnumerable<Type> PublishedTypes() => new[] { typeof(AuditRecord) };
+
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store(new AuditRecord());
+        return default;
+    }
+}
+";
+
+        CompileWithGenerator(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ShouldBeEmpty();
+
+        string.Join("\n", RunGenerator(source).generatedSources)
+            .ShouldNotContain(
+                "public override global::System.Collections.Generic.IEnumerable<global::System.Type> PublishedTypes()");
+    }
+
+    [Fact]
+    public void registers_published_types_from_conventional_create_methods_with_a_primary_constructor()
+    {
+        // Same marten#5192 break on the other emission site: a conventional-method EventProjection
+        // gets its registration in <T>.EventProjection.g.cs rather than <T>.TypeRegistration.g.cs.
+        var source = EventProjectionPreamble + @"
+public class Recorder { }
+
+public partial class ConventionalPrimaryCtorProjection(Recorder recorder) : TestEventProjection
+{
+    public AuditRecord Create(AuditableEvent e) => new AuditRecord();
+}
+";
+
+        CompileWithGenerator(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.ToString())
+            .ShouldBeEmpty();
+
+        string.Join("\n", RunGenerator(source).generatedSources)
+            .ShouldContain("typeof(global::Test.AuditRecord)");
     }
 }

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -112,6 +112,14 @@ internal sealed class CandidateInfo
     public List<EventConstructorInfo> EventConstructors { get; set; } = new();
     public bool HasDefaultConstructor { get; set; }
     public bool HasExistingParameterlessConstructor { get; set; } // On the projection class itself
+
+    /// <summary>
+    /// True when the projection — or a user-written base class between it and ProjectionBase —
+    /// already overrides PublishedTypes(). The generator yields to a hand-written override rather
+    /// than emitting a second one and tripping CS0111. See marten#5192.
+    /// </summary>
+    public bool HasExistingPublishedTypesOverride { get; set; }
+
     // EventProjection-specific
     public INamedTypeSymbol? OperationsType { get; set; } // TOperations from JasperFxEventProjectionBase<TOperations, TQuerySession>
     /// <summary>
@@ -240,7 +248,8 @@ internal static class AggregateAnalyzer
             QuerySessionType = baseInfo.querySessionType,
             Methods = methods,
             HasDefaultConstructor = HasParameterlessConstructor(baseInfo.docType),
-            HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol)
+            HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol),
+            HasExistingPublishedTypesOverride = HasPublishedTypesOverride(classSymbol)
         };
     }
 
@@ -951,7 +960,8 @@ internal static class AggregateAnalyzer
                 QuerySessionType = baseInfo.querySessionType,
                 DiscoveredPublishedTypes = discoveredTypes,
                 UnresolvedDocumentOperations = unresolved,
-                HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol)
+                HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol),
+            HasExistingPublishedTypesOverride = HasPublishedTypesOverride(classSymbol)
             };
         }
 
@@ -972,7 +982,8 @@ internal static class AggregateAnalyzer
             OperationsType = baseInfo.operationsType,
             QuerySessionType = baseInfo.querySessionType,
             Methods = methods,
-            HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol)
+            HasExistingParameterlessConstructor = HasExplicitParameterlessConstructor(classSymbol),
+            HasExistingPublishedTypesOverride = HasPublishedTypesOverride(classSymbol)
         };
     }
 
@@ -1551,6 +1562,27 @@ internal static class AggregateAnalyzer
         return type.InstanceConstructors.Any(c =>
             c.Parameters.Length == 0 &&
             !c.IsImplicitlyDeclared);
+    }
+
+    /// <summary>
+    /// Does this projection, or a user-written base class beneath ProjectionBase, already override
+    /// <c>ProjectionBase.PublishedTypes()</c>? The generator defers to it rather than emitting a
+    /// competing override. See marten#5192.
+    /// </summary>
+    private static bool HasPublishedTypesOverride(INamedTypeSymbol type)
+    {
+        var current = type;
+        while (current != null && current.Name != "ProjectionBase")
+        {
+            foreach (var member in current.GetMembers("PublishedTypes"))
+            {
+                if (member is IMethodSymbol { IsOverride: true, Parameters.Length: 0 }) return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -556,8 +556,8 @@ internal static class EvolverCodeEmitter
         sb.AppendLine($"partial class {className}{typeParams}");
         sb.AppendLine("{");
 
-        // Emit constructor that registers published document types from Create/Transform methods
-        EmitEventProjectionConstructor(sb, info, className);
+        // Register the document types published by Create/Transform methods
+        EmitConventionalPublishedTypes(sb, info);
 
         EmitEventProjectionApplyAsync(sb, info);
 
@@ -573,7 +573,7 @@ internal static class EvolverCodeEmitter
     }
 
     /// <summary>
-    /// Emits a partial class with only a constructor that registers published document types.
+    /// Emits a partial class that registers published document types and nothing else.
     /// Used for EventProjection subclasses that have an explicit ApplyAsync override and
     /// call Store/Insert/Delete with document types that need to be registered.
     /// See https://github.com/JasperFx/marten/issues/4166
@@ -609,17 +609,8 @@ internal static class EvolverCodeEmitter
         sb.AppendLine($"partial class {className}{typeParams}");
         sb.AppendLine("{");
 
-        if (!info.HasExistingParameterlessConstructor && info.DiscoveredPublishedTypes.Count > 0)
-        {
-            sb.AppendLine($"    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-            sb.AppendLine($"    public {className}()");
-            sb.AppendLine("    {");
-            foreach (var docType in info.DiscoveredPublishedTypes.Select(t => Fqn(t)).Distinct())
-            {
-                sb.AppendLine($"        RegisterPublishedType(typeof({docType}));");
-            }
-            sb.AppendLine("    }");
-        }
+        EmitPublishedTypesOverride(sb, info,
+            info.DiscoveredPublishedTypes.Select(Fqn).Distinct().ToList());
 
         sb.AppendLine("}");
 
@@ -646,15 +637,12 @@ internal static class EvolverCodeEmitter
     }
 
     /// <summary>
-    /// Emits a constructor that registers document types published by Create/Transform methods
-    /// as published types, so that the document storage is generated for code-gen scenarios.
+    /// Registers the document types published by Create/Transform methods, so that the document
+    /// storage is generated for code-gen scenarios.
     /// See https://github.com/JasperFx/marten/issues/4166
     /// </summary>
-    private static void EmitEventProjectionConstructor(StringBuilder sb, CandidateInfo info, string className)
+    private static void EmitConventionalPublishedTypes(StringBuilder sb, CandidateInfo info)
     {
-        // Skip if the class already has an explicit parameterless constructor
-        if (info.HasExistingParameterlessConstructor) return;
-
         // Collect distinct entity return types from Create/Transform methods
         var publishedTypes = info.Methods
             .Where(m => m.EntityReturnType != null && (m.MethodName == "Create" || m.MethodName == "Transform"))
@@ -662,15 +650,44 @@ internal static class EvolverCodeEmitter
             .Distinct()
             .ToList();
 
-        if (publishedTypes.Count == 0) return;
+        EmitPublishedTypesOverride(sb, info, publishedTypes);
+    }
 
-        sb.AppendLine($"    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public {className}()");
+    /// <summary>
+    /// Declares the discovered published document types by overriding
+    /// <c>ProjectionBase.PublishedTypes()</c> in the user's partial class.
+    ///
+    /// <para>This used to be emitted as a parameterless constructor calling
+    /// <c>RegisterPublishedType</c>, which was wrong on two counts (marten#5192). A constructor is
+    /// illegal on a type that declares a primary constructor —
+    /// <c>partial class MyProjection(ILogger logger) : EventProjection</c> — because C# requires
+    /// every other constructor to chain through it, so the generated file broke the build with
+    /// CS8862. And when the projection is container-built (Marten's
+    /// <c>AddProjectionWithServices&lt;T&gt;</c>, which is precisely what a projection taking an
+    /// <c>ILogger</c> has to use), the container calls the dependency-taking constructor, so the
+    /// generated parameterless one never ran and the published types were silently never
+    /// registered at all.</para>
+    ///
+    /// <para>An override is immune to both: it does not care how the instance was constructed, and
+    /// chaining through <c>base.PublishedTypes()</c> keeps hand-written <c>RegisterPublishedType</c>
+    /// calls and <c>Options.StorageTypes</c> flowing. Skipped when the author already wrote their
+    /// own override — theirs wins.</para>
+    /// </summary>
+    private static void EmitPublishedTypesOverride(StringBuilder sb, CandidateInfo info, List<string> publishedTypes)
+    {
+        if (publishedTypes.Count == 0) return;
+        if (info.HasExistingPublishedTypesOverride) return;
+
+        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
+        sb.AppendLine("    public override global::System.Collections.Generic.IEnumerable<global::System.Type> PublishedTypes()");
         sb.AppendLine("    {");
+        sb.AppendLine("        var publishedTypes = new global::System.Collections.Generic.List<global::System.Type>(base.PublishedTypes());");
         foreach (var typeName in publishedTypes)
         {
-            sb.AppendLine($"        RegisterPublishedType(typeof({typeName}));");
+            sb.AppendLine($"        if (!publishedTypes.Contains(typeof({typeName}))) publishedTypes.Add(typeof({typeName}));");
         }
+
+        sb.AppendLine("        return publishedTypes;");
         sb.AppendLine("    }");
         sb.AppendLine();
     }


### PR DESCRIPTION
Fixes the source generator break reported in [marten#5192](https://github.com/JasperFx/marten/issues/5192).

## The bug

An `EventProjection`'s discovered published document types were registered by emitting a parameterless constructor into the user's partial class:

```csharp
partial class MyProjection
{
    public MyProjection() { RegisterPublishedType(typeof(Thing)); }
}
```

A constructor is the wrong extension point, and it failed two ways.

**1. It broke the build (the reported symptom).** On a type that declares a primary constructor — `partial class MyProjection(ILogger<MyProjection> logger) : EventProjection` — C# requires every other constructor to chain through the primary one, so the generated file failed the whole compilation with **CS8862**.

**2. It silently did nothing, which is worse.** A projection that takes dependencies has to be registered through Marten's `AddProjectionWithServices`, so the container calls the dependency-taking constructor and the generated parameterless one never ran. Published types went unregistered, and `#626`'s teardown registration — which reads `PublishedTypes()` — had nothing to register. Verified against Marten 9.22.4:

```
new MyProjection(logger).PublishedTypes()  ->  []
```

## The fix

Emit an override of the virtual `ProjectionBase.PublishedTypes()` instead:

```csharp
public override IEnumerable<Type> PublishedTypes()
{
    var publishedTypes = new List<Type>(base.PublishedTypes());
    if (!publishedTypes.Contains(typeof(Thing))) publishedTypes.Add(typeof(Thing));
    return publishedTypes;
}
```

An override does not care how the instance was constructed, and chaining through `base.PublishedTypes()` keeps hand-written `RegisterPublishedType` calls and `Options.StorageTypes` flowing. The generator yields when the author already wrote their own override. Both emission sites are covered: `EmitEventProjectionTypeRegistrationPartial` (an `ApplyAsync` override) and the conventional-method path.

The emitted code deliberately avoids LINQ — `CompileWithGenerator` in the test harness does not reference `System.Linq`, and generated code should not assume a consumer's reference set either.

## Regression window

Neither defect was reachable before **2.38.0**. Discovery used to be syntactic, so only an explicit `Store<Doc>(x)` produced a registration and the far more common `Store(doc)` produced none at all. #611 made discovery semantic and both spellings started emitting the constructor. Bisected on the consumer side: Marten 9.22.2 builds, Marten 9.22.3 does not.

## Behavior change worth a second look

The old guard skipped registration entirely when the class already had an explicit parameterless constructor — it existed only because you cannot add a second one. An override has no such conflict, so those projections now get their published types registered too. That is the intended #4166 behavior, but it means an upgrade can newly provision document storage, and newly register teardown targets under #626, for a projection that was quietly getting neither.

## Verification

- SG tests **34/34**, including four new ones: primary-constructor projection compiles clean, container-built projection actually registers, generator defers to a hand-written override, and the conventional-method emission site.
- `EventTests` **730/730** on net9.0 and net10.0; full solution builds.
- End-to-end through the real delivery path: packed this generator locally, packed a Marten that bundles it, and pointed the reproduction at that package. All three previously-broken shapes compile and report `PublishedTypes: [Thing]`. Full `Marten.slnx` builds and Marten's `EventSourcingTests` runs **1627 passed / 0 failed / 7 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
