### PR TITLE
gh-647: persistence abstractions for the document slice JasperFx.Events did not cover

### DIFF
--- a/src/EventStoreTests/Documents/InMemoryDocumentComplianceFixture.cs
+++ b/src/EventStoreTests/Documents/InMemoryDocumentComplianceFixture.cs
@@ -1,0 +1,46 @@
+using JasperFx.Events.ComplianceTests;
+using JasperFx.Events.Documents;
+
+namespace EventStoreTests.Documents;
+
+/// <summary>
+/// Enrolls <see cref="InMemoryDocumentStore" /> in the shared document compliance suites.
+/// </summary>
+/// <remarks>
+/// Three overrides, no generics — which is the point being demonstrated. Compare
+/// <c>EventStoreComplianceFixture&lt;TOperations, TQuerySession&gt;</c>, whose sixteen abstract
+/// members exist because so much of the event surface is only reachable through a product's own
+/// session type.
+/// </remarks>
+public class InMemoryDocumentComplianceFixture : DocumentStorageComplianceFixture
+{
+    private readonly InMemoryDocumentStore _store = new();
+
+    protected override Task BuildStoreAsync(DocumentComplianceConfig config)
+    {
+        // Nothing to build: an in-memory store has no schema, and it creates storage for a document
+        // type on first use. Both are legitimate answers to this seam member.
+        _ = config;
+        return Task.CompletedTask;
+    }
+
+    public override IDocumentSessionFactory Sessions => _store;
+
+    public override Task CleanDocumentDataAsync()
+    {
+        _store.Clear();
+        return Task.CompletedTask;
+    }
+}
+
+public class in_memory_document_session_compliance
+    : DocumentSessionCompliance<InMemoryDocumentComplianceFixture>;
+
+public class in_memory_document_load_and_store_compliance
+    : DocumentLoadAndStoreCompliance<InMemoryDocumentComplianceFixture>;
+
+public class in_memory_document_delete_compliance
+    : DocumentDeleteCompliance<InMemoryDocumentComplianceFixture>;
+
+public class in_memory_document_query_compliance
+    : DocumentQueryCompliance<InMemoryDocumentComplianceFixture>;

--- a/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
+++ b/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
@@ -1,0 +1,208 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using JasperFx.Events.Documents;
+
+namespace EventStoreTests.Documents;
+
+/// <summary>
+/// A deliberately naive, in-memory implementation of the jasperfx#647 document contract.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Not a product and not shipped — it exists so the shared document compliance suites are actually
+/// executed by something before Marten, Polecat and Fisher enroll in them. A compliance suite nobody
+/// has ever run is a liability: it can encode an assertion that no correct store could satisfy, and
+/// the first three teams to hit it have no way to tell a suite bug from a product bug.
+/// </para>
+/// <para>
+/// It also stands as the smallest possible proof that the contract is implementable without reaching
+/// past it — everything below is dictionaries, <c>AsQueryable()</c> and one query-provider wrapper.
+/// </para>
+/// </remarks>
+public class InMemoryDocumentStore : IDocumentSessionFactory<InMemoryDocumentSession, InMemoryDocumentSession>
+{
+    private readonly ConcurrentDictionary<Type, ConcurrentDictionary<object, object>> _documents = new();
+
+    public InMemoryDocumentSession LightweightSession() => new(this);
+
+    public InMemoryDocumentSession QuerySession() => new(this);
+
+    IDocumentSessionOperations IDocumentSessionFactory.LightweightSession() => LightweightSession();
+
+    IDocumentReadOperations IDocumentSessionFactory.QuerySession() => QuerySession();
+
+    public void Clear() => _documents.Clear();
+
+    internal ConcurrentDictionary<object, object> StorageFor(Type documentType)
+        => _documents.GetOrAdd(documentType, _ => new ConcurrentDictionary<object, object>());
+
+    internal IReadOnlyList<T> SnapshotOf<T>() => StorageFor(typeof(T)).Values.Cast<T>().ToList();
+
+    /// <summary>
+    /// Resolve a document's identity from a conventional <c>Id</c> member. The document contract does
+    /// not abstract identity configuration, so the simplest convention both products already honor is
+    /// enough here.
+    /// </summary>
+    internal static object IdentityOf<T>(T document)
+    {
+        var property = typeof(T).GetProperty("Id", BindingFlags.Public | BindingFlags.Instance)
+                       ?? throw new InvalidOperationException(
+                           $"{typeof(T).FullName} has no public Id property.");
+
+        return property.GetValue(document)
+               ?? throw new InvalidOperationException($"{typeof(T).FullName} has a null Id.");
+    }
+}
+
+/// <summary>
+/// A session over <see cref="InMemoryDocumentStore" />. One type serves as both the writable and the
+/// read-only session, which is legal — the contract's tiers are about what a caller may do, not about
+/// how many classes a store needs.
+/// </summary>
+public class InMemoryDocumentSession : IDocumentSessionOperations
+{
+    private readonly InMemoryDocumentStore _store;
+    private readonly List<Action> _pending = new();
+
+    internal InMemoryDocumentSession(InMemoryDocumentStore store) => _store = store;
+
+    public Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull
+        => Task.FromResult(load<T>(id));
+
+    public Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull
+        => Task.FromResult(load<T>(id));
+
+    private T? load<T>(object id) where T : notnull
+        => _store.StorageFor(typeof(T)).TryGetValue(id, out var found) ? (T)found : default;
+
+    public IQueryable<T> Query<T>() where T : notnull
+        => InMemoryDocumentQueryable<T>.Wrap(_store.SnapshotOf<T>().AsQueryable());
+
+    public void Store<T>(params T[] entities) where T : notnull
+    {
+        foreach (var entity in entities)
+        {
+            var id = InMemoryDocumentStore.IdentityOf(entity);
+            _pending.Add(() => _store.StorageFor(typeof(T))[id] = entity);
+        }
+    }
+
+    public void Delete<T>(T entity) where T : notnull
+        => deleteById<T>(InMemoryDocumentStore.IdentityOf(entity));
+
+    public void Delete<T>(Guid id) where T : notnull => deleteById<T>(id);
+
+    public void Delete<T>(string id) where T : notnull => deleteById<T>(id);
+
+    private void deleteById<T>(object id) where T : notnull
+        => _pending.Add(() => _store.StorageFor(typeof(T)).TryRemove(id, out _));
+
+    public void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+    {
+        var matches = expression.Compile();
+        _pending.Add(() =>
+        {
+            var storage = _store.StorageFor(typeof(T));
+            foreach (var pair in storage.ToArray())
+            {
+                if (matches((T)pair.Value))
+                {
+                    storage.TryRemove(pair.Key, out _);
+                }
+            }
+        });
+    }
+
+    public Task SaveChangesAsync(CancellationToken token = default)
+    {
+        foreach (var change in _pending)
+        {
+            change();
+        }
+
+        _pending.Clear();
+
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _pending.Clear();
+        GC.SuppressFinalize(this);
+        return default;
+    }
+}
+
+/// <summary>
+/// Wraps an <see cref="IQueryable{T}" /> so that every LINQ operator applied to it keeps returning a
+/// queryable whose provider implements <see cref="IDocumentQueryExecutor" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the whole of what a store owes the async terminators, and the reason the hook hangs off
+/// the provider: <see cref="IQueryable.Provider" /> is what <c>System.Linq.Queryable</c> threads
+/// through <c>Where</c> / <c>Select</c> / <c>OrderBy</c>, so wrapping it once at
+/// <c>Query&lt;T&gt;()</c> survives an arbitrarily long chain.
+/// </para>
+/// <para>
+/// It implements <see cref="IOrderedQueryable{T}" />, not merely <see cref="IQueryable{T}" />,
+/// because <c>Queryable.OrderBy</c> hard-casts its provider's <c>CreateQuery&lt;T&gt;</c> result to
+/// <see cref="IOrderedQueryable{T}" /> — a queryable wrapper that only implements
+/// <see cref="IQueryable{T}" /> throws <see cref="InvalidCastException" /> on the first
+/// <c>OrderBy</c>. This is a constraint of <c>System.Linq</c> rather than of the document contract,
+/// but any store wrapping its queryable has to satisfy it, so it is called out here.
+/// </para>
+/// </remarks>
+internal class InMemoryDocumentQueryable<T> : IOrderedQueryable<T>
+{
+    private readonly IQueryable<T> _inner;
+
+    internal InMemoryDocumentQueryable(InMemoryDocumentQueryProvider provider, IQueryable<T> inner)
+    {
+        Provider = provider;
+        _inner = inner;
+    }
+
+    internal static IQueryable<T> Wrap(IQueryable<T> inner)
+        => new InMemoryDocumentQueryable<T>(new InMemoryDocumentQueryProvider(inner.Provider), inner);
+
+    public Type ElementType => _inner.ElementType;
+
+    public Expression Expression => _inner.Expression;
+
+    public IQueryProvider Provider { get; }
+
+    public IEnumerator<T> GetEnumerator() => _inner.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal class InMemoryDocumentQueryProvider : IQueryProvider, IDocumentQueryExecutor
+{
+    private readonly IQueryProvider _inner;
+
+    internal InMemoryDocumentQueryProvider(IQueryProvider inner) => _inner = inner;
+
+    public IQueryable CreateQuery(Expression expression) => _inner.CreateQuery(expression);
+
+    public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        => new InMemoryDocumentQueryable<TElement>(this, _inner.CreateQuery<TElement>(expression));
+
+    public object? Execute(Expression expression) => _inner.Execute(expression);
+
+    public TResult Execute<TResult>(Expression expression) => _inner.Execute<TResult>(expression);
+
+    public Task<IReadOnlyList<TDoc>> ExecuteToListAsync<TDoc>(IQueryable<TDoc> queryable, CancellationToken token)
+        => Task.FromResult<IReadOnlyList<TDoc>>(queryable.ToList());
+
+    public Task<TDoc?> ExecuteFirstOrDefaultAsync<TDoc>(IQueryable<TDoc> queryable, CancellationToken token)
+        => Task.FromResult<TDoc?>(queryable.FirstOrDefault());
+
+    public Task<int> ExecuteCountAsync<TDoc>(IQueryable<TDoc> queryable, CancellationToken token)
+        => Task.FromResult(queryable.Count());
+
+    public Task<bool> ExecuteAnyAsync<TDoc>(IQueryable<TDoc> queryable, CancellationToken token)
+        => Task.FromResult(queryable.Any());
+}

--- a/src/EventStoreTests/EventStoreTests.csproj
+++ b/src/EventStoreTests/EventStoreTests.csproj
@@ -22,6 +22,14 @@
     <ItemGroup>
         <ProjectReference Include="..\JasperFx.Events\JasperFx.Events.csproj" />
         <ProjectReference Include="..\JasperFx\JasperFx.csproj"/>
+        <!--
+          The document compliance suites (jasperfx#647) are enrolled here against an in-memory
+          reference implementation so the shared suite is actually executed in this repo rather than
+          shipping unrun to Marten / Polecat / Fisher. A plain ProjectReference is enough for the
+          *document* suites: unlike the event suites they involve no source-generated dispatchers, so
+          none of the reasons the package ships as source apply to compiling them here.
+        -->
+        <ProjectReference Include="..\JasperFx.Events.ComplianceTests\JasperFx.Events.ComplianceTests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/JasperFx.Events.ComplianceTests/ComplianceDocuments.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceDocuments.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// A document with a <see cref="Guid" /> identity — the default identity style in every Critter
+/// Stack store.
+/// </summary>
+/// <remarks>
+/// Deliberately a mutable POCO with a plain <c>Id</c> property, which is the one document shape all
+/// three stores' identity conventions agree on. Strong-typed identifiers, <c>[Identity]</c>
+/// attributes and non-conventional identity members are product-specific configuration and are out
+/// of scope for the document contract.
+/// </remarks>
+public class ComplianceWidget
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Color { get; set; } = string.Empty;
+    public int Weight { get; set; }
+}
+
+/// <summary>
+/// A document with a <see cref="string" /> identity, so the suites can hold both
+/// <c>LoadAsync</c> / <c>Delete</c> identity overloads to the same definition.
+/// </summary>
+public class ComplianceGadget
+{
+    public string Id { get; set; } = string.Empty;
+    public string Kind { get; set; } = string.Empty;
+    public int Weight { get; set; }
+}

--- a/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Store-neutral description of the document store configuration a document compliance suite needs.
+/// A suite fills one of these in; the fixture replays it against its own store.
+/// </summary>
+/// <remarks>
+/// Far thinner than <see cref="ComplianceStoreConfig" />, and that is the point rather than an
+/// oversight. The document contract (jasperfx#647) is seven operations, so a suite needs nothing but
+/// a schema to live in and the document types it will exercise — there is no registrar interface
+/// here because there is nothing store-specific left to register.
+/// </remarks>
+public sealed class DocumentComplianceConfig
+{
+    /// <summary>
+    /// Optional schema/namespace override. When null the fixture picks its own.
+    /// </summary>
+    public string? SchemaName { get; set; }
+
+    /// <summary>
+    /// The document types the suite will store, query and delete. Stores that create document
+    /// storage on demand may ignore this; stores that need to be told up front use it.
+    /// </summary>
+    public List<Type> DocumentTypes { get; } = new();
+
+    public DocumentComplianceConfig AddDocumentType<T>() where T : notnull
+    {
+        DocumentTypes.Add(typeof(T));
+        return this;
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/DocumentStorageComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentStorageComplianceFixture.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The seam between the shared document compliance suites and a concrete store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three members wide, and unlike
+/// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}" /> it is <em>not</em> generic
+/// over the store's session pair. That asymmetry is the headline result of jasperfx#647 rather than
+/// an inconsistency: the event compliance fixture has to be generic because so much of the event
+/// surface is only reachable through a product's own session type, whereas everything the document
+/// suites do runs through <see cref="IDocumentSessionFactory" /> and the three session contracts. If
+/// a document suite ever needs a fixture member to reach past those interfaces, that is evidence the
+/// contract has a hole — fix the contract, do not widen this seam.
+/// </para>
+/// <para>
+/// A store that also implements <see cref="IDocumentSessionFactory{TOperations,TQuerySession}" />
+/// proves that at compile time in its own fixture; nothing here needs to know.
+/// </para>
+/// </remarks>
+public abstract class DocumentStorageComplianceFixture : IAsyncLifetime
+{
+    private Action<DocumentComplianceConfig>? _lastConfiguration;
+
+    /// <summary>
+    /// Cancellation token handed to every store call the suites make. Overridable rather than
+    /// hard-coded so a consumer can swap in its own budget.
+    /// </summary>
+    public virtual CancellationToken Cancellation => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    /// Build (or rebuild) the store for the supplied configuration.
+    /// </summary>
+    /// <remarks>
+    /// Keyed on the identity of the <paramref name="configure" /> delegate exactly as
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.ConfigureAsync" /> is:
+    /// suites hold their standard configuration in a static field, so repeated calls across the test
+    /// methods of one class are free.
+    /// </remarks>
+    public async Task ConfigureAsync(Action<DocumentComplianceConfig> configure)
+    {
+        if (ReferenceEquals(_lastConfiguration, configure))
+        {
+            return;
+        }
+
+        var config = new DocumentComplianceConfig();
+        configure(config);
+
+        await BuildStoreAsync(config).ConfigureAwait(false);
+
+        _lastConfiguration = configure;
+    }
+
+    /// <summary>
+    /// Construct the store from the store-neutral configuration and make sure its schema exists.
+    /// </summary>
+    protected abstract Task BuildStoreAsync(DocumentComplianceConfig config);
+
+    /// <summary>
+    /// The store, as the shared session-opening contract. The only member the suites read state
+    /// through.
+    /// </summary>
+    public abstract IDocumentSessionFactory Sessions { get; }
+
+    /// <summary>
+    /// Per-test isolation: remove all document data without dropping schema.
+    /// </summary>
+    /// <remarks>
+    /// Not expressible through the contract on purpose — wiping a store is administration, and
+    /// <see cref="IDocumentWriteOperations.DeleteWhere{T}" /> would only cover document types the
+    /// suite already knows about. Both products spell this on their own <c>Advanced</c> surface,
+    /// which the contract deliberately does not abstract.
+    /// </remarks>
+    public abstract Task CleanDocumentDataAsync();
+
+    public virtual ValueTask InitializeAsync() => default;
+
+    public virtual ValueTask DisposeAsync() => default;
+}

--- a/src/JasperFx.Events.ComplianceTests/DocumentStorageComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentStorageComplianceSuite.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Base class for every shared document compliance suite. Owns the fixture lifecycle and forwards
+/// the three seam members so the [Fact] bodies read like ordinary document store tests.
+/// </summary>
+/// <typeparam name="TFixture">The store's concrete document fixture.</typeparam>
+/// <remarks>
+/// A consuming store enrolls a suite with a single empty subclass:
+/// <code>
+/// public class document_query_compliance : DocumentQueryCompliance&lt;MyDocumentFixture&gt;;
+/// </code>
+/// </remarks>
+public abstract class DocumentStorageComplianceSuite<TFixture> : IAsyncLifetime
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    protected readonly TFixture theFixture = new();
+
+    /// <summary>
+    /// The suite's standard store configuration. Implementations MUST return the same delegate
+    /// instance every time (hold it in a static field) so the fixture can skip redundant rebuilds.
+    /// </summary>
+    protected abstract Action<DocumentComplianceConfig> Configuration { get; }
+
+    public virtual async ValueTask InitializeAsync()
+    {
+        await theFixture.InitializeAsync().ConfigureAwait(false);
+        await theFixture.ConfigureAsync(Configuration).ConfigureAwait(false);
+        await theFixture.CleanDocumentDataAsync().ConfigureAwait(false);
+    }
+
+    public virtual ValueTask DisposeAsync() => theFixture.DisposeAsync();
+
+    protected CancellationToken Cancellation => theFixture.Cancellation;
+
+    /// <summary>
+    /// Open a writable, committable session. Callers dispose it.
+    /// </summary>
+    protected IDocumentSessionOperations LightweightSession()
+        => theFixture.Sessions.LightweightSession();
+
+    /// <summary>
+    /// Open a read-only session. Callers dispose it.
+    /// </summary>
+    protected IDocumentReadOperations QuerySession() => theFixture.Sessions.QuerySession();
+
+    /// <summary>
+    /// Store documents and commit them in one throwaway session — the setup step almost every test
+    /// starts with.
+    /// </summary>
+    protected async Task PersistAsync<T>(params T[] documents) where T : notnull
+    {
+        await using var session = LightweightSession();
+        session.Store(documents);
+        await session.SaveChangesAsync(Cancellation).ConfigureAwait(false);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -151,22 +151,72 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
 | Subscriptions | `SubscriptionCompliance` |
 
+### The document contract (jasperfx#647)
+
+A second, independent family covers the small *document* slice that `JasperFx.Events` now abstracts
+alongside the event store — `JasperFx.Events.Documents`:
+
+| Area | Suite |
+|---|---|
+| Session opening and the transaction boundary | `DocumentSessionCompliance` |
+| `Store` and `LoadAsync`, both identity styles | `DocumentLoadAndStoreCompliance` |
+| `Delete`, its identity overloads, and `DeleteWhere` | `DocumentDeleteCompliance` |
+| `Query<T>()`, its minimum translatable operator set, and the async terminators | `DocumentQueryCompliance` |
+
+Enrollment is deliberately much cheaper than the event side. `DocumentStorageComplianceFixture` has
+**three** abstract members — build a store, hand back an `IDocumentSessionFactory`, wipe the data —
+and is **not generic** over the store's session pair, because everything the document suites do runs
+through the shared contracts. That asymmetry is the result being demonstrated, not an inconsistency:
+if a document suite ever needs a fixture member that reaches past the interfaces, the contract has a
+hole and the contract is what should change.
+
+```csharp
+public class my_document_fixture : DocumentStorageComplianceFixture
+{
+    protected override Task BuildStoreAsync(DocumentComplianceConfig config) { /* ... */ }
+    public override IDocumentSessionFactory Sessions => _store;
+    public override Task CleanDocumentDataAsync() { /* ... */ }
+}
+
+public class document_query_compliance : DocumentQueryCompliance<my_document_fixture>;
+```
+
+These suites are the one part of the library that is executed inside this repo as well as by its
+consumers: `EventStoreTests` enrolls an in-memory reference implementation, so the shared definition
+is known to be satisfiable before three products are held to it. That reference implementation is a
+test double, not a product — it exists to keep the suite honest.
+
+Note that a consumer whose test project carries a global `using Marten;` (or the Polecat equivalent)
+will hit an ambiguity between that product's async LINQ terminators and
+`JasperFx.Events.Documents.DocumentQueryableExtensions`, which share names and receiver types.
+Scoping or removing the global using for the compliance compile resolves it.
+
 ## What is deliberately out of scope
 
 Storage layout and DDL, table partitioning, node distribution / HotCold, and high-water detection
 internals. If a behavior only makes sense in terms of one engine's storage, it belongs in that
 product's own test suite, not here.
 
-**LINQ and query-provider behavior are out of scope permanently**, not pending a contract. The
+**General LINQ and query-provider behavior is out of scope permanently**, not pending a contract. The
 stores' query languages diverge structurally enough that a shared suite would pin coincidence rather
 than contract. This has been the position since the library was designed; it is restated here
 because it had drifted into "blocked until a shared document store contract exists", which wrongly
 reads as deferred work. It is not deferred. A file like `Polecat.Tests/Linq/additional_linq_operator_tests.cs`
 is a product-owned test file, not a port awaiting absorption (marten#5155).
 
-The rest of the document-db side — patching, session semantics — stays out for the different reason
-that no shared document store contract exists yet. That one genuinely is an open question rather
-than a settled exclusion.
+`DocumentQueryCompliance` is not a counter-example to that, and must not be allowed to grow into
+one. It pins a closed **minimum translatable set** — `Where`, `Select`, `OrderBy` /
+`OrderByDescending`, `ThenBy` / `ThenByDescending`, `Take`, `Skip`, `Distinct` — because a consumer
+holding only an `IQueryable<T>` has no way to discover whether a store translates those or silently
+does not. That set is closed by measurement (the operators `CritterWatch.Services` actually applies
+to a `Query<T>()` chain), not open by principle. Operators outside it stay product-owned however many
+stores happen to support them.
+
+Session semantics *are* now in scope, via the document contract above. The rest of the document-db
+side — patching, bulk insert, LINQ joins / grouping / `Include`, soft-delete semantics, document
+metadata, session listeners, the stores' `Advanced` surfaces and schema management — stays out, and
+that exclusion is now a settled boundary rather than an open question: those are the surfaces
+jasperfx#647 deliberately declined to abstract.
 
 New cross-store event sourcing behavior should land as a compliance suite first, and only then be
 enrolled by each product.

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentDeleteCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentDeleteCompliance.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// <see cref="IDocumentWriteOperations.Delete{T}(T)" />, its two identity overloads, and
+/// <see cref="IDocumentWriteOperations.DeleteWhere{T}" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>DeleteWhere</c> is the operation most likely to diverge between stores, because it is the only
+/// write in the contract whose effect is decided by the database at commit time rather than by the
+/// session. Two consequences are asserted here: it must match documents the session never loaded,
+/// and it must not fire until <c>SaveChangesAsync</c>.
+/// </para>
+/// <para>
+/// Soft deletes are deliberately not covered. A store may implement deletion however it likes as
+/// long as a deleted document stops being visible through <c>LoadAsync</c> and <c>Query</c>; the
+/// contract is about visibility, not about rows.
+/// </para>
+/// </remarks>
+public abstract class DocumentDeleteCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+        config.AddDocumentType<ComplianceWidget>();
+        config.AddDocumentType<ComplianceGadget>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task delete_by_entity()
+    {
+        var id = Guid.NewGuid();
+        var widget = new ComplianceWidget { Id = id, Name = "Doomed" };
+        await PersistAsync(widget);
+
+        await using (var session = LightweightSession())
+        {
+            session.Delete(widget);
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        (await query.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_guid_identity()
+    {
+        var id = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Doomed" });
+
+        await using (var session = LightweightSession())
+        {
+            session.Delete<ComplianceWidget>(id);
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        (await query.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_by_string_identity()
+    {
+        await PersistAsync(new ComplianceGadget { Id = "gadget-doomed", Kind = "lever" });
+
+        await using (var session = LightweightSession())
+        {
+            session.Delete<ComplianceGadget>("gadget-doomed");
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        (await query.LoadAsync<ComplianceGadget>("gadget-doomed", Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task deleting_a_missing_identity_is_a_no_op()
+    {
+        await using var session = LightweightSession();
+
+        session.Delete<ComplianceWidget>(Guid.NewGuid());
+        session.Delete<ComplianceGadget>("never-existed");
+
+        await session.SaveChangesAsync(Cancellation);
+    }
+
+    [Fact]
+    public async Task delete_is_not_applied_until_save_changes()
+    {
+        var id = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Still here" });
+
+        await using var session = LightweightSession();
+        session.Delete<ComplianceWidget>(id);
+
+        await using (var before = QuerySession())
+        {
+            (await before.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldNotBeNull();
+        }
+
+        await session.SaveChangesAsync(Cancellation);
+
+        await using var after = QuerySession();
+        (await after.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task delete_where_removes_only_the_matching_documents()
+    {
+        await PersistAsync(
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "keep", Color = "blue" },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "drop", Color = "red" },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "drop", Color = "red" });
+
+        await using (var session = LightweightSession())
+        {
+            session.DeleteWhere<ComplianceWidget>(x => x.Color == "red");
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var survivors = await query.Query<ComplianceWidget>().ToListAsync(Cancellation);
+
+        survivors.Count.ShouldBe(1);
+        survivors.Single().Color.ShouldBe("blue");
+    }
+
+    [Fact]
+    public async Task delete_where_matches_documents_the_session_never_loaded()
+    {
+        await PersistAsync(
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "heavy", Weight = 100 },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "light", Weight = 1 });
+
+        // A brand new session that has never seen either document.
+        await using (var session = LightweightSession())
+        {
+            session.DeleteWhere<ComplianceWidget>(x => x.Weight > 50);
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var survivors = await query.Query<ComplianceWidget>().ToListAsync(Cancellation);
+
+        survivors.Count.ShouldBe(1);
+        survivors.Single().Name.ShouldBe("light");
+    }
+
+    [Fact]
+    public async Task delete_where_is_not_applied_until_save_changes()
+    {
+        await PersistAsync(new ComplianceWidget { Id = Guid.NewGuid(), Name = "doomed", Color = "red" });
+
+        await using var session = LightweightSession();
+        session.DeleteWhere<ComplianceWidget>(x => x.Color == "red");
+
+        await using (var before = QuerySession())
+        {
+            (await before.Query<ComplianceWidget>().CountAsync(Cancellation)).ShouldBe(1);
+        }
+
+        await session.SaveChangesAsync(Cancellation);
+
+        await using var after = QuerySession();
+        (await after.Query<ComplianceWidget>().CountAsync(Cancellation)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task delete_where_matching_nothing_is_a_no_op()
+    {
+        await PersistAsync(new ComplianceWidget { Id = Guid.NewGuid(), Name = "safe", Color = "green" });
+
+        await using (var session = LightweightSession())
+        {
+            session.DeleteWhere<ComplianceWidget>(x => x.Color == "chartreuse");
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        (await query.Query<ComplianceWidget>().CountAsync(Cancellation)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task delete_only_touches_the_named_document_type()
+    {
+        var widgetId = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = widgetId, Name = "widget", Weight = 100 });
+        await PersistAsync(new ComplianceGadget { Id = "gadget-1", Kind = "lever", Weight = 100 });
+
+        await using (var session = LightweightSession())
+        {
+            session.DeleteWhere<ComplianceWidget>(x => x.Weight == 100);
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        (await query.LoadAsync<ComplianceWidget>(widgetId, Cancellation)).ShouldBeNull();
+        (await query.LoadAsync<ComplianceGadget>("gadget-1", Cancellation)).ShouldNotBeNull();
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentLoadAndStoreCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentLoadAndStoreCompliance.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// <see cref="IDocumentWriteOperations.Store{T}" /> and
+/// <see cref="IDocumentReadOperations.LoadAsync{T}(Guid,System.Threading.CancellationToken)" /> —
+/// both identity styles, the upsert semantics of <c>Store</c>, and the miss case.
+/// </summary>
+/// <remarks>
+/// <c>Store</c> is an upsert on every Critter Stack store, not an insert: storing an identity that
+/// already exists replaces it rather than throwing. That is the behavior consumers rely on and the
+/// one place three implementations could plausibly read the contract differently, so it is asserted
+/// directly rather than left implicit.
+/// </remarks>
+public abstract class DocumentLoadAndStoreCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+        config.AddDocumentType<ComplianceWidget>();
+        config.AddDocumentType<ComplianceGadget>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task store_and_load_by_guid_identity()
+    {
+        var id = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Cog", Color = "blue", Weight = 11 });
+
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceWidget>(id, Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(id);
+        loaded.Name.ShouldBe("Cog");
+    }
+
+    [Fact]
+    public async Task store_and_load_by_string_identity()
+    {
+        await PersistAsync(new ComplianceGadget { Id = "gadget-42", Kind = "ratchet", Weight = 3 });
+
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceGadget>("gadget-42", Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe("gadget-42");
+        loaded.Kind.ShouldBe("ratchet");
+    }
+
+    [Fact]
+    public async Task load_returns_null_for_a_missing_guid_identity()
+    {
+        await using var query = QuerySession();
+
+        (await query.LoadAsync<ComplianceWidget>(Guid.NewGuid(), Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task load_returns_null_for_a_missing_string_identity()
+    {
+        await using var query = QuerySession();
+
+        (await query.LoadAsync<ComplianceGadget>("nothing-here", Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task store_accepts_many_documents_in_one_call()
+    {
+        var widgets = new[]
+        {
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "A" },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "B" },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "C" }
+        };
+
+        await using (var session = LightweightSession())
+        {
+            session.Store(widgets);
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var all = await query.Query<ComplianceWidget>().ToListAsync(Cancellation);
+
+        all.Count.ShouldBe(3);
+        all.Select(x => x.Name).OrderBy(x => x).ShouldBe(new[] { "A", "B", "C" });
+    }
+
+    [Fact]
+    public async Task storing_an_existing_identity_overwrites_it()
+    {
+        var id = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Original", Weight = 1 });
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Replacement", Weight = 2 });
+
+        await using var query = QuerySession();
+
+        var loaded = await query.LoadAsync<ComplianceWidget>(id, Cancellation);
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Replacement");
+        loaded.Weight.ShouldBe(2);
+
+        (await query.Query<ComplianceWidget>().CountAsync(Cancellation)).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task storing_the_same_identity_twice_within_one_session_keeps_the_last_write()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = LightweightSession())
+        {
+            session.Store(new ComplianceWidget { Id = id, Name = "First" });
+            session.Store(new ComplianceWidget { Id = id, Name = "Last" });
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceWidget>(id, Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Last");
+    }
+
+    [Fact]
+    public async Task a_writable_session_can_read_as_well_as_write()
+    {
+        var id = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Readable" });
+
+        await using var session = LightweightSession();
+        var loaded = await session.LoadAsync<ComplianceWidget>(id, Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Readable");
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentQueryCompliance.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// <see cref="IDocumentReadOperations.Query{T}" /> and the
+/// <see cref="DocumentQueryableExtensions" /> terminators.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>This is not a LINQ conformance suite, and must not become one.</strong> The Critter Stack
+/// position — stated in this library's README and unchanged — is that LINQ provider behavior is out
+/// of shared-compliance scope permanently, because the stores' query languages diverge structurally
+/// enough that a broad shared suite would pin coincidence rather than contract.
+/// </para>
+/// <para>
+/// What is asserted here is narrower and different in kind: the <em>minimum translatable set</em>
+/// that <see cref="IDocumentReadOperations.Query{T}" /> promises. A store-agnostic consumer holding
+/// only <c>IQueryable&lt;T&gt;</c> has no way to discover whether <c>OrderBy</c> is translated
+/// server-side or silently unsupported, so the operators that contract covers — <c>Where</c>,
+/// <c>Select</c>, <c>OrderBy</c> / <c>OrderByDescending</c>, <c>ThenBy</c>, <c>Take</c>,
+/// <c>Skip</c>, <c>Distinct</c> — are pinned. They are exactly the operators the measured consumer
+/// surface uses (jasperfx#647). Anything beyond them stays product-owned; a store is free to support
+/// more and is never held to it here.
+/// </para>
+/// <para>
+/// <see cref="a_queryable_composes_across_statements" /> pins the shape rather than an operator, and
+/// is why <c>Query&lt;T&gt;()</c> returns a real <see cref="IQueryable{T}" /> instead of a fluent
+/// builder: real consumer code conditionally adds clauses to a query held in a local.
+/// </para>
+/// </remarks>
+public abstract class DocumentQueryCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+        config.AddDocumentType<ComplianceWidget>();
+        config.AddDocumentType<ComplianceGadget>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    private Task theWidgetsAsync()
+    {
+        return PersistAsync(
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "alpha", Color = "red", Weight = 1 },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "bravo", Color = "red", Weight = 2 },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "charlie", Color = "blue", Weight = 3 },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "delta", Color = "blue", Weight = 4 },
+            new ComplianceWidget { Id = Guid.NewGuid(), Name = "echo", Color = "green", Weight = 5 });
+    }
+
+    [Fact]
+    public async Task query_returns_every_committed_document()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+        var all = await query.Query<ComplianceWidget>().ToListAsync(Cancellation);
+
+        all.Count.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task query_over_an_empty_document_type_returns_an_empty_list()
+    {
+        await using var query = QuerySession();
+        var all = await query.Query<ComplianceWidget>().ToListAsync(Cancellation);
+
+        all.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task where_filters()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+        var red = await query.Query<ComplianceWidget>().Where(x => x.Color == "red").ToListAsync(Cancellation);
+
+        red.Count.ShouldBe(2);
+        red.Select(x => x.Name).OrderBy(x => x).ShouldBe(new[] { "alpha", "bravo" });
+    }
+
+    [Fact]
+    public async Task where_over_a_captured_collection()
+    {
+        await theWidgetsAsync();
+
+        var wanted = new[] { "alpha", "echo" };
+
+        await using var query = QuerySession();
+        var matches = await query.Query<ComplianceWidget>()
+            .Where(x => wanted.Contains(x.Name))
+            .ToListAsync(Cancellation);
+
+        matches.Count.ShouldBe(2);
+        matches.Select(x => x.Name).OrderBy(x => x).ShouldBe(new[] { "alpha", "echo" });
+    }
+
+    [Fact]
+    public async Task select_projects_to_a_scalar()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+        var names = await query.Query<ComplianceWidget>()
+            .Where(x => x.Color == "blue")
+            .Select(x => x.Name)
+            .ToListAsync(Cancellation);
+
+        names.OrderBy(x => x).ShouldBe(new[] { "charlie", "delta" });
+    }
+
+    [Fact]
+    public async Task order_by_and_order_by_descending()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        var ascending = await query.Query<ComplianceWidget>()
+            .OrderBy(x => x.Weight)
+            .Select(x => x.Weight)
+            .ToListAsync(Cancellation);
+        ascending.ShouldBe(new[] { 1, 2, 3, 4, 5 });
+
+        var descending = await query.Query<ComplianceWidget>()
+            .OrderByDescending(x => x.Weight)
+            .Select(x => x.Weight)
+            .ToListAsync(Cancellation);
+        descending.ShouldBe(new[] { 5, 4, 3, 2, 1 });
+    }
+
+    [Fact]
+    public async Task then_by_breaks_ties()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        var descendingTieBreak = await query.Query<ComplianceWidget>()
+            .OrderBy(x => x.Color)
+            .ThenByDescending(x => x.Weight)
+            .Select(x => x.Name)
+            .ToListAsync(Cancellation);
+        descendingTieBreak.ShouldBe(new[] { "delta", "charlie", "echo", "bravo", "alpha" });
+
+        var ascendingTieBreak = await query.Query<ComplianceWidget>()
+            .OrderBy(x => x.Color)
+            .ThenBy(x => x.Weight)
+            .Select(x => x.Name)
+            .ToListAsync(Cancellation);
+        ascendingTieBreak.ShouldBe(new[] { "charlie", "delta", "echo", "alpha", "bravo" });
+    }
+
+    [Fact]
+    public async Task take_and_skip_page_a_result_set()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        var firstPage = await query.Query<ComplianceWidget>()
+            .OrderBy(x => x.Weight)
+            .Take(2)
+            .Select(x => x.Weight)
+            .ToListAsync(Cancellation);
+        firstPage.ShouldBe(new[] { 1, 2 });
+
+        var secondPage = await query.Query<ComplianceWidget>()
+            .OrderBy(x => x.Weight)
+            .Skip(2)
+            .Take(2)
+            .Select(x => x.Weight)
+            .ToListAsync(Cancellation);
+        secondPage.ShouldBe(new[] { 3, 4 });
+    }
+
+    [Fact]
+    public async Task distinct_over_a_projected_scalar()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+        var colors = await query.Query<ComplianceWidget>()
+            .Select(x => x.Color)
+            .Distinct()
+            .ToListAsync(Cancellation);
+
+        colors.OrderBy(x => x).ShouldBe(new[] { "blue", "green", "red" });
+    }
+
+    [Fact]
+    public async Task first_or_default_hits_and_misses()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        var hit = await query.Query<ComplianceWidget>()
+            .Where(x => x.Name == "charlie")
+            .FirstOrDefaultAsync(Cancellation);
+        hit.ShouldNotBeNull();
+        hit.Weight.ShouldBe(3);
+
+        var miss = await query.Query<ComplianceWidget>()
+            .Where(x => x.Name == "zulu")
+            .FirstOrDefaultAsync(Cancellation);
+        miss.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task first_or_default_with_a_predicate()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        var hit = await query.Query<ComplianceWidget>().FirstOrDefaultAsync(x => x.Name == "delta", Cancellation);
+        hit.ShouldNotBeNull();
+        hit.Weight.ShouldBe(4);
+
+        (await query.Query<ComplianceWidget>().FirstOrDefaultAsync(x => x.Name == "zulu", Cancellation))
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task first_or_default_respects_the_ordering()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        var lightest = await query.Query<ComplianceWidget>()
+            .OrderBy(x => x.Weight)
+            .FirstOrDefaultAsync(Cancellation);
+        lightest.ShouldNotBeNull();
+        lightest.Name.ShouldBe("alpha");
+
+        var heaviest = await query.Query<ComplianceWidget>()
+            .OrderByDescending(x => x.Weight)
+            .FirstOrDefaultAsync(Cancellation);
+        heaviest.ShouldNotBeNull();
+        heaviest.Name.ShouldBe("echo");
+    }
+
+    [Fact]
+    public async Task count_with_and_without_a_predicate()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        (await query.Query<ComplianceWidget>().CountAsync(Cancellation)).ShouldBe(5);
+        (await query.Query<ComplianceWidget>().CountAsync(x => x.Color == "red", Cancellation)).ShouldBe(2);
+        (await query.Query<ComplianceWidget>().Where(x => x.Weight > 3).CountAsync(Cancellation)).ShouldBe(2);
+        (await query.Query<ComplianceWidget>().CountAsync(x => x.Color == "chartreuse", Cancellation)).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task any_with_and_without_a_predicate()
+    {
+        await theWidgetsAsync();
+
+        await using var query = QuerySession();
+
+        (await query.Query<ComplianceWidget>().AnyAsync(Cancellation)).ShouldBeTrue();
+        (await query.Query<ComplianceWidget>().AnyAsync(x => x.Color == "green", Cancellation)).ShouldBeTrue();
+        (await query.Query<ComplianceWidget>().AnyAsync(x => x.Color == "chartreuse", Cancellation)).ShouldBeFalse();
+        (await query.Query<ComplianceGadget>().AnyAsync(Cancellation)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_queryable_composes_across_statements()
+    {
+        await theWidgetsAsync();
+
+        await using var session = QuerySession();
+
+        // The shape real consumer code uses: hold the queryable, add clauses conditionally, and
+        // terminate once. Nothing here would compile against a fluent builder.
+        IQueryable<ComplianceWidget> query = session.Query<ComplianceWidget>();
+
+        string? colorFilter = "red";
+        int? minimumWeight = 2;
+
+        if (colorFilter != null)
+        {
+            query = query.Where(x => x.Color == colorFilter);
+        }
+
+        if (minimumWeight != null)
+        {
+            query = query.Where(x => x.Weight >= minimumWeight.Value);
+        }
+
+        var results = await query.OrderByDescending(x => x.Weight).Take(10).ToListAsync(Cancellation);
+
+        results.Count.ShouldBe(1);
+        results.Single().Name.ShouldBe("bravo");
+    }
+
+    [Fact]
+    public async Task a_queryable_can_be_narrowed_by_a_shared_helper()
+    {
+        await theWidgetsAsync();
+
+        await using var session = QuerySession();
+
+        var heavy = await OnlyHeavierThan(session.Query<ComplianceWidget>(), 3).ToListAsync(Cancellation);
+
+        heavy.Count.ShouldBe(2);
+        heavy.Select(x => x.Name).OrderBy(x => x).ShouldBe(new[] { "delta", "echo" });
+    }
+
+    /// <summary>
+    /// Consumers factor shared predicates into helpers that take and return
+    /// <see cref="IQueryable{T}" />. That only works if <c>Query&lt;T&gt;()</c> hands back the real
+    /// interface.
+    /// </summary>
+    private static IQueryable<ComplianceWidget> OnlyHeavierThan(IQueryable<ComplianceWidget> source, int weight)
+        => source.Where(x => x.Weight > weight);
+
+    [Fact]
+    public async Task query_does_not_see_uncommitted_writes_from_another_session()
+    {
+        await theWidgetsAsync();
+
+        await using var writer = LightweightSession();
+        writer.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "foxtrot", Color = "red", Weight = 6 });
+
+        await using var query = QuerySession();
+        var names = await query.Query<ComplianceWidget>().Select(x => x.Name).ToListAsync(Cancellation);
+
+        names.ShouldNotContain("foxtrot");
+        names.Count.ShouldBe(5);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentSessionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentSessionCompliance.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Session semantics: what <see cref="IDocumentSessionFactory" /> hands back, and where the
+/// transaction boundary is.
+/// </summary>
+/// <remarks>
+/// The load-bearing assertion here is <see cref="changes_are_invisible_until_save_changes" />. Every
+/// other operation in the contract is meaningless without it — a store that flushed on
+/// <c>Store</c> would pass the load, query and delete suites and still be unusable by a consumer
+/// that relies on a unit of work.
+/// </remarks>
+public abstract class DocumentSessionCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+        config.AddDocumentType<ComplianceWidget>();
+        config.AddDocumentType<ComplianceGadget>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task lightweight_session_round_trips_a_document()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = LightweightSession())
+        {
+            session.Store(new ComplianceWidget { Id = id, Name = "Sprocket", Color = "red", Weight = 4 });
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceWidget>(id, Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Sprocket");
+        loaded.Color.ShouldBe("red");
+        loaded.Weight.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task changes_are_invisible_until_save_changes()
+    {
+        var id = Guid.NewGuid();
+
+        await using var session = LightweightSession();
+        session.Store(new ComplianceWidget { Id = id, Name = "Uncommitted" });
+
+        await using (var other = QuerySession())
+        {
+            (await other.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldBeNull();
+        }
+
+        await session.SaveChangesAsync(Cancellation);
+
+        await using var after = QuerySession();
+        (await after.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task abandoning_a_session_without_saving_discards_the_work()
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = LightweightSession())
+        {
+            session.Store(new ComplianceWidget { Id = id, Name = "Never saved" });
+            // deliberately no SaveChangesAsync
+        }
+
+        await using var query = QuerySession();
+        (await query.LoadAsync<ComplianceWidget>(id, Cancellation)).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task save_changes_with_no_pending_work_is_a_no_op()
+    {
+        await using var session = LightweightSession();
+
+        await session.SaveChangesAsync(Cancellation);
+        await session.SaveChangesAsync(Cancellation);
+    }
+
+    [Fact]
+    public async Task saving_twice_does_not_replay_the_first_batch()
+    {
+        var id = Guid.NewGuid();
+
+        await using var session = LightweightSession();
+        session.Store(new ComplianceWidget { Id = id, Name = "First", Weight = 1 });
+        await session.SaveChangesAsync(Cancellation);
+
+        session.Store(new ComplianceWidget { Id = id, Name = "Second", Weight = 2 });
+        await session.SaveChangesAsync(Cancellation);
+
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceWidget>(id, Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Name.ShouldBe("Second");
+        loaded.Weight.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task sessions_are_independent_units_of_work()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+
+        await using var one = LightweightSession();
+        await using var two = LightweightSession();
+
+        one.Store(new ComplianceWidget { Id = first, Name = "One" });
+        two.Store(new ComplianceWidget { Id = second, Name = "Two" });
+
+        await one.SaveChangesAsync(Cancellation);
+
+        await using (var query = QuerySession())
+        {
+            (await query.LoadAsync<ComplianceWidget>(first, Cancellation)).ShouldNotBeNull();
+            (await query.LoadAsync<ComplianceWidget>(second, Cancellation)).ShouldBeNull();
+        }
+
+        await two.SaveChangesAsync(Cancellation);
+
+        await using var after = QuerySession();
+        (await after.LoadAsync<ComplianceWidget>(second, Cancellation)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task a_query_session_can_read_every_document_type()
+    {
+        var widgetId = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = widgetId, Name = "Widget" });
+        await PersistAsync(new ComplianceGadget { Id = "gadget-1", Kind = "lever" });
+
+        await using var query = QuerySession();
+
+        (await query.LoadAsync<ComplianceWidget>(widgetId, Cancellation)).ShouldNotBeNull();
+        (await query.LoadAsync<ComplianceGadget>("gadget-1", Cancellation)).ShouldNotBeNull();
+    }
+}

--- a/src/JasperFx.Events/Documents/DocumentQueryableExtensions.cs
+++ b/src/JasperFx.Events/Documents/DocumentQueryableExtensions.cs
@@ -1,0 +1,133 @@
+using System.Linq.Expressions;
+
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// Store-agnostic asynchronous terminators for a document <see cref="IQueryable{T}" /> returned by
+/// <see cref="IDocumentReadOperations.Query{T}" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extension methods rather than interface members, because the composable half of the query has to
+/// be the real <see cref="IQueryable{T}" /> — real consumer code holds a queryable in a local and
+/// adds <c>Where</c> / <c>OrderBy</c> / <c>Take</c> clauses to it across several statements, and
+/// <c>System.Linq.Queryable</c>'s operators all return a plain <see cref="IQueryable{T}" />. Any
+/// interface-member spelling of the terminators would be unreachable the moment a single standard
+/// LINQ operator was applied.
+/// </para>
+/// <para>
+/// Execution dispatches through <see cref="IDocumentQueryExecutor" />, which a store's LINQ provider
+/// implements. That is the same design EF Core (<c>IAsyncQueryProvider</c>) and both Critter Stack
+/// stores already use for their own terminators, so no store has to invent anything new to satisfy
+/// it.
+/// </para>
+/// <para>
+/// <strong>Name collision.</strong> These methods share their names and receiver type with each
+/// store's own terminators (Marten's <c>Marten.QueryableExtensions</c>). A file that imports both
+/// <c>JasperFx.Events.Documents</c> and <c>Marten</c> will get an ambiguity on
+/// <c>ToListAsync</c> — neither candidate is better. This is why the document contract lives in its
+/// own namespace rather than in the root <c>JasperFx.Events</c> namespace that consumers import
+/// everywhere: the terminators are opt-in, and the code that opts in is precisely the code that has
+/// no business importing a store. Where both are genuinely needed in one file, call the intended one
+/// statically (<c>DocumentQueryableExtensions.ToListAsync(query, token)</c>).
+/// </para>
+/// <para>
+/// The cancellation parameter is named <c>token</c> on every overload, matching both products.
+/// Consumer code passes it by name; renaming it would be a source-breaking change.
+/// </para>
+/// </remarks>
+public static class DocumentQueryableExtensions
+{
+    /// <summary>
+    /// Execute the query and return every matching result.
+    /// </summary>
+    public static Task<IReadOnlyList<T>> ToListAsync<T>(this IQueryable<T> queryable,
+        CancellationToken token = default)
+    {
+        return ExecutorFor(queryable).ExecuteToListAsync(queryable, token);
+    }
+
+    /// <summary>
+    /// Execute the query and return the first result, or the default value when there are none.
+    /// </summary>
+    public static Task<T?> FirstOrDefaultAsync<T>(this IQueryable<T> queryable,
+        CancellationToken token = default)
+    {
+        return ExecutorFor(queryable).ExecuteFirstOrDefaultAsync(queryable, token);
+    }
+
+    /// <summary>
+    /// Execute the query, narrowed by an additional predicate, and return the first result or the
+    /// default value when there are none.
+    /// </summary>
+    public static Task<T?> FirstOrDefaultAsync<T>(this IQueryable<T> queryable,
+        Expression<Func<T, bool>> predicate, CancellationToken token = default)
+    {
+        var narrowed = queryable.Where(predicate);
+        return ExecutorFor(narrowed).ExecuteFirstOrDefaultAsync(narrowed, token);
+    }
+
+    /// <summary>
+    /// Execute the query as a count of matching rows.
+    /// </summary>
+    public static Task<int> CountAsync<T>(this IQueryable<T> queryable, CancellationToken token = default)
+    {
+        return ExecutorFor(queryable).ExecuteCountAsync(queryable, token);
+    }
+
+    /// <summary>
+    /// Execute the query, narrowed by an additional predicate, as a count of matching rows.
+    /// </summary>
+    public static Task<int> CountAsync<T>(this IQueryable<T> queryable,
+        Expression<Func<T, bool>> predicate, CancellationToken token = default)
+    {
+        var narrowed = queryable.Where(predicate);
+        return ExecutorFor(narrowed).ExecuteCountAsync(narrowed, token);
+    }
+
+    /// <summary>
+    /// Execute the query as an existence check.
+    /// </summary>
+    public static Task<bool> AnyAsync<T>(this IQueryable<T> queryable, CancellationToken token = default)
+    {
+        return ExecutorFor(queryable).ExecuteAnyAsync(queryable, token);
+    }
+
+    /// <summary>
+    /// Execute the query, narrowed by an additional predicate, as an existence check.
+    /// </summary>
+    public static Task<bool> AnyAsync<T>(this IQueryable<T> queryable,
+        Expression<Func<T, bool>> predicate, CancellationToken token = default)
+    {
+        var narrowed = queryable.Where(predicate);
+        return ExecutorFor(narrowed).ExecuteAnyAsync(narrowed, token);
+    }
+
+    /// <summary>
+    /// Resolve the store's asynchronous execution hook for a queryable — its provider first, then the
+    /// queryable itself.
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the queryable came from a LINQ provider that has not implemented
+    /// <see cref="IDocumentQueryExecutor" /> — an in-memory <c>IEnumerable.AsQueryable()</c>, for
+    /// instance. Silently falling back to synchronous, client-side evaluation would turn a missing
+    /// implementation into a production performance bug rather than a compile-time-visible gap.
+    /// </exception>
+    internal static IDocumentQueryExecutor ExecutorFor<T>(IQueryable<T> queryable)
+    {
+        ArgumentNullException.ThrowIfNull(queryable);
+
+        if (queryable.Provider is IDocumentQueryExecutor fromProvider)
+        {
+            return fromProvider;
+        }
+
+        if (queryable is IDocumentQueryExecutor fromQueryable)
+        {
+            return fromQueryable;
+        }
+
+        throw new NotSupportedException(
+            $"The LINQ provider '{queryable.Provider.GetType().FullName}' does not implement {nameof(IDocumentQueryExecutor)}, so this query cannot be executed asynchronously. Queryables passed to {nameof(DocumentQueryableExtensions)} must originate from {nameof(IDocumentReadOperations)}.{nameof(IDocumentReadOperations.Query)}<T>() on a document store that supports the JasperFx document contract.");
+    }
+}

--- a/src/JasperFx.Events/Documents/IDocumentQueryExecutor.cs
+++ b/src/JasperFx.Events/Documents/IDocumentQueryExecutor.cs
@@ -1,0 +1,47 @@
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// The asynchronous execution hook behind <see cref="DocumentQueryableExtensions" />. Implemented by
+/// a store's LINQ <see cref="IQueryProvider" /> (or, failing that, by its queryable type).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IQueryable{T}" /> has no asynchronous execution path of its own, so every LINQ-capable
+/// data access library invents one; Marten, Polecat and EF Core each did. This is the shared version
+/// of that hook, and it is the only piece of the document contract a store must implement outside
+/// its session types.
+/// </para>
+/// <para>
+/// Four primitives, no predicate overloads: the predicate forms on
+/// <see cref="DocumentQueryableExtensions" /> compose <c>Queryable.Where</c> before dispatching
+/// here, so adding them costs an implementer nothing.
+/// </para>
+/// <para>
+/// The hook hangs off the provider rather than the queryable because <see cref="IQueryable.Provider" />
+/// is preserved by definition across every LINQ operator, whereas the queryable's own type is only
+/// preserved by convention. <see cref="DocumentQueryableExtensions" /> checks the queryable as a
+/// fallback for stores that find that more natural.
+/// </para>
+/// </remarks>
+public interface IDocumentQueryExecutor
+{
+    /// <summary>
+    /// Execute the query and return every matching result.
+    /// </summary>
+    Task<IReadOnlyList<T>> ExecuteToListAsync<T>(IQueryable<T> queryable, CancellationToken token);
+
+    /// <summary>
+    /// Execute the query and return the first result, or the default value when there are none.
+    /// </summary>
+    Task<T?> ExecuteFirstOrDefaultAsync<T>(IQueryable<T> queryable, CancellationToken token);
+
+    /// <summary>
+    /// Execute the query as a count of matching rows.
+    /// </summary>
+    Task<int> ExecuteCountAsync<T>(IQueryable<T> queryable, CancellationToken token);
+
+    /// <summary>
+    /// Execute the query as an existence check.
+    /// </summary>
+    Task<bool> ExecuteAnyAsync<T>(IQueryable<T> queryable, CancellationToken token);
+}

--- a/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
@@ -1,0 +1,89 @@
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// The read half of the store-agnostic document session contract: load one document by identity,
+/// or start a LINQ query over a document type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tier one of three, mirroring the shape the event side already settled on
+/// (<see cref="IQueryEventStore" /> → <see cref="IEventOperations" /> →
+/// <see cref="IEventStoreOperations" />):
+/// </para>
+/// <list type="table">
+///   <listheader><term>Tier</term><description>Marten / Polecat binding</description></listheader>
+///   <item>
+///     <term><see cref="IDocumentReadOperations" /></term>
+///     <description>Marten <c>IQuerySession</c>, Polecat <c>IQuerySession</c></description>
+///   </item>
+///   <item>
+///     <term><see cref="IDocumentWriteOperations" /></term>
+///     <description>Marten <c>IDocumentOperations</c>, Polecat <c>IDocumentOperations</c></description>
+///   </item>
+///   <item>
+///     <term><see cref="IDocumentSessionOperations" /></term>
+///     <description>Marten <c>IDocumentSession</c>, Polecat <c>IDocumentSession</c></description>
+///   </item>
+/// </list>
+/// <para>
+/// This contract is deliberately tiny — it is the *document* slice a store-agnostic consumer needs
+/// alongside <c>JasperFx.Events</c>, not a document store facade. Patching, bulk insert, LINQ joins /
+/// grouping / <c>Include</c>, soft-delete semantics, document metadata, session listeners, the
+/// stores' <c>Advanced</c> surfaces and schema management are all out of scope by design; a consumer
+/// that needs those takes a dependency on a concrete store. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/647" />.
+/// </para>
+/// <para>
+/// Identity overloads are limited to <see cref="Guid" /> and <see cref="string" /> — the two the
+/// measured consumer surface uses. Numeric identities and tenant-scoped reads can be added
+/// additively later without breaking any implementer.
+/// </para>
+/// </remarks>
+public interface IDocumentReadOperations : IAsyncDisposable
+{
+    /// <summary>
+    /// Load a single document by its <see cref="Guid" /> identity, or <see langword="null" /> when
+    /// no document exists with that identity.
+    /// </summary>
+    Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    /// Load a single document by its <see cref="string" /> identity, or <see langword="null" /> when
+    /// no document exists with that identity.
+    /// </summary>
+    Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    /// Start a LINQ query over a document type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A genuine <see cref="IQueryable{T}" /> rather than a fluent builder, because real consumer
+    /// code composes a query across statements — hold the queryable in a local, conditionally add
+    /// <c>Where</c> clauses, then order and terminate it. Anything narrower would not compile
+    /// against the call sites this contract exists to serve.
+    /// </para>
+    /// <para>
+    /// The compliance contract covers the operators the measured consumer surface needs —
+    /// <c>Where</c>, <c>Select</c>, <c>OrderBy</c> / <c>OrderByDescending</c>, <c>ThenBy</c>,
+    /// <c>Take</c>, <c>Skip</c>, <c>Distinct</c> — terminated by the
+    /// <see cref="DocumentQueryableExtensions" /> async methods. Everything else a store's LINQ
+    /// provider happens to support stays a product concern and is deliberately not held to a shared
+    /// definition; the stores' query languages diverge structurally enough that a broader shared
+    /// suite would pin coincidence rather than contract.
+    /// </para>
+    /// <para>
+    /// Products whose <c>Query&lt;T&gt;()</c> returns their own queryable interface (Marten's
+    /// <c>IMartenQueryable&lt;T&gt;</c>) satisfy this with a one-line explicit implementation; C#
+    /// interface implementation is not return-type covariant.
+    /// </para>
+    /// <para>
+    /// Implementers that wrap another provider should note one <c>System.Linq</c> constraint:
+    /// <c>Queryable.OrderBy</c> hard-casts the result of <c>IQueryProvider.CreateQuery&lt;T&gt;</c>
+    /// to <see cref="IOrderedQueryable{T}" />, so a wrapper implementing only
+    /// <see cref="IQueryable{T}" /> fails at the first <c>OrderBy</c>. Both current stores already
+    /// satisfy this; it is stated because a new store's first wrapper usually does not.
+    /// </para>
+    /// </remarks>
+    IQueryable<T> Query<T>() where T : notnull;
+}

--- a/src/JasperFx.Events/Documents/IDocumentSessionFactory.cs
+++ b/src/JasperFx.Events/Documents/IDocumentSessionFactory.cs
@@ -1,0 +1,68 @@
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// Opens document sessions without naming a concrete store. Binds to Marten's
+/// <c>IDocumentStore</c> and Polecat's <c>IDocumentStore</c>, including their ancillary
+/// (typed) store registrations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The non-generic form is the one that decouples a consumer: it hands back the shared session
+/// contracts, so nothing downstream has to name <c>Marten.IDocumentSession</c> or its Polecat
+/// counterpart. This mirrors how the event side already works — <see cref="IEventStore" /> is
+/// non-generic and <see cref="IEventStore{TOperations,TQuerySession}" /> layers the concrete session
+/// pair on top for store-generic infrastructure.
+/// </para>
+/// <para>
+/// Tenant-scoped session opening is deliberately absent. The measured consumer surface opens no
+/// tenant-scoped document sessions, and multi-tenancy beyond what <c>JasperFx.MultiTenancy</c>
+/// already exposes is out of scope for this contract. Overloads taking a tenant id can be added
+/// additively later.
+/// </para>
+/// </remarks>
+public interface IDocumentSessionFactory
+{
+    /// <summary>
+    /// Open a writable, committable session with no identity map — the cheap default for
+    /// read-modify-write work.
+    /// </summary>
+    IDocumentSessionOperations LightweightSession();
+
+    /// <summary>
+    /// Open a read-only session for querying.
+    /// </summary>
+    IDocumentReadOperations QuerySession();
+}
+
+/// <summary>
+/// The store-generic form of <see cref="IDocumentSessionFactory" />, handing back a product's own
+/// session types rather than the shared contracts.
+/// </summary>
+/// <typeparam name="TOperations">
+/// The product's committable session type — Marten <c>IDocumentSession</c>, Polecat
+/// <c>IDocumentSession</c>.
+/// </typeparam>
+/// <typeparam name="TQuerySession">The product's read-only session type.</typeparam>
+/// <remarks>
+/// <para>
+/// Exists for infrastructure that is itself generic over the session pair — the same reason
+/// <see cref="IEventStore{TOperations,TQuerySession}" /> exists alongside <see cref="IEventStore" />.
+/// Application code should prefer the non-generic interface; closing this one over a product's types
+/// re-couples the caller to that product, which is the thing this contract is here to avoid.
+/// </para>
+/// <para>
+/// Note that <typeparamref name="TOperations" /> here is the <em>committable</em> session, which on
+/// Marten is a different type from the <c>TOperations</c> of the projection generics
+/// (<c>IDocumentOperations</c>, which cannot commit). See <see cref="IDocumentWriteOperations" />.
+/// </para>
+/// </remarks>
+public interface IDocumentSessionFactory<TOperations, TQuerySession> : IDocumentSessionFactory
+    where TOperations : TQuerySession, IDocumentSessionOperations
+    where TQuerySession : IDocumentReadOperations
+{
+    /// <inheritdoc cref="IDocumentSessionFactory.LightweightSession" />
+    new TOperations LightweightSession();
+
+    /// <inheritdoc cref="IDocumentSessionFactory.QuerySession" />
+    new TQuerySession QuerySession();
+}

--- a/src/JasperFx.Events/Documents/IDocumentSessionOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentSessionOperations.cs
@@ -1,0 +1,21 @@
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// A committable document session: everything <see cref="IDocumentWriteOperations" /> can enlist,
+/// plus the transaction boundary that flushes it.
+/// </summary>
+/// <remarks>
+/// Tier three of three, and the tier a store-agnostic consumer actually holds. Binds to Marten's
+/// <c>IDocumentSession</c> and Polecat's <c>IDocumentSession</c>.
+/// </remarks>
+public interface IDocumentSessionOperations : IDocumentWriteOperations
+{
+    /// <summary>
+    /// Commit every pending change enlisted in this session's unit of work as a single transaction.
+    /// </summary>
+    /// <remarks>
+    /// The parameter is named <c>token</c> deliberately and must stay that way: both products spell
+    /// it <c>token</c>, and real consumer code passes it by name.
+    /// </remarks>
+    Task SaveChangesAsync(CancellationToken token = default);
+}

--- a/src/JasperFx.Events/Documents/IDocumentWriteOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentWriteOperations.cs
@@ -1,0 +1,58 @@
+using System.Linq.Expressions;
+
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// The mutating half of the store-agnostic document session contract — enlist documents into the
+/// session's unit of work. Deliberately carries no commit: see
+/// <see cref="IDocumentSessionOperations" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tier two of three. The split between "mutate" and "commit" is not decoration — it is the seam the
+/// products already draw. Marten's <c>IDocumentOperations</c> has <c>Store</c> / <c>Delete</c> /
+/// <c>DeleteWhere</c> but <em>not</em> <c>SaveChangesAsync</c>, which lives on
+/// <c>IDocumentSession</c>. That is exactly why a projection's <c>RaiseSideEffects</c> receives
+/// <c>IDocumentOperations</c>: a projection may write, but may not commit — the daemon owns the
+/// transaction boundary. Collapsing the two tiers would hand projections a commit they must never
+/// call.
+/// </para>
+/// <para>
+/// Consequence worth stating plainly: the <c>TOperations</c> of the projection generics
+/// (<see cref="Aggregation.JasperFxSingleStreamProjectionBase{TDoc,TId,TOperations,TQuerySession}" />,
+/// Marten's <c>IDocumentOperations</c>) is this tier, while a consumer holding a committable session
+/// wants the tier below it. The two are not the same type on Marten, so the document session
+/// contract cannot simply reuse the projection generics' closure.
+/// </para>
+/// </remarks>
+public interface IDocumentWriteOperations : IDocumentReadOperations
+{
+    /// <summary>
+    /// Enlist one or more documents to be inserted or updated when the session is committed.
+    /// </summary>
+    void Store<T>(params T[] entities) where T : notnull;
+
+    /// <summary>
+    /// Enlist a document for deletion when the session is committed.
+    /// </summary>
+    void Delete<T>(T entity) where T : notnull;
+
+    /// <summary>
+    /// Enlist the document with this <see cref="Guid" /> identity for deletion when the session is
+    /// committed. Deleting an identity that does not exist is a no-op rather than an error.
+    /// </summary>
+    void Delete<T>(Guid id) where T : notnull;
+
+    /// <summary>
+    /// Enlist the document with this <see cref="string" /> identity for deletion when the session is
+    /// committed. Deleting an identity that does not exist is a no-op rather than an error.
+    /// </summary>
+    void Delete<T>(string id) where T : notnull;
+
+    /// <summary>
+    /// Enlist a criteria-based delete — every document of this type matching the expression is
+    /// removed when the session is committed. Matching happens at commit time in the database, not
+    /// against documents already loaded into the session.
+    /// </summary>
+    void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull;
+}

--- a/src/JasperFx.Events/README.md
+++ b/src/JasperFx.Events/README.md
@@ -9,6 +9,7 @@ Provides:
 - **Slicing & grouping** — `SliceGroup`, `EventSlice`, `IEventSlicer` for fan-out projection topologies.
 - **Event metadata** — `IEvent`, `IEventRegistry`, type registry primitives.
 - **Descriptors** — `EventStoreUsage` and friends, surfaced through `IEventStoreUsageSource` to monitoring tools (CritterWatch).
+- **Documents** (`JasperFx.Events.Documents`) — the small document-session slice a store-agnostic consumer needs alongside the event store: `IDocumentReadOperations` / `IDocumentWriteOperations` / `IDocumentSessionOperations`, `IDocumentSessionFactory`, and async LINQ terminators over `IQueryable<T>`. Seven operations, not a document store facade.
 
 ## Quick start
 


### PR DESCRIPTION
Closes #647. Design decision record and full premise-check are in [this issue comment](https://github.com/JasperFx/jasperfx/issues/647#issuecomment-5256970425); this is the summary.

**Additive only.** Every type is new — no existing public member changed, none removed, no new abstract member on an existing interface. Marten #5216, Polecat #443 and Fisher #68 can land on their own schedules. `<JasperFxVersion>` untouched.

## The contract — `JasperFx.Events.Documents`

Three tiers, mirroring the shape the event side already settled on (`IQueryEventStore` → `IEventOperations` → `IEventStoreOperations`):

| Tier | Contract | Marten / Polecat |
|---|---|---|
| read | `IDocumentReadOperations` — `LoadAsync`, `Query<T>()` | `IQuerySession` |
| write | `IDocumentWriteOperations` — `Store`, `Delete`, `DeleteWhere` | `IDocumentOperations` |
| commit | `IDocumentSessionOperations` — `SaveChangesAsync` | `IDocumentSession` |

Three rather than two because Marten's `IDocumentOperations` has the mutations but **not** `SaveChangesAsync` — a projection may write and must never commit, since the daemon owns the transaction boundary. So the projection generics' `TOperations` is not the type a consumer holding a committable session wants, and modelling directly on them (as the issue proposed) would hand every projection a `SaveChangesAsync` it must not call.

`IDocumentSessionFactory` opens sessions. Its generic form layers on exactly as `IEventStore<,>` layers over `IEventStore`, but the **non-generic** form is what actually decouples a consumer.

Names avoid `IDocumentSession` / `IQuerySession` / `IDocumentStore` / `IDocumentOperations` deliberately — all four are taken in both products, and a same-named base interface in a different namespace is a permanent papercut for implementers.

## Async terminators

Extension methods over `IQueryable<T>`, dispatching through `IDocumentQueryExecutor` implemented by the store's query provider — the same shape EF Core and both our stores already use.

Interface members were rejected on a hard constraint, not taste: real consumer code holds a query in a local and adds clauses across statements, and every `System.Linq.Queryable` operator returns a plain `IQueryable<T>`. Member terminators would be unreachable after a single `Where`. A compliance test pins this.

A store implements **four** primitives; the predicate overloads compose `Queryable.Where` inside the extension. Cancellation parameters are named `token` on every member — consumer code passes it by name, so that is now contract.

Namespaced away from root `JasperFx.Events` on purpose: the terminators share names with `Marten.QueryableExtensions`, so keeping them opt-in avoids an ambiguity across every file that imports the root namespace.

## Compliance, from day one

Four suites / 41 tests — `DocumentSessionCompliance`, `DocumentLoadAndStoreCompliance`, `DocumentDeleteCompliance`, `DocumentQueryCompliance` — over a fixture with **three** abstract members that is **not generic** over the session pair, unlike `EventStoreComplianceFixture<TOperations, TQuerySession>` and its sixteen. That asymmetry is the result being demonstrated: everything the document suites do runs through the shared contracts. It also gives a standing invariant — if a document suite ever needs a fixture member reaching past the interfaces, the *contract* has a hole, and widening the seam is the wrong fix.

One deviation from "no store implementations here": `EventStoreTests` enrolls an in-memory reference implementation so the suite is **executed in this repo** instead of shipping unrun to three teams. A compliance suite nobody has run can encode an assertion no correct store could satisfy, and the first teams to hit it cannot tell a suite bug from a product bug. It paid for itself on the first run — it caught that `Queryable.OrderBy` hard-casts `IQueryProvider.CreateQuery<T>`'s result to `IOrderedQueryable<T>`, so a wrapping queryable implementing only `IQueryable<T>` throws on the first `OrderBy`. Now documented on `Query<T>()` rather than being three separate debugging sessions.

## Scope

Held to the measured consumer surface. Re-measuring `CritterWatch.Services` corrected the issue on two points, both folded in:

- the LINQ set also needs `OrderBy` / `OrderByDescending` / `ThenBy` / `Take` / `Skip` / `Distinct`, the `AnyAsync` terminator and a predicate overload of `CountAsync` — free from a real `IQueryable<T>`, but now pinned by the suite as a closed *minimum translatable set*
- `Query<T>()` must return a genuine `IQueryable<T>`, not a fluent builder

Out, and staying out: patching, bulk insert, LINQ joins / grouping / `Include`, soft-delete semantics, document metadata, session listeners, the stores' `Advanced` surfaces, schema management, tenant-scoped session overloads (zero measured call sites; additive later).

The issue comment also lists the six `CritterWatch.Services` surfaces this contract deliberately does **not** cover, so "seven operations decouples the consumer" is on the record as not quite true.

## Gate

`dotnet build jasperfx.slnx` — 0 errors. EventStoreTests 114, EventTests 746, CoreTests 574, CodegenTests 419, CommandLineTests 295 — all green on net9.0 and net10.0. Verified the new suites land in the source package's `contentFiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ri7jHRKhaFNBesQM1B5i1k