### PR TITLE
fix(source-generator): report unregistered published types instead of skipping in silence

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// Shared compilation harness for the generator's regression suites.
+///
+/// <para>Each issue's tests live in their own file rather than all landing at the end of
+/// AggregateEvolverGeneratorTests, so independent fixes to the generator do not collide on one test
+/// file. This type is what makes that practical — the content is deliberately identical wherever it
+/// appears, so branches that both introduce it merge without a conflict.</para>
+/// </summary>
+internal static class GeneratorHarness
+{
+    private static List<MetadataReference> References()
+    {
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IEvent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Guid).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Collections.dll")));
+
+        return references;
+    }
+
+    private static CSharpCompilation Compilation(string source)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: References(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    /// <summary>Runs the generator and returns its diagnostics plus every generated source.</summary>
+    public static (ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) Run(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out _, out var diagnostics);
+
+        var generatedSources = driver.GetRunResult().GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToArray();
+
+        return (diagnostics, generatedSources);
+    }
+
+    /// <summary>
+    /// Errors reported inside generated files only. The stub projection bases these fixtures use are
+    /// not valid types on their own, so an unfiltered assertion would report the harness rather than
+    /// the emission under test.
+    /// </summary>
+    public static string[] GeneratedCodeErrors(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Compiles with the generator loaded twice, as it is when bundled as a built-in analyzer in two
+    /// referenced packages (#462). The second copy is a distinct generator TYPE on purpose: the driver
+    /// derives generated file paths from the generator's type name, so two instances of the same type
+    /// would collide on path alone (CS0433), which is a different problem entirely.
+    /// </summary>
+    public static ImmutableArray<Diagnostic> CompileWithTwoCopies(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new AggregateEvolverGenerator().AsSourceGenerator(),
+            new SecondCopyOfTheGenerator().AsSourceGenerator());
+
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics();
+    }
+
+    /// <summary>Errors inside generated files after the generator ran twice over one compilation.</summary>
+    public static string[] DoubleLoadGeneratedCodeErrors(string source)
+    {
+        return CompileWithTwoCopies(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Stand-in for the same generator arriving from a second referenced package (#462). Delegates to the
+/// real generator; only its type identity differs, which is what gives it its own generated file paths.
+/// </summary>
+[Generator]
+public sealed class SecondCopyOfTheGenerator : IIncrementalGenerator
+{
+    private readonly AggregateEvolverGenerator _inner = new();
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) => _inner.Initialize(context);
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/PublishedTypeRegistrationDiagnosticTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/PublishedTypeRegistrationDiagnosticTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.CodeAnalysis;
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// #654: a non-partial EventProjection with an explicit ApplyAsync override was dropped before
+/// analysis finished, so the document types it writes were never registered as published types and —
+/// alone among the generator's skips — nothing was reported. The registration is a PublishedTypes()
+/// override emitted into the user's class, so a non-partial projection genuinely cannot have one;
+/// the fix is to say so rather than to emit.
+/// </summary>
+public class PublishedTypeRegistrationDiagnosticTests
+{
+    private const string Preamble = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public interface ITestQuerySession { }
+
+public interface ITestOperations : ITestQuerySession, IStorageOperations
+{
+    void Store<T>(T entity) where T : notnull;
+}
+
+public abstract class TestEventProjection : JasperFxEventProjectionBase<ITestOperations, ITestQuerySession>
+{
+    protected override void storeEntity<T>(ITestOperations ops, T entity) => ops.Store(entity);
+}
+
+public class AuditRecord { public Guid Id { get; set; } }
+public class AuditableEvent { }
+";
+
+    [Fact]
+    public void reports_unregistered_published_types_for_a_non_partial_event_projection()
+    {
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class NonPartialExplicitApply : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+
+        var warning = diagnostics.Single(d => d.Id == "JFXEVT006");
+        warning.Severity.ShouldBe(DiagnosticSeverity.Warning);
+        warning.GetMessage().ShouldContain("'AuditRecord'");
+        warning.GetMessage().ShouldContain("not declared partial");
+    }
+
+    [Fact]
+    public void no_diagnostic_when_a_non_partial_event_projection_writes_nothing_registrable()
+    {
+        // Nothing to register, so nothing to report.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public class NonPartialNoStores : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        return default;
+    }
+}
+");
+
+        generatedSources.ShouldBeEmpty();
+        diagnostics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void partial_event_projection_still_registers_its_published_types()
+    {
+        // The partial path is untouched.
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Preamble + @"
+public partial class PartialExplicitApply : TestEventProjection
+{
+    public override ValueTask ApplyAsync(ITestOperations operations, IEvent e, CancellationToken cancellation)
+    {
+        operations.Store(new AuditRecord());
+        return default;
+    }
+}
+");
+
+        string.Join("\n", generatedSources).ShouldContain("typeof(global::Test.AuditRecord)");
+        diagnostics.ShouldNotContain(d => d.Id == "JFXEVT006");
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -941,8 +941,12 @@ internal static class AggregateAnalyzer
             // Even with an explicit override, we should still discover document types
             // used in Store/Insert/Delete calls so they can be registered as published types.
             // See https://github.com/JasperFx/marten/issues/4166
-            if (!isPartial) return null;
-
+            //
+            // Discovery runs whether or not the class is `partial`. The registration itself is a
+            // PublishedTypes() override emitted into the user's class, so a non-partial projection
+            // genuinely cannot have one — but bailing out here made that the one skip in the whole
+            // generator that produced no diagnostic at all. The candidate is built either way and
+            // EmitEventProjectionTypeRegistration reports JFXEVT006 instead of emitting. See #654.
             var unresolved = new List<UnresolvedDocumentOperation>();
             var discoveredTypes = DiscoverDocumentTypesFromMethodBodies(classDecl, classSymbol,
                 baseInfo.operationsType, semanticModel, unresolved);

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -482,6 +482,28 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
 
     private static void EmitEventProjectionTypeRegistration(SourceProductionContext context, CandidateInfo info)
     {
+        // A non-partial projection cannot receive the generated PublishedTypes() override. Say so once,
+        // naming what went unregistered, rather than skipping in silence. The per-operation JFXEVT005
+        // notes are suppressed here — nothing at all is being registered for this projection, so
+        // pointing at individual unregistrable calls would only add noise. See #654.
+        if (!info.IsPartial)
+        {
+            if (info.DiscoveredPublishedTypes.Count > 0)
+            {
+                var typeList = string.Join(", ", info.DiscoveredPublishedTypes
+                    .Select(t => $"'{t.Name}'")
+                    .Distinct());
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.UnregisteredPublishedTypes,
+                    info.ClassSyntax.Identifier.GetLocation(),
+                    info.ClassSymbol.Name,
+                    typeList));
+            }
+
+            return;
+        }
+
         foreach (var unresolved in info.UnresolvedDocumentOperations)
         {
             context.ReportDiagnostic(Diagnostic.Create(

--- a/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
+++ b/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
@@ -43,6 +43,23 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// An EventProjection with an explicit <c>ApplyAsync</c> writes documents the generator can name,
+    /// but the registration is a <c>PublishedTypes()</c> override emitted into the projection class, so
+    /// a non-partial projection cannot receive one. Warning rather than error: nothing fails at runtime,
+    /// the store provisions that document's storage on demand, and only the ahead-of-time surfaces
+    /// (schema creation, known document types, rebuild teardown) come up short. Before this the skip was
+    /// entirely silent. See #654.
+    /// </summary>
+    public static readonly DiagnosticDescriptor UnregisteredPublishedTypes = new(
+        id: "JFXEVT006",
+        title: "Published document types cannot be registered",
+        messageFormat:
+            "'{0}' writes document type(s) {1} from its ApplyAsync override, but is not declared partial, so they are not registered as published types; declare the projection partial, or register them with RegisterPublishedType",
+        category: "JasperFx.Events",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     public static readonly DiagnosticDescriptor HasLambdaRegistrations = new(
         id: "JFXEVT004",
         title: "Has lambda registrations",


### PR DESCRIPTION
Closes #654

## Why

`AnalyzeEventProjectionSubclass` bailed on a non-partial EventProjection with an explicit `ApplyAsync` override:

```csharp
if (HasApplyAsyncOverride(classSymbol))
{
    if (!isPartial) return null;   // no candidate, no diagnostic, no registration
```

Returning `null` means no candidate at all, so unlike every other skip in the generator this one produced **no diagnostic whatsoever**. The document types discovered from the projection's `Store` / `Insert` / `Delete` calls were silently never registered as published types.

## Changes

Discovery now runs regardless of the modifier, and the emission step reports **JFXEVT006** naming the projection and the document types that went unregistered.

Emission still requires `partial` — the registration is a `PublishedTypes()` override written into the user's class, so a non-partial projection genuinely cannot receive one. The fix is the diagnostic, not new emission. The per-operation `JFXEVT005` notes are suppressed in that case: nothing is being registered for the projection at all, so pointing at individual calls would only add noise.

**Severity is Warning, not Error.** Nothing fails at runtime — the store provisions the document's storage on demand, and only the ahead-of-time surfaces (schema creation, known document types, rebuild teardown) come up short. That is also why this went unnoticed.

## Test plan

`PublishedTypeRegistrationDiagnosticTests`: reports with the document type named; stays silent when there is nothing registrable; the partial path still registers as before.

Source generator tests 37 passed; EventTests 746 on net9.0 and net10.0; EventStoreTests 114.
