### PR TITLE
fix(source-generator): only require `partial` where the dispatcher lives in the user's class

### DIFF
--- a/docs/codegen/projection-apply-dispatch.md
+++ b/docs/codegen/projection-apply-dispatch.md
@@ -31,7 +31,7 @@ The SG emits one of five shapes through `EvolverCodeEmitter`
 
 | Mode | Emits | How runtime picks it up |
 |---|---|---|
-| `PartialProjection` | Partial method on the user's projection class (`Evolve` / `EvolveAsync` / `DetermineActionAsync`) | `JasperFxAggregationProjectionBase.isOverridden(...)` returns `true` for the generated override and `_usesConventionalApplication = false` — `AggregateApplication` is never invoked for dispatch. |
+| `PartialProjection` | Standalone `file`-scoped evolver + assembly-level `[GeneratedEvolverAttribute]` carrying the projection type. Falls back to an `Evolve` / `EvolveAsync` / `DetermineActionAsync` override injected into the user's class when the evolver cannot do the job — dispatch has to run on a DI-built instance (marten#4787), or the projection is generic / not visible from another file. | `tryUseAssemblyRegisteredEvolver(...)` binds the registered evolver; for the injected-override fallback, `isOverridden(...)` returns `true` first and `_usesConventionalApplication = false`. Either way `AggregateApplication` is never invoked for dispatch. |
 | `SelfAggregating` | Standalone evolver class implementing `IGeneratedSyncEvolver<TDoc,TId>` or `IGeneratedSyncDetermineAction<TDoc,TId>` + an assembly-level `[GeneratedEvolverAttribute]` | `JasperFxAggregationProjectionBase.tryUseAssemblyRegisteredEvolver(...)` activates and binds the evolver. |
 | `SelfAggregatingEvolve` | Standalone evolver class implementing `IGeneratedAsyncEvolver<TDoc,TId>` + `[GeneratedEvolverAttribute]` | Same as above. |
 | `EventProjection` | Partial `ApplyAsync(TOperations, IEvent, CancellationToken)` override on the user's `JasperFxEventProjectionBase<TOperations>` subclass | The override wins at vtable dispatch. `EventProjectionApplication` is only used when the base `ApplyAsync` is not overridden. |
@@ -156,6 +156,14 @@ emit shape or a reflective rewrite.
    (e.g. those that override `ApplyAsync` or `Evolve*` directly) do not need
    to be `partial`. The fail-fast exception message at registration spells
    out this narrower condition.
+
+   > Narrowed again since. Moving the aggregation dispatcher to a file-scoped
+   > evolver (#462) removed the requirement for `SingleStreamProjection` /
+   > `MultiStreamProjection` subclasses as well — it survives only where the
+   > dispatcher still has to be written into the user's class: an
+   > `EventProjection`, a projection dispatching on a DI-built instance
+   > (marten#4787), and generic or non-visible projections. Reported as
+   > `JFXEVT003` at build time.
 
 ## What shipped in #276
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -79,27 +79,35 @@ public Task ApplyAsync(TOperations operations,
 
 > `ProjectionLifecycle` (the `Inline` / `Async` / `Live` enum passed to `Projections.Add<T>(...)`) moved to the same `JasperFx.Events.Projections` namespace for the same reason. `using JasperFx.Events.Projections;` covers both.
 
-#### Convention-based projection subclasses must be declared `partial`
+#### Convention-based projections are dispatched by the source generator
 
-Conventional `Apply` / `Create` / `ShouldDelete` methods on a **projection subclass** — one that derives from `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, or `EventProjection` — are now dispatched by the compile-time `JasperFx.Events.SourceGenerator`. Pre-2.0 they were dispatched by runtime reflection; **in 2.0 there is no runtime reflection fallback.** For the generator to emit its `[GeneratedEvolver]` dispatcher, the projection class must be declared `partial`, and its convention methods must be `public`.
+Conventional `Apply` / `Create` / `ShouldDelete` methods on a **projection subclass** — one that derives from `SingleStreamProjection<TDoc, TId>`, `MultiStreamProjection<TDoc, TId>`, or `EventProjection` — are now dispatched by the compile-time `JasperFx.Events.SourceGenerator`. Pre-2.0 they were dispatched by runtime reflection; **in 2.0 there is no runtime reflection fallback.** The convention methods must be `public` so the generated dispatcher can call them.
 
 ```csharp
-// before (JasperFx.Events 1.x) — reflection dispatched the conventional methods
 public class TripProjection : SingleStreamProjection<Trip, Guid>
-{
-    public Trip Create(IEvent<TripStarted> e) => new() { Id = e.StreamId };
-    public void Apply(Travel e, Trip trip) => trip.Traveled += e.TotalDistance();
-}
-
-// after (JasperFx.Events 2.0) — `partial` lets the source generator emit the dispatcher
-public partial class TripProjection : SingleStreamProjection<Trip, Guid>
 {
     public Trip Create(IEvent<TripStarted> e) => new() { Id = e.StreamId };
     public void Apply(Travel e, Trip trip) => trip.Traveled += e.TotalDistance();
 }
 ```
 
-A non-`partial` subclass with conventional methods fails fast at projection registration (e.g. inside `AddMarten(opts => opts.Projections.Add<TripProjection>(...))`) rather than on first event dispatch:
+**Most projections do not need to be `partial`.** The dispatcher for an aggregation projection is emitted as a separate, file-scoped type registered through `[assembly: GeneratedEvolver(...)]`, so it needs nothing from your declaration. This covers self-aggregating snapshot types registered via `Snapshot<T>` (or the single-arg `SingleStreamProjection<T>` / `AggregateStream<T>` forms) as well as `SingleStreamProjection<TDoc, TId>` / `MultiStreamProjection<TDoc, TId>` subclasses.
+
+`partial` is required only where the dispatcher has to be generated **into the projection class itself**, which the generator reports as `JFXEVT003` at build time:
+
+- an **`EventProjection`** subclass using conventional methods — its dispatcher is an `ApplyAsync` override on your class;
+- a projection whose conventional methods are **instance** methods and which has **no public parameterless constructor** — a DI-activated projection, or an abstract projection base class. Dispatch has to run on the real instance so injected dependencies are populated;
+- a **generic** projection, or one nested behind `private` / `protected`, which a separate type cannot name. Every containing type has to be `partial` too.
+
+```csharp
+// needs `partial`: dispatch must run on the DI-built instance
+public partial class TripProjection(ILogger<TripProjection> logger) : SingleStreamProjection<Trip, Guid>
+{
+    public void Apply(Travel e, Trip trip) => logger.LogInformation("...");
+}
+```
+
+When a projection needs `partial` and does not have it, the build fails with `JFXEVT003` naming the declaration that is missing the modifier. If the generator never ran at all — for instance because the project reference excludes the `analyzers` asset — the failure instead surfaces at projection registration:
 
 ```
 JasperFx.Events.Projections.InvalidProjectionException:
@@ -107,8 +115,6 @@ No source-generated dispatcher found for TripProjection. Conventional
 Apply/Create/ShouldDelete methods are dispatched by the compile-time
 JasperFx.Events.SourceGenerator; there is no runtime fallback.
 ```
-
-**Self-aggregating snapshot types do _not_ need `partial`.** A type that carries its own `Apply`/`Create` methods and is registered via `Snapshot<T>` (or the single-arg `SingleStreamProjection<T>` / `AggregateStream<T>` self-aggregation forms) is handled without a projection subclass and needs no `partial` keyword.
 
 Two escape hatches if the generated dispatcher is not what you want:
 

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -405,39 +405,6 @@ public class MembersJoined { public int Count { get; set; } }
     }
 
     [Fact]
-    public void skips_non_partial_projection()
-    {
-        var source = @"
-using System;
-using JasperFx.Events;
-using JasperFx.Events.Aggregation;
-using JasperFx.Events.Projections;
-
-namespace Test;
-
-public class MyAggregate { public int Count { get; set; } }
-public class MyEvent { }
-
-public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
-    where TDoc : notnull where TId : notnull
-{
-    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
-}
-
-public class NonPartial : SingleStreamProjection<MyAggregate, Guid>
-{
-    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
-}
-";
-        var (diagnostics, generatedSources) = RunGenerator(source);
-
-        // Should not generate any override for non-partial class
-        generatedSources.ShouldBeEmpty();
-        // Should have JFXEVT003 info diagnostic
-        diagnostics.Any(d => d.Id == "JFXEVT003").ShouldBeTrue();
-    }
-
-    [Fact]
     public void emits_async_evolver_for_async_self_aggregating_apply()
     {
         // Async self-aggregating Apply/Create handlers are now supported via

--- a/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// Shared compilation harness for the generator's regression suites.
+///
+/// <para>Each issue's tests live in their own file rather than all landing at the end of
+/// AggregateEvolverGeneratorTests, so independent fixes to the generator do not collide on one test
+/// file. This type is what makes that practical — the content is deliberately identical wherever it
+/// appears, so branches that both introduce it merge without a conflict.</para>
+/// </summary>
+internal static class GeneratorHarness
+{
+    private static List<MetadataReference> References()
+    {
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IEvent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Guid).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Collections.dll")));
+
+        return references;
+    }
+
+    private static CSharpCompilation Compilation(string source)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: References(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    /// <summary>Runs the generator and returns its diagnostics plus every generated source.</summary>
+    public static (ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) Run(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out _, out var diagnostics);
+
+        var generatedSources = driver.GetRunResult().GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToArray();
+
+        return (diagnostics, generatedSources);
+    }
+
+    /// <summary>
+    /// Errors reported inside generated files only. The stub projection bases these fixtures use are
+    /// not valid types on their own, so an unfiltered assertion would report the harness rather than
+    /// the emission under test.
+    /// </summary>
+    public static string[] GeneratedCodeErrors(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Compiles with the generator loaded twice, as it is when bundled as a built-in analyzer in two
+    /// referenced packages (#462). The second copy is a distinct generator TYPE on purpose: the driver
+    /// derives generated file paths from the generator's type name, so two instances of the same type
+    /// would collide on path alone (CS0433), which is a different problem entirely.
+    /// </summary>
+    public static ImmutableArray<Diagnostic> CompileWithTwoCopies(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new AggregateEvolverGenerator().AsSourceGenerator(),
+            new SecondCopyOfTheGenerator().AsSourceGenerator());
+
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics();
+    }
+
+    /// <summary>Errors inside generated files after the generator ran twice over one compilation.</summary>
+    public static string[] DoubleLoadGeneratedCodeErrors(string source)
+    {
+        return CompileWithTwoCopies(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Stand-in for the same generator arriving from a second referenced package (#462). Delegates to the
+/// real generator; only its type identity differs, which is what gives it its own generated file paths.
+/// </summary>
+[Generator]
+public sealed class SecondCopyOfTheGenerator : IIncrementalGenerator
+{
+    private readonly AggregateEvolverGenerator _inner = new();
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) => _inner.Initialize(context);
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/OwnDispatchOverrideTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/OwnDispatchOverrideTests.cs
@@ -1,0 +1,126 @@
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// Overriding Evolve / EvolveAsync / DetermineAction / DetermineActionAsync is the documented way to
+/// opt out of conventional dispatch, and it needs nothing from the generator. AnalyzeProjectionSubclass
+/// returns null for those before candidacy is considered at all — which matters now that JFXEVT003 is
+/// an error, since a false positive here would fail the build rather than print a stray message.
+/// </summary>
+public class OwnDispatchOverrideTests
+{
+    private const string Preamble = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class MyAggregate { public int Count { get; set; } }
+public class MyEvent { }
+public interface ISecondaryStore { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+";
+
+    [Theory]
+    [InlineData("public override global::Test.MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e) => snapshot;")]
+    [InlineData("public override ValueTask<MyAggregate?> EvolveAsync(MyAggregate? snapshot, Guid id, object session, IEvent e, CancellationToken cancellation) => new(snapshot);")]
+    public void a_non_partial_projection_that_overrides_evolve_is_left_alone(string overrideDeclaration)
+    {
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class WritesItsOwnDispatch : SingleStreamProjection<MyAggregate, Guid>
+{
+    " + overrideDeclaration + @"
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_non_partial_projection_that_overrides_evolve_and_has_conventional_methods_is_left_alone()
+    {
+        // The two together are a configuration conflict the runtime rejects at registration
+        // (AssembleAndAssertValidity), not something to fail the build over.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class OverrideAndConventions : SingleStreamProjection<MyAggregate, Guid>
+{
+    public override MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e) => snapshot;
+
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_di_activated_projection_that_overrides_evolve_is_left_alone()
+    {
+        // The shape that would otherwise take the JFXEVT003 branch — instance conventional methods,
+        // no public parameterless constructor, not partial — but it dispatches itself.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class DiActivatedWithOwnDispatch : SingleStreamProjection<MyAggregate, Guid>
+{
+    private readonly ISecondaryStore _store;
+    public DiActivatedWithOwnDispatch(ISecondaryStore store) { _store = store; }
+
+    public override MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e) => snapshot;
+
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_non_partial_event_projection_that_overrides_apply_async_is_left_alone()
+    {
+        // Same principle on the EventProjection side: an explicit ApplyAsync IS the dispatcher.
+        var (diagnostics, _) = GeneratorHarness.Run(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public interface ITestQuerySession { }
+
+public interface ITestOperations : ITestQuerySession, IStorageOperations
+{
+    void Store<T>(T entity) where T : notnull;
+}
+
+public abstract class TestEventProjection : JasperFxEventProjectionBase<ITestOperations, ITestQuerySession>
+{
+    protected override void storeEntity<T>(ITestOperations ops, T entity) => ops.Store(entity);
+}
+
+public class EventProjectionWithOwnDispatch : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        return default;
+    }
+}
+");
+
+        diagnostics.ShouldNotContain(d => d.Id == "JFXEVT003");
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/PartialRequirementTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/PartialRequirementTests.cs
@@ -1,0 +1,219 @@
+using Microsoft.CodeAnalysis;
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// #650: candidacy for an aggregation projection subclass used to be gated on the `partial` modifier,
+/// left over from the pre-#462 emission that injected members into the user's class. Since #462 the
+/// dispatcher is a standalone file-scoped evolver that needs nothing from the user's declaration, so
+/// the gate only produced silence — no evolver, a clean build, and
+/// "No source-generated dispatcher found" when the store was built.
+///
+/// <para>`partial` survives only where the dispatcher is still written into the projection class
+/// itself, reported as JFXEVT003.</para>
+/// </summary>
+public class PartialRequirementTests
+{
+    private const string Preamble = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class MyAggregate { public int Count { get; set; } }
+public class MyEvent { }
+public class CreateEvent { }
+public interface ISecondaryStore { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+";
+
+    private const string EventProjectionPreamble = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public interface ITestQuerySession { }
+
+public interface ITestOperations : ITestQuerySession, IStorageOperations
+{
+    void Store<T>(T entity) where T : notnull;
+}
+
+public abstract class TestEventProjection : JasperFxEventProjectionBase<ITestOperations, ITestQuerySession>
+{
+    protected override void storeEntity<T>(ITestOperations ops, T entity) => ops.Store(entity);
+}
+
+public class AuditRecord { public Guid Id { get; set; } }
+public class AuditableEvent { }
+";
+
+    [Fact]
+    public void generates_evolver_for_non_partial_projection()
+    {
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class NonPartial : SingleStreamProjection<MyAggregate, Guid>
+{
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+");
+        var generated = string.Join("\n", generatedSources);
+
+        generated.ShouldContain("file sealed class NonPartial_GuidEvolver");
+        generated.ShouldContain(
+            "[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.MyAggregate), typeof(global::Test.NonPartial_GuidEvolver), typeof(global::Test.NonPartial))]");
+        generated.ShouldContain("_projection.Apply(data,");
+
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void generates_evolver_for_non_partial_projection_with_static_methods()
+    {
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class NonPartialStatic : SingleStreamProjection<MyAggregate, Guid>
+{
+    public static MyAggregate Create(CreateEvent e) => new MyAggregate();
+    public static void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+");
+        var generated = string.Join("\n", generatedSources);
+
+        generated.ShouldContain("global::Test.NonPartialStatic.Create(data)");
+        // Static dispatch needs no instance at all, shadow or otherwise.
+        generated.ShouldNotContain("_projectionInstance");
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void reports_error_for_non_partial_projection_that_needs_a_di_built_instance()
+    {
+        // The one aggregation shape that still requires `partial`: dispatch has to run on the
+        // DI-resolved instance (marten#4787), which means an override injected into the user's class.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class NonPartialDi : SingleStreamProjection<MyAggregate, Guid>
+{
+    private readonly ISecondaryStore _store;
+    public NonPartialDi(ISecondaryStore store) { _store = store; }
+
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+
+        var notPartial = diagnostics.Single(d => d.Id == "JFXEVT003");
+        notPartial.Severity.ShouldBe(DiagnosticSeverity.Error);
+        notPartial.GetMessage().ShouldContain("'NonPartialDi' is not declared partial");
+        notPartial.GetMessage().ShouldContain("no public parameterless constructor");
+    }
+
+    [Fact]
+    public void generic_projection_dispatches_through_an_injected_override()
+    {
+        // A file-scoped evolver cannot name an open generic type, so this used to emit
+        // `typeof(global::Test.GenericProjection<T>)` and break the consumer build with CS0246.
+        var source = Preamble + @"
+public partial class GenericProjection<T> : SingleStreamProjection<MyAggregate, Guid> where T : class
+{
+    public static void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+";
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(source);
+        var generated = string.Join("\n", generatedSources);
+
+        generated.ShouldContain("partial class GenericProjection<T>");
+        generated.ShouldNotContain("file sealed class");
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void nested_non_visible_projection_dispatches_through_an_injected_override()
+    {
+        // Same story, but CS0122: `file`-scoped types cannot be nested, so the evolver could not
+        // reach a projection hidden behind `private`.
+        var source = Preamble + @"
+public partial class Outer
+{
+    private partial class Inner : SingleStreamProjection<MyAggregate, Guid>
+    {
+        public static void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+    }
+}
+";
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(source);
+        var generated = string.Join("\n", generatedSources);
+
+        generated.ShouldContain("partial class Outer");
+        generated.ShouldContain("partial class Inner");
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void reports_error_when_the_containing_type_of_an_injected_projection_is_not_partial()
+    {
+        // The generated file re-opens every containing type, so a non-partial container would fail
+        // the consumer build with CS0260 — name it instead.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class Outer
+{
+    private partial class Inner : SingleStreamProjection<MyAggregate, Guid>
+    {
+        public static void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+    }
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+
+        var notPartial = diagnostics.Single(d => d.Id == "JFXEVT003");
+        notPartial.Severity.ShouldBe(DiagnosticSeverity.Error);
+        notPartial.GetMessage().ShouldContain("its containing type 'Outer' is not declared partial");
+    }
+
+    [Fact]
+    public void non_partial_event_projection_still_reports_an_error()
+    {
+        // Unlike an aggregation subclass, an EventProjection's dispatcher IS an ApplyAsync override on
+        // the user's own class, so `partial` remains genuinely required here.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(EventProjectionPreamble + @"
+public class NonPartialEventProjection : TestEventProjection
+{
+    public AuditRecord Create(AuditableEvent e) => new AuditRecord();
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+
+        var notPartial = diagnostics.Single(d => d.Id == "JFXEVT003");
+        notPartial.Severity.ShouldBe(DiagnosticSeverity.Error);
+        notPartial.GetMessage().ShouldContain("EventProjection");
+    }
+
+    [Fact]
+    public void file_scoped_emission_survives_the_generator_being_loaded_twice()
+    {
+        // #462: the file-scoped evolver is what makes a twice-loaded generator safe. Widening
+        // candidacy to non-partial projections must not walk that back — they take the same path.
+        GeneratorHarness.DoubleLoadGeneratedCodeErrors(Preamble + @"
+public class NonPartialTwice : SingleStreamProjection<MyAggregate, Guid>
+{
+    public static void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+").ShouldBeEmpty();
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -227,7 +227,11 @@ internal static class AggregateAnalyzer
             {
                 Mode = CandidateMode.None,
                 ClassSymbol = classSymbol,
-                ClassSyntax = classDecl
+                ClassSyntax = classDecl,
+                // Carried so the CandidateMode.None diagnostic path can tell "opted out via lambda
+                // registrations" from "not partial" — otherwise a *partial* projection using the
+                // lambda API reports JFXEVT003 ("is not partial"), which is simply false.
+                IsPartial = isPartial
             };
         }
 
@@ -238,7 +242,15 @@ internal static class AggregateAnalyzer
 
         return new CandidateInfo
         {
-            Mode = isPartial ? CandidateMode.PartialProjection : CandidateMode.None,
+            // NOT gated on `partial`. The dispatcher for an aggregation projection subclass is emitted
+            // as a standalone `file sealed class` registered through [assembly: GeneratedEvolver(...)]
+            // (#462) — it calls the projection's public conventional methods from the outside and never
+            // needs a second declaration of the user's type. The only emission that still injects members
+            // into the user's class is the DI-override path (marten#4787), which checks IsPartial itself
+            // and reports JFXEVT003 when the modifier is missing. Gating candidacy on the modifier was
+            // left over from the pre-#462 member-injection emission and silently skipped every
+            // non-partial projection, surfacing much later as "No source-generated dispatcher found".
+            Mode = CandidateMode.PartialProjection,
             ClassSymbol = classSymbol,
             ClassSyntax = classDecl,
             IsPartial = isPartial,

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -404,28 +404,20 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
                 break;
 
             case CandidateMode.None:
-                // Emit diagnostics for why we're skipping
-                if (!info.IsPartial && info.ClassSymbol != null)
+                // The only remaining reason an analyzed candidate lands here is a non-partial
+                // EventProjection subclass: its dispatcher IS an ApplyAsync override written into the
+                // user's class, so `partial` is genuinely required (unlike the aggregation subclasses,
+                // whose dispatcher is a standalone file-scoped evolver — see AnalyzeProjectionSubclass).
+                if (!info.IsPartial
+                    && info.ClassSymbol != null
+                    && AggregateAnalyzer.FindEventProjectionBase(info.ClassSymbol) != null)
                 {
-                    // Check if it's a projection that could have been generated
-                    var projBase = AggregateAnalyzer.FindAggregationProjectionBase(info.ClassSymbol);
-                    if (projBase != null)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            DiagnosticDescriptors.NotPartial,
-                            info.ClassSyntax.Identifier.GetLocation(),
-                            info.ClassSymbol.Name));
-                    }
-
-                    // Check if it's an event projection that could have been generated
-                    var eventProjBase = AggregateAnalyzer.FindEventProjectionBase(info.ClassSymbol);
-                    if (eventProjBase != null)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            DiagnosticDescriptors.NotPartial,
-                            info.ClassSyntax.Identifier.GetLocation(),
-                            info.ClassSymbol.Name));
-                    }
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.NotPartial,
+                        info.ClassSyntax.Identifier.GetLocation(),
+                        info.ClassSymbol.Name,
+                        $"'{info.ClassSymbol.Name}' is not declared partial",
+                        "an EventProjection's ApplyAsync dispatcher is generated as an override on the projection class itself"));
                 }
                 break;
         }
@@ -468,8 +460,44 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
     {
         if (info.Methods.Count == 0) return;
 
+        // Most projections are dispatched by a standalone file-scoped evolver that needs nothing from
+        // the user's declaration. The shapes that DO need the dispatcher written into the projection
+        // class itself need `partial` there — and on every containing type. Fail loudly when it is
+        // missing; the alternative is the runtime's "No source-generated dispatcher found" at store
+        // construction, or CS0260 inside a file the consumer cannot edit.
+        if (EvolverCodeEmitter.RequiresMemberInjection(info))
+        {
+            var missing = EvolverCodeEmitter.DescribeMissingPartialDeclaration(info);
+            if (missing != null)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.NotPartial,
+                    info.ClassSyntax.Identifier.GetLocation(),
+                    info.ClassSymbol.Name,
+                    missing,
+                    DescribeWhyMemberInjectionIsNeeded(info)));
+                return;
+            }
+        }
+
         var source = EvolverCodeEmitter.EmitPartialProjection(info);
         context.AddSource(SafeHintName(info.ClassSymbol, ".Evolver"), source);
+    }
+
+    /// <summary>
+    /// The half of JFXEVT003 that tells the user WHY the dispatcher has to live in their own class,
+    /// so "declare it partial" does not read as an arbitrary framework demand.
+    /// </summary>
+    private static string DescribeWhyMemberInjectionIsNeeded(CandidateInfo info)
+    {
+        var notNameable = EvolverCodeEmitter.DescribeWhyNotNameableFromFileScope(info.ClassSymbol);
+        if (notNameable != null)
+        {
+            return $"{notNameable}, so the dispatcher cannot be generated as a separate type";
+        }
+
+        return "its conventional methods are instance methods and it has no public parameterless constructor, "
+               + "so the dispatcher has to run on the projection instance itself";
     }
 
     private static void EmitEventProjection(SourceProductionContext context, CandidateInfo info)

--- a/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
+++ b/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
@@ -20,12 +20,22 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The projection has conventional methods the generator cannot dispatch without a second
+    /// declaration of the user's class. There is no runtime fallback for this — the projection throws
+    /// <c>InvalidProjectionException</c> when the store is built (see
+    /// <c>JasperFxAggregationProjectionBase.AssembleAndAssertValidity</c>) — so this is an error rather
+    /// than the Info-level "falling back to runtime expression compilation" note it used to be. That
+    /// message described the pre-2.0 FEC fallback, which the 9.0 projections rework deleted, and Info
+    /// severity kept it out of CLI builds entirely.
+    /// </summary>
     public static readonly DiagnosticDescriptor NotPartial = new(
         id: "JFXEVT003",
-        title: "Projection is not partial",
-        messageFormat: "Projection '{0}' is not partial; falling back to runtime expression compilation",
+        title: "Projection must be declared partial",
+        messageFormat:
+            "No dispatcher can be generated for projection '{0}' because {1} — {2}. Conventional Apply/Create/ShouldDelete methods are dispatched by the compile-time source generator and there is no runtime fallback.",
         category: "JasperFx.Events",
-        defaultSeverity: DiagnosticSeverity.Info,
+        defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
     /// <summary>

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -51,18 +51,10 @@ internal static class EvolverCodeEmitter
     /// </summary>
     public static string EmitPartialProjection(CandidateInfo info)
     {
-        // marten#4787: when a projection requires a DI-resolved instance for its conventional
-        // Apply/Create/ShouldDelete methods (it has at least one instance-on-projection handler AND
-        // no public parameterless constructor), the file-scoped Evolver dispatcher silently NREs on
-        // any deref of an injected field — its shadow projection is built via
-        // RuntimeHelpers.GetUninitializedObject, which skips the constructor. Route to the alternative
-        // emission that adds an override directly to the user's partial class so `this` (the DI-built
-        // instance) handles dispatch and injected fields are populated. Stateless / parameterless-ctor
-        // / aggregate-only / static-only projections keep the file-scoped Evolver — no perf regression
-        // for the cases that don't need DI.
-        if (NeedsProjectionInstance(info)
-            && !HasPublicParameterlessCtor(info.ClassSymbol)
-            && info.IsPartial)
+        // Two shapes cannot be dispatched from a file-scoped evolver and fall back to injecting the
+        // override into the user's own partial class — see RequiresMemberInjection. The caller has
+        // already verified the required `partial` modifiers are in place (JFXEVT003 otherwise).
+        if (RequiresMemberInjection(info))
         {
             return EmitPartialProjectionWithDIOverride(info);
         }
@@ -152,6 +144,102 @@ internal static class EvolverCodeEmitter
     {
         return info.Methods.Any(m => !m.IsStatic && !m.IsOnAggregate);
     }
+
+    /// <summary>
+    /// True when dispatch cannot be a standalone file-scoped evolver and has to be injected into the
+    /// user's own class instead. Two shapes qualify:
+    ///
+    /// <list type="number">
+    /// <item>marten#4787 — at least one conventional method lives on the projection instance and the
+    /// projection has no public parameterless constructor, so the evolver's shadow instance (built with
+    /// <c>RuntimeHelpers.GetUninitializedObject</c>, skipping the constructor) would NRE on the first
+    /// deref of an injected field. Also catches an abstract projection base class, whose implicit
+    /// constructor is protected. Dispatching on <c>this</c> instead gives the DI-built instance.</item>
+    /// <item>The evolver could not name the projection at all from its own file — see
+    /// <see cref="DescribeWhyNotNameableFromFileScope"/>.</item>
+    /// </list>
+    ///
+    /// Everything else (static-only, aggregate-side, or instance methods on a projection with a public
+    /// parameterless constructor) keeps the file-scoped evolver, which is the emission that makes the
+    /// double-load scenario in <see cref="EmitPartialProjection"/> safe.
+    /// </summary>
+    public static bool RequiresMemberInjection(CandidateInfo info)
+    {
+        return (NeedsProjectionInstance(info) && !HasPublicParameterlessCtor(info.ClassSymbol))
+               || DescribeWhyNotNameableFromFileScope(info.ClassSymbol) != null;
+    }
+
+    /// <summary>
+    /// Why a <c>file</c>-scoped evolver cannot name <paramref name="projectionType"/>, or <c>null</c>
+    /// when it can. The evolver lives in its own generated file and <c>file</c>-scoped types cannot be
+    /// nested, so a projection behind <c>private</c> / <c>protected</c> is unreachable (CS0122) and an
+    /// open generic projection cannot be named from a non-generic type (CS0246). Both shapes emitted
+    /// uncompilable code before these were routed to member injection instead.
+    /// </summary>
+    public static string? DescribeWhyNotNameableFromFileScope(INamedTypeSymbol projectionType)
+    {
+        for (INamedTypeSymbol? current = projectionType; current != null; current = current.ContainingType)
+        {
+            var self = ReferenceEquals(current, projectionType);
+
+            if (current.TypeParameters.Length > 0)
+            {
+                return self
+                    ? "it is generic"
+                    : $"it is nested inside the generic type '{current.Name}'";
+            }
+
+            switch (current.DeclaredAccessibility)
+            {
+                case Accessibility.Private:
+                case Accessibility.Protected:
+                case Accessibility.ProtectedAndInternal:
+                    var how = Describe(current.DeclaredAccessibility);
+                    return self
+                        ? $"it is declared {how}"
+                        : $"its containing type '{current.Name}' is declared {how}";
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The declaration that blocks member injection, or <c>null</c> when every declaration that has to
+    /// carry <c>partial</c> does. The generated override is written into the projection's own class, so
+    /// the projection and — because the generated file has to re-open them — each of its containing
+    /// types must be <c>partial</c>; a non-partial container fails the consumer build with CS0260.
+    /// </summary>
+    public static string? DescribeMissingPartialDeclaration(CandidateInfo info)
+    {
+        if (!info.IsPartial) return $"'{info.ClassSymbol.Name}' is not declared partial";
+
+        for (var container = info.ClassSymbol.ContainingType; container != null; container = container.ContainingType)
+        {
+            if (!IsDeclaredPartial(container))
+            {
+                return $"its containing type '{container.Name}' is not declared partial";
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsDeclaredPartial(INamedTypeSymbol type)
+    {
+        return type.DeclaringSyntaxReferences
+            .Select(r => r.GetSyntax())
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax>()
+            .Any(d => d.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PartialKeyword)));
+    }
+
+    private static string Describe(Accessibility accessibility) => accessibility switch
+    {
+        Accessibility.Private => "private",
+        Accessibility.Protected => "protected",
+        Accessibility.ProtectedAndInternal => "private protected",
+        _ => accessibility.ToString().ToLowerInvariant()
+    };
 
     /// <summary>
     /// marten#4787 alternative dispatch: emit the projection's Evolve / EvolveAsync /

--- a/src/JasperFx.Events/Aggregation/AggregateApplication.cs
+++ b/src/JasperFx.Events/Aggregation/AggregateApplication.cs
@@ -123,10 +123,13 @@ internal class AggregateApplication<TAggregate, TQuerySession> : IAggregator<TAg
                "JasperFx.Events.SourceGenerator; there is no runtime fallback. Ensure that analyzer runs in the " +
                $"assembly that defines {typeof(TAggregate).FullNameInCode()} (for Marten consumers the generator " +
                "ships inside the Marten NuGet package, so verify the project reference does not exclude the " +
-               "'analyzers' asset). A self-aggregating type registered via Snapshot<T> / SingleStreamProjection<T> / " +
-               "AggregateStream<T> does NOT need to be `partial`; a projection subclass that uses convention methods " +
-               "DOES need to be declared `partial`. Alternatively, override " +
-               "Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.";
+               "'analyzers' asset). Most projections do NOT need to be `partial` — neither a self-aggregating type " +
+               "registered via Snapshot<T> / SingleStreamProjection<T> / AggregateStream<T>, nor an aggregation " +
+               "projection subclass, whose dispatcher is generated as a separate type. `partial` is required only " +
+               "where the dispatcher has to be generated into the projection class itself: an EventProjection, or a " +
+               "projection whose conventional methods are instance methods and which has no public parameterless " +
+               "constructor (a DI-activated projection, for instance). The generator reports JFXEVT003 in those " +
+               "cases. Alternatively, override Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.";
     }
 
     // IAggregator<>: the runtime aggregator contract. Reachable only when the registration-time

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Runtime.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.Runtime.cs
@@ -153,9 +153,13 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
             "JasperFx.Events.SourceGenerator; there is no runtime fallback. Ensure that analyzer runs in the " +
             $"assembly that defines {typeof(TDoc).FullNameInCode()} (for Marten consumers the generator ships inside " +
             "the Marten NuGet package, so verify the project reference does not exclude the 'analyzers' asset). " +
-            "A self-aggregating type registered via Snapshot<T> / SingleStreamProjection<T> / AggregateStream<T> does " +
-            "NOT need to be `partial`; a projection subclass that uses convention methods DOES need to be declared " +
-            "`partial`. Alternatively, override Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.");
+            "Most projections do NOT need to be `partial` — neither a self-aggregating type registered via " +
+            "Snapshot<T> / SingleStreamProjection<T> / AggregateStream<T>, nor an aggregation projection subclass, " +
+            "whose dispatcher is generated as a separate type. `partial` is required only where the dispatcher has " +
+            "to be generated into the projection class itself: an EventProjection, or a projection whose conventional " +
+            "methods are instance methods and which has no public parameterless constructor (a DI-activated " +
+            "projection, for instance). The generator reports JFXEVT003 in those cases. Alternatively, override " +
+            "Evolve / EvolveAsync / DetermineAction / DetermineActionAsync directly.");
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Narrows the `partial` requirement on projections to the paths that actually need it, and makes the diagnostic for those paths tell the truth.

Closes #650

## Why

`AnalyzeProjectionSubclass` mapped every non-partial aggregation projection subclass to `CandidateMode.None`, so nothing was emitted: build clean, then `InvalidProjectionException: No source-generated dispatcher found` at `DocumentStore` construction. The gate is unchanged from the original generator commit, when dispatch *was* members injected into the user's class. #462 moved aggregation dispatch to a standalone `file sealed class` registered through `[assembly: GeneratedEvolver(...)]` — which calls the projection's public methods from the outside and needs nothing from the user's declaration — but the gate was never narrowed to match. `IsCandidateClass` already makes this argument for records (marten#4557).

## Changes

**Candidacy no longer looks at the modifier.** `AnalyzeProjectionSubclass` always yields `CandidateMode.PartialProjection`; `IsPartial` is still carried for the emitter.

**`partial` is now required only where the dispatcher is written into the projection class itself**, reported as `JFXEVT003` naming the declaration that lacks it:

| shape | why it needs `partial` |
|---|---|
| `EventProjection` subclass with conventional methods | its dispatcher *is* an `ApplyAsync` override on the user's class |
| instance methods + no public parameterless ctor | dispatch has to run on the DI-built instance (marten#4787); the evolver's `GetUninitializedObject` shadow leaves injected fields null. Also covers abstract projection base classes |
| generic projection, or one behind `private`/`protected` | a separate `file`-scoped type cannot name it |

**Generic and non-visible projections now work.** They previously emitted `typeof(Foo<T>)` (CS0246) or an unreachable type reference (CS0122) *even when declared `partial`* — a build break in generated code the consumer cannot edit. They now route to the member-injection emission, which already handles type parameters and containing types. A non-partial containing type would produce CS0260, so that is checked and reported as `JFXEVT003` too.

**JFXEVT003 rescoped, corrected, and raised to Error.** It said *"falling back to runtime expression compilation"* at `Info`. No such fallback exists — `AggregateApplication` is validity-only and both `AggregateApplication.cs` and `JasperFxAggregationProjectionBase.Runtime.cs` throw *"there is no runtime fallback"* — and `Info` diagnostics never appear in a CLI build, verified at both `-v n` and `-v d`. It also no longer fires where nothing is wrong: for a projection whose conventional methods live on the aggregate, or for a *partial* projection using constructor lambda registrations.

**Runtime messages and docs** updated to the narrower rule (`AggregateApplication.MissingDispatcherMessage`, the `EvolveAsync` backstop, `docs/migration-guide.md`, and the stale mode table in `docs/codegen/projection-apply-dispatch.md`, which still described the pre-#462 emission).

## Test plan

- `JasperFx.Events.SourceGenerator.Tests`: 46 passed. `skips_non_partial_projection` encoded the old behaviour and is removed; `PartialRequirementTests` covers its replacement plus the static-method shape, the DI shape (error), generic and private-nested projections (now emit and compile), a non-partial container (error naming it), the EventProjection case (still an error), and a double-load regression test.
- `OwnDispatchOverrideTests` pins the paths that must NOT reach the new error: a projection supplying its own `Evolve` / `EvolveAsync` override is skipped before candidacy, including the DI-activated shape that would otherwise take the JFXEVT003 branch.
- New tests live in their own files rather than at the end of `AggregateEvolverGeneratorTests`, sharing a `GeneratorHarness` whose content is identical across the related PRs so they do not collide on one test file at merge time.
- `EventTests`: 746 passed on net9.0 and net10.0. `EventStoreTests`: 114 passed on both.
- **#462 double-load re-verified.** Two *distinct* generator types over one compilation — two instances of the same type collide on generated file path alone (CS0433), which is unrelated to double loading. Every file-scoped emission is clean; the pre-existing member-injection path (marten#4787) still trips CS0111 under a double load, unchanged by this PR and filed separately.
- **Marten 9.23.0 corpus.** Built `src/EventSourcingTests` with this generator swapped in for the published analyzer: 0 errors, no `JFXEVT` diagnostics, and the generated output is byte-identical to the published generator's across all 245 files. Every projection in Marten's suite is already `partial`, so this is a no-regression result rather than a behaviour change there.

## Breaking change

`JFXEVT003` goes from `Info` (invisible) to `Error`. A projection that needs `partial` and does not have it now fails the build instead of failing at store construction. Every affected consumer is already broken at runtime today; the change moves the failure earlier and names the fix. Suppressible per-project with `dotnet_diagnostic.JFXEVT003.severity` if anyone needs a staged upgrade.

## Pipeline dedupe

`MarkSeen` adds the aggregate type to the cross-pipeline `seen` set for any `PartialProjection` candidate, which now includes non-partial subclasses, so it is worth stating why that changes nothing. When the aggregate is declared in the same compilation, pipeline 1 emits its self-aggregating evolver from its own declaration and both registrations are present — verified identical with and without this change. When it is declared in another assembly, pipelines 2 and 3 never emitted for it in the first place: `AnalyzeRefersToAggregate` requires a `DeclaringSyntaxReference` (AggregateAnalyzer.cs:1633) and returns null without one. Verified end to end by compiling the aggregate into a referenced assembly and registering `Snapshot<T>` in the host — nothing is emitted there either way, which is exactly why marten#4557 was fixed by running the generator in the aggregate's own assembly.
