### PR TITLE
fix(events): only treat a genuine override of the dispatch virtuals as an override

### DIFF
--- a/src/EventTests/Projections/HidingDispatchVirtualTests.cs
+++ b/src/EventTests/Projections/HidingDispatchVirtualTests.cs
@@ -1,0 +1,96 @@
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Projections;
+
+// #656: declaring a dispatch method without `override` hides the base virtual rather than replacing
+// it — the compiler says so with CS0114 — but isOverridden used to count it as an override purely
+// because it is declared outside JasperFx.Events. With conventional methods alongside, registration
+// failed claiming a conflict the author never wrote; without them, dispatch reached the base virtual
+// and threw NotImplementedException at the first event.
+public partial class HidesEvolveAndUsesConventions : SingleStreamProjection<MyAggregate, Guid>
+{
+    public new MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e)
+    {
+        // Never reached by dispatch — it is not an override. Kept as the author wrote it.
+        snapshot ??= new MyAggregate();
+        snapshot.ACount += 100;
+        return snapshot;
+    }
+
+    public void Apply(AEvent e, MyAggregate a) => a.ACount++;
+}
+
+// A same-named helper used to be enough to break registration outright: Type.GetMethod(string) throws
+// AmbiguousMatchException as soon as more than one method carries the name.
+public partial class OverloadsEvolveName : SingleStreamProjection<MyAggregate, Guid>
+{
+    public string Evolve(string somethingElse) => somethingElse;
+
+    public void Apply(AEvent e, MyAggregate a) => a.ACount++;
+}
+
+public class OverridesEvolveWithConventions : SingleStreamProjection<MyAggregate, Guid>
+{
+    public override MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e)
+    {
+        snapshot ??= new MyAggregate();
+        snapshot.ACount += 100;
+        return snapshot;
+    }
+}
+
+public class hiding_a_dispatch_virtual
+{
+    [Fact]
+    public async Task a_hiding_evolve_does_not_claim_the_dispatch_path()
+    {
+        var projection = new HidesEvolveAndUsesConventions();
+
+        // Used to throw: "can only use the override of 'Evolve' or conventional Apply/Create/
+        // ShouldDelete methods, but not both".
+        Should.NotThrow(() => projection.AssembleAndAssertValidity());
+
+        var (snapshot, _) = await projection.DetermineActionAsync(
+            new FakeSession(),
+            new MyAggregate(),
+            Guid.NewGuid(),
+            new NulloIdentitySetter<MyAggregate, Guid>(),
+            [new Event<AEvent>(new AEvent()) { Sequence = 1 }],
+            CancellationToken.None);
+
+        // The generated dispatcher ran the conventional Apply — not the hiding method, which would
+        // have added 100.
+        snapshot!.ACount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void a_same_named_helper_does_not_break_registration()
+    {
+        var projection = new OverloadsEvolveName();
+
+        // Used to throw AmbiguousMatchException out of Type.GetMethod("Evolve").
+        Should.NotThrow(() => projection.AssembleAndAssertValidity());
+    }
+
+    [Fact]
+    public async Task a_real_override_still_owns_dispatch()
+    {
+        // The other half of the contract: a genuine override must keep winning over both the
+        // generated evolver and the conventional methods.
+        var projection = new OverridesEvolveWithConventions();
+        projection.AssembleAndAssertValidity();
+
+        var (snapshot, _) = await projection.DetermineActionAsync(
+            new FakeSession(),
+            new MyAggregate(),
+            Guid.NewGuid(),
+            new NulloIdentitySetter<MyAggregate, Guid>(),
+            [new Event<AEvent>(new AEvent()) { Sequence = 1 }],
+            CancellationToken.None);
+
+        snapshot!.ACount.ShouldBe(100);
+    }
+}

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -157,17 +157,57 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
         }
     }
 
+    /// <summary>
+    /// True when the projection genuinely overrides one of the dispatch virtuals, in which case that
+    /// override owns event application and neither the generated evolver nor the conventional methods
+    /// are consulted.
+    ///
+    /// <para>Declaring the method without <c>override</c> — the compiler's CS0114 case, whether or not
+    /// the author added <c>new</c> — hides the base virtual instead of replacing it. It used to count
+    /// here, purely because it is declared outside JasperFx.Events, and the consequences were entirely
+    /// silent: with conventional methods alongside it, registration failed claiming the projection
+    /// "can only use the override of 'Evolve' or conventional Apply/Create/ShouldDelete methods, but
+    /// not both" — a conflict the author never wrote — and without them, dispatch reached the base
+    /// virtual and threw <c>NotImplementedException("Did you forget to implement this?")</c> at the
+    /// first event. <see cref="MethodInfo.GetBaseDefinition"/> separates the two: an override reports
+    /// the base-class declaration, a hiding member reports itself. See #656.</para>
+    /// </summary>
     private bool isOverridden(string methodName)
     {
-        return GetType().GetMethod(methodName)!.DeclaringType!.Assembly != typeof(IEvent).Assembly;
+        var method = findDispatchMethod(methodName);
+
+        return method != null
+               && method.DeclaringType!.Assembly != typeof(IEvent).Assembly
+               && method.GetBaseDefinition().DeclaringType!.Assembly == typeof(IEvent).Assembly;
     }
 
     private bool isSourceGeneratedOverride(string methodName)
     {
-        var method = GetType().GetMethod(methodName);
+        var method = findDispatchMethod(methodName);
         return method != null
                && method.DeclaringType!.Assembly != typeof(IEvent).Assembly
                && method.IsDefined(typeof(System.CodeDom.Compiler.GeneratedCodeAttribute), false);
+    }
+
+    /// <summary>
+    /// The dispatch virtual named <paramref name="methodName"/> as this projection sees it.
+    /// <c>Type.GetMethod(string)</c> throws <see cref="AmbiguousMatchException"/> as soon as the
+    /// projection declares any other method of the same name — a private <c>Evolve(string)</c> helper
+    /// was enough to break registration — so match on the base declaration's signature instead.
+    /// </summary>
+    private MethodInfo? findDispatchMethod(string methodName)
+    {
+        var baseDeclaration = typeof(JasperFxAggregationProjectionBase<TDoc, TId, TOperations, TQuerySession>)
+            .GetMethods()
+            .FirstOrDefault(m => m.Name == methodName);
+
+        if (baseDeclaration == null) return null;
+
+        var parameterTypes = baseDeclaration.GetParameters().Select(p => p.ParameterType).ToArray();
+
+        return GetType().GetMethods()
+            .FirstOrDefault(m => m.Name == methodName
+                                 && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
     }
 
     [MemberNotNullWhen(true, nameof(_evolve))]


### PR DESCRIPTION
Closes #656

## Why

`isOverridden` asked only where a method was declared:

```csharp
return GetType().GetMethod(methodName)!.DeclaringType!.Assembly != typeof(IEvent).Assembly;
```

A method that merely *hides* the base virtual — declared without `override`, which the compiler already reports as CS0114 — is declared on the user's class, so this returned `true`. Hiding is not overriding: the virtual call still lands on the base implementation, and because this check runs before `tryUseAssemblyRegisteredEvolver`, the generated dispatcher was skipped too.

Both outcomes were silent about the real cause, and both are verified in the issue:

- **with conventional methods alongside** — registration threw *"This projection can only use the override of 'Evolve' or conventional Apply/Create/ShouldDelete methods, but not both"*, a conflict the author never wrote, while their `Apply` had a perfectly good evolver going unused;
- **without them** — registration succeeded and the first event failed with `NotImplementedException("Did you forget to implement this?")` from the base virtual.

## Changes

`MethodInfo.GetBaseDefinition()` separates the two: an override reports the base-class declaration, a hiding member reports itself.

The same lookup also went through `Type.GetMethod(string)`, which throws `AmbiguousMatchException` as soon as the projection declares any other method of that name — a private `Evolve(string)` helper was enough to break registration outright. Resolution now matches the base declaration's signature.

## Test plan

`HidingDispatchVirtualTests`, all three verified failing without the fix:

- a hiding `Evolve` alongside conventions registers cleanly and dispatch runs the conventional `Apply` (`ACount == 1`, not the hiding method's `+= 100`);
- a same-named helper registers instead of throwing `AmbiguousMatchException`;
- a **real** `override` still owns dispatch over both the evolver and the conventions (`ACount == 100`) — the contract this must not break.

EventTests 749 passed on net9.0 and net10.0; EventStoreTests 114; source generator tests 34.
