### PR TITLE
Compliance wave 8: conjoined event tenancy and subscriptions (2.45.0)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.44.0</JasperFxVersion>
+        <JasperFxVersion>2.45.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -77,6 +77,25 @@ public sealed class ComplianceStoreConfig
     /// </remarks>
     public bool EnableHeaders { get; set; }
 
+    /// <summary>
+    /// Slice the event store by tenant within one database — "conjoined" tenancy, where every
+    /// stream and event carries a tenant id and reads are scoped to one tenant.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The only seam this needs. Both products spell the setting identically —
+    /// <c>Events.TenancyStyle = TenancyStyle.Conjoined</c>, over the <em>shared</em>
+    /// <c>JasperFx.MultiTenancy.TenancyStyle</c> enum — but on their own event options rather than
+    /// on any shared interface, so it has to come through the registrar.
+    /// </para>
+    /// <para>
+    /// Opening a tenant-scoped session needs nothing: <c>IEventStore&lt;TOperations,
+    /// TQuerySession&gt;.OpenSession(IEventDatabase, string tenantId)</c> is already on the shared
+    /// generic interface and implemented by both stores.
+    /// </para>
+    /// </remarks>
+    public bool ConjoinedEventTenancy { get; set; }
+
     public List<Type> EventTypes { get; } = new();
 
     public List<(Type Tag, string Suffix, Type? Aggregate)> TagTypes { get; } = new();
@@ -160,6 +179,16 @@ public sealed class ComplianceStoreConfig
     public ComplianceStoreConfig AddMaskingRule<TEvent>(Func<TEvent, TEvent> rule) where TEvent : notnull
     {
         _registrations.Add(registrar => registrar.AddMaskingRule(rule));
+        return this;
+    }
+
+    /// <summary>
+    /// Register the shared compliance subscription with the store's async daemon.
+    /// </summary>
+    /// <inheritdoc cref="IComplianceStoreRegistrar.Subscribe" path="/remarks"/>
+    public ComplianceStoreConfig Subscribe(ComplianceSubscription subscription)
+    {
+        _registrations.Add(registrar => registrar.Subscribe(subscription));
         return this;
     }
 

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -199,6 +199,11 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     public virtual bool SupportsLiveAggregationRegistration => true;
 
     /// <summary>
+    /// False where the store cannot slice one database by tenant.
+    /// </summary>
+    public virtual bool SupportsConjoinedEventTenancy => true;
+
+    /// <summary>
     /// False where the store cannot run the async projection daemon in the test environment.
     /// </summary>
     public virtual bool SupportsAsyncDaemon => true;

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -80,4 +80,19 @@ public interface IComplianceStoreRegistrar
     /// is total in practice.
     /// </remarks>
     void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle);
+
+    /// <summary>
+    /// Register the shared compliance subscription with the store's async daemon.
+    /// </summary>
+    /// <remarks>
+    /// Typed as the concrete <see cref="ComplianceSubscription"/>, which is unusual for this
+    /// interface and is deliberate. Neither product exposes a public <c>Subscribe</c> overload
+    /// taking the shared <c>ISubscriptionSource&lt;TOperations, TQuerySession&gt;</c> — both take
+    /// their own <c>ISubscription</c>, and their <c>registerSubscription</c> is private — so there
+    /// is no shared type to accept here. The library owns <c>ComplianceSubscription</c> and each
+    /// consumer completes it as a partial implementing its own interface, so naming the concrete
+    /// type is the one spelling that works on both. Implementations should pin the subscription
+    /// name to <see cref="ComplianceSubscription.SubscriptionName"/>.
+    /// </remarks>
+    void Subscribe(ComplianceSubscription subscription);
 }

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -44,11 +44,12 @@ store's session pair. Everything portable in the suites runs through the shared 
 no shared interface declares — store construction from a `ComplianceStoreConfig`, session
 acquisition, `SaveChangesAsync`, document load-back, batched DCB queries, and teardown.
 
-**3. One partial class, for the flat-table suite only.** `FlatTableProjectionCompliance` is the one
-suite whose shared type cannot be reached by an alias: every product's flat-table projection base
-takes constructor arguments describing where the table lives, and those signatures genuinely differ,
-so no single `base(...)` call satisfies all of them. Declaring the primary key column is per-product
-for the same reason — that API hangs off each dialect's own `Table` type. The library owns the table
+**3. Two partial classes**, for the two suites whose shared type cannot be reached by an alias.
+
+`FlatTableProjectionCompliance` is the first: every product's flat-table projection base takes
+constructor arguments describing where the table lives, and those signatures genuinely differ, so no
+single `base(...)` call satisfies all of them. Declaring the primary key column is per-product for
+the same reason — that API hangs off each dialect's own `Table` type. The library owns the table
 name, the projection name and every event mapping; a consumer supplies the rest:
 
 ```csharp
@@ -67,6 +68,29 @@ public partial class ComplianceFlatTableProjection : FlatTableProjection
 If your base takes a literal schema name rather than resolving the store's, pass
 `ComplianceFlatTableProjection.SchemaName` — the suite configures its store with the same constant,
 and the two have to agree or the projection writes into a table the suite is not reading.
+
+`SubscriptionCompliance` is the second, for a subtler reason. Both products declare `ISubscription`
+with an *identical* member — `Task<IChangeListener> ProcessEventsAsync(EventRange,
+ISubscriptionController, IDocumentOperations, CancellationToken)` — but `IChangeListener` is a
+per-product type, so the signature cannot be written once. The library owns the recording, the
+waiting and the subscription name; a consumer supplies only the interface implementation:
+
+```csharp
+namespace JasperFx.Events.ComplianceTests;
+
+public partial class ComplianceSubscription : ISubscription   // your product's ISubscription
+{
+    public Task<IChangeListener> ProcessEventsAsync(EventRange page, ISubscriptionController controller,
+        IDocumentOperations operations, CancellationToken cancellationToken)
+    {
+        Record(page.Events);
+        return Task.FromResult<IChangeListener>(NullChangeListener.Instance);
+    }
+}
+```
+
+Your registrar's `Subscribe` should pin the name to `ComplianceSubscription.SubscriptionName`;
+progression is keyed on it and the products disagree on what an unnamed subscription defaults to.
 
 Then enroll each suite with an empty subclass:
 
@@ -124,6 +148,8 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Batch data masking of stored events | `EventDataMaskingCompliance` |
 | Projection rebuild and catch-up semantics | `RebuildAndCatchUpCompliance` |
 | The projection error path and dead letters | `DeadLetterCompliance` |
+| Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
+| Subscriptions | `SubscriptionCompliance` |
 
 ## What is deliberately out of scope
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Conjoined tenancy events and aggregate
+
+public record ConsignmentBooked(string Destination);
+
+public record ConsignmentScanned(string Location);
+
+public record ConsignmentDelivered;
+
+public partial class ComplianceConsignment
+{
+    public Guid Id { get; set; }
+    public string Destination { get; set; } = string.Empty;
+    public int ScanCount { get; set; }
+    public bool Delivered { get; set; }
+
+    public static ComplianceConsignment Create(ConsignmentBooked e) => new() { Destination = e.Destination };
+
+    public void Apply(ConsignmentScanned _) => ScanCount++;
+
+    public void Apply(ConsignmentDelivered _) => Delivered = true;
+}
+
+#endregion
+
+/// <summary>
+/// Conjoined event tenancy — one database, many tenants, with every stream and event scoped to a
+/// tenant id.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The property under test is <em>isolation</em>, and it is worth pinning across stores because the
+/// failure mode is silent and asymmetric: a store that leaks across tenants still returns correct
+/// answers for the tenant that happens to own the data, and only misbehaves for the other one. So
+/// every test here checks both directions — what a tenant can see, and what it must not.
+/// </para>
+/// <para>
+/// The suite deliberately reuses one stream id across two tenants. Under conjoined tenancy the
+/// identity of a stream is (tenant, id), not id alone, and reusing the id is the sharpest way to
+/// show it: a store that keys on id alone will either collide on append or return one tenant's
+/// events to the other.
+/// </para>
+/// <para>
+/// Cost is a single seam member, <see cref="ComplianceStoreConfig.ConjoinedEventTenancy"/>. Opening
+/// a tenant-scoped session needs nothing new — <c>IEventStore&lt;TOperations,
+/// TQuerySession&gt;.OpenSession(IEventDatabase, string)</c> is already shared and implemented by
+/// both products, reached here by casting the fixture's non-generic <see cref="IEventStore"/> to
+/// the closed generic, which is safe because this suite is generic over the same pair the store
+/// closes over (marten#5148).
+/// </para>
+/// </remarks>
+public abstract class ConjoinedEventTenancyCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private const string TenantA = "acme";
+    private const string TenantB = "globex";
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_conjoined";
+        config.ConjoinedEventTenancy = true;
+
+        config.AddEventType<ConsignmentBooked>();
+        config.AddEventType<ConsignmentScanned>();
+        config.AddEventType<ConsignmentDelivered>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// A session bound to one tenant, through the shared generic store surface.
+    /// </summary>
+    private async Task<TOperations> openForTenantAsync(string tenantId)
+    {
+        var store = (IEventStore<TOperations, TQuerySession>)theFixture.EventStore;
+
+        var databases = await theFixture.EventStore.AllDatabases();
+        var database = databases.First();
+
+        return store.OpenSession(database, tenantId);
+    }
+
+    private async Task appendAsync(string tenantId, Guid streamId, params object[] events)
+    {
+        await using var session = await openForTenantAsync(tenantId);
+        EventsFor(session).StartStream<ComplianceConsignment>(streamId, events);
+        await SaveChangesAsync(session);
+    }
+
+    [Fact]
+    public async Task events_appended_for_one_tenant_are_not_visible_to_another()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+
+        await using var query = await openForTenantAsync(TenantB);
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_tenant_sees_its_own_events()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+
+        await using var query = await openForTenantAsync(TenantA);
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(2);
+        events[0].Data.ShouldBeOfType<ConsignmentBooked>();
+        events[1].Data.ShouldBeOfType<ConsignmentScanned>();
+    }
+
+    /// <summary>
+    /// Under conjoined tenancy a stream's identity is (tenant, id), not id alone.
+    /// </summary>
+    [Fact]
+    public async Task the_same_stream_id_lives_independently_in_two_tenants()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+        await appendAsync(TenantB, streamId, new ConsignmentBooked("Lisbon"));
+
+        await using (var a = await openForTenantAsync(TenantA))
+        {
+            var events = await EventsFor(a).FetchStreamAsync(streamId, token: Cancellation);
+            events.Count.ShouldBe(2);
+            events[0].Data.ShouldBeOfType<ConsignmentBooked>().Destination.ShouldBe("Boston");
+        }
+
+        await using var b = await openForTenantAsync(TenantB);
+        var others = await EventsFor(b).FetchStreamAsync(streamId, token: Cancellation);
+        others.Count.ShouldBe(1);
+        others[0].Data.ShouldBeOfType<ConsignmentBooked>().Destination.ShouldBe("Lisbon");
+    }
+
+    [Fact]
+    public async Task stream_state_is_scoped_to_the_tenant()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"),
+            new ConsignmentScanned("Hub"));
+        await appendAsync(TenantB, streamId, new ConsignmentBooked("Lisbon"));
+
+        await using (var a = await openForTenantAsync(TenantA))
+        {
+            var state = await EventsFor(a).FetchStreamStateAsync(streamId, Cancellation);
+            state.ShouldNotBeNull();
+            state.Version.ShouldBe(3);
+        }
+
+        await using var b = await openForTenantAsync(TenantB);
+        var otherState = await EventsFor(b).FetchStreamStateAsync(streamId, Cancellation);
+        otherState.ShouldNotBeNull();
+        otherState.Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task stream_state_is_null_for_a_tenant_that_has_no_such_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"));
+
+        await using var b = await openForTenantAsync(TenantB);
+        var state = await EventsFor(b).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task every_event_is_stamped_with_its_tenant()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+
+        await using var query = await openForTenantAsync(TenantA);
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.ShouldAllBe(x => x.TenantId == TenantA);
+    }
+
+    [Fact]
+    public async Task live_aggregation_is_scoped_to_the_tenant()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"),
+            new ConsignmentScanned("Hub"), new ConsignmentDelivered());
+        await appendAsync(TenantB, streamId, new ConsignmentBooked("Lisbon"));
+
+        await using (var a = await openForTenantAsync(TenantA))
+        {
+            var consignment = await EventsFor(a).AggregateStreamAsync<ComplianceConsignment>(streamId, token: Cancellation);
+            consignment.ShouldNotBeNull();
+            consignment.Destination.ShouldBe("Boston");
+            consignment.ScanCount.ShouldBe(2);
+            consignment.Delivered.ShouldBeTrue();
+        }
+
+        await using var b = await openForTenantAsync(TenantB);
+        var other = await EventsFor(b).AggregateStreamAsync<ComplianceConsignment>(streamId, token: Cancellation);
+        other.ShouldNotBeNull();
+        other.Destination.ShouldBe("Lisbon");
+        other.ScanCount.ShouldBe(0);
+        other.Delivered.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task appending_to_one_tenant_does_not_move_another_tenants_version()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(TenantA, streamId, new ConsignmentBooked("Boston"));
+        await appendAsync(TenantB, streamId, new ConsignmentBooked("Lisbon"));
+
+        await using (var a = await openForTenantAsync(TenantA))
+        {
+            EventsFor(a).Append(streamId, new ConsignmentScanned("Depot"), new ConsignmentScanned("Hub"));
+            await SaveChangesAsync(a);
+        }
+
+        await using var b = await openForTenantAsync(TenantB);
+        var state = await EventsFor(b).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(1);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/SubscriptionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/SubscriptionCompliance.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Subscription events
+
+public record BeaconLit(string Name);
+
+public record BeaconDimmed(int Level);
+
+public record BeaconExtinguished;
+
+/// <summary>
+/// The portable half of the shared compliance subscription: everything about recording what the
+/// daemon delivered, and waiting for it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the second shared type in the library that cannot be reached by an alias alone — the
+/// same shape as <c>ComplianceFlatTableProjection</c>, and for the same reason. Both products
+/// declare their own <c>ISubscription</c> with an identical member,
+/// <c>Task&lt;IChangeListener&gt; ProcessEventsAsync(EventRange, ISubscriptionController,
+/// IDocumentOperations, CancellationToken)</c> — but <c>IChangeListener</c> is per-product, so the
+/// signature cannot be written once. Each consumer supplies a small partial implementing its own
+/// interface and calling <see cref="Record"/>.
+/// </para>
+/// <para>
+/// Recording is under a lock because the daemon delivers pages from its own threads. An
+/// unsynchronized <c>List.Add</c> here would be the marten#5085 class of bug — a test-side data
+/// race that presents as an impossible assertion failure rather than as a race.
+/// </para>
+/// </remarks>
+public partial class ComplianceSubscription
+{
+    /// <summary>
+    /// The daemon-facing name, pinned rather than defaulted — the products disagree on whether an
+    /// unnamed subscription takes its short type name or its full name, and progression is keyed
+    /// on it.
+    /// </summary>
+    public const string SubscriptionName = "ComplianceSubscription";
+
+    private readonly object _lock = new();
+    private readonly List<IEvent> _received = new();
+    private int _pageCount;
+
+    public IReadOnlyList<IEvent> Received
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _received.ToArray();
+            }
+        }
+    }
+
+    public int PageCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _pageCount;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Called by each consumer's partial from its own <c>ProcessEventsAsync</c>.
+    /// </summary>
+    protected void Record(IEnumerable<IEvent> events)
+    {
+        lock (_lock)
+        {
+            _received.AddRange(events);
+            _pageCount++;
+        }
+    }
+
+    /// <summary>
+    /// Poll until at least <paramref name="count"/> events from <paramref name="streamId"/> have
+    /// arrived, or give up.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Scoped to one stream on purpose. A suite cannot wait on a store-wide total, because this
+    /// subscription instance is shared across the suite's tests and earlier tests' events may still
+    /// be in flight — a total-count latch would be satisfied by the wrong events.
+    /// </para>
+    /// <para>
+    /// And it cannot wait on "non-stale projection data" either: that tracks *projections*, and a
+    /// store configured with a subscription and no projections can report non-stale before the
+    /// subscription has been handed anything at all. Waiting on the subscription's own delivery is
+    /// the only signal that means what these tests need.
+    /// </para>
+    /// <para>
+    /// Polling rather than a <c>TaskCompletionSource</c> because the assertions are about how many
+    /// events arrive, and a latch on a count cannot also show that no further ones followed.
+    /// </para>
+    /// </remarks>
+    public async Task WaitForStreamEventCountAsync(Guid streamId, int count, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (Received.Count(x => x.StreamId == streamId) >= count) return;
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException(
+            $"Timed out after {timeout} waiting for {count} events from stream {streamId}; " +
+            $"the subscription received {Received.Count(x => x.StreamId == streamId)} from that stream " +
+            $"and {Received.Count} in total.");
+    }
+}
+
+#endregion
+
+/// <summary>
+/// Subscriptions — the "do something with every event, in order, exactly once" surface that is not
+/// a projection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The guarantees worth pinning are ordering and completeness: a subscription sees every event the
+/// store appended, in sequence order, across however many pages the daemon chooses to deliver. Page
+/// boundaries are an implementation detail and are deliberately never asserted — only that the
+/// union of the pages is right and monotonic.
+/// </para>
+/// <para>
+/// Cost is a per-consumer partial on <see cref="ComplianceSubscription"/> plus one registrar
+/// member. That is more than most suites and it is the honest price: neither product exposes a
+/// public <c>Subscribe</c> overload taking the shared <c>ISubscriptionSource&lt;TOperations,
+/// TQuerySession&gt;</c>, even though both prefer it internally, and their
+/// <c>registerSubscription</c> is private in both (marten#5151).
+/// </para>
+/// </remarks>
+public abstract class SubscriptionCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// One subscription instance for the whole suite, because the configuration delegate is what
+    /// the fixture keys a store rebuild on — a new instance per test would need a new delegate.
+    /// Tests therefore assert on what arrived for the streams they appended, never on a total.
+    /// </summary>
+    private static readonly ComplianceSubscription _subscription = new();
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_subscriptions";
+
+        config.AddEventType<BeaconLit>();
+        config.AddEventType<BeaconDimmed>();
+        config.AddEventType<BeaconExtinguished>();
+
+        config.Subscribe(_subscription);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessDaemonIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+    }
+
+    private async Task<Guid> aBeaconAsync(params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId,
+            events.Length == 0 ? [new BeaconLit("Amon Din")] : events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private IReadOnlyList<IEvent> receivedFor(Guid streamId)
+        => _subscription.Received.Where(x => x.StreamId == streamId).ToArray();
+
+    [Fact]
+    public async Task a_subscription_receives_the_events_that_were_appended()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Amon Din"), new BeaconDimmed(3),
+            new BeaconExtinguished());
+
+        await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 3, _timeout);
+
+        receivedFor(streamId).Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task the_events_arrive_with_their_data_intact()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Eilenach"), new BeaconDimmed(7));
+
+        await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 2, _timeout);
+
+        var received = receivedFor(streamId);
+
+        received.Select(x => x.Data).OfType<BeaconLit>().Single().Name.ShouldBe("Eilenach");
+        received.Select(x => x.Data).OfType<BeaconDimmed>().Single().Level.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task the_events_arrive_in_sequence_order()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Nardol"), new BeaconDimmed(1),
+            new BeaconDimmed(2), new BeaconExtinguished());
+
+        await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 4, _timeout);
+
+        var received = receivedFor(streamId);
+        received.Count.ShouldBe(4);
+
+        // Monotonic on both axes, whatever page boundaries the daemon chose.
+        received.Select(x => x.Sequence).ShouldBe(received.Select(x => x.Sequence).OrderBy(x => x));
+        received.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
+    }
+
+    [Fact]
+    public async Task a_subscription_sees_events_from_every_stream()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var first = await aBeaconAsync(new BeaconLit("Erelas"), new BeaconDimmed(1));
+        var second = await aBeaconAsync(new BeaconLit("Min-Rimmon"));
+        var third = await aBeaconAsync(new BeaconLit("Calenhad"), new BeaconExtinguished());
+
+        await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(first, 2, _timeout);
+        await _subscription.WaitForStreamEventCountAsync(second, 1, _timeout);
+        await _subscription.WaitForStreamEventCountAsync(third, 2, _timeout);
+
+        receivedFor(first).Count.ShouldBe(2);
+        receivedFor(second).Count.ShouldBe(1);
+        receivedFor(third).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task events_appended_after_the_daemon_started_still_arrive()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        await StartDaemonAsync();
+
+        // Appended only after the daemon is already running, so this is catch-up-from-live rather
+        // than the cold replay every other test in this suite exercises.
+        var streamId = await aBeaconAsync(new BeaconLit("Halifirien"), new BeaconDimmed(9));
+
+        await _subscription.WaitForStreamEventCountAsync(streamId, 2, _timeout);
+
+        receivedFor(streamId).Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task each_event_is_delivered_once()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Amon Anwar"), new BeaconDimmed(4),
+            new BeaconExtinguished());
+
+        await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 3, _timeout);
+
+        var received = receivedFor(streamId);
+
+        // Redelivery is the failure this catches: a duplicate page would show up as repeated
+        // sequences rather than as a wrong total, since the count assertion alone would pass if a
+        // page were dropped AND another duplicated.
+        received.Select(x => x.Sequence).Distinct().Count().ShouldBe(received.Count);
+        received.Count.ShouldBe(3);
+    }
+}


### PR DESCRIPTION
The last two suites in the event sourcing backlog — marten#5148 and marten#5151. Library **26 → 28 suites, 216 → 230 tests**. With these, the ES compliance backlog is **empty**.

| Suite | Tests | Seam cost |
|---|---|---|
| `ConjoinedEventTenancyCompliance` | 8 | **one config member** |
| `SubscriptionCompliance` | 6 | one partial + one registrar member |

## `ConjoinedEventTenancyCompliance` — misfiled, like the last two

#5148 was filed as needing a tenant-scoped session seam. It doesn't:
`IEventStore<TOperations, TQuerySession>.OpenSession(IEventDatabase, string tenantId)` is **already on the shared generic interface** and implemented by both products, and `TenancyStyle` is **already a shared JasperFx enum** (`JasperFx/MultiTenancy/TenancyStyle.cs`) that both spell identically as `Events.TenancyStyle = TenancyStyle.Conjoined`. Reached with the same cast trick wave 7 introduced. The only cost is `ComplianceStoreConfig.ConjoinedEventTenancy`.

The property under test is **isolation**, and it's worth pinning across stores because the failure mode is silent and asymmetric: a store that leaks across tenants still answers correctly for the tenant that owns the data, and misbehaves only for the other one. So every test checks both directions — what a tenant can see, and what it must not.

The suite deliberately **reuses one stream id across two tenants**. Under conjoined tenancy a stream's identity is (tenant, id), not id alone, and reusing the id is the sharpest way to show it: a store keying on id alone either collides on append or hands one tenant's events to the other.

## `SubscriptionCompliance` — the cost estimate held exactly

Unlike #5148, #5151's filed cost was right. Both products declare `ISubscription` with an identical member, but `IChangeListener` is a per-product type, so the signature cannot be written once — the same shape as `ComplianceFlatTableProjection`. Neither exposes a public `Subscribe` overload taking the shared `ISubscriptionSource<,>` even though both prefer it internally, and `registerSubscription` is private in both.

What's pinned is ordering and completeness. Page boundaries are deliberately **never** asserted — only that the union of the pages is right, monotonic, and free of redelivery.

### A design flaw the suite caught in itself

The tests originally waited on `WaitForNonStaleProjectionDataAsync`. That tracks **projections**, and this suite's store registers none — so it could report non-stale before the subscription had been handed anything at all, and one test failed for exactly that reason.

Replaced with `ComplianceSubscription.WaitForStreamEventCountAsync`, scoped to a single stream because the subscription instance is shared across the suite's tests and a store-wide total would be satisfied by the wrong events.

Recording is under a lock: the daemon delivers pages from its own threads, and an unsynchronized `List.Add` here would be the marten#5085 class of bug — a test-side data race presenting as an impossible assertion failure.

## Verification

Both stores **14/14** on the new suites — Polecat green on the first run, no capability gates and no product gaps found. Full compliance **230/230 on each**. Marten full `EventSourcingTests` **1796 / 0 / 7**; Polecat full suite running.

Consumer adoptions will be verified against locally packed `2.45.0-local.N` artifacts before publish, not just source-linked.

Closes JasperFx/marten#5148
Closes JasperFx/marten#5151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpDCvJcBDZerieJB4JEHde