### PR TITLE
Compliance wave 7: projection rebuild/catch-up and the dead letter path (2.44.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.43.0</JasperFxVersion>
+        <JasperFxVersion>2.44.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -122,6 +122,8 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Strong-typed identifiers on aggregates | `StrongTypedIdentityCompliance` |
 | Stream compacting into a `Compacted<T>` snapshot | `StreamCompactingCompliance` |
 | Batch data masking of stored events | `EventDataMaskingCompliance` |
+| Projection rebuild and catch-up semantics | `RebuildAndCatchUpCompliance` |
+| The projection error path and dead letters | `DeadLetterCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/DeadLetterCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DeadLetterCompliance.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Dead letter events and aggregate
+
+public record ReactorStarted(string Name);
+
+public record ReactorPulsed(int Output);
+
+/// <summary>
+/// Applying this event always throws. It is the whole mechanism of this suite: a poison event in an
+/// otherwise ordinary stream, so the error path can be exercised without any store-specific hook.
+/// </summary>
+public record ReactorFaulted(string Reason);
+
+public partial class ComplianceReactor
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Output { get; set; }
+
+    public static ComplianceReactor Create(ReactorStarted e) => new() { Name = e.Name };
+
+    public void Apply(ReactorPulsed e) => Output += e.Output;
+
+    public void Apply(ReactorFaulted e)
+        => throw new InvalidOperationException($"Reactor fault: {e.Reason}");
+}
+
+#endregion
+
+/// <summary>
+/// The projection error path — what happens to an async projection when applying an event throws,
+/// and what the store records about it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two behaviours are worth pinning across stores and neither is obvious. First, that a skip policy
+/// actually <em>skips</em>: the shard survives the poison event and keeps projecting the events
+/// after it, rather than stopping or silently dropping the rest of the stream. Second, that the
+/// skipped event is <em>recorded</em> rather than lost — a dead letter row a human or a monitoring
+/// tool can find, carrying enough to identify the event and the failure.
+/// </para>
+/// <para>
+/// The error policy is reached through <c>IEventStore&lt;TOperations, TQuerySession&gt;.ContinuousErrors</c>,
+/// and the dead letters through <c>IEventStore.AllDatabases()</c> →
+/// <c>IEventDatabase.QueryDeadLetterEventsAsync</c>. Both are already shared, so this suite needs no
+/// seam addition — the reason it moved out of the "needs a seam" group (marten#5149). The cast from
+/// the fixture's non-generic <see cref="IEventStore"/> to the closed generic is safe because this
+/// suite is generic over the same pair the store closes over.
+/// </para>
+/// <para>
+/// Deliberately not asserted: the stop-on-error policy. Whether a shard pauses, stops, or faults —
+/// and how a caller observes that — is expressed differently enough between the products that
+/// encoding one shape here would pin an implementation rather than a promise. The skip path is the
+/// one both products document.
+/// </para>
+/// </remarks>
+public abstract class DeadLetterCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_dead_letters";
+        config.Snapshot<ComplianceReactor>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessDaemonIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+    }
+
+    /// <summary>
+    /// Turn on skip-and-record for apply errors, through the shared error-handling options.
+    /// </summary>
+    private void skipApplyErrors()
+    {
+        var store = (IEventStore<TOperations, TQuerySession>)theFixture.EventStore;
+        store.ContinuousErrors.SkipApplyErrors = true;
+    }
+
+    private async Task<Guid> aFaultingReactorAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceReactor>(streamId,
+            new ReactorStarted("Alpha"),
+            new ReactorPulsed(10),
+            new ReactorFaulted("coolant"),
+            new ReactorPulsed(5));
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task<DeadLetterEvent[]> deadLettersAsync()
+    {
+        var databases = await theFixture.EventStore.AllDatabases();
+
+        // Compose rather than a constructor: jasperfx#419 made it the single path for building a
+        // shard identity, and the products only agree on the grammar it produces.
+        var shard = ShardName.Compose(nameof(ComplianceReactor));
+
+        var all = new System.Collections.Generic.List<DeadLetterEvent>();
+        foreach (var database in databases)
+        {
+            var rows = await database
+                .QueryDeadLetterEventsAsync(shard, null, 0, 100, Cancellation);
+            all.AddRange(rows);
+        }
+
+        return all.ToArray();
+    }
+
+    [Fact]
+    public async Task the_shard_survives_a_poison_event_and_keeps_going()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        skipApplyErrors();
+        var streamId = await aFaultingReactorAsync();
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+        var reactor = await LoadDocumentAsync<ComplianceReactor>(query, streamId);
+
+        reactor.ShouldNotBeNull();
+        reactor.Name.ShouldBe("Alpha");
+
+        // 10 before the fault and 5 after it: the poison event was skipped, not the rest of the
+        // stream. A store that stopped at the fault would report 10.
+        reactor.Output.ShouldBe(15);
+    }
+
+    [Fact]
+    public async Task the_skipped_event_is_recorded_as_a_dead_letter()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        skipApplyErrors();
+        await aFaultingReactorAsync();
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        var deadLetters = await deadLettersAsync();
+
+        deadLetters.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task the_dead_letter_row_identifies_the_projection_and_the_failure()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        skipApplyErrors();
+        await aFaultingReactorAsync();
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        var deadLetter = (await deadLettersAsync()).First();
+
+        deadLetter.ProjectionName.ShouldBe(nameof(ComplianceReactor));
+
+        // Enough to find the offending event again, and enough to say what went wrong.
+        deadLetter.EventSequence.ShouldBeGreaterThan(0);
+        deadLetter.ExceptionMessage.ShouldNotBeNullOrEmpty();
+
+        // ExceptionType names the INNER exception -- the one the projection actually threw -- while
+        // ExceptionMessage carries the wrapping ApplyEventException's own message, which is composed
+        // by the daemon and is not the place to look for the original reason. Asserting the inner
+        // type rather than searching the message is what the shared ctor actually promises
+        // (DeadLetterEvent.cs: ExceptionType = ex.InnerException?.GetType().NameInCode()).
+        deadLetter.ExceptionType.ShouldBe(nameof(InvalidOperationException));
+    }
+
+    [Fact]
+    public async Task a_stream_with_no_faults_produces_no_dead_letters()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        skipApplyErrors();
+
+        var streamId = Guid.NewGuid();
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceReactor>(streamId,
+                new ReactorStarted("Beta"), new ReactorPulsed(7));
+            await SaveChangesAsync(session);
+        }
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        (await deadLettersAsync()).ShouldBeEmpty();
+
+        await using var query = OpenSession();
+        var reactor = await LoadDocumentAsync<ComplianceReactor>(query, streamId);
+        reactor.ShouldNotBeNull();
+        reactor.Output.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task one_faulting_stream_does_not_stop_another_stream_from_projecting()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        skipApplyErrors();
+
+        await aFaultingReactorAsync();
+
+        var healthyId = Guid.NewGuid();
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceReactor>(healthyId,
+                new ReactorStarted("Gamma"), new ReactorPulsed(42));
+            await SaveChangesAsync(session);
+        }
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+        var healthy = await LoadDocumentAsync<ComplianceReactor>(query, healthyId);
+
+        healthy.ShouldNotBeNull();
+        healthy.Output.ShouldBe(42);
+    }
+
+    [Fact]
+    public async Task skip_apply_errors_is_readable_back_off_the_shared_options()
+    {
+        // Not a daemon test -- it pins that the error-handling options a caller sets are the same
+        // live object the store consults, rather than a copy handed out per read. If this ever
+        // returns a snapshot the two tests above would silently stop configuring anything.
+        var store = (IEventStore<TOperations, TQuerySession>)theFixture.EventStore;
+
+        store.ContinuousErrors.SkipApplyErrors = true;
+        store.ContinuousErrors.SkipApplyErrors.ShouldBeTrue();
+
+        store.ContinuousErrors.SkipApplyErrors = false;
+        store.ContinuousErrors.SkipApplyErrors.ShouldBeFalse();
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/RebuildAndCatchUpCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/RebuildAndCatchUpCompliance.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Rebuild and catch-up events and aggregates
+
+public record TurbineInstalled(string Site);
+
+public record TurbineSpun(int Revolutions);
+
+public record TurbineHalted;
+
+public partial class ComplianceTurbine
+{
+    public Guid Id { get; set; }
+    public string Site { get; set; } = string.Empty;
+    public int TotalRevolutions { get; set; }
+    public int SpinCount { get; set; }
+    public bool Halted { get; set; }
+
+    public static ComplianceTurbine Create(TurbineInstalled e) => new() { Site = e.Site };
+
+    public void Apply(TurbineSpun e)
+    {
+        TotalRevolutions += e.Revolutions;
+        SpinCount++;
+    }
+
+    public void Apply(TurbineHalted _) => Halted = true;
+}
+
+/// <summary>
+/// A second async projection over the same events, so a rebuild of one can be shown not to disturb
+/// the other. Counts only installations, so its state is trivially distinguishable.
+/// </summary>
+public partial class ComplianceTurbineAudit
+{
+    public Guid Id { get; set; }
+    public string Site { get; set; } = string.Empty;
+    public int Revisions { get; set; }
+
+    public static ComplianceTurbineAudit Create(TurbineInstalled e) => new() { Site = e.Site, Revisions = 1 };
+
+    public void Apply(TurbineSpun _) => Revisions++;
+}
+
+#endregion
+
+/// <summary>
+/// Projection rebuild and catch-up — replaying an async projection from the event stream, and the
+/// guarantees a caller is entitled to about what the replay leaves behind.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AsyncDaemonCompliance"/> already smoke-tests that a daemon catches up and that a
+/// rebuild reproduces state. This suite is about the parts that are easy to get subtly wrong and
+/// that have historically diverged: whether a rebuild <em>tears down</em> before it replays, whether
+/// it is idempotent, whether the several ways of naming a projection agree, and whether rebuilding
+/// one projection disturbs another.
+/// </para>
+/// <para>
+/// <strong>The teardown assertion is the one that matters most.</strong> A rebuild that replays onto
+/// whatever rows survived looks correct for every stream whose events still exist, and is wrong only
+/// for the rows the replay can no longer produce — so it passes any test that checks a live
+/// aggregate and fails only on stale state. That exact divergence was a real product gap found by
+/// the flat-table suite (polecat#415), which is why this suite pins it for document projections too,
+/// by planting a document the replay cannot possibly produce and requiring the rebuild to remove it.
+/// </para>
+/// <para>
+/// No seam addition: the whole rebuild surface — <c>RebuildProjectionAsync</c> in its several
+/// overloads, <c>CatchUpAsync</c>, <c>PrepareForRebuildsAsync</c> — is declared on the shared
+/// <see cref="Daemon.IProjectionDaemon"/>, which the fixture already hands back from
+/// <c>StartDaemonAsync</c>. That is why this landed in the "portable" group after all, despite
+/// being filed as needing one (marten#5150).
+/// </para>
+/// </remarks>
+public abstract class RebuildAndCatchUpCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_rebuild";
+        config.Snapshot<ComplianceTurbine>(SnapshotLifecycle.Async);
+        config.Snapshot<ComplianceTurbineAudit>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessDaemonIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+    }
+
+    private async Task<Guid> aTurbineAsync(string site = "North Ridge")
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceTurbine>(streamId,
+            new TurbineInstalled(site),
+            new TurbineSpun(10),
+            new TurbineSpun(15));
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task<ComplianceTurbine?> turbineAsync(Guid id)
+    {
+        await using var query = OpenSession();
+        return await LoadDocumentAsync<ComplianceTurbine>(query, id);
+    }
+
+    [Fact]
+    public async Task a_rebuild_reproduces_the_projected_state()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+        turbine.Site.ShouldBe("North Ridge");
+        turbine.TotalRevolutions.ShouldBe(25);
+        turbine.SpinCount.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// The teardown guarantee: a rebuild starts from an empty slate, not from whatever survived.
+    /// </summary>
+    [Fact]
+    public async Task a_rebuild_removes_state_the_replay_cannot_produce()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        // A document with no backing events at all. Nothing in the replay can produce it, so a
+        // rebuild that tears down first must remove it, and a rebuild that merely replays on top
+        // will leave it sitting there.
+        var orphanId = Guid.NewGuid();
+        await using (var session = OpenSession())
+        {
+            StoreDocument(session, new ComplianceTurbine
+            {
+                Id = orphanId, Site = "Nowhere", TotalRevolutions = 999, SpinCount = 99
+            });
+            await SaveChangesAsync(session);
+        }
+
+        (await turbineAsync(orphanId)).ShouldNotBeNull();
+
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        (await turbineAsync(orphanId)).ShouldBeNull();
+
+        // ... and the real stream is still there afterwards.
+        (await turbineAsync(streamId)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task rebuilding_twice_is_idempotent()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+
+        // Not 50 / 4 -- the second pass must replace rather than accumulate.
+        turbine.TotalRevolutions.ShouldBe(25);
+        turbine.SpinCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_rebuild_picks_up_events_appended_after_the_first_catch_up()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new TurbineSpun(5), new TurbineHalted());
+            await SaveChangesAsync(session);
+        }
+
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+        turbine.TotalRevolutions.ShouldBe(30);
+        turbine.SpinCount.ShouldBe(3);
+        turbine.Halted.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task rebuilding_one_projection_leaves_another_alone()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        await using var query = OpenSession();
+        var audit = await LoadDocumentAsync<ComplianceTurbineAudit>(query, streamId);
+
+        audit.ShouldNotBeNull();
+        audit.Site.ShouldBe("North Ridge");
+        audit.Revisions.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// Naming a projection by its view type and by its registered name have to select the same
+    /// projection, or a caller who rebuilds by name silently rebuilds nothing.
+    /// </summary>
+    [Fact]
+    public async Task rebuilding_by_projection_name_agrees_with_rebuilding_by_view_type()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        // Plant the orphan again -- if the named rebuild silently matched no projection, the orphan
+        // would survive and this would fail, where a bare state assertion would not.
+        var orphanId = Guid.NewGuid();
+        await using (var session = OpenSession())
+        {
+            StoreDocument(session, new ComplianceTurbine { Id = orphanId, Site = "Nowhere" });
+            await SaveChangesAsync(session);
+        }
+
+        await daemon.RebuildProjectionAsync(nameof(ComplianceTurbine), Cancellation);
+
+        (await turbineAsync(orphanId)).ShouldBeNull();
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+        turbine.TotalRevolutions.ShouldBe(25);
+    }
+
+    [Fact]
+    public async Task rebuilding_a_projection_with_no_events_is_not_an_error()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var daemon = await StartDaemonAsync();
+
+        // No streams at all in this store yet.
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        await using var query = OpenSession();
+        var turbine = await LoadDocumentAsync<ComplianceTurbine>(query, Guid.NewGuid());
+        turbine.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task catch_up_advances_the_projection_without_a_full_daemon_run()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await daemon.CatchUpAsync(_timeout, Cancellation);
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+        turbine.TotalRevolutions.ShouldBe(25);
+    }
+
+    [Fact]
+    public async Task catch_up_is_safe_to_call_when_there_is_nothing_to_do()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await daemon.CatchUpAsync(_timeout, Cancellation);
+        await daemon.CatchUpAsync(_timeout, Cancellation);
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+        turbine.TotalRevolutions.ShouldBe(25);
+        turbine.SpinCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task prepare_for_rebuilds_leaves_the_daemon_able_to_rebuild()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aTurbineAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.PrepareForRebuildsAsync();
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        var turbine = await turbineAsync(streamId);
+        turbine.ShouldNotBeNull();
+        turbine.TotalRevolutions.ShouldBe(25);
+    }
+
+    [Fact]
+    public async Task a_rebuild_reproduces_every_stream_not_just_the_last()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var first = await aTurbineAsync("North Ridge");
+        var second = await aTurbineAsync("South Bank");
+        var third = await aTurbineAsync("East Flats");
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.RebuildProjectionAsync<ComplianceTurbine>(Cancellation);
+
+        foreach (var (id, site) in new[] { (first, "North Ridge"), (second, "South Bank"), (third, "East Flats") })
+        {
+            var turbine = await turbineAsync(id);
+            turbine.ShouldNotBeNull();
+            turbine.Site.ShouldBe(site);
+            turbine.TotalRevolutions.ShouldBe(25);
+        }
+    }
+}


### PR DESCRIPTION
The last two event-sourcing suites in the backlog — marten#5150 and marten#5149. Library **24 → 26 suites, 199 → 216 tests**.

## Both needed zero seam additions — the backlog had them misfiled

They were grouped under "needs a seam addition." Checking the shared surfaces rather than the issue text says otherwise:

- **`IProjectionDaemon` already declares the entire rebuild surface** — seven `RebuildProjectionAsync` overloads, both `CatchUpAsync` forms, `PrepareForRebuildsAsync` — and the fixture's `StartDaemonAsync()` already hands one back.
- **The error policy and dead letters are both already shared** — `IEventStore<TOperations, TQuerySession>.ContinuousErrors` for the former, `IEventStore.AllDatabases()` → `IEventDatabase.QueryDeadLetterEventsAsync` for the latter. I verified both products *override* both rather than inheriting the empty-array DIMs before writing a line.

One wrinkle worth knowing generally: `ContinuousErrors` is on the **generic** `IEventStore<,>` while the fixture exposes the non-generic `IEventStore`. The suite casts, which is safe precisely because it is generic over the same pair the store closes over — that reaches the whole generic store surface without adding seam.

## `RebuildAndCatchUpCompliance` — 11 tests

`AsyncDaemonCompliance` already smoke-tests catch-up and a basic rebuild, so this covers what's easy to get subtly wrong: teardown-before-replay, idempotency, agreement between the by-view-type and by-name overloads, isolation from a second projection, catch-up without a full daemon run, and `PrepareForRebuildsAsync`.

**The teardown test is the one that matters.** A rebuild that replays onto surviving rows looks correct for every stream whose events still exist, and is wrong only for rows the replay can no longer produce — so it passes any test that checks a live aggregate. That exact divergence was a real product gap found by the flat-table suite (polecat#415). So this plants a document the replay cannot possibly produce and requires the rebuild to remove it.

The by-name test plants the orphan too, deliberately: a named rebuild that silently matched no projection would otherwise pass a state assertion that was already true.

## `DeadLetterCompliance` — 6 tests

A poison event whose `Apply` always throws, which needs no store-specific hook. Pins that a skip policy actually **skips** — the shard survives and keeps projecting events *after* the fault, not just before it — and that the skipped event is **recorded** rather than lost, with enough on the row to identify the event and the failure.

Corrected mid-flight: `ExceptionMessage` carries the wrapping `ApplyEventException`'s own message, not the inner reason, while `ExceptionType` names the inner exception. Asserting the inner type is what the shared ctor actually promises; searching the message for the thrown text does not work, and was my first draft.

**Deliberately not asserted:** the stop-on-error policy. How a shard pauses, stops or faults is expressed differently enough between the products that encoding one shape would pin an implementation rather than a promise.

## ⚠️ Disclosure — an intermittent failure I could not reproduce

`a_rebuild_reproduces_the_projected_state` failed **twice on Polecat** early in development, both times at ~31s, and has passed every run since — **7 consecutive full 216-test compliance runs**, including one immediately after a container restart.

It is not the rebuild shard timeout (that defaults to 5 minutes — checked). I have no error text and no reproduction, so I am not guess-fixing it or quietly hardening the test to make it go away. Recording it so it doesn't look clean: **if this resurfaces in either CI, this is the first sighting.**

## Verification

Marten 17/17 on the two new suites, full `EventSourcingTests` running. Polecat 17/17, full compliance **216/216**, full suite running.

Closes JasperFx/marten#5149
Closes JasperFx/marten#5150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde