### PR TITLE
Compliance wave 6: stream compacting and event data masking (2.43.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.42.2</JasperFxVersion>
+        <JasperFxVersion>2.43.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -139,6 +139,30 @@ public sealed class ComplianceStoreConfig
         return this;
     }
 
+    /// <summary>
+    /// Register a mutating masking rule for an event type.
+    /// </summary>
+    /// <remarks>
+    /// Both products spell this <c>Events.AddMaskingRuleForProtectedInformation&lt;T&gt;</c> with
+    /// identical signatures, but on their own event options rather than on any shared interface,
+    /// which is the whole reason this seam member exists.
+    /// </remarks>
+    public ComplianceStoreConfig AddMaskingRule<TEvent>(Action<TEvent> rule) where TEvent : notnull
+    {
+        _registrations.Add(registrar => registrar.AddMaskingRule(rule));
+        return this;
+    }
+
+    /// <summary>
+    /// Register a replacing masking rule for an event type — the form a <c>record</c> needs.
+    /// </summary>
+    /// <inheritdoc cref="AddMaskingRule{TEvent}(Action{TEvent})" path="/remarks"/>
+    public ComplianceStoreConfig AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull
+    {
+        _registrations.Add(registrar => registrar.AddMaskingRule(rule));
+        return this;
+    }
+
     public ComplianceStoreConfig LiveAggregation<TDoc>() where TDoc : notnull
     {
         LiveAggregations.Add(typeof(TDoc));

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -174,6 +174,26 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
         string tableName, CancellationToken token);
 
     /// <summary>
+    /// Execute a batch data-masking operation against already-stored events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Protected.IEventDataMasking"/> itself is shared — it was lifted into
+    /// <c>JasperFx.Events.Protected</c> in jasperfx#635 — but the entry point that hands one out is
+    /// not. Both products spell it <c>Advanced.ApplyEventDataMasking(Action&lt;IEventDataMasking&gt;,
+    /// CancellationToken)</c>, and both <c>Advanced</c> surfaces are store-specific types that share
+    /// no interface, so the lift alone did not make masking reachable from a shared suite. This is
+    /// the one member that closes that gap.
+    /// </para>
+    /// <para>
+    /// Deliberately not typed as "give me the store's advanced operations" — that would drag an
+    /// unbounded product surface into the seam. The suite asks for the one operation it needs.
+    /// </para>
+    /// </remarks>
+    public abstract Task ApplyEventDataMaskingAsync(
+        Action<Protected.IEventDataMasking> configure, CancellationToken token);
+
+    /// <summary>
     /// False in stores that build live aggregators automatically and reject explicit registration.
     /// </summary>
     public virtual bool SupportsLiveAggregationRegistration => true;

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -51,6 +51,25 @@ public interface IComplianceStoreRegistrar
     void RegisterValueType<TValue>() where TValue : notnull;
 
     /// <summary>
+    /// Register a mutating masking rule for an event type — the in-place form, for events whose
+    /// protected members are settable.
+    /// </summary>
+    /// <remarks>
+    /// Both products spell this <c>Events.AddMaskingRuleForProtectedInformation&lt;T&gt;</c> with
+    /// identical signatures, but on their own event options rather than on any shared interface, so
+    /// it has to come through the registrar. Rules are contravariant on both: a rule registered
+    /// against an interface applies to every event type implementing it.
+    /// </remarks>
+    void AddMaskingRule<TEvent>(Action<TEvent> rule) where TEvent : notnull;
+
+    /// <summary>
+    /// Register a replacing masking rule for an event type — the functional form, which is what a
+    /// <c>record</c> with init-only members needs.
+    /// </summary>
+    /// <inheritdoc cref="AddMaskingRule{TEvent}(Action{TEvent})" path="/remarks"/>
+    void AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull;
+
+    /// <summary>
     /// Register an already-constructed projection instance.
     /// </summary>
     /// <remarks>

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -120,6 +120,8 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Multi-stream projection grouping and fan-out | `MultiStreamProjectionCompliance` |
 | Snapshot lifecycle equivalence (Inline / Async / Live) | `SnapshotLifecycleCompliance` |
 | Strong-typed identifiers on aggregates | `StrongTypedIdentityCompliance` |
