### PR TITLE
Per-tenant high-water polling is bounded at thousands of tenants

### DIFF
--- a/src/EventTests/Daemon/HighWater/TenantedHighWaterCoordinator_scale_Tests.cs
+++ b/src/EventTests/Daemon/HighWater/TenantedHighWaterCoordinator_scale_Tests.cs
@@ -1,0 +1,396 @@
+using System.Collections.Concurrent;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// jasperfx#644: at 2,173 tenants × ~4,400 agents the per-tenant high-water path OOM'd the host. Three
+// compounding causes, each pinned here through observable seams rather than allocation assertions:
+//   1. routing was O(tenants × agents) name comparisons per cycle,
+//   2. every cycle re-routed and re-persisted every tenant even when no mark moved (thousands of queued
+//      agent commands + sequential database writes per cycle, forever), and
+//   3. nothing bounded concurrent cycles — the unguarded OnNext trigger and the watchdog's
+//      "abandon the hung poll" both stacked live full cycles without limit.
+// The fix: group agents by tenant, route/persist only advanced marks, retire a superseded in-flight
+// cycle via a cycle epoch, and coalesce background triggers into a single-flight cycle with at most one
+// trailing rerun.
+public class TenantedHighWaterCoordinator_scale_Tests
+{
+    private static HighWaterStatistics stat(string tenantId, long mark)
+        => new() { TenantId = tenantId, CurrentMark = mark, LastMark = mark, HighestSequence = mark + 1 };
+
+    [Fact]
+    public async Task unchanged_tenants_are_not_rerouted_and_not_repersisted()
+    {
+        var detector = new ScaleDetector(tenants => new HighWaterVector(tenants.Select(t => stat(t, 10))));
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1", "t2"]);
+
+        var agentT1 = new RecordingAgent(ShardName.Compose("Orders", "All", "t1"));
+        var agentT2 = new RecordingAgent(ShardName.Compose("Orders", "All", "t2"));
+        var agents = new ISubscriptionAgent[] { agentT1, agentT2 };
+
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+
+        // First cycle routed and persisted each tenant once; the two flat follow-up cycles did neither.
+        agentT1.Marks.ShouldBe([10L]);
+        agentT2.Marks.ShouldBe([10L]);
+        detector.Persisted.Count(x => x.TenantId == "t1").ShouldBe(1);
+        detector.Persisted.Count(x => x.TenantId == "t2").ShouldBe(1);
+
+        // The readings themselves still come back every cycle (observability contract unchanged) and the
+        // liveness heartbeat still stamps flat cycles.
+        coordinator.LastPolledAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task an_advanced_tenant_is_rerouted_and_repersisted()
+    {
+        var marks = new Dictionary<string, long> { ["t1"] = 10, ["t2"] = 20 };
+        var detector = new ScaleDetector(tenants => new HighWaterVector(tenants.Select(t => stat(t, marks[t]))));
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1", "t2"]);
+
+        var agentT1 = new RecordingAgent(ShardName.Compose("Orders", "All", "t1"));
+        var agentT2 = new RecordingAgent(ShardName.Compose("Orders", "All", "t2"));
+        var agents = new ISubscriptionAgent[] { agentT1, agentT2 };
+
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+
+        marks["t1"] = 15; // only t1 advances
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+
+        agentT1.Marks.ShouldBe([10L, 15L]);
+        agentT2.Marks.ShouldBe([20L]);
+        detector.Persisted.Where(x => x.TenantId == "t1").Select(x => x.Sequence).ShouldBe([10L, 15L]);
+        detector.Persisted.Where(x => x.TenantId == "t2").Select(x => x.Sequence).ShouldBe([20L]);
+    }
+
+    [Fact]
+    public async Task at_thousands_of_tenants_a_cycle_only_works_the_tenants_that_advanced()
+    {
+        const int tenantCount = 3000;
+        const int agentsPerTenant = 2;
+
+        var marks = new Dictionary<string, long>();
+        var tenants = new List<string>(tenantCount);
+        var agents = new List<ISubscriptionAgent>(tenantCount * agentsPerTenant);
+        var agentsByTenant = new Dictionary<string, List<RecordingAgent>>();
+
+        for (var i = 0; i < tenantCount; i++)
+        {
+            var tenantId = $"tenant{i:D5}";
+            tenants.Add(tenantId);
+            marks[tenantId] = 100;
+
+            var bucket = new List<RecordingAgent>();
+            for (var j = 0; j < agentsPerTenant; j++)
+            {
+                var agent = new RecordingAgent(ShardName.Compose($"Projection{j}", "All", tenantId));
+                bucket.Add(agent);
+                agents.Add(agent);
+            }
+
+            agentsByTenant[tenantId] = bucket;
+        }
+
+        var detector = new ScaleDetector(polled => new HighWaterVector(polled.Select(t => stat(t, marks[t]))));
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(tenants);
+
+        // Cycle 1: everything is new, so every tenant is routed to exactly its own agents and persisted once.
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+        agents.Cast<RecordingAgent>().ShouldAllBe(x => x.Marks.Count == 1 && x.Marks[0] == 100L);
+        detector.Persisted.Count.ShouldBe(tenantCount);
+
+        // Cycle 2: only 25 tenants advance. The cycle's routed/persisted work must be proportional to the
+        // 25 advanced tenants, NOT to tenants × agents — this is the gh-644 steady-state shape.
+        var advanced = tenants.Where((_, i) => i % 120 == 0).Take(25).ToArray();
+        advanced.Length.ShouldBe(25);
+        foreach (var tenantId in advanced)
+        {
+            marks[tenantId] = 250;
+        }
+
+        detector.Persisted.Clear();
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+
+        detector.Persisted.Select(x => x.TenantId).OrderBy(x => x).ShouldBe(advanced.OrderBy(x => x));
+        detector.Persisted.ShouldAllBe(x => x.Sequence == 250L);
+
+        var totalRoutedInCycle2 = agents.Cast<RecordingAgent>().Sum(x => x.Marks.Count) -
+                                  tenantCount * agentsPerTenant;
+        totalRoutedInCycle2.ShouldBe(advanced.Length * agentsPerTenant);
+        foreach (var tenantId in advanced)
+        {
+            agentsByTenant[tenantId].ShouldAllBe(x => x.Marks.SequenceEqual(new[] { 100L, 250L }));
+        }
+    }
+
+    [Fact]
+    public async Task a_newer_cycle_retires_an_in_flight_cycle_without_losing_tenants()
+    {
+        // Cycle A parks inside its first per-tenant persist; cycle B starts and runs to completion while A
+        // is parked. When A resumes it must retire itself at the next reading instead of grinding through
+        // the remaining tenants — that leaked "abandoned but still running" cycle, once per watchdog
+        // window, was the gh-644 OOM. B covers everything A never reached, so the hand-off is gapless.
+        var detector = new ScaleDetector(polled =>
+            new HighWaterVector(polled.OrderBy(x => x).Select(t => stat(t, 10))));
+
+        var firstPersistEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstPersist = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var gateArmed = 1;
+        detector.PersistGate = async () =>
+        {
+            if (Interlocked.CompareExchange(ref gateArmed, 0, 1) == 1)
+            {
+                firstPersistEntered.SetResult();
+                await releaseFirstPersist.Task;
+            }
+        };
+
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1", "t2", "t3"]);
+
+        var agents = new ISubscriptionAgent[]
+        {
+            new RecordingAgent(ShardName.Compose("P", "All", "t1")),
+            new RecordingAgent(ShardName.Compose("P", "All", "t2")),
+            new RecordingAgent(ShardName.Compose("P", "All", "t3"))
+        };
+
+        var cycleA = coordinator.PollAndRouteAsync(agents, CancellationToken.None);
+        await firstPersistEntered.Task; // A is parked persisting its first tenant
+
+        await coordinator.PollAndRouteAsync(agents, CancellationToken.None); // B runs to completion
+
+        releaseFirstPersist.SetResult();
+        await cycleA;
+
+        // A persisted exactly the one tenant it was parked on; B persisted all three (A had recorded no
+        // successful persists when B ran). A never touched its remaining two tenants.
+        detector.Persisted.Count.ShouldBe(4);
+        detector.Persisted.Select(x => x.TenantId).Distinct().Count().ShouldBe(3);
+
+        // Every agent still saw its tenant's mark at least once — supersession loses nothing.
+        agents.Cast<RecordingAgent>().ShouldAllBe(x => x.Marks.Contains(10L));
+    }
+
+    [Fact]
+    public async Task coalesced_polls_are_single_flight_with_one_trailing_rerun()
+    {
+        // Simulates the daemon's background triggers (OnNext fast path + cadence timer) stacking up while
+        // one slow cycle runs: every trigger beyond the first must coalesce into at most ONE trailing
+        // rerun, never a concurrent cycle each. The unguarded fire-and-forget version of this is exactly
+        // how cycles piled up to the gh-644 OOM.
+        var detectEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDetect = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstDetect = 1;
+
+        var detector = new ScaleDetector(polled => new HighWaterVector(polled.Select(t => stat(t, 10))))
+        {
+            DetectGate = async () =>
+            {
+                if (Interlocked.CompareExchange(ref firstDetect, 0, 1) == 1)
+                {
+                    detectEntered.SetResult();
+                    await releaseDetect.Task;
+                }
+            }
+        };
+
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1"]);
+
+        IReadOnlyList<ISubscriptionAgent> agentsSource() => [new RecordingAgent(ShardName.Compose("P", "All", "t1"))];
+
+        var owner = coordinator.PollAndRouteCoalescedAsync(agentsSource, CancellationToken.None);
+        await detectEntered.Task; // the owning cycle is now parked mid-poll
+
+        // A burst of background triggers lands while the owner is in flight — every one must coalesce.
+        for (var i = 0; i < 50; i++)
+        {
+            (await coordinator.PollAndRouteCoalescedAsync(agentsSource, CancellationToken.None))
+                .ShouldBeFalse();
+        }
+
+        detector.PollCount.ShouldBe(1); // nothing ran concurrently with the parked owner
+
+        releaseDetect.SetResult();
+        (await owner).ShouldBeTrue();
+
+        // The 50 triggers collapsed into exactly one trailing rerun on the owner: 2 cycles total, and at
+        // no point did two detections overlap.
+        detector.PollCount.ShouldBe(2);
+        detector.MaxConcurrentPolls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task abandon_in_flight_poll_lets_a_fresh_cycle_start_and_retires_the_wedged_one()
+    {
+        // The daemon watchdog's restart seam: a cycle wedged in the detector holds the single-flight
+        // guard. AbandonInFlightPoll must release the guard so a fresh coalesced cycle can run, and the
+        // wedged cycle must retire itself when it finally wakes.
+        var detectEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDetect = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstDetect = 1;
+
+        var detector = new ScaleDetector(polled => new HighWaterVector(polled.Select(t => stat(t, 10))))
+        {
+            DetectGate = async () =>
+            {
+                if (Interlocked.CompareExchange(ref firstDetect, 0, 1) == 1)
+                {
+                    detectEntered.SetResult();
+                    await releaseDetect.Task;
+                }
+            }
+        };
+
+        var coordinator = new TenantedHighWaterCoordinator(detector);
+        coordinator.PolledTenants.SetTenants(["t1"]);
+
+        IReadOnlyList<ISubscriptionAgent> agentsSource() => [new RecordingAgent(ShardName.Compose("P", "All", "t1"))];
+
+        var wedged = coordinator.PollAndRouteCoalescedAsync(agentsSource, CancellationToken.None);
+        await detectEntered.Task;
+
+        // While the guard is held, triggers coalesce...
+        (await coordinator.PollAndRouteCoalescedAsync(agentsSource, CancellationToken.None)).ShouldBeFalse();
+
+        // ...until the watchdog abandons the wedged cycle. A fresh cycle must then run for real.
+        coordinator.AbandonInFlightPoll();
+        (await coordinator.PollAndRouteCoalescedAsync(agentsSource, CancellationToken.None)).ShouldBeTrue();
+        detector.Persisted.Count.ShouldBe(1); // the fresh cycle did the work
+
+        // The wedged cycle wakes, sees it was superseded, and does no per-tenant work of its own.
+        releaseDetect.SetResult();
+        await wedged;
+        detector.Persisted.Count.ShouldBe(1);
+    }
+
+    // A deliberately hand-rolled agent double: NSubstitute proxies are too heavy at 6,000 instances, and
+    // the only seam this suite observes is MarkHighWater.
+    private sealed class RecordingAgent : ISubscriptionAgent
+    {
+        public RecordingAgent(ShardName name) => Name = name;
+
+        public List<long> Marks { get; } = new();
+
+        public ShardName Name { get; }
+        public long Position => 0;
+        public AgentStatus Status => AgentStatus.Running;
+        public DateTimeOffset? PausedTime => null;
+        public ISubscriptionMetrics Metrics => null!;
+        public ShardExecutionMode Mode => ShardExecutionMode.Continuous;
+        public ErrorHandlingOptions ErrorOptions => new();
+        public AsyncOptions Options => new();
+
+        public void MarkHighWater(long sequence)
+        {
+            lock (Marks)
+            {
+                Marks.Add(sequence);
+            }
+        }
+
+        public ValueTask MarkSuccessAsync(long processedCeiling) => default;
+        public Task ReportCriticalFailureAsync(Exception ex) => Task.CompletedTask;
+        public Task ReportCriticalFailureAsync(Exception ex, long lastProcessed) => Task.CompletedTask;
+        public Task RecordDeadLetterEventAsync(IEvent @event, Exception ex) => Task.CompletedTask;
+        public Task RecordDeadLetterEventAsync(DeadLetterEvent @event) => Task.CompletedTask;
+        public Task StopAndDrainAsync(CancellationToken token) => Task.CompletedTask;
+        public Task HardStopAsync() => Task.CompletedTask;
+        public Task StartAsync(SubscriptionExecutionRequest request) => Task.CompletedTask;
+
+        public Task ReplayAsync(SubscriptionExecutionRequest request, long highWaterMark, TimeSpan timeout)
+            => Task.CompletedTask;
+
+        public void MarkSkipped(long sequence)
+        {
+        }
+    }
+
+    // A partitioned detector whose vector is computed from the polled set, with optional async gates so a
+    // test can park a cycle mid-detect or mid-persist and observe concurrency.
+    private sealed class ScaleDetector : IHighWaterDetector
+    {
+        private readonly Func<IReadOnlyCollection<string>, HighWaterVector> _factory;
+        private int _concurrentPolls;
+        private int _maxConcurrentPolls;
+        private int _pollCount;
+
+        public ScaleDetector(Func<IReadOnlyCollection<string>, HighWaterVector> factory) => _factory = factory;
+
+        public Func<Task>? DetectGate { get; set; }
+        public Func<Task>? PersistGate { get; set; }
+
+        public int PollCount => Volatile.Read(ref _pollCount);
+        public int MaxConcurrentPolls => Volatile.Read(ref _maxConcurrentPolls);
+
+        public ConcurrentQueue<(string TenantId, long Sequence, DateTimeOffset Timestamp)> Persisted { get; } = new();
+
+        public Uri DatabaseUri { get; } = new("fake://db");
+        public bool SupportsTenantPartitioning => true;
+
+        public Task<HighWaterStatistics> Detect(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics());
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token)
+            => Task.FromResult(new HighWaterStatistics());
+
+        public async Task<HighWaterVector> DetectForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+        {
+            Interlocked.Increment(ref _pollCount);
+            var live = Interlocked.Increment(ref _concurrentPolls);
+            try
+            {
+                InterlockedMax(ref _maxConcurrentPolls, live);
+                if (DetectGate != null)
+                {
+                    await DetectGate();
+                }
+
+                return _factory(tenantIds);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _concurrentPolls);
+            }
+        }
+
+        public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => DetectForTenantsAsync(tenantIds, token);
+
+        public async Task MarkHighWaterForTenantAsync(string tenantId, long sequence, DateTimeOffset timestamp,
+            CancellationToken token)
+        {
+            if (PersistGate != null)
+            {
+                await PersistGate();
+            }
+
+            Persisted.Enqueue((tenantId, sequence, timestamp));
+        }
+
+        private static void InterlockedMax(ref int location, int value)
+        {
+            int current;
+            while (value > (current = Volatile.Read(ref location)))
+            {
+                if (Interlocked.CompareExchange(ref location, value, current) == current)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/TenantedHighWaterCoordinator.cs
@@ -24,6 +24,30 @@ public class TenantedHighWaterCoordinator
     // daemon watchdog thread, so written/read via Interlocked.
     private long _lastPolledAtTicks;
 
+    // jasperfx#644: cycle supersession. Each PollAndRouteAsync stamps a new epoch; an in-flight cycle
+    // checks the epoch per reading and retires itself as soon as a newer cycle (coalesced rerun, watchdog
+    // restart, or an awaited priming poll) has started — the newer cycle re-reads every tenant, so nothing
+    // is lost. Without this, the daemon watchdog's "abandon the hung poll and start fresh" left the
+    // abandoned cycle RUNNING, stacking one full live cycle per staleness window until OOM.
+    private int _pollEpoch;
+
+    // jasperfx#644: single-flight + one trailing rerun for the daemon's background poll triggers.
+    // _pollInFlight is 0 when free, otherwise the owning call's ticket — ownership matters so that a
+    // cycle the watchdog abandoned cannot, on finally waking, release a guard that has since been handed
+    // to a fresh cycle.
+    private long _pollInFlight;
+    private long _pollTicketSource;
+    private int _pollQueued;
+
+    // jasperfx#644: the last mark actually routed to agents / successfully persisted, per tenant. Lets the
+    // steady-state cycle skip tenants whose mark did not advance instead of re-routing (one queued command
+    // per agent per cycle) and re-persisting (one database write per tenant per cycle) 2,000+ unchanged
+    // tenants forever. A failed persist is NOT recorded, so it retries next cycle exactly like the old
+    // unconditional write did.
+    private readonly Dictionary<string, long> _lastRoutedMarks = new();
+    private readonly Dictionary<string, long> _lastPersistedMarks = new();
+    private readonly object _marksLock = new();
+
     public TenantedHighWaterCoordinator(IHighWaterDetector detector, ILogger? logger = null)
     {
         _monitor = new VectorizedHighWaterMonitor(detector, logger);
@@ -90,20 +114,73 @@ public class TenantedHighWaterCoordinator
     public async Task<IReadOnlyList<TenantHighWaterReading>> PollAndRouteAsync(
         IReadOnlyList<ISubscriptionAgent> agents, CancellationToken token)
     {
+        var epoch = Interlocked.Increment(ref _pollEpoch);
+
         var readings = await _monitor.PollAsync(token).ConfigureAwait(false);
 
         // jasperfx#539: a completed vectorized poll is one cycle of the per-tenant high-water path — stamp
         // the liveness heartbeat even when no tenant's mark moved.
         Interlocked.Exchange(ref _lastPolledAtTicks, DateTimeOffset.UtcNow.UtcTicks);
 
+        // jasperfx#644: group the agents by tenant once — O(agents) — instead of scanning every agent for
+        // every reading, which is O(tenants × agents) per cycle and at field scale (2,173 tenants ×
+        // ~4,400 agents) was ~9.5 million name comparisons per poll, on a timer, forever.
+        Dictionary<string, List<ISubscriptionAgent>>? agentsByTenant = null;
+        foreach (var agent in agents)
+        {
+            var agentTenant = agent.Name.TenantId;
+            if (agentTenant == null)
+            {
+                continue;
+            }
+
+            agentsByTenant ??= new Dictionary<string, List<ISubscriptionAgent>>();
+            if (!agentsByTenant.TryGetValue(agentTenant, out var bucket))
+            {
+                agentsByTenant[agentTenant] = bucket = new List<ISubscriptionAgent>();
+            }
+
+            bucket.Add(agent);
+        }
+
         foreach (var reading in readings)
         {
-            foreach (var agent in agents)
+            // jasperfx#644: retire this cycle as soon as a newer one has started. The newer cycle re-reads
+            // every tenant with fresher statistics and the shared last-routed/last-persisted bookkeeping
+            // keeps the hand-off gapless, so two full cycles never grind to completion side by side.
+            if (token.IsCancellationRequested || Volatile.Read(ref _pollEpoch) != epoch)
             {
-                // Route only to that tenant's shards. A tenant's stale mark never reaches another tenant.
-                if (agent.Name.TenantId == reading.TenantId)
+                break;
+            }
+
+            var mark = reading.Statistics.CurrentMark;
+
+            // Route only to that tenant's shards. A tenant's stale mark never reaches another tenant.
+            // jasperfx#644: and only when the mark actually advanced — agents drop a non-advancing mark
+            // anyway (SubscriptionAgent.Apply ignores <= HighWaterMark) and a newly started tenant agent
+            // is seeded from CeilingFor at start, so re-routing an unchanged mark every cycle was pure
+            // per-cycle allocation (one queued command per agent, forever).
+            if (reading.TenantId != null && agentsByTenant != null &&
+                agentsByTenant.TryGetValue(reading.TenantId, out var tenantAgents))
+            {
+                bool advanced;
+                lock (_marksLock)
                 {
-                    agent.MarkHighWater(reading.Statistics.CurrentMark);
+                    advanced = !_lastRoutedMarks.TryGetValue(reading.TenantId, out var lastRouted) ||
+                               mark > lastRouted;
+                }
+
+                if (advanced)
+                {
+                    foreach (var agent in tenantAgents)
+                    {
+                        agent.MarkHighWater(mark);
+                    }
+
+                    lock (_marksLock)
+                    {
+                        _lastRoutedMarks[reading.TenantId] = mark;
+                    }
                 }
             }
 
@@ -111,23 +188,101 @@ public class TenantedHighWaterCoordinator
             // a daemon restart (the store-global HighWaterMark row cannot represent multiple tenants).
             // jasperfx#449: carry the per-tenant timestamp through so the persisted row exposes
             // per-tenant staleness. No-op for detectors that don't override the write.
-            if (reading.TenantId != null && reading.Statistics.CurrentMark > 0)
+            // jasperfx#644: skipped when the mark has not advanced past the last successfully persisted
+            // value — the row already says exactly this, and re-writing it for thousands of flat tenants
+            // per cycle was the bulk of each cycle's database work.
+            if (reading.TenantId != null && mark > 0)
             {
-                try
+                bool shouldPersist;
+                lock (_marksLock)
                 {
-                    await _detector
-                        .MarkHighWaterForTenantAsync(reading.TenantId, reading.Statistics.CurrentMark,
-                            reading.Statistics.Timestamp, token)
-                        .ConfigureAwait(false);
+                    shouldPersist = !_lastPersistedMarks.TryGetValue(reading.TenantId, out var lastPersisted) ||
+                                    mark > lastPersisted;
                 }
-                catch (Exception e)
+
+                if (shouldPersist)
                 {
-                    _logger.LogError(e, "Error persisting per-tenant high-water mark for tenant {TenantId}",
-                        reading.TenantId);
+                    try
+                    {
+                        await _detector
+                            .MarkHighWaterForTenantAsync(reading.TenantId, mark,
+                                reading.Statistics.Timestamp, token)
+                            .ConfigureAwait(false);
+
+                        lock (_marksLock)
+                        {
+                            _lastPersistedMarks[reading.TenantId] = mark;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Error persisting per-tenant high-water mark for tenant {TenantId}",
+                            reading.TenantId);
+                    }
                 }
             }
         }
 
         return readings;
+    }
+
+    /// <summary>
+    /// jasperfx#644: single-flight wrapper over <see cref="PollAndRouteAsync" /> for the daemon's
+    /// background triggers (the OnNext high-water fast path and the cadence timer). At most one cycle runs
+    /// at a time; a trigger that arrives mid-cycle latches exactly ONE trailing rerun instead of stacking
+    /// another concurrent full cycle — at thousands of tenants a cycle is slow enough that unguarded
+    /// triggers pile live cycles up without bound (the gh-644 OOM). Awaited priming paths that need a
+    /// completed poll for a just-activated tenant keep calling <see cref="PollAndRouteAsync" /> directly.
+    /// Returns true when this call ran at least one cycle, false when it coalesced into an in-flight one.
+    /// </summary>
+    public async Task<bool> PollAndRouteCoalescedAsync(
+        Func<IReadOnlyList<ISubscriptionAgent>> agentsSource, CancellationToken token)
+    {
+        while (true)
+        {
+            var ticket = Interlocked.Increment(ref _pollTicketSource);
+            if (Interlocked.CompareExchange(ref _pollInFlight, ticket, 0) != 0)
+            {
+                // A cycle is running; its owner picks this up as one trailing rerun.
+                Interlocked.Exchange(ref _pollQueued, 1);
+                return false;
+            }
+
+            try
+            {
+                do
+                {
+                    await PollAndRouteAsync(agentsSource(), token).ConfigureAwait(false);
+                } while (!token.IsCancellationRequested &&
+                         Interlocked.CompareExchange(ref _pollQueued, 0, 1) == 1);
+            }
+            finally
+            {
+                // Release only if still the owner — AbandonInFlightPoll may have already handed the
+                // guard to a fresh cycle while this one was wedged.
+                Interlocked.CompareExchange(ref _pollInFlight, 0, ticket);
+            }
+
+            // Close the release race: a trigger that latched between the loop's last check and the
+            // release above would otherwise be dropped. If another caller has already re-acquired the
+            // flag, the top of the loop re-latches and hands the rerun to them.
+            if (token.IsCancellationRequested || Interlocked.CompareExchange(ref _pollQueued, 0, 1) != 1)
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// jasperfx#644: the daemon watchdog's restart seam. Releases the single-flight guard so a fresh cycle
+    /// can start even though a wedged one never returned, and bumps the epoch so the wedged cycle — which
+    /// is still running, "abandoned" only in the sense that nobody awaits it — retires itself at its next
+    /// reading instead of grinding on as a leaked concurrent full cycle.
+    /// </summary>
+    public void AbandonInFlightPoll()
+    {
+        Interlocked.Increment(ref _pollEpoch);
+        Volatile.Write(ref _pollQueued, 0);
+        Interlocked.Exchange(ref _pollInFlight, 0L);
     }
 }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -63,7 +63,6 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
     // against the OnNext-driven fast path so an active system still polls once per global tick.
     private readonly Timer? _tenantHighWaterTimer;
     private DateTimeOffset _lastTenantHighWaterPoll;
-    private int _tenantHighWaterPollInFlight;
 
     // jasperfx#539: highest store-global mark that has already driven a per-tenant poll. OnNext re-triggers a
     // tenant poll only on a genuine advance past this, so the per-cycle high-water HEARTBEAT publications
@@ -1175,13 +1174,50 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
                 _lastTenantPollTriggerMark = value.Sequence;
 
                 // Reuse the global high-water cadence to drive one vectorized per-tenant poll.
-                _ = pollTenantHighWaterAsync();
+                // jasperfx#644: through the coalesced path — this fire-and-forget used to start a brand-new
+                // full cycle per global-mark advance with no in-flight guard, and at thousands of tenants a
+                // cycle is slower than the advance rate, so concurrent cycles stacked up without bound.
+                _ = pollTenantHighWaterCoalescedAsync();
             }
         }
 
         _shardStateTracker?.Add(value);
     }
 
+    // jasperfx#644: the background-trigger flavor (OnNext fast path + cadence timer). Coalesces into the
+    // coordinator's single-flight cycle instead of stacking a concurrent full cycle per trigger. The
+    // heartbeat is published only by the call that actually ran a cycle — a coalesced trigger's work is
+    // covered by the in-flight cycle's own trailing rerun and heartbeat.
+    private async Task pollTenantHighWaterCoalescedAsync()
+    {
+        if (_tenantHighWater == null)
+        {
+            return;
+        }
+
+        _lastTenantHighWaterPoll = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var ran = await _tenantHighWater
+                .PollAndRouteCoalescedAsync(CurrentAgents, _cancellation.Token)
+                .ConfigureAwait(false);
+
+            if (ran)
+            {
+                await publishHighWaterStatusAsync(ShardAction.Updated, "Running").ConfigureAwait(false);
+            }
+        }
+        catch (Exception e)
+        {
+            Logger.LogError(e, "Error polling per-tenant high water for database {Name}", Database.Identifier);
+        }
+    }
+
+    // The awaited flavor for priming paths (StartAgentAsync/StartAllAsync/rebuild ceilings) that need a
+    // COMPLETED poll covering a just-activated tenant — these must not coalesce into a cycle that took its
+    // tenant snapshot before the activation. jasperfx#644: bounded by their callers (operator/startup
+    // driven); an overlapping background cycle is retired by the coordinator's epoch supersession.
     private async Task pollTenantHighWaterAsync()
     {
         if (_tenantHighWater == null)
@@ -1228,7 +1264,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
     // jasperfx#539: Path B restart seam. The per-tenant path is timer-driven, so remediation is a stop/re-arm
     // of the cadence timer plus clearing any wedged in-flight guard so a fresh poll can start. A hung poll is
-    // abandoned (its result is ignored on completion), mirroring HighWaterAgent's non-blocking restart.
+    // abandoned, mirroring HighWaterAgent's non-blocking restart — and jasperfx#644: "abandoned" now means
+    // the coordinator bumps its cycle epoch so the wedged cycle actually retires itself when it wakes,
+    // instead of grinding on as a leaked concurrent full cycle (one per staleness window was the OOM).
     private void restartTenantHighWater()
     {
         if (_tenantHighWaterTimer == null)
@@ -1236,7 +1274,7 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             return;
         }
 
-        Volatile.Write(ref _tenantHighWaterPollInFlight, 0);
+        _tenantHighWater?.AbandonInFlightPoll();
         _tenantHighWaterTimer.Stop();
 
         if (!_cancellation.IsCancellationRequested)
@@ -1343,19 +1381,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             return;
         }
 
-        if (Interlocked.CompareExchange(ref _tenantHighWaterPollInFlight, 1, 0) == 1)
-        {
-            return;
-        }
-
-        try
-        {
-            await pollTenantHighWaterAsync().ConfigureAwait(false);
-        }
-        finally
-        {
-            Volatile.Write(ref _tenantHighWaterPollInFlight, 0);
-        }
+        // jasperfx#644: single-flight (plus one trailing rerun) now lives in the coordinator, shared with
+        // the OnNext fast path, so no trigger source can stack a concurrent full cycle.
+        await pollTenantHighWaterCoalescedAsync().ConfigureAwait(false);
     }
 
     // Keep the vectorized monitor's polled-tenant set in step with the shards currently assigned to this


### PR DESCRIPTION
Fixes #644 — `System.OutOfMemoryException` (exit 139) in `TenantedHighWaterCoordinator.PollAndRouteAsync` at 2,173 tenants / ~4,400 agents on a 512-database sharded deployment.

## Root cause — three compounding defects

1. **Quadratic routing.** Every reading was compared against every agent (`agent.Name.TenantId == reading.TenantId`): ~9.5M string comparisons per cycle at field scale.
2. **Unconditional per-cycle work for flat tenants.** Every cycle re-routed every tenant's mark (one queued `Command` allocation per agent per cycle into an unbounded command block) and ran 2,173 sequential awaited `MarkHighWaterForTenantAsync` DB writes even when nothing advanced — pushing cycle time into the tens of seconds reported in the issue.
3. **Unbounded concurrent cycles — the actual OOM mechanism.** The `OnNext(HighWaterMark)` fast path fired `_ = pollTenantHighWaterAsync()` with no in-flight guard, and once a cycle exceeded `HighWaterStalenessThreshold` (guaranteed at this scale by 1+2), the #539 watchdog's restart **cleared the in-flight guard while the abandoned cycle was still running**. Each staleness window leaked one live cycle retaining its full reading list, `CurrentAgents()` snapshot, and `HighWaterVector`; the leaked cycles slowed each other via DB contention so the threshold kept tripping — monotonic pile-up until the heap hit the container limit.

## The fix

`TenantedHighWaterCoordinator`:
- Agents are grouped by `TenantId` once per cycle — routing is **O(tenants + agents)**.
- **Delta routing/persistence**: per-tenant last-routed and last-successfully-persisted marks; only tenants whose mark advanced are routed/persisted. Safe because new agents seed from `CeilingFor` at start and `SubscriptionAgent.Apply` drops non-advancing marks; failed persists aren't recorded, so they retry next cycle.
- **Cycle epoch supersession**: a newer cycle retires an in-flight one at its next reading, with shared bookkeeping keeping the hand-off gapless — the watchdog's "abandon" now actually releases the old cycle's work.
- New `PollAndRouteCoalescedAsync` (single-flight with a ticket-owned guard and at most one trailing rerun; release race closed) and `AbandonInFlightPoll()` for the watchdog.

`JasperFxAsyncDaemon`:
- The `OnNext` fast path and the cadence timer both route through the coalesced path.
- Awaited priming polls (`StartAgentAsync` / `StartAllAsync` / rebuild ceilings) deliberately stay on the direct path so a just-activated tenant's ceiling is always covered by a completed poll.
- The watchdog restart calls `AbandonInFlightPoll()` instead of blindly clearing the daemon-side in-flight flag (field removed).

## Tests

New `TenantedHighWaterCoordinator_scale_Tests` (6 tests, observable seams, no allocation assertions): unchanged tenants are not re-routed/re-persisted; advanced tenants are; a 3,000-tenant × 6,000-agent cycle where a follow-up cycle's work is exactly proportional to the 25 advanced tenants; supersession retires an in-flight cycle without losing tenants; 50 concurrent triggers coalesce into exactly 2 cycles with max detected concurrency 1; abandon releases a wedged guard and the wedged cycle does no work on waking.

EventTests: **746/746 passing on net9.0 and net10.0** (all pre-existing coordinator/vectorized/daemon high-water tests unmodified). Full solution builds clean.

## Proposed 2.46.0 release-note line

> Per-tenant high-water polling is now bounded at thousands of tenants: agent routing is O(tenants + agents) instead of O(tenants × agents), only tenants whose mark advanced are re-routed/re-persisted, and background poll triggers coalesce into a single in-flight cycle (a superseded or watchdog-abandoned cycle now actually retires instead of running to completion) — fixes the host-process OutOfMemoryException at 2,000+ tenants (#644)

🤖 Generated with [Claude Code](https://claude.com/claude-code)