### PR TITLE
gh-640: RecentlyUsedCache.CompactIfNecessary no longer over-evicts — rebuild from survivors instead of ImHashMap.Remove

### DIFF
--- a/src/CoreTests/RecentlyUsedCacheCompactionTests.cs
+++ b/src/CoreTests/RecentlyUsedCacheCompactionTests.cs
@@ -1,0 +1,243 @@
+using JasperFx.Core;
+using Shouldly;
+
+namespace CoreTests;
+
+/// <summary>
+/// Regression coverage for gh-640: RecentlyUsedCache.CompactIfNecessary lost
+/// more entries than it should ~0.8% of the time. Root cause: ImTools 4.0.0's
+/// ImHashMap.Remove corrupts the tree when applied to a map that has already
+/// absorbed a previous Remove — survivors that were never removed become
+/// unreachable to TryFind while Count() may still include them. The fix
+/// rebuilds both maps from the survivors instead of calling Remove, so every
+/// tree is only ever built by AddOrUpdate from Empty.
+///
+/// These tests are fully deterministic: keys are Guids built from a seeded
+/// Random, so the ImHashMap tree shape is identical on every run. The
+/// [InlineData] seeds are shapes that provably corrupted under the old
+/// Remove-based compaction (found by a 20,000-seed sweep against a pure
+/// ImTools 4.0.0 repro of the same insert/remove sequence — ~1% failed).
+/// </summary>
+public class RecentlyUsedCacheCompactionTests
+{
+    private static Guid SeededGuid(Random rng)
+    {
+        var bytes = new byte[16];
+        rng.NextBytes(bytes);
+        return new Guid(bytes);
+    }
+
+    private static (RecentlyUsedCache<Guid, Item> cache, List<Guid> ids) seededCache(int seed, int count, int limit)
+    {
+        var rng = new Random(seed);
+        var cache = new RecentlyUsedCache<Guid, Item> { Limit = limit };
+        var ids = new List<Guid>();
+        for (var i = 0; i < count; i++)
+        {
+            var id = SeededGuid(rng);
+            ids.Add(id);
+            cache.Store(id, new Item(id));
+        }
+
+        // The seeded byte streams used here never produce duplicate Guids,
+        // but guard anyway so a future edit can't silently weaken the test.
+        ids.Distinct().Count().ShouldBe(count);
+
+        return (cache, ids);
+    }
+
+    private static void assertFullyConsistent(RecentlyUsedCache<Guid, Item> cache, List<Guid> ids, ISet<Guid> expectedPresent)
+    {
+        foreach (var id in ids)
+        {
+            cache.TryFind(id, out _).ShouldBe(expectedPresent.Contains(id),
+                $"key {id} findability disagreed with expectation");
+        }
+
+        cache.Count.ShouldBe(expectedPresent.Count);
+    }
+
+    // These seeds produced ImHashMap tree shapes that the old Remove-based
+    // compaction provably corrupted (count and/or findability wrong).
+    [Theory]
+    [InlineData(83)]
+    [InlineData(214)]
+    [InlineData(220)]
+    [InlineData(507)]
+    [InlineData(596)]
+    [InlineData(1220)]
+    [InlineData(1563)]
+    public void compact_keeps_every_survivor_findable_on_known_hostile_tree_shapes(int seed)
+    {
+        var (cache, ids) = seededCache(seed, 110, 100);
+
+        cache.CompactIfNecessary();
+
+        // LRU: the 10 oldest (first stored) are evicted, the other 100 survive
+        var expected = ids.Skip(10).ToHashSet();
+        assertFullyConsistent(cache, ids, expected);
+    }
+
+    [Fact]
+    public void compact_seeded_sweep_never_loses_survivors()
+    {
+        // 2,000 deterministic tree shapes. Under the old Remove-based
+        // compaction ~1% of these rounds lost extra entries or reported a
+        // Count that disagreed with TryFind.
+        for (var seed = 0; seed < 2000; seed++)
+        {
+            var (cache, ids) = seededCache(seed, 110, 100);
+
+            cache.CompactIfNecessary();
+
+            var survivors = ids.Skip(10).Count(id => cache.TryFind(id, out _));
+            var ghosts = ids.Take(10).Count(id => cache.TryFind(id, out _));
+
+            survivors.ShouldBe(100, $"seed {seed}: survivors lost");
+            ghosts.ShouldBe(0, $"seed {seed}: evicted keys still findable");
+            cache.Count.ShouldBe(100, $"seed {seed}: Count disagrees with contents");
+        }
+    }
+
+    [Fact]
+    public void compact_at_exactly_the_limit_is_a_noop()
+    {
+        var (cache, ids) = seededCache(42, 100, 100);
+
+        cache.CompactIfNecessary();
+
+        assertFullyConsistent(cache, ids, ids.ToHashSet());
+    }
+
+    [Fact]
+    public void compact_under_the_limit_is_a_noop()
+    {
+        var (cache, ids) = seededCache(42, 60, 100);
+
+        cache.CompactIfNecessary();
+
+        assertFullyConsistent(cache, ids, ids.ToHashSet());
+    }
+
+    [Fact]
+    public void compact_one_over_the_limit_removes_exactly_one()
+    {
+        var (cache, ids) = seededCache(42, 101, 100);
+
+        cache.CompactIfNecessary();
+
+        assertFullyConsistent(cache, ids, ids.Skip(1).ToHashSet());
+    }
+
+    [Fact]
+    public void repeated_compactions_hold_the_limit_and_keep_survivors()
+    {
+        var rng = new Random(83);
+        var cache = new RecentlyUsedCache<Guid, Item> { Limit = 100 };
+        var ids = new List<Guid>();
+
+        // Five waves of overflow + compaction. Each compaction leaves trees
+        // that the next round mutates again — exactly the repeated-removal
+        // history that corrupted the old implementation.
+        for (var wave = 0; wave < 5; wave++)
+        {
+            for (var i = 0; i < 30; i++)
+            {
+                var id = SeededGuid(rng);
+                ids.Add(id);
+                cache.Store(id, new Item(id));
+            }
+
+            cache.CompactIfNecessary();
+
+            var expectedCount = Math.Min(ids.Count, 100);
+            var expected = ids.Skip(ids.Count - expectedCount).ToHashSet();
+            assertFullyConsistent(cache, ids, expected);
+        }
+    }
+
+    [Fact]
+    public void try_remove_then_compact_stays_consistent()
+    {
+        var (cache, ids) = seededCache(83, 110, 100);
+
+        // Interleave targeted removals with compaction — the mixed
+        // removal history is what the old code corrupted.
+        cache.TryRemove(ids[50]);
+        cache.TryRemove(ids[75]);
+
+        cache.CompactIfNecessary();
+
+        // 108 remain before compaction; the 8 oldest surviving keys go
+        var expected = ids.Where((_, i) => i != 50 && i != 75).Skip(8).ToHashSet();
+        assertFullyConsistent(cache, ids, expected);
+    }
+
+    [Fact]
+    public void try_remove_missing_key_is_a_noop()
+    {
+        var (cache, ids) = seededCache(42, 50, 100);
+
+        cache.TryRemove(Guid.NewGuid());
+
+        assertFullyConsistent(cache, ids, ids.ToHashSet());
+    }
+
+    [Fact]
+    public void many_sequential_try_removes_never_corrupt()
+    {
+        var (cache, ids) = seededCache(83, 110, 100);
+
+        // Remove every other key one at a time — under the old code each
+        // Remove after the first operated on an already-removed-from tree.
+        var removed = new HashSet<Guid>();
+        for (var i = 0; i < ids.Count; i += 2)
+        {
+            cache.TryRemove(ids[i]);
+            removed.Add(ids[i]);
+        }
+
+        assertFullyConsistent(cache, ids, ids.Where(id => !removed.Contains(id)).ToHashSet());
+    }
+
+    [Fact]
+    public void concurrent_store_and_compact_stays_consistent()
+    {
+        // RecentlyUsedCache claims thread safety (#226). Hammer Store and
+        // CompactIfNecessary concurrently, then verify the quiesced cache
+        // is internally consistent: Count agrees with TryFind for every
+        // key ever stored, and the limit holds after a final compaction.
+        var cache = new RecentlyUsedCache<Guid, Item> { Limit = 100 };
+        const int writerCount = 4;
+        const int perWriter = 500;
+
+        var batches = Enumerable.Range(0, writerCount)
+            .Select(_ => Enumerable.Range(0, perWriter)
+                .Select(_ => Guid.NewGuid()).ToArray())
+            .ToArray();
+
+        Parallel.For(0, writerCount + 1, worker =>
+        {
+            if (worker == writerCount)
+            {
+                for (var i = 0; i < 200; i++)
+                {
+                    cache.CompactIfNecessary();
+                }
+            }
+            else
+            {
+                foreach (var id in batches[worker])
+                {
+                    cache.Store(id, new Item(id));
+                }
+            }
+        });
+
+        cache.CompactIfNecessary();
+        cache.Count.ShouldBe(100);
+
+        var findable = batches.SelectMany(x => x).Count(id => cache.TryFind(id, out _));
+        findable.ShouldBe(100);
+    }
+}

--- a/src/CoreTests/RecentlyUsedCacheTests.cs
+++ b/src/CoreTests/RecentlyUsedCacheTests.cs
@@ -49,10 +49,18 @@ public class RecentlyUsedCacheTests
 
         theCache.CompactIfNecessary();
 
-        // The first 10 should have removed
+        // The first 10 should have been removed...
         for (int i = 0; i < 10; i++)
         {
-            theCache.TryFind(items[0].Id, out var _).ShouldBeFalse();
+            theCache.TryFind(items[i].Id, out var _).ShouldBeFalse();
+        }
+
+        // ...and ONLY the first 10 — gh-640: the old Remove-based compaction
+        // could silently drop extra survivors while still reporting a
+        // plausible Count.
+        for (int i = 10; i < 110; i++)
+        {
+            theCache.TryFind(items[i].Id, out var _).ShouldBeTrue();
         }
 
         theCache.Count.ShouldBe(theCache.Limit);

--- a/src/EventStoreTests/RecentlyUsedCacheTests.cs
+++ b/src/EventStoreTests/RecentlyUsedCacheTests.cs
@@ -38,10 +38,18 @@ public class RecentlyUsedCacheTests
 
         theCache.CompactIfNecessary();
 
-        // The first 10 should have removed
+        // The first 10 should have been removed...
         for (int i = 0; i < 10; i++)
         {
-            theCache.TryFind(items[0].Id, out var _).ShouldBeFalse();
+            theCache.TryFind(items[i].Id, out var _).ShouldBeFalse();
+        }
+
+        // ...and ONLY the first 10 — gh-640: the old Remove-based compaction
+        // could silently drop extra survivors while still reporting a
+        // plausible Count.
+        for (int i = 10; i < 110; i++)
+        {
+            theCache.TryFind(items[i].Id, out var _).ShouldBeTrue();
         }
 
         theCache.Count.ShouldBe(theCache.Limit);

--- a/src/JasperFx/Core/RecentlyUsedCache.cs
+++ b/src/JasperFx/Core/RecentlyUsedCache.cs
@@ -140,21 +140,14 @@ public class RecentlyUsedCache<TKey, TItem>: IAggregateCache<TKey, TItem> where 
             var extraCount = _items.Count() - Limit;
             if (extraCount <= 0) return;
 
-            var toRemove = _times
+            var doomed = _times
                 .Enumerate()
                 .OrderBy(x => x.Value)
                 .Select(x => x.Key)
                 .Take(extraCount)
-                .ToArray();
+                .ToHashSet();
 
-            foreach (var key in toRemove)
-            {
-                // Drop from BOTH maps. Earlier code redundantly removed
-                // from `_items` twice and never touched `_times`, leaving
-                // it to grow unboundedly across the cache's lifetime.
-                _items = _items.Remove(key);
-                _times = _times.Remove(key);
-            }
+            rebuildWithout(doomed);
         }
     }
 
@@ -162,8 +155,42 @@ public class RecentlyUsedCache<TKey, TItem>: IAggregateCache<TKey, TItem> where 
     {
         lock (_lock)
         {
-            _items = _items.Remove(key);
-            _times = _times.Remove(key);
+            if (!_items.Contains(key) && !_times.Contains(key)) return;
+
+            rebuildWithout([key]);
         }
+    }
+
+    // gh-640: NEVER call ImHashMap.Remove here. ImTools 4.0.0's Remove
+    // corrupts the tree when it is applied to a map that has already
+    // absorbed a previous Remove — survivors that were never removed
+    // become unreachable to TryFind while Count() may still include
+    // them (a pure-ImTools repro shows ~1% of seeded 110-key rounds
+    // losing up to 6 extra entries after 10 sequential Removes; a
+    // single Remove on an add-only tree never corrupts). Latest stable
+    // ImTools is 4.0.0, so there is no upgrade path. Instead of
+    // removing, rebuild both maps from the survivors so every tree in
+    // this class is only ever built by AddOrUpdate from Empty. O(n)
+    // per removal, but n is bounded by Limit + the between-compaction
+    // overflow, so the cost is trivial next to the aggregate fetches
+    // this cache exists to avoid.
+    private void rebuildWithout(IReadOnlyCollection<TKey> doomed)
+    {
+        var items = ImHashMap<TKey, TItem>.Empty;
+        foreach (var entry in _items.Enumerate())
+        {
+            if (doomed.Contains(entry.Key)) continue;
+            items = items.AddOrUpdate(entry.Key, entry.Value);
+        }
+
+        var times = ImHashMap<TKey, long>.Empty;
+        foreach (var entry in _times.Enumerate())
+        {
+            if (doomed.Contains(entry.Key)) continue;
+            times = times.AddOrUpdate(entry.Key, entry.Value);
+        }
+
+        _items = items;
+        _times = times;
     }
 }


### PR DESCRIPTION
Closes #640

## Root cause

The ~0.8% `compact_moves_off_the_first_ones` failure is not a flake and not in `RecentlyUsedCache`'s locking or LRU ordering: **ImTools 4.0.0's `ImHashMap.Remove` corrupts the tree when it is applied to a map that has already absorbed a previous `Remove`.**

A pure-ImTools repro (no JasperFx types: add 110 seeded-Guid keys, `Remove` the first 10 one at a time, then probe) shows:

- **201 of 20,000 seeded rounds fail (~1%)** — up to 6 *extra* survivors become unreachable to `TryFind`, and `Count()` can disagree with findability in either direction (e.g. `count=100, survivorsFound=95`).
- **A single `Remove` on an add-only tree never corrupts** — 0 failures in 25,000 seeded rounds across map sizes 5–110. The fault is strictly *remove-after-remove*: step-tracing seed 83 shows removals #0–#7 each behave perfectly, then removal #8 drops two entries.

So `CompactIfNecessary`'s loop of 10 sequential `Remove`s was rolling those dice 9 times per compaction, which is exactly the observed ~0.8% failure rate.

## The fix (usage-side, deliberately)

ImTools 4.0.0 is the latest stable release (only a 5.0.0-preview exists beyond it), so there is no upgrade path. Rather than vendoring ImTools, `RecentlyUsedCache` now never calls `ImHashMap.Remove` at all: `CompactIfNecessary` and `TryRemove` rebuild both maps from the survivors via `AddOrUpdate` from `Empty`. The class-level invariant is now that every tree is only ever built by `AddOrUpdate`, which the repro shows is safe. Rebuild is O(n), but n is bounded by `Limit` plus the between-compaction overflow, so the cost is trivial next to the aggregate fetches this cache exists to avoid (`AggregationRunner`).

## Deterministic reproduction, kept as tests

Keys are Guids built from a seeded `Random`, so the ImHashMap tree shape is bit-identical every run (verified: the same 8 tests fail identically on net9.0 and net10.0 against the old code, and the failing seeds match the standalone sweep). New coverage in `CoreTests/RecentlyUsedCacheCompactionTests.cs`:

- `[Theory]` over seven seeds that provably corrupted the old compaction (83, 214, 220, 507, 596, 1220, 1563) asserting every survivor findable, every victim gone, `Count` exact
- a 2,000-seed sweep of the same invariant (~20 seeds failed pre-fix)
- compaction at exactly the limit / under the limit (no-ops) and one-over (removes exactly one)
- five repeated overflow+compaction waves
- interleaved `TryRemove` + compaction, 55 sequential `TryRemove`s, `TryRemove` of a missing key
- concurrent `Store` × `CompactIfNecessary` consistency check (the type claims thread safety per #226)

Also strengthened the existing `compact_moves_off_the_first_ones` in both CoreTests and EventStoreTests — it looped over `items[0]` ten times and never checked that survivors were still findable, which is why it only caught the bug on the ~0.8% of rounds where the count happened to land wrong.

Verified red-before-fix (8 deterministic failures with the old `Remove`-based compaction) and green after: CoreTests 574/574 passed on net9.0 + net10.0; EventStoreTests 72/72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)