+| Stream compacting into a `Compacted<T>` snapshot | `StreamCompactingCompliance` |
+| Batch data masking of stored events | `EventDataMaskingCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventDataMaskingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventDataMaskingCompliance.cs
@@ -279,13 +279,17 @@ public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySe
         var events = await eventsForAsync(streamId);
 
         var contacted = events.Single(x => x.Data is SubjectContacted);
-        contacted.Headers.ShouldNotBeNull();
-        contacted.Headers!["erasure"].ShouldBe("case-17");
+
+        // Through GetHeader and compared as a string, following EventMetadataCompliance: header
+        // values do not round-trip as the same runtime type on both stores (one rehydrates them as
+        // the CLR type, the other as a JsonElement), and that divergence is out of scope here.
+        contacted.GetHeader("erasure").ShouldNotBeNull();
+        contacted.GetHeader("erasure")!.ToString().ShouldBe("case-17");
 
         // Every other event in the same stream is left without the header.
         foreach (var @event in events.Where(x => x.Data is not SubjectContacted))
         {
-            (@event.Headers?.ContainsKey("erasure") ?? false).ShouldBeFalse();
+            @event.GetHeader("erasure").ShouldBeNull();
         }
     }
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventDataMaskingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventDataMaskingCompliance.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Event data masking events
+
+/// <summary>
+/// Implemented by two event types so a rule registered against the interface can be shown to reach
+/// both — masking rules match contravariantly on both products.
+/// </summary>
+public interface IComplianceSubjectEvent
+{
+    string Subject { get; set; }
+}
+
+public class SubjectRegistered: IComplianceSubjectEvent
+{
+    public string Subject { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}
+
+public class SubjectContacted: IComplianceSubjectEvent
+{
+    public string Subject { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A record, so the replacing <c>Func&lt;T,T&gt;</c> rule form has something with init-only members
+/// to work against. The mutating form cannot express this.
+/// </summary>
+public record SubjectNoteAdded(string Author, string Note);
+
+/// <summary>
+/// Carries no masking rule at all, so it can prove that a masking pass leaves unregistered event
+/// types alone rather than blanking everything in the stream.
+/// </summary>
+public class SubjectClosed
+{
+    public string Reason { get; set; } = string.Empty;
+}
+
+#endregion
+
+/// <summary>
+/// Batch data masking of already-stored events — the GDPR-style erasure path, where protected
+/// information is rewritten in place without rewriting or replaying the stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two halves have to agree for this to work, and each store owns one: the <em>rules</em>, declared
+/// per event type on the store's event options, and the <em>selection</em>, declared per operation
+/// through <see cref="Protected.IEventDataMasking"/>. A rule with no matching selection does
+/// nothing; a selection with no matching rule also does nothing. Every test here pins the
+/// intersection, and — just as importantly — pins what stays untouched, because a masking bug that
+/// over-applies is far worse than one that under-applies.
+/// </para>
+/// <para>
+/// <see cref="Protected.IEventDataMasking"/> became shared in jasperfx#635, but the entry point
+/// that hands one out did not: both products expose it as
+/// <c>Advanced.ApplyEventDataMasking(...)</c> on store-specific advanced-operations types that
+/// share no interface. So this suite costs exactly three seam members —
+/// <c>ApplyEventDataMaskingAsync</c> on the fixture and the two <c>AddMaskingRule</c> overloads on
+/// the config — and marten#5154's "the lift makes it portable" framing was half right: the lift
+/// made the <em>vocabulary</em> shared, not the reach.
+/// </para>
+/// <para>
+/// Deliberately not asserted: what an empty masking request does. One product's own tests pin it as
+/// throwing, and nothing documents that as a cross-store contract, so encoding it here would pin an
+/// implementation detail rather than a promise — the same trap the FetchLatest suite hit over
+/// uncommitted appends.
+/// </para>
+/// </remarks>
+public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private const string Masked = "*****";
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_masking";
+        config.EnableHeaders = true;
+
+        config.AddEventType<SubjectRegistered>();
+        config.AddEventType<SubjectContacted>();
+        config.AddEventType<SubjectNoteAdded>();
+        config.AddEventType<SubjectClosed>();
+
+        // Contravariant: one rule against the interface reaches both implementing event types.
+        config.AddMaskingRule<IComplianceSubjectEvent>(x => x.Subject = Masked);
+
+        // A second rule against a concrete type, to prove rules compose rather than replace.
+        config.AddMaskingRule<SubjectRegistered>(x => x.Email = Masked);
+
+        // The replacing form, which is the only one a record with init-only members can use.
+        config.AddMaskingRule<SubjectNoteAdded>(x => x with { Note = Masked });
+    };
+
+    /// <summary>
+    /// Same rules, string stream identity, so the string <c>IncludeStream</c> overload has a store
+    /// it can actually address.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _stringConfiguration = config =>
+    {
+        config.SchemaName = "compliance_masking_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+        config.EnableHeaders = true;
+
+        config.AddEventType<SubjectRegistered>();
+        config.AddEventType<SubjectContacted>();
+        config.AddEventType<SubjectClosed>();
+
+        config.AddMaskingRule<IComplianceSubjectEvent>(x => x.Subject = Masked);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static object[] theSubjectEvents() =>
+    [
+        new SubjectRegistered { Subject = "Hilda Ravenswood", Email = "hilda@example.com" },
+        new SubjectContacted { Subject = "Hilda Ravenswood", Channel = "email" },
+        new SubjectNoteAdded("caseworker", "Lives at 14 Rookery Lane"),
+        new SubjectClosed { Reason = "resolved" }
+    ];
+
+    private async Task<Guid> aSubjectAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, theSubjectEvents());
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task<IReadOnlyList<IEvent>> eventsForAsync(Guid streamId)
+    {
+        await using var query = OpenSession();
+        return await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+    }
+
+    [Fact]
+    public async Task a_rule_masks_the_matching_event_in_an_included_stream()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+        var registered = events.Select(x => x.Data).OfType<SubjectRegistered>().Single();
+
+        registered.Subject.ShouldBe(Masked);
+    }
+
+    [Fact]
+    public async Task rules_compose_rather_than_replace_one_another()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+        var registered = events.Select(x => x.Data).OfType<SubjectRegistered>().Single();
+
+        // The interface rule and the concrete rule both ran against the same event.
+        registered.Subject.ShouldBe(Masked);
+        registered.Email.ShouldBe(Masked);
+    }
+
+    [Fact]
+    public async Task a_rule_registered_against_an_interface_reaches_every_implementing_event()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+
+        events.Select(x => x.Data).OfType<SubjectRegistered>().Single().Subject.ShouldBe(Masked);
+        events.Select(x => x.Data).OfType<SubjectContacted>().Single().Subject.ShouldBe(Masked);
+    }
+
+    [Fact]
+    public async Task the_replacing_rule_form_masks_a_record()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+        var note = events.Select(x => x.Data).OfType<SubjectNoteAdded>().Single();
+
+        note.Note.ShouldBe(Masked);
+
+        // Replaced, not blanked: members the rule did not touch survive.
+        note.Author.ShouldBe("caseworker");
+    }
+
+    [Fact]
+    public async Task an_event_type_with_no_rule_is_left_alone()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+        var closed = events.Select(x => x.Data).OfType<SubjectClosed>().Single();
+
+        closed.Reason.ShouldBe("resolved");
+    }
+
+    [Fact]
+    public async Task a_stream_that_was_not_included_is_untouched()
+    {
+        var included = await aSubjectAsync();
+        var excluded = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(included), Cancellation);
+
+        var events = await eventsForAsync(excluded);
+        var registered = events.Select(x => x.Data).OfType<SubjectRegistered>().Single();
+
+        registered.Subject.ShouldBe("Hilda Ravenswood");
+        registered.Email.ShouldBe("hilda@example.com");
+    }
+
+    [Fact]
+    public async Task masking_does_not_add_events_or_change_the_stream_version()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        await using var query = OpenSession();
+
+        var state = await EventsFor(query).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(4);
+
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+        events.Count.ShouldBe(4);
+        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
+    }
+
+    [Fact]
+    public async Task a_stream_filter_narrows_the_masking_to_matching_events()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(
+            x => x.IncludeStream(streamId, e => e.Data is SubjectContacted), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+
+        events.Select(x => x.Data).OfType<SubjectContacted>().Single().Subject.ShouldBe(Masked);
+
+        // The filter excluded this one even though a rule matches its type.
+        events.Select(x => x.Data).OfType<SubjectRegistered>().Single()
+            .Subject.ShouldBe("Hilda Ravenswood");
+    }
+
+    [Fact]
+    public async Task added_headers_land_on_the_masked_events_only()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(
+            x => x.IncludeStream(streamId, e => e.Data is SubjectContacted).AddHeader("erasure", "case-17"),
+            Cancellation);
+
+        var events = await eventsForAsync(streamId);
+
+        var contacted = events.Single(x => x.Data is SubjectContacted);
+        contacted.Headers.ShouldNotBeNull();
+        contacted.Headers!["erasure"].ShouldBe("case-17");
+
+        // Every other event in the same stream is left without the header.
+        foreach (var @event in events.Where(x => x.Data is not SubjectContacted))
+        {
+            (@event.Headers?.ContainsKey("erasure") ?? false).ShouldBeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task a_string_identified_stream_masks_the_same_way()
+    {
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var streamKey = $"subject/{Guid.NewGuid():N}";
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamKey,
+                new SubjectRegistered { Subject = "Hilda Ravenswood", Email = "hilda@example.com" },
+                new SubjectClosed { Reason = "resolved" });
+            await SaveChangesAsync(session);
+        }
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamKey), Cancellation);
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamKey, token: Cancellation);
+
+        events.Select(x => x.Data).OfType<SubjectRegistered>().Single().Subject.ShouldBe(Masked);
+        events.Select(x => x.Data).OfType<SubjectClosed>().Single().Reason.ShouldBe("resolved");
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamCompactingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamCompactingCompliance.cs
@@ -1,0 +1,440 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Protected;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Stream compacting events and aggregate
+
+public record MeterInstalled(string Location);
+
+public record MeterRead(int Reading);
+
+public record MeterServiced;
+
+/// <summary>
+/// Folds into a running total, so a compacted stream and an uncompacted one are distinguishable
+/// only by what is stored, never by what the aggregate says.
+/// </summary>
+public partial class ComplianceMeter
+{
+    public Guid Id { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public int Total { get; set; }
+    public int ReadCount { get; set; }
+    public int ServiceCount { get; set; }
+
+    public static ComplianceMeter Create(MeterInstalled e) => new() { Location = e.Location };
+
+    public void Apply(MeterRead e)
+    {
+        Total += e.Reading;
+        ReadCount++;
+    }
+
+    public void Apply(MeterServiced _) => ServiceCount++;
+}
+
+/// <summary>
+/// The same aggregate keyed by a string, for the string-identified half. A separate type rather
+/// than a reused one because stream identity is a store-level setting and the identity type of the
+/// aggregate document has to agree with it — registering a Guid-keyed document in an
+/// <c>AsString</c> store is a configuration error on both products, not a runtime surprise.
+/// </summary>
+public partial class ComplianceStringMeter
+{
+    public string Id { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public int Total { get; set; }
+    public int ReadCount { get; set; }
+    public int ServiceCount { get; set; }
+
+    public static ComplianceStringMeter Create(MeterInstalled e) => new() { Location = e.Location };
+
+    public void Apply(MeterRead e)
+    {
+        Total += e.Reading;
+        ReadCount++;
+    }
+
+    public void Apply(MeterServiced _) => ServiceCount++;
+}
+
+#endregion
+
+/// <summary>
+/// <c>CompactStreamAsync&lt;T&gt;</c> — replacing a stream's earlier events with a single
+/// <c>Compacted&lt;T&gt;</c> snapshot event, without changing what the stream aggregates to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The whole point of compacting is that it is supposed to be invisible from the read side: the
+/// events go away, the answer does not change. So every test here pairs a storage assertion (how
+/// many events survive, and what the survivor is) with a behavioural one (what the stream still
+/// aggregates to). A store that drops the folded state, or folds it and then loses the events it
+/// should have kept, fails the second half while passing the first.
+/// </para>
+/// <para>
+/// The declaration was lifted onto <see cref="IEventStoreOperations"/> in jasperfx#635 as
+/// default-implemented members that throw, so this suite reaches it through the shared operations
+/// surface and needs no seam addition at all. A store without compacting would surface as a
+/// <see cref="NotSupportedException"/> from the DIM rather than a compile error, which is the point
+/// of that shape — see marten#5153.
+/// </para>
+/// <para>
+/// <strong>Version preservation is the assertion most likely to catch drift.</strong> Compacting is
+/// destructive to rows but must NOT rewind the stream: the stream version after compacting a
+/// nine-event stream is still nine, and the surviving <c>Compacted&lt;T&gt;</c> event carries that
+/// version rather than version one. Only one product's own tests pinned this before the suite
+/// existed; the other asserted merely that appending afterwards still worked, which passes
+/// vacuously if the version rewound and then climbed again.
+/// </para>
+/// <para>
+/// Out of scope on purpose: the <c>Timestamp</c> cut-off on the request. Deriving a cut-off that
+/// discriminates requires two commits with server-side timestamps far enough apart to order
+/// reliably on a CI host that is not the database host, and the version cut-off already covers the
+/// partial-compaction path deterministically.
+/// </para>
+/// </remarks>
+public abstract class StreamCompactingCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_compacting";
+        config.Snapshot<ComplianceMeter>(SnapshotLifecycle.Inline);
+    };
+
+    /// <summary>
+    /// Stream identity is a store-level setting, so the string-keyed half needs its own store.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _stringConfiguration = config =>
+    {
+        config.SchemaName = "compliance_compacting_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+        config.Snapshot<ComplianceStringMeter>(SnapshotLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// Nine events: one install, six reads totalling 210, two services. Deliberately more than a
+    /// handful so a version cut-off can land in the middle with events on both sides.
+    /// </summary>
+    private static object[] theNineEvents() =>
+    [
+        new MeterInstalled("Substation A"),
+        new MeterRead(10),
+        new MeterRead(20),
+        new MeterServiced(),
+        new MeterRead(30),
+        new MeterRead(40),
+        new MeterServiced(),
+        new MeterRead(50),
+        new MeterRead(60)
+    ];
+
+    private async Task<Guid> aMeterAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceMeter>(streamId, theNineEvents());
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task compacting_at_the_latest_leaves_a_single_compacted_event()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<Compacted<ComplianceMeter>>();
+    }
+
+    [Fact]
+    public async Task the_compacted_event_carries_the_folded_snapshot()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        var compacted = events.Single().Data.ShouldBeOfType<Compacted<ComplianceMeter>>();
+
+        compacted.Snapshot.ShouldNotBeNull();
+        compacted.Snapshot.Location.ShouldBe("Substation A");
+        compacted.Snapshot.Total.ShouldBe(210);
+        compacted.Snapshot.ReadCount.ShouldBe(6);
+        compacted.Snapshot.ServiceCount.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Compacting is destructive to rows but must not rewind the stream.
+    /// </summary>
+    [Fact]
+    public async Task compacting_preserves_the_stream_version()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+
+        var state = await EventsFor(query).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(9);
+
+        // ... and the survivor is stamped with that version, not with version 1.
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+        events.Single().Version.ShouldBe(9);
+    }
+
+    [Fact]
+    public async Task aggregating_a_compacted_stream_reproduces_the_pre_compaction_state()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var meter = await EventsFor(query).AggregateStreamAsync<ComplianceMeter>(streamId, token: Cancellation);
+
+        meter.ShouldNotBeNull();
+        meter.Location.ShouldBe("Substation A");
+        meter.Total.ShouldBe(210);
+        meter.ReadCount.ShouldBe(6);
+        meter.ServiceCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task compacting_at_a_version_keeps_the_events_after_it()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session)
+                .CompactStreamAsync<ComplianceMeter>(streamId, x => x.Version = 5);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        // The five compacted events collapse into one, and versions 6-9 survive untouched.
+        events.Count.ShouldBe(5);
+
+        var compacted = events[0].Data.ShouldBeOfType<Compacted<ComplianceMeter>>();
+        events[0].Version.ShouldBe(5);
+
+        // Only the first five events are folded into the snapshot: one install, three reads
+        // totalling 60, one service.
+        compacted.Snapshot.Total.ShouldBe(60);
+        compacted.Snapshot.ReadCount.ShouldBe(3);
+        compacted.Snapshot.ServiceCount.ShouldBe(1);
+
+        events.Skip(1).Select(x => x.Version).ShouldBe(new long[] { 6, 7, 8, 9 });
+    }
+
+    [Fact]
+    public async Task compacting_at_a_version_still_aggregates_to_the_whole_stream()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session)
+                .CompactStreamAsync<ComplianceMeter>(streamId, x => x.Version = 5);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var meter = await EventsFor(query).AggregateStreamAsync<ComplianceMeter>(streamId, token: Cancellation);
+
+        meter.ShouldNotBeNull();
+        meter.Total.ShouldBe(210);
+        meter.ReadCount.ShouldBe(6);
+        meter.ServiceCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task appending_after_compacting_continues_the_stream()
+    {
+        var streamId = await aMeterAsync();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new MeterRead(90));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+        events.Count.ShouldBe(2);
+        events.Last().Version.ShouldBe(10);
+
+        var meter = await EventsFor(query).AggregateStreamAsync<ComplianceMeter>(streamId, token: Cancellation);
+        meter.ShouldNotBeNull();
+        meter.Total.ShouldBe(300);
+        meter.ReadCount.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task compacting_twice_is_idempotent()
+    {
+        var streamId = await aMeterAsync();
+
+        for (var i = 0; i < 2; i++)
+        {
+            await using var session = OpenSession();
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+        events.Count.ShouldBe(1);
+
+        // The second pass must not re-fold the snapshot into a snapshot-of-a-snapshot, and must not
+        // double-count what the first pass already folded.
+        var compacted = events.Single().Data.ShouldBeOfType<Compacted<ComplianceMeter>>();
+        compacted.Snapshot.Total.ShouldBe(210);
+        compacted.Snapshot.ReadCount.ShouldBe(6);
+
+        var meter = await EventsFor(query).AggregateStreamAsync<ComplianceMeter>(streamId, token: Cancellation);
+        meter.ShouldNotBeNull();
+        meter.Total.ShouldBe(210);
+    }
+
+    [Fact]
+    public async Task compacting_a_stream_that_does_not_exist_is_a_no_op()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+        await SaveChangesAsync(session);
+
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+        events.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task the_archiver_sees_the_events_that_are_about_to_be_replaced()
+    {
+        var streamId = await aMeterAsync();
+        var archiver = new RecordingArchiver();
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId, x =>
+            {
+                x.Version = 5;
+                x.Archiver = archiver;
+            });
+            await SaveChangesAsync(session);
+        }
+
+        // Called once, before the destructive step, with exactly the events being replaced.
+        archiver.Calls.ShouldBe(1);
+        archiver.Events.Count.ShouldBe(5);
+        archiver.Events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task a_string_identified_stream_compacts_the_same_way()
+    {
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var streamKey = $"meter/{Guid.NewGuid():N}";
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceStringMeter>(streamKey, theNineEvents());
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceStringMeter>(streamKey);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+
+        var events = await EventsFor(query).FetchStreamAsync(streamKey, token: Cancellation);
+        events.Count.ShouldBe(1);
+        events.Single().Version.ShouldBe(9);
+
+        var compacted = events.Single().Data.ShouldBeOfType<Compacted<ComplianceStringMeter>>();
+        compacted.Snapshot.Total.ShouldBe(210);
+
+        var meter = await EventsFor(query)
+            .AggregateStreamAsync<ComplianceStringMeter>(streamKey, token: Cancellation);
+        meter.ShouldNotBeNull();
+        meter.Total.ShouldBe(210);
+    }
+
+    /// <summary>
+    /// Nested so it can close <see cref="IEventsArchiver{TOperations}"/> over the suite's own
+    /// <typeparamref name="TOperations"/> — the request carries the non-generic marker and each
+    /// product downcasts to the closed generic at execution time.
+    /// </summary>
+    private sealed class RecordingArchiver: IEventsArchiver<TOperations>
+    {
+        public int Calls { get; private set; }
+
+        public IReadOnlyList<IEvent> Events { get; private set; } = Array.Empty<IEvent>();
+
+        public Task MaybeArchiveAsync<T>(TOperations operations, StreamCompactingRequest<T> request,
+            IReadOnlyList<IEvent> events, CancellationToken cancellation) where T : class
+        {
+            Calls++;
+            Events = events;
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
The two suites the 2.41.0 lifts existed to enable — marten#5153 and marten#5154. Library **22 → 24 suites, 178 → 199 tests**.

| Suite | Tests | Seam cost |
|---|---|---|
| `StreamCompactingCompliance` | 11 | **none** |
| `EventDataMaskingCompliance` | 10 | 3 members |

## `StreamCompactingCompliance` — zero seam, which is the point

`CompactStreamAsync<T>` is reached through the shared `IEventStoreOperations`, so this suite costs nothing but the file. That is exactly what the lift was for.

Compacting is supposed to be invisible from the read side, so every test pairs a **storage** assertion (how many events survive, and what the survivor is) with a **behavioural** one (what the stream still aggregates to). A store that drops the folded state, or folds it and then loses the events it should have kept, fails the second half while passing the first.

Covered: compact-at-latest, compact-at-version with the later events surviving untouched, idempotency, the no-op on a stream that does not exist, appending afterwards, the archiver callback, and the string-identified stream.

**Version preservation gets its own test** because it was the likeliest place to drift. Only Marten's own tests pinned that compacting a nine-event stream leaves the version at nine and stamps the surviving `Compacted<T>` with it. Polecat's mirror asserted only that appending afterwards still worked — which passes vacuously if the version rewound and then climbed again.

## `EventDataMaskingCompliance` — and a correction to #5154's framing

Lifting `IEventDataMasking` made the **vocabulary** shared, not the reach. Both products hand one out through `Advanced.ApplyEventDataMasking(...)` on store-specific advanced-operations types that share no interface, and register rules through their own event options. So the suite costs three seam members: `ApplyEventDataMaskingAsync` on the fixture, and the two `AddMaskingRule` overloads (`Action<T>` and `Func<T,T>`) on the config.

## ⚠️ Found a real bug — present in **both** products

`EventGraph.TryMask` ran its maskers as:

```csharp
matched = matched || masker.TryMask(e);
```

`||` short-circuits. The first rule to match an event stops every later rule from being invoked at all. Register two rules that both apply — one on an interface and one on the concrete type, say — and **only the first-registered one ever runs, while the operation still reports success**. For a right-to-erasure feature that means protected information silently survives a masking pass that looked like it worked.

The implementations are byte-identical in both repos, so this is two fixes rather than one — the code was duplicated, not shared. `rules_compose_rather_than_replace_one_another` is the test that catches it, and it failed on Marten before the fix.

## Deliberate omissions, both recorded in the suite docs

- **What an empty masking request does.** One product's own tests pin it as throwing; nothing documents that as a cross-store contract. Encoding it would pin an implementation detail rather than a promise — the same trap the `FetchLatest` suite hit over uncommitted appends.
- **The `Timestamp` cut-off on a compacting request.** Deriving one that discriminates needs two commits with server-side timestamps far enough apart to order reliably on a CI host that is not the database host, and the version cut-off already covers partial compaction deterministically.

## Verification

Marten (via `ComplianceSourceDir`): compacting **11/11**, masking **10/10**, and Marten's own 11 `removing_protected_information` tests still green alongside the product fix. Polecat verification lands with its adoption PR.

Bumps `JasperFxVersion` to **2.43.0** — a merge touching shipped code that does not bump the version is silently skipped by `--skip-duplicate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde