### PR TITLE
feat(scenario): wake the high-water agent in process instead of polling (marten#5195)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.42.1</JasperFxVersion>
+        <JasperFxVersion>2.42.2</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/TestSupport/projection_scenario_tests.cs
+++ b/src/EventTests/TestSupport/projection_scenario_tests.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using JasperFx.Core;
 using JasperFx.Events;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
 using JasperFx.Events.TestSupport;
 using NSubstitute;
 using Shouldly;
@@ -211,6 +213,149 @@ public interface IFakeOperations: IFakeQuerySession, IStorageOperations;
 /// Closes the scenario over throwaway session interfaces so the sequencing, flushing, and
 /// failure-handling logic can be exercised without a running store.
 /// </summary>
+/// <summary>
+/// marten#5195. A scenario wipes the event store and then starts the daemon, so the high-water agent's
+/// first look sees an empty store, reads CaughtUp, and settles into SlowPollingTime -- and lands back
+/// there after every batch drains. Rather than slow the store down, the scenario signals the agent
+/// directly: it owns both the appends and the daemon, so it knows activity is coming.
+/// </summary>
+public class projection_scenario_wakeup_tests
+{
+    private readonly FakeProjectionScenario theScenario = new();
+    private readonly DaemonSettings theSettings = new();
+
+    public projection_scenario_wakeup_tests()
+    {
+        theScenario.Settings = theSettings;
+        theScenario.HasAsync = true;
+    }
+
+    [Fact]
+    public async Task installs_an_in_process_wakeup_while_the_scenario_runs()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.WakeupDuringCommit.ShouldBeOfType<ScenarioDaemonWakeup>();
+    }
+
+    [Fact]
+    public async Task restores_the_previous_wakeup_when_the_run_finishes()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theSettings.Wakeup.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task never_displaces_a_wakeup_the_store_already_configured()
+    {
+        // A store that wired up a real wakeup -- Marten's LISTEN/NOTIFY, say -- already does this job,
+        // and swapping it out would change what the scenario is exercising.
+        var existing = new TaskDelayDaemonWakeup();
+        theSettings.Wakeup = existing;
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.WakeupDuringCommit.ShouldBeSameAs(existing);
+        theSettings.Wakeup.ShouldBeSameAs(existing);
+    }
+
+    [Fact]
+    public async Task leaves_the_settings_alone_when_there_are_no_async_projections()
+    {
+        // No daemon is built at all, so there is nothing to wake.
+        theScenario.HasAsync = false;
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.WakeupDuringCommit.ShouldBeNull();
+        theSettings.Wakeup.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_store_that_opts_out_is_untouched()
+    {
+        theScenario.Settings = null;
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+
+        theScenario.WakeupDuringCommit.ShouldBeNull();
+    }
+}
+
+public class scenario_daemon_wakeup_tests
+{
+    private readonly ScenarioDaemonWakeup theWakeup = new();
+
+    [Fact]
+    public async Task a_pulse_releases_the_wait_well_inside_the_timeout()
+    {
+        theWakeup.Pulse();
+
+        var stopwatch = Stopwatch.StartNew();
+        await theWakeup.WaitAsync(30.Seconds(), CancellationToken.None);
+        stopwatch.Stop();
+
+        stopwatch.Elapsed.ShouldBeLessThan(5.Seconds());
+    }
+
+    [Fact]
+    public async Task the_signal_is_sticky_across_an_idle_gap()
+    {
+        // An append that lands while the agent is busy detecting, rather than waiting, must still wake
+        // the wait that follows -- otherwise the scenario stalls exactly when it is doing work.
+        theWakeup.Pulse();
+        await Task.Yield();
+
+        var stopwatch = Stopwatch.StartNew();
+        await theWakeup.WaitAsync(30.Seconds(), CancellationToken.None);
+        stopwatch.Stop();
+
+        stopwatch.Elapsed.ShouldBeLessThan(5.Seconds());
+    }
+
+    [Fact]
+    public async Task without_a_pulse_it_waits_out_the_timeout()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        await theWakeup.WaitAsync(250.Milliseconds(), CancellationToken.None);
+        stopwatch.Stop();
+
+        stopwatch.Elapsed.ShouldBeGreaterThanOrEqualTo(150.Milliseconds());
+    }
+
+    [Fact]
+    public async Task repeated_pulses_collapse_into_one_pending_wake()
+    {
+        // The agent re-reads the real high-water mark every cycle, so one wake already covers every
+        // append committed so far. Queueing more would only spin the loop against an unchanged sequence.
+        for (var i = 0; i < 25; i++) theWakeup.Pulse();
+
+        await theWakeup.WaitAsync(30.Seconds(), CancellationToken.None);
+
+        var stopwatch = Stopwatch.StartNew();
+        await theWakeup.WaitAsync(250.Milliseconds(), CancellationToken.None);
+        stopwatch.Stop();
+
+        stopwatch.Elapsed.ShouldBeGreaterThanOrEqualTo(150.Milliseconds());
+    }
+
+    [Fact]
+    public async Task a_cancelled_wait_throws_rather_than_hanging()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(
+            () => theWakeup.WaitAsync(30.Seconds(), cancellation.Token));
+    }
+}
+
 public class FakeProjectionScenario: ProjectionScenario<IFakeOperations, IFakeQuerySession>
 {
     public IFakeOperations Operations { get; } = Substitute.For<IFakeOperations>();
@@ -221,6 +366,14 @@ public class FakeProjectionScenario: ProjectionScenario<IFakeOperations, IFakeQu
 
     public bool HasAsync { get; set; }
     public bool Cleaned { get; private set; }
+
+    /// <summary>marten#5195: the settings the scenario borrows Wakeup from. Null opts out.</summary>
+    public DaemonSettings? Settings { get; set; }
+
+    protected override DaemonSettings? DaemonSettings => Settings;
+
+    /// <summary>Whatever wakeup was installed at the moment the scenario last committed.</summary>
+    public IDaemonWakeup? WakeupDuringCommit { get; private set; }
     public int SaveCount { get; private set; }
     public string? OpenedTenant { get; private set; }
     public string? DaemonTenant { get; private set; }
@@ -248,6 +401,7 @@ public class FakeProjectionScenario: ProjectionScenario<IFakeOperations, IFakeQu
     protected override Task SaveChangesAsync(IFakeOperations session, CancellationToken ct)
     {
         SaveCount++;
+        WakeupDuringCommit = Settings?.Wakeup;
         return Task.CompletedTask;
     }
 

--- a/src/JasperFx.Events/TestSupport/ProjectionScenario.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenario.cs
@@ -1,5 +1,6 @@
 using JasperFx.Core;
 using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
 
 namespace JasperFx.Events.TestSupport;
 
@@ -29,15 +30,37 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
 
     private IProjectionDaemon? Daemon { get; set; }
 
+    private ScenarioDaemonWakeup? _wakeup;
+    private IDaemonWakeup? _previousWakeup;
+    private bool _wakeupInstalled;
+
+    /// <summary>
+    ///     The daemon settings the scenario's own daemon will run under, when the store exposes them.
+    ///     Returning them lets the scenario borrow <see cref="DaemonSettings.Wakeup" /> for the duration of a
+    ///     run so that its appends wake the high-water agent immediately instead of waiting out
+    ///     <see cref="DaemonSettings.SlowPollingTime" /> at every batch boundary (marten#5195). The previous
+    ///     value is always restored when the run finishes.
+    ///     <para>
+    ///     Null — the default — opts out entirely, and the scenario behaves exactly as it did before. A store
+    ///     that already supplies its own wakeup keeps it: the scenario never displaces one.
+    ///     </para>
+    /// </summary>
+    protected virtual DaemonSettings? DaemonSettings => null;
+
     internal ScenarioStep<TOperations, TQuerySession>? NextStep => _steps.Count != 0 ? _steps.Peek() : null;
 
     internal IEventOperations SessionEvents => EventsFor(_session!);
 
     internal TQuerySession QuerySession => _session!;
 
-    internal Task CommitAsync(CancellationToken ct)
+    internal async Task CommitAsync(CancellationToken ct)
     {
-        return SaveChangesAsync(_session!, ct);
+        await SaveChangesAsync(_session!, ct).ConfigureAwait(false);
+
+        // marten#5195: the events are committed, so tell the high-water agent to look NOW rather than
+        // sleeping out the rest of its polling interval. Null whenever the store did not opt into the
+        // wakeup seam, in which case the scenario polls exactly as it always did.
+        _wakeup?.Pulse();
     }
 
     internal Task AwaitNonStaleDataAsync(CancellationToken ct)
@@ -148,6 +171,10 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
 
         if (HasAnyAsyncProjections)
         {
+            // Must happen BEFORE the daemon is built: HighWaterAgent captures settings.Wakeup in its
+            // constructor, so installing it afterwards would have no effect on this run.
+            installWakeup();
+
             Daemon = await BuildDaemonAsync(TenantId).ConfigureAwait(false);
             await Daemon.StartAllAsync().ConfigureAwait(false);
         }
@@ -233,10 +260,46 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
                 Daemon.SafeDispose();
             }
 
+            // After the daemon is down, so no poll loop is still holding the wakeup we are removing.
+            restoreWakeup();
+
             if (_session is not null)
             {
                 await _session.DisposeAsync().ConfigureAwait(false);
             }
         }
+    }
+
+    /// <summary>
+    /// Borrow <see cref="DaemonSettings.Wakeup"/> for this run. Deliberately conservative: a store that
+    /// opted out, or that already carries its own wakeup (a real LISTEN/NOTIFY implementation, say), is
+    /// left completely alone -- that wakeup already does this job, and displacing it would change what
+    /// the scenario is testing.
+    /// </summary>
+    private void installWakeup()
+    {
+        var settings = DaemonSettings;
+        if (settings is null || settings.Wakeup is not null) return;
+
+        _wakeup = new ScenarioDaemonWakeup();
+        _previousWakeup = settings.Wakeup;
+        settings.Wakeup = _wakeup;
+        _wakeupInstalled = true;
+    }
+
+    private void restoreWakeup()
+    {
+        if (!_wakeupInstalled) return;
+
+        // Only take it back out if it is still ours. Anything else means something outside the scenario
+        // changed the setting mid-run, and stomping that would be worse than leaving it.
+        var settings = DaemonSettings;
+        if (settings is not null && ReferenceEquals(settings.Wakeup, _wakeup))
+        {
+            settings.Wakeup = _previousWakeup;
+        }
+
+        _wakeupInstalled = false;
+        _wakeup = null;
     }
 }

--- a/src/JasperFx.Events/TestSupport/ScenarioDaemonWakeup.cs
+++ b/src/JasperFx.Events/TestSupport/ScenarioDaemonWakeup.cs
@@ -1,0 +1,57 @@
+using JasperFx.Events.Daemon.HighWater;
+
+namespace JasperFx.Events.TestSupport;
+
+/// <summary>
+/// An in-process <see cref="IDaemonWakeup"/> for <see cref="ProjectionScenario{TOperations,TQuerySession}"/>.
+///
+/// <para>A scenario owns both ends of the problem — it appends the events AND it runs the daemon that
+/// must notice them — so it can signal the high-water agent directly. No database round trip and no
+/// LISTEN/NOTIFY: the wake is a semaphore release in the same process.</para>
+///
+/// <para>Without it a scenario pays <c>SlowPollingTime</c> (1s by default) at every batch boundary. The
+/// harness wipes the event store and then starts the daemon, so the agent's first look sees an empty
+/// store and settles into the slow interval; and after each batch drains, <c>CurrentMark ==
+/// HighestSequence</c> puts it right back there. Every append then races a sleeping agent. See marten#5195.</para>
+/// </summary>
+internal sealed class ScenarioDaemonWakeup: IDaemonWakeup
+{
+    private readonly SemaphoreSlim _signal = new(0, 1);
+
+    /// <summary>
+    /// Wake the high-water agent now. Safe to call from any thread and safe to call when nothing is waiting —
+    /// the signal is sticky, so an append that lands between two waits still wakes the following one.
+    /// </summary>
+    public void Pulse()
+    {
+        // Cap the pending signal at one. A burst of appends does not need a wake apiece: the agent re-reads
+        // the real high-water mark on every cycle, so a single wake already covers everything committed so
+        // far, and queueing more would only spin the loop against an unchanged sequence. CurrentCount is a
+        // racy read, hence the SemaphoreFullException guard rather than a lock.
+        if (_signal.CurrentCount != 0) return;
+
+        try
+        {
+            _signal.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // Another thread pulsed between the check and the release. One pending wake is all we wanted.
+        }
+    }
+
+    public async Task WaitAsync(TimeSpan timeout, CancellationToken token)
+    {
+        // False means the timeout elapsed with no append, which is the ordinary idle path -- the agent polls
+        // as it always would. True means an append woke us early, which is the whole point.
+        await _signal.WaitAsync(timeout, token).ConfigureAwait(false);
+    }
+
+    public void Dispose()
+    {
+        // Deliberately does NOT dispose the semaphore. The high-water agent's poll loop may still be sitting
+        // in WaitAsync when the scenario tears down, and disposing underneath it would surface as an
+        // ObjectDisposedException inside the loop. SemaphoreSlim holds no unmanaged resource unless
+        // AvailableWaitHandle is touched, which this type never does, so there is nothing to leak.
+    }
+}


### PR DESCRIPTION
Addresses the larger half of [marten#5195](https://github.com/JasperFx/marten/issues/5195).

## The problem

Almost none of a `ProjectionScenario`'s wall clock is work. A scenario with one batch boundary took ~1.3s against a local Postgres, of which under 200ms was building the daemon, the wipe, and the projection actually catching up.

The harness inflicts most of it on itself. `ExecuteAsync` wipes the event store and *then* starts the daemon, so the high-water agent's first `Detect()` lands on `HighWaterStatistics.InterpretStatus`'s `HighestSequence == 1 && CurrentMark == 0` branch, reads `CaughtUp`, and settles into `SlowPollingTime` — one second by default. Every append then races a sleeping agent.

**It is not a one-time startup cost**, which is worth stressing because it rules out one of the fixes the reporter proposed. After each batch drains, `CurrentMark == HighestSequence` puts the agent straight back into the slow interval, so the penalty recurs at *every* boundary. Starting the daemon before the wipe would only help the first append. And a boundary is the harness's main expressive feature — it is how a scenario says "these appends must land in different daemon batches" — so today the more precisely a test describes its batching, the slower it gets.

## The fix

A scenario owns both ends of this: it appends the events **and** it runs the daemon that has to notice them. So it can simply say so, which is exactly what `IDaemonWakeup` exists for.

`ScenarioDaemonWakeup` is an in-process implementation — a `SemaphoreSlim` release, no database round trip and no LISTEN/NOTIFY — that `CommitAsync` pulses after each commit. The signal is sticky, so an append landing while the agent is mid-detect still wakes the wait that follows, and repeated pulses collapse into one because the agent re-reads the real high-water mark every cycle anyway.

Stores opt in by overriding the new `DaemonSettings` property. It defaults to null, so **Polecat is unaffected until it opts in**. Marten returns `_store.Options.Projections`, since its `ProjectionGraph` *is* the `DaemonSettings` the daemon reads. Two deliberate conservatisms: installation happens before `BuildDaemonAsync` because `HighWaterAgent` captures `settings.Wakeup` in its constructor, and a store that already configured its own wakeup keeps it — that wakeup already does this job, and displacing it would change what the scenario is testing.

## Measured

Marten, default polling (1s / 250ms), scenario wall clock:

| boundaries | before | after |
|---|---|---|
| 1 | 1290ms | 300ms |
| 3 | 3357ms | 815ms |
| 5 | — | 1320ms |

## What this does not fix

A flat ~250ms per boundary remains, from the hard-coded `Task.Delay(250ms)` in Marten's own `WaitForNonStaleDataAsync` poll loop — the other half of marten#5195, deliberately left out.

I built that half too and then backed it out, because replacing the flat delays with a 5ms-doubling backoff destabilizes `DaemonTests.EventProjections.event_projections_end_to_end_ihost.run_simultaneously`. Isolated carefully, since the first comparison was confounded by the local pack also moving JasperFx.Events 2.41.0 → 2.42.x:

| configuration | failures |
|---|---|
| Marten master baseline | 0/18 |
| master + local JasperFx 2.42.x (version delta alone) | 0/18 |
| this wakeup only | 0/12 |
| wakeup + poll backoff | **2/21** |

The `isCaughtUp` predicate is monotone — progression rows only advance — so polling faster cannot observe a state a slower poll would have missed; it can only return sooner. Which means the 250ms was papering over a latent race in that test, which starts two daemons and asserts `distances.Count == travels.Count` immediately after the wait. That deserves its own investigation rather than a tuned magic number, so it stays on marten#5195.

## Verification

`EventTests` 740/740 on net9.0 and net10.0 (10 new), full solution builds, and Marten's scenario suite is 27/27 against a local pack of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde
