### PR TITLE
docs: LINQ is out of compliance scope permanently, not pending a contract

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -153,10 +153,20 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 
 ## What is deliberately out of scope
 
-Storage layout and DDL, table partitioning, node distribution / HotCold, high-water detection
-internals, and anything on the document-db side (LINQ, patching, session semantics) — the last
-because no shared document store contract exists yet. If a behavior only makes sense in terms of one
-engine's storage, it belongs in that product's own test suite, not here.
+Storage layout and DDL, table partitioning, node distribution / HotCold, and high-water detection
+internals. If a behavior only makes sense in terms of one engine's storage, it belongs in that
+product's own test suite, not here.
+
+**LINQ and query-provider behavior are out of scope permanently**, not pending a contract. The
+stores' query languages diverge structurally enough that a shared suite would pin coincidence rather
+than contract. This has been the position since the library was designed; it is restated here
+because it had drifted into "blocked until a shared document store contract exists", which wrongly
+reads as deferred work. It is not deferred. A file like `Polecat.Tests/Linq/additional_linq_operator_tests.cs`
+is a product-owned test file, not a port awaiting absorption (marten#5155).
+
+The rest of the document-db side — patching, session semantics — stays out for the different reason
+that no shared document store contract exists yet. That one genuinely is an open question rather
+than a settled exclusion.
 
 New cross-store event sourcing behavior should land as a compliance suite first, and only then be
 enrolled by each product.


### PR DESCRIPTION
One-paragraph split in the compliance library's "What is deliberately out of scope" section. Docs only.

## The problem

The section lumped LINQ in with the rest of the document-db side and gave them one shared reason — out *"because no shared document store contract exists yet."*

That reads as deferral, and it had started to function as one. `Polecat.Tests/Linq/additional_linq_operator_tests.cs` (19 tests) was still being carried as a port awaiting absorption, and the program's exit criterion tracked it as blocked work rather than as a product-owned file.

## The fix

LINQ was never deferred. The Phase 3 design listed it as a day-one non-goal:

> No LINQ/query-provider compliance (store query languages diverge structurally).

So the two reasons get split, because they are genuinely different:

- **LINQ / query providers** — out **permanently**, on the merits. The stores' query languages diverge structurally enough that a shared suite would pin coincidence rather than contract.
- **Patching and session semantics** — out because no shared document store contract exists yet. That one really is an open question.

Decided on [marten#5155](https://github.com/JasperFx/marten/issues/5155), where the program-level consequences are recorded.

## Notes

- The README ships inside the source-only package (verified byte-identical against the published 2.45.0), so this reaches consumers — but it is docs only. **No version bump**: nothing shippable changed, and it rides into whatever publish comes next. The `AssertVersionIsUnpublished` guard still does the right thing if someone tries to republish 2.45.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrQZYcL13PEek7FErj9PGx