### PR TITLE
refactor(source-generator): drop the opt-out for removed lambda registration APIs

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// Shared compilation harness for the generator's regression suites.
+///
+/// <para>Each issue's tests live in their own file rather than all landing at the end of
+/// AggregateEvolverGeneratorTests, so independent fixes to the generator do not collide on one test
+/// file. This type is what makes that practical — the content is deliberately identical wherever it
+/// appears, so branches that both introduce it merge without a conflict.</para>
+/// </summary>
+internal static class GeneratorHarness
+{
+    private static List<MetadataReference> References()
+    {
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IEvent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Guid).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Collections.dll")));
+
+        return references;
+    }
+
+    private static CSharpCompilation Compilation(string source)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: References(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    /// <summary>Runs the generator and returns its diagnostics plus every generated source.</summary>
+    public static (ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) Run(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out _, out var diagnostics);
+
+        var generatedSources = driver.GetRunResult().GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToArray();
+
+        return (diagnostics, generatedSources);
+    }
+
+    /// <summary>
+    /// Errors reported inside generated files only. The stub projection bases these fixtures use are
+    /// not valid types on their own, so an unfiltered assertion would report the harness rather than
+    /// the emission under test.
+    /// </summary>
+    public static string[] GeneratedCodeErrors(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Compiles with the generator loaded twice, as it is when bundled as a built-in analyzer in two
+    /// referenced packages (#462). The second copy is a distinct generator TYPE on purpose: the driver
+    /// derives generated file paths from the generator's type name, so two instances of the same type
+    /// would collide on path alone (CS0433), which is a different problem entirely.
+    /// </summary>
+    public static ImmutableArray<Diagnostic> CompileWithTwoCopies(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new AggregateEvolverGenerator().AsSourceGenerator(),
+            new SecondCopyOfTheGenerator().AsSourceGenerator());
+
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics();
+    }
+
+    /// <summary>Errors inside generated files after the generator ran twice over one compilation.</summary>
+    public static string[] DoubleLoadGeneratedCodeErrors(string source)
+    {
+        return CompileWithTwoCopies(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Stand-in for the same generator arriving from a second referenced package (#462). Delegates to the
+/// real generator; only its type identity differs, which is what gives it its own generated file paths.
+/// </summary>
+[Generator]
+public sealed class SecondCopyOfTheGenerator : IIncrementalGenerator
+{
+    private readonly AggregateEvolverGenerator _inner = new();
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) => _inner.Initialize(context);
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/LambdaOptOutRemovalTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/LambdaOptOutRemovalTests.cs
@@ -1,0 +1,94 @@
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// #655: the analyzer used to skip any projection whose constructor invoked ProjectEvent /
+/// CreateEvent / DeleteEvent with arguments, and its EventProjection counterpart matched the raw
+/// substring "Project&lt;" over the constructor's text. Those inline lambda registration APIs were
+/// removed in JasperFx 2.0 / Marten 9.0 (#286), so the only thing either check could still match was
+/// user code that happens to look like them — silently leaving that projection with no dispatcher,
+/// surfacing later as "No source-generated dispatcher found" at store construction.
+/// </summary>
+public class LambdaOptOutRemovalTests
+{
+    [Fact]
+    public void a_constructor_call_named_like_a_removed_lambda_api_no_longer_suppresses_dispatch()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class MyAggregate { public int Count { get; set; } }
+public class MyEvent { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+
+public partial class ProjectionWithOwnHelper : SingleStreamProjection<MyAggregate, Guid>
+{
+    public ProjectionWithOwnHelper()
+    {
+        ProjectEvent(""not the removed API, just a method of mine"");
+    }
+
+    private void ProjectEvent(string note) { }
+
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+";
+        var (_, generatedSources) = GeneratorHarness.Run(source);
+
+        string.Join("\n", generatedSources).ShouldContain("ProjectionWithOwnHelper");
+    }
+
+    [Fact]
+    public void an_event_projection_constructor_mentioning_project_no_longer_suppresses_dispatch()
+    {
+        // The EventProjection half was a substring match, so even a comment could disable generation.
+        var source = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public interface ITestQuerySession { }
+
+public interface ITestOperations : ITestQuerySession, IStorageOperations
+{
+    void Store<T>(T entity) where T : notnull;
+}
+
+public abstract class TestEventProjection : JasperFxEventProjectionBase<ITestOperations, ITestQuerySession>
+{
+    protected override void storeEntity<T>(ITestOperations ops, T entity) => ops.Store(entity);
+}
+
+public class AuditRecord { public Guid Id { get; set; } }
+public class AuditableEvent { }
+
+public partial class EventProjectionWithComment : TestEventProjection
+{
+    public EventProjectionWithComment()
+    {
+        // Project<AuditRecord> used to live here
+    }
+
+    public AuditRecord Create(AuditableEvent e) => new AuditRecord();
+}
+";
+        var (_, generatedSources) = GeneratorHarness.Run(source);
+
+        string.Join("\n", generatedSources).ShouldContain("EventProjectionWithComment");
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -169,12 +169,6 @@ internal static class AggregateAnalyzer
 
     private const string ProjectionBaseFullName = "JasperFx.Events.Projections.ProjectionBase";
 
-    private static readonly string[] LambdaMethodNames =
-        { "ProjectEvent", "CreateEvent", "DeleteEvent" };
-
-    private static readonly string[] EventProjectionLambdaMethodNames =
-        { "Project<", "ProjectAsync<" };
-
     public static CandidateInfo? Analyze(GeneratorSyntaxContext context, CancellationToken ct)
     {
         var classDecl = context.Node as TypeDeclarationSyntax;
@@ -219,17 +213,6 @@ internal static class AggregateAnalyzer
         // Check if it already overrides Evolve/EvolveAsync/DetermineAction/DetermineActionAsync
         if (HasExplicitOverride(classSymbol))
             return null;
-
-        // Check if constructor has lambda registrations
-        if (HasLambdaRegistrations(classDecl))
-        {
-            return new CandidateInfo
-            {
-                Mode = CandidateMode.None,
-                ClassSymbol = classSymbol,
-                ClassSyntax = classDecl
-            };
-        }
 
         var methods = DiscoverConventionalMethods(classSymbol, baseInfo.docType, classSymbol);
         var ctorDeleteTypes = DiscoverConstructorDeleteEventTypes(classDecl, semanticModel, ct);
@@ -965,10 +948,6 @@ internal static class AggregateAnalyzer
             };
         }
 
-        // Check if constructor has lambda registrations (Project<T> / ProjectAsync<T>)
-        if (HasEventProjectionLambdaRegistrations(classDecl))
-            return null;
-
         var methods = DiscoverEventProjectionMethods(classSymbol, baseInfo.operationsType);
 
         if (methods.Count == 0) return null;
@@ -1302,23 +1281,6 @@ internal static class AggregateAnalyzer
             .Any(m => m.IsOverride && m.Name == "ApplyAsync");
     }
 
-    private static bool HasEventProjectionLambdaRegistrations(TypeDeclarationSyntax classDecl)
-    {
-        var constructors = classDecl.Members.OfType<ConstructorDeclarationSyntax>();
-        foreach (var ctor in constructors)
-        {
-            if (ctor.Body == null) continue;
-            var text = ctor.Body.ToFullString();
-            foreach (var name in EventProjectionLambdaMethodNames)
-            {
-                if (text.Contains(name))
-                    return true;
-            }
-        }
-
-        return false;
-    }
-
     private static bool HasExplicitOverride(INamedTypeSymbol classSymbol)
     {
         return classSymbol.GetMembers()
@@ -1375,47 +1337,6 @@ internal static class AggregateAnalyzer
         }
 
         return result;
-    }
-
-    private static bool HasLambdaRegistrations(TypeDeclarationSyntax classDecl)
-    {
-        // Only ProjectEvent / CreateEvent / DeleteEvent invocations that *take
-        // an argument* (a handler / predicate lambda) opt the projection out of
-        // SG dispatch — those were the inline-lambda APIs JasperFx 2.0 removed.
-        // The parameterless variant `DeleteEvent<T>()` is still a supported way
-        // to declare delete-on events from the constructor and must NOT block
-        // dispatcher emission. See #297. A plain substring match on the body
-        // (previous implementation) misclassified `DeleteEvent<T>()` as a
-        // lambda registration and silently skipped dispatcher emission.
-        var constructors = classDecl.Members.OfType<ConstructorDeclarationSyntax>();
-        foreach (var ctor in constructors)
-        {
-            if (ctor.Body == null) continue;
-            foreach (var invocation in ctor.Body.DescendantNodes().OfType<InvocationExpressionSyntax>())
-            {
-                if (invocation.ArgumentList.Arguments.Count == 0) continue;
-
-                var simpleName = invocation.Expression switch
-                {
-                    MemberAccessExpressionSyntax m => m.Name,
-                    GenericNameSyntax g => g,
-                    IdentifierNameSyntax i => (SimpleNameSyntax?)i,
-                    _ => null
-                };
-
-                var name = (simpleName as GenericNameSyntax)?.Identifier.ValueText
-                           ?? (simpleName as IdentifierNameSyntax)?.Identifier.ValueText;
-
-                if (name == null) continue;
-
-                foreach (var lambdaName in LambdaMethodNames)
-                {
-                    if (name == lambdaName) return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
+++ b/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
@@ -4,14 +4,6 @@ namespace JasperFx.Events.SourceGenerator;
 
 internal static class DiagnosticDescriptors
 {
-    public static readonly DiagnosticDescriptor AsyncSelfAggregating = new(
-        id: "JFXEVT001",
-        title: "Self-aggregating type has async methods",
-        messageFormat: "Self-aggregating type '{0}' has async methods; falling back to runtime expression compilation",
-        category: "JasperFx.Events",
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
-
     public static readonly DiagnosticDescriptor CannotInferIdentity = new(
         id: "JFXEVT002",
         title: "Cannot infer identity type",
@@ -41,13 +33,5 @@ internal static class DiagnosticDescriptors
             "'{0}' calls {1} on its session with document type '{2}', which cannot be registered as a published type; call it with a concrete document type so the projection registers it",
         category: "JasperFx.Events",
         defaultSeverity: DiagnosticSeverity.Info,
-        isEnabledByDefault: true);
-
-    public static readonly DiagnosticDescriptor HasLambdaRegistrations = new(
-        id: "JFXEVT004",
-        title: "Has lambda registrations",
-        messageFormat: "Skipping '{0}' — has lambda registrations in constructor",
-        category: "JasperFx.Events",
-        defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 }


### PR DESCRIPTION
Closes #655

## Why

`AggregateAnalyzer.HasLambdaRegistrations` skipped any projection whose constructor invoked `ProjectEvent` / `CreateEvent` / `DeleteEvent` with arguments, and its EventProjection counterpart matched the raw substring `"Project<"` over the constructor's text.

Those inline-lambda registration APIs were removed in JasperFx 2.0 / Marten 9.0 (#286). Marten's docs say so in three places and route users to method conventions instead. What survives on the aggregation base is `DeleteEvent<TEvent>()` and `TransformsEvent<TEvent>()`, both parameterless — and the check requires at least one argument, so it can no longer match a supported API at all.

That leaves only false positives: a user-defined helper that happens to share one of those names, or — for EventProjection — a mere mention of `Project<` in a comment. When it fired, the projection got no dispatcher and nothing was reported, surfacing later as `No source-generated dispatcher found` at store construction.

## Changes

Both detectors removed, along with `JFXEVT004` (which described this skip) and `JFXEVT001` — neither was ever passed to `ReportDiagnostic`, and `JFXEVT001` also promised the runtime expression-compilation fallback that no longer exists, for a condition (async self-aggregating handlers) that has been supported since #297.

## Test plan

`LambdaOptOutRemovalTests` pins both false positives: a projection with its own `ProjectEvent(string)` helper, and an EventProjection whose constructor only mentions `Project<` in a comment. Both now get dispatchers.

Source generator tests 36 passed; EventTests 746 on net9.0 and net10.0; EventStoreTests 114.
