### PR TITLE
fix(source-generator): compose ShouldDelete with Create/Apply for the same event type

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// Shared compilation harness for the generator's regression suites.
+///
+/// <para>Each issue's tests live in their own file rather than all landing at the end of
+/// AggregateEvolverGeneratorTests, so independent fixes to the generator do not collide on one test
+/// file. This type is what makes that practical — the content is deliberately identical wherever it
+/// appears, so branches that both introduce it merge without a conflict.</para>
+/// </summary>
+internal static class GeneratorHarness
+{
+    private static List<MetadataReference> References()
+    {
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IEvent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Guid).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Collections.dll")));
+
+        return references;
+    }
+
+    private static CSharpCompilation Compilation(string source)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: References(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    /// <summary>Runs the generator and returns its diagnostics plus every generated source.</summary>
+    public static (ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) Run(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out _, out var diagnostics);
+
+        var generatedSources = driver.GetRunResult().GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToArray();
+
+        return (diagnostics, generatedSources);
+    }
+
+    /// <summary>
+    /// Errors reported inside generated files only. The stub projection bases these fixtures use are
+    /// not valid types on their own, so an unfiltered assertion would report the harness rather than
+    /// the emission under test.
+    /// </summary>
+    public static string[] GeneratedCodeErrors(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Compiles with the generator loaded twice, as it is when bundled as a built-in analyzer in two
+    /// referenced packages (#462). The second copy is a distinct generator TYPE on purpose: the driver
+    /// derives generated file paths from the generator's type name, so two instances of the same type
+    /// would collide on path alone (CS0433), which is a different problem entirely.
+    /// </summary>
+    public static ImmutableArray<Diagnostic> CompileWithTwoCopies(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new AggregateEvolverGenerator().AsSourceGenerator(),
+            new SecondCopyOfTheGenerator().AsSourceGenerator());
+
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics();
+    }
+
+    /// <summary>Errors inside generated files after the generator ran twice over one compilation.</summary>
+    public static string[] DoubleLoadGeneratedCodeErrors(string source)
+    {
+        return CompileWithTwoCopies(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Stand-in for the same generator arriving from a second referenced package (#462). Delegates to the
+/// real generator; only its type identity differs, which is what gives it its own generated file paths.
+/// </summary>
+[Generator]
+public sealed class SecondCopyOfTheGenerator : IIncrementalGenerator
+{
+    private readonly AggregateEvolverGenerator _inner = new();
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) => _inner.Initialize(context);
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/ShouldDeleteCompositionTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/ShouldDeleteCompositionTests.cs
@@ -1,0 +1,157 @@
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// #652: an event type covered by both a delete and a Create/Apply produced two arms in one
+/// DetermineAction switch. The delete arm's `case T data:` is unguarded, so the second was
+/// unreachable and the consumer build failed with CS8120 inside generated code it cannot edit.
+/// A ShouldDelete predicate that returns false still has to fold the event in, so the Create/Apply
+/// body belongs in the delete arm's else; a constructor-registered DeleteEvent&lt;T&gt;() is
+/// unconditional and suppresses it instead.
+/// </summary>
+public class ShouldDeleteCompositionTests
+{
+    private const string Preamble = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class MyEvent { }
+public class CreateEvent { }
+
+public class SelfAgg
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public void Apply(MyEvent e) { Count++; }
+}
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+";
+
+    [Fact]
+    public void should_delete_and_apply_for_the_same_event_type_compiles()
+    {
+        var source = Preamble + @"
+public partial class DeleteAndApply : SingleStreamProjection<SelfAgg, Guid>
+{
+    public bool ShouldDelete(MyEvent e) => false;
+}
+";
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(source);
+        var generated = SourceFor(generatedSources, "DeleteAndApply");
+
+        // One arm for the event type, with the apply moved into the delete predicate's else.
+        CountOccurrences(generated, "case global::Test.MyEvent data:").ShouldBe(1);
+        generated.ShouldContain("snapshot.Apply(data);");
+
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void should_delete_predicate_that_returns_false_still_applies_the_event()
+    {
+        // The semantic half: the self-aggregating path avoided the collision by dropping the Apply
+        // arm outright, which made `ShouldDelete(E) => false` silently disable `Apply(E)`.
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public class MyEvent { }
+
+public class SelfAggWithDelete
+{
+    public Guid Id { get; set; }
+    public int Count { get; set; }
+    public void Apply(MyEvent e) { Count++; }
+    public bool ShouldDelete(MyEvent e) => false;
+}
+";
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(source);
+        var generated = string.Join("\n", generatedSources);
+
+        CountOccurrences(generated, "case global::Test.MyEvent data:").ShouldBe(1);
+        generated.ShouldContain("snapshot = null;");
+        generated.ShouldContain("else");
+        generated.ShouldContain("snapshot.Apply(data);");
+
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void constructor_delete_event_registration_suppresses_apply_for_that_type()
+    {
+        // DeleteEvent<T>() is unconditional, mirroring the runtime's MatchesAnyDeleteType short
+        // circuit, so the Create/Apply arm for that type is dropped rather than moved into an else.
+        var source = Preamble + @"
+public partial class CtorDeleteAndApply : SingleStreamProjection<SelfAgg, Guid>
+{
+    public CtorDeleteAndApply()
+    {
+        DeleteEvent<MyEvent>();
+    }
+
+    public SelfAgg Create(CreateEvent e) => new SelfAgg();
+}
+";
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(source);
+        var generated = SourceFor(generatedSources, "CtorDeleteAndApply");
+
+        CountOccurrences(generated, "case global::Test.MyEvent").ShouldBe(1);
+        generated.ShouldNotContain("Apply(data)");
+
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void should_delete_and_create_for_the_same_event_type_compiles()
+    {
+        var source = Preamble + @"
+public partial class DeleteAndCreate : SingleStreamProjection<SelfAgg, Guid>
+{
+    public bool ShouldDelete(CreateEvent e) => false;
+    public SelfAgg Create(CreateEvent e) => new SelfAgg();
+}
+";
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(source);
+        var generated = SourceFor(generatedSources, "DeleteAndCreate");
+
+        CountOccurrences(generated, "case global::Test.CreateEvent data:").ShouldBe(1);
+        generated.ShouldContain("if (snapshot == null)");
+
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    /// <summary>The generated file for one type, when a fixture emits an evolver for several.</summary>
+    private static string SourceFor(string[] generatedSources, string typeName)
+    {
+        return generatedSources.Single(s => s.Contains(typeName));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = haystack.IndexOf(needle, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = haystack.IndexOf(needle, index + needle.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -307,6 +307,173 @@ internal static class EvolverCodeEmitter
     /// dispatches DetermineActionAsync as a single call (no <c>evolveDefaultAsync</c>-style per-event
     /// catch wrapper above us).
     /// </summary>
+    /// <summary>
+    /// Emits the per-event switch arms shared by both DetermineAction dispatch shapes — the file-scoped
+    /// evolver and the override injected into the user's class. They differ only in whether conventional
+    /// methods bind to <c>this</c> or to the evolver's projection instance.
+    ///
+    /// <para>Delete arms come first and own their event type outright. Their <c>case T data:</c> is
+    /// unguarded, so a separate Create/Apply arm for the same type would be an unreachable duplicate case
+    /// (CS8120) and the consumer build would fail on generated code — see #652. A <c>ShouldDelete</c>
+    /// predicate that returns <c>false</c> still has to fold the event in, so the Create/Apply body moves
+    /// inside the delete arm's <c>else</c>. A constructor-registered <c>DeleteEvent&lt;T&gt;()</c> is
+    /// unconditional — it mirrors the runtime's <c>MatchesAnyDeleteType</c> short circuit in
+    /// <c>buildActionAsync</c> — so those event types drop their Create/Apply entirely.</para>
+    /// </summary>
+    private static void EmitDetermineActionSwitchArms(StringBuilder sb, CandidateInfo info, bool isAsync,
+        bool dispatchOnThis)
+    {
+        // ShouldDelete overloads sharing an event type are coalesced into one arm and OR'd together, so
+        // the snapshot is dropped if any overload returns true.
+        var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
+        var shouldDeleteByEventType = shouldDeleteMethods
+            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
+            .OrderByDescending(g => GetTypeDepth(g.Key))
+            .ToList();
+        var shouldDeleteEventTypes = new HashSet<ITypeSymbol>(
+            shouldDeleteMethods.Select(m => m.EventType), SymbolEqualityComparer.Default);
+        var ctorDeleteEventTypes = info.ConstructorDeleteEventTypes
+            .Where(t => !shouldDeleteEventTypes.Contains(t))
+            .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
+            .OrderByDescending(t => GetTypeDepth(t))
+            .ToList();
+
+        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
+        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
+
+        var deleteHandledTypes = new HashSet<ITypeSymbol>(shouldDeleteEventTypes, SymbolEqualityComparer.Default);
+        foreach (var eventType in ctorDeleteEventTypes) deleteHandledTypes.Add(eventType);
+
+        foreach (var group in shouldDeleteByEventType)
+        {
+            const string dataVar = "data";
+            sb.AppendLine($"                case {Fqn(group.Key)} {dataVar}:");
+            sb.Append("                    if (snapshot != null && (");
+            var first = true;
+            foreach (var method in group)
+            {
+                if (!first) sb.Append(" || ");
+                first = false;
+                EmitShouldDeleteCall(sb, method, dataVar, dispatchOnThis: dispatchOnThis);
+            }
+
+            sb.AppendLine("))");
+            sb.AppendLine("                    {");
+            sb.AppendLine("                        snapshot = null;");
+            sb.AppendLine("                    }");
+
+            var create = createMethods.FirstOrDefault(m =>
+                SymbolEqualityComparer.Default.Equals(m.EventType, group.Key));
+            var apply = applyMethods.FirstOrDefault(m =>
+                SymbolEqualityComparer.Default.Equals(m.EventType, group.Key));
+
+            if (create != null || apply != null)
+            {
+                sb.AppendLine("                    else");
+                sb.AppendLine("                    {");
+                EmitCreateApplyStatements(sb, info, create, apply, isAsync, "                        ",
+                    dispatchOnThis);
+                sb.AppendLine("                    }");
+            }
+
+            sb.AppendLine("                    break;");
+        }
+
+        foreach (var eventType in ctorDeleteEventTypes)
+        {
+            sb.AppendLine($"                case {Fqn(eventType)}:");
+            sb.AppendLine("                    snapshot = null;");
+            sb.AppendLine("                    break;");
+        }
+
+        foreach (var method in createMethods)
+        {
+            if (deleteHandledTypes.Contains(method.EventType)) continue;
+
+            sb.AppendLine($"                case {Fqn(method.EventType)} data when snapshot == null:");
+            sb.Append("                    snapshot = ");
+            EmitCreateCall(sb, method, "data", "e", isAsync, dispatchOnThis: dispatchOnThis);
+            sb.AppendLine(";");
+            sb.AppendLine("                    break;");
+        }
+
+        foreach (var method in applyMethods)
+        {
+            if (deleteHandledTypes.Contains(method.EventType)) continue;
+
+            var eventTypeName = Fqn(method.EventType);
+            var hasCreateForType = createMethods.Any(c =>
+                SymbolEqualityComparer.Default.Equals(c.EventType, method.EventType));
+
+            if (hasCreateForType)
+            {
+                // Create already owns the null-snapshot half of this event type.
+                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
+            }
+            else if (info.HasDefaultConstructor)
+            {
+                sb.AppendLine($"                case {eventTypeName} data:");
+                sb.AppendLine($"                    snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
+            }
+            else
+            {
+                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
+            }
+
+            sb.Append("                    ");
+            EmitApplyCallStatement(sb, method, "data", "e", isAsync, dispatchOnThis: dispatchOnThis);
+            sb.AppendLine("                    break;");
+        }
+    }
+
+    /// <summary>
+    /// Emits Create/Apply for a single event type as plain statements at <paramref name="indent"/>,
+    /// for use inside a delete arm where the guarded <c>when snapshot == null</c> / <c>when snapshot
+    /// != null</c> arms are not available. Create and Apply for the same event type stay mutually
+    /// exclusive — one or the other runs for a single event, never both, matching the guarded arms.
+    /// </summary>
+    private static void EmitCreateApplyStatements(StringBuilder sb, CandidateInfo info,
+        ConventionalMethodInfo? create, ConventionalMethodInfo? apply, bool isAsync, string indent,
+        bool dispatchOnThis)
+    {
+        if (create != null)
+        {
+            sb.AppendLine($"{indent}if (snapshot == null)");
+            sb.AppendLine($"{indent}{{");
+            sb.Append($"{indent}    snapshot = ");
+            EmitCreateCall(sb, create, "data", "e", isAsync, dispatchOnThis: dispatchOnThis);
+            sb.AppendLine(";");
+            sb.AppendLine($"{indent}}}");
+
+            if (apply != null)
+            {
+                sb.AppendLine($"{indent}else");
+                sb.AppendLine($"{indent}{{");
+                sb.Append($"{indent}    ");
+                EmitApplyCallStatement(sb, apply, "data", "e", isAsync, dispatchOnThis: dispatchOnThis);
+                sb.AppendLine($"{indent}}}");
+            }
+
+            return;
+        }
+
+        if (apply == null) return;
+
+        if (info.HasDefaultConstructor)
+        {
+            sb.AppendLine($"{indent}snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
+            sb.Append(indent);
+            EmitApplyCallStatement(sb, apply, "data", "e", isAsync, dispatchOnThis: dispatchOnThis);
+            return;
+        }
+
+        sb.AppendLine($"{indent}if (snapshot != null)");
+        sb.AppendLine($"{indent}{{");
+        sb.Append($"{indent}    ");
+        EmitApplyCallStatement(sb, apply, "data", "e", isAsync, dispatchOnThis: dispatchOnThis);
+        sb.AppendLine($"{indent}}}");
+    }
+
     private static void EmitDetermineActionAsOverride(StringBuilder sb, CandidateInfo info)
     {
         var docType = Fqn(info.AggregateType!);
@@ -332,79 +499,7 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("            switch (e.Data)");
         sb.AppendLine("            {");
 
-        var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
-        var shouldDeleteByEventType = shouldDeleteMethods
-            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
-            .OrderByDescending(g => GetTypeDepth(g.Key))
-            .ToList();
-        var shouldDeleteEventTypes = new HashSet<ITypeSymbol>(
-            shouldDeleteMethods.Select(m => m.EventType), SymbolEqualityComparer.Default);
-        var ctorDeleteEventTypes = info.ConstructorDeleteEventTypes
-            .Where(t => !shouldDeleteEventTypes.Contains(t))
-            .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
-            .OrderByDescending(t => GetTypeDepth(t))
-            .ToList();
-
-        foreach (var group in shouldDeleteByEventType)
-        {
-            var eventTypeName = Fqn(group.Key);
-            var dataVar = "data";
-            sb.AppendLine($"                case {eventTypeName} {dataVar}:");
-            sb.Append("                    if (snapshot != null && (");
-            bool first = true;
-            foreach (var method in group)
-            {
-                if (!first) sb.Append(" || ");
-                first = false;
-                EmitShouldDeleteCall(sb, method, dataVar, dispatchOnThis: true);
-            }
-            sb.AppendLine("))");
-            sb.AppendLine("                        snapshot = null;");
-            sb.AppendLine("                    break;");
-        }
-        foreach (var eventType in ctorDeleteEventTypes)
-        {
-            sb.AppendLine($"                case {Fqn(eventType)}:");
-            sb.AppendLine("                    snapshot = null;");
-            sb.AppendLine("                    break;");
-        }
-
-        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
-        foreach (var method in createMethods)
-        {
-            var eventTypeName = Fqn(method.EventType);
-            sb.AppendLine($"                case {eventTypeName} data when snapshot == null:");
-            sb.Append("                    snapshot = ");
-            EmitCreateCall(sb, method, "data", "e", isAsync, dispatchOnThis: true);
-            sb.AppendLine(";");
-            sb.AppendLine("                    break;");
-        }
-
-        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
-        foreach (var method in applyMethods)
-        {
-            var eventTypeName = Fqn(method.EventType);
-            bool hasCreateForType = createMethods.Any(c =>
-                SymbolEqualityComparer.Default.Equals(c.EventType, method.EventType));
-
-            if (hasCreateForType)
-            {
-                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
-            }
-            else if (info.HasDefaultConstructor)
-            {
-                sb.AppendLine($"                case {eventTypeName} data:");
-                sb.AppendLine($"                    snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
-            }
-            else
-            {
-                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
-            }
-
-            sb.Append("                    ");
-            EmitApplyCallStatement(sb, method, "data", "e", isAsync, dispatchOnThis: true);
-            sb.AppendLine("                    break;");
-        }
+        EmitDetermineActionSwitchArms(sb, info, isAsync, dispatchOnThis: true);
 
         sb.AppendLine("            }");
         sb.AppendLine("            }");
@@ -1371,92 +1466,7 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("            switch (e.Data)");
         sb.AppendLine("            {");
 
-        // ShouldDelete cases first — coalesce overloads sharing the same event
-        // type into a single switch arm so the compiler doesn't flag duplicate
-        // arms as unreachable (CS8120). Multiple ShouldDelete overloads on the
-        // same event type are OR'd together so the snapshot is dropped if any
-        // overload returns true.
-        var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
-        var shouldDeleteByEventType = shouldDeleteMethods
-            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
-            .OrderByDescending(g => GetTypeDepth(g.Key))
-            .ToList();
-        // Constructor-side `DeleteEvent<T>()` registrations — the kept Marten
-        // 9.0 API for "this event type always deletes the aggregate." Emit one
-        // arm per event type that sets `snapshot = null` unconditionally.
-        // Skip types that already have a ShouldDelete handler so we don't emit
-        // duplicate switch arms (CS8120). See #297.
-        var shouldDeleteEventTypes = new HashSet<ITypeSymbol>(
-            shouldDeleteMethods.Select(m => m.EventType), SymbolEqualityComparer.Default);
-        var ctorDeleteEventTypes = info.ConstructorDeleteEventTypes
-            .Where(t => !shouldDeleteEventTypes.Contains(t))
-            .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
-            .OrderByDescending(t => GetTypeDepth(t))
-            .ToList();
-        foreach (var group in shouldDeleteByEventType)
-        {
-            var eventTypeName = Fqn(group.Key);
-            var dataVar = "data";
-            sb.AppendLine($"                case {eventTypeName} {dataVar}:");
-            sb.Append("                    if (snapshot != null && (");
-            bool first = true;
-            foreach (var method in group)
-            {
-                if (!first) sb.Append(" || ");
-                first = false;
-                EmitShouldDeleteCall(sb, method, dataVar);
-            }
-            sb.AppendLine("))");
-            sb.AppendLine("                        snapshot = null;");
-            sb.AppendLine("                    break;");
-        }
-        foreach (var eventType in ctorDeleteEventTypes)
-        {
-            sb.AppendLine($"                case {Fqn(eventType)}:");
-            sb.AppendLine("                    snapshot = null;");
-            sb.AppendLine("                    break;");
-        }
-
-        // Create cases — coalesce by event type, prefer projection-defined over aggregate-defined.
-        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
-        foreach (var method in createMethods)
-        {
-            var eventTypeName = Fqn(method.EventType);
-            sb.AppendLine($"                case {eventTypeName} data when snapshot == null:");
-            sb.Append("                    snapshot = ");
-            EmitCreateCall(sb, method, "data", "e", isAsync);
-            sb.AppendLine(";");
-            sb.AppendLine("                    break;");
-        }
-
-        // Apply cases — coalesce by event type.
-        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
-        foreach (var method in applyMethods)
-        {
-            var eventTypeName = Fqn(method.EventType);
-            // For apply methods where there's no create, we need to handle null snapshot
-            bool hasCreateForType = createMethods.Any(c =>
-                SymbolEqualityComparer.Default.Equals(c.EventType, method.EventType));
-
-            if (hasCreateForType)
-            {
-                // Apply only when snapshot exists
-                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
-            }
-            else if (info.HasDefaultConstructor)
-            {
-                sb.AppendLine($"                case {eventTypeName} data:");
-                sb.AppendLine($"                    snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
-            }
-            else
-            {
-                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
-            }
-
-            sb.Append("                    ");
-            EmitApplyCallStatement(sb, method, "data", "e", isAsync);
-            sb.AppendLine("                    break;");
-        }
+        EmitDetermineActionSwitchArms(sb, info, isAsync, dispatchOnThis: false);
 
         sb.AppendLine("            }");
         sb.AppendLine("            }");
@@ -1785,7 +1795,15 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("            switch (e.Data)");
         sb.AppendLine("            {");
 
-        // ShouldDelete - set snapshot to null and continue processing (allows re-creation)
+        // Create + Apply
+        var createMethods = info.Methods.Where(m => m.MethodName == "Create").ToList();
+        var applyMethods = info.Methods.Where(m => m.MethodName == "Apply").ToList();
+
+        // ShouldDelete - set snapshot to null and continue processing (allows re-creation).
+        // The arm is unguarded, so it owns its event type: a separate Create/Apply arm for the same
+        // type would be an unreachable duplicate case (CS8120). A predicate that returns false still
+        // has to fold the event in, so that body goes in the else rather than being dropped — before
+        // #652 it was skipped entirely and declaring ShouldDelete(E) silently disabled Apply(E).
         var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
         foreach (var method in shouldDeleteMethods)
         {
@@ -1794,15 +1812,28 @@ internal static class EvolverCodeEmitter
             sb.Append("                    if (snapshot != null && ");
             EmitSelfAggregatingShouldDeleteCall(sb, method, "data");
             sb.AppendLine(")");
+            sb.AppendLine("                    {");
             sb.AppendLine("                        snapshot = null;");
+            sb.AppendLine("                    }");
+
+            var deleteCreate = createMethods.FirstOrDefault(m =>
+                SymbolEqualityComparer.Default.Equals(m.EventType, method.EventType));
+            var deleteApply = applyMethods.FirstOrDefault(m =>
+                SymbolEqualityComparer.Default.Equals(m.EventType, method.EventType));
+
+            if (deleteCreate != null || deleteApply != null)
+            {
+                sb.AppendLine("                    else");
+                sb.AppendLine("                    {");
+                EmitSelfAggregatingCreateApplyStatements(sb, info, deleteCreate, deleteApply,
+                    "                        ");
+                sb.AppendLine("                    }");
+            }
+
             sb.AppendLine("                    break;");
         }
 
-        // Create + Apply
-        var createMethods = info.Methods.Where(m => m.MethodName == "Create").ToList();
-        var applyMethods = info.Methods.Where(m => m.MethodName == "Apply").ToList();
-
-        // Group by event type (excluding ShouldDelete events already handled)
+        // Group by event type (excluding ShouldDelete events already handled above)
         var handledDeleteTypes = new HashSet<ITypeSymbol>(shouldDeleteMethods.Select(m => m.EventType),
             SymbolEqualityComparer.Default);
 
@@ -1876,6 +1907,51 @@ internal static class EvolverCodeEmitter
             "            return exists ? (null, global::JasperFx.Events.Daemon.ActionType.Delete) : (null, global::JasperFx.Events.Daemon.ActionType.Nothing);");
         sb.AppendLine($"        return (snapshot, global::JasperFx.Events.Daemon.ActionType.Store);");
         sb.AppendLine("    }");
+    }
+
+    /// <summary>
+    /// Self-aggregating counterpart to <see cref="EmitCreateApplyStatements"/>: Create/Apply for one
+    /// event type as plain statements at <paramref name="indent"/>, for use inside a delete arm.
+    /// </summary>
+    private static void EmitSelfAggregatingCreateApplyStatements(StringBuilder sb, CandidateInfo info,
+        ConventionalMethodInfo? create, ConventionalMethodInfo? apply, string indent)
+    {
+        if (create != null)
+        {
+            sb.AppendLine($"{indent}if (snapshot == null)");
+            sb.AppendLine($"{indent}{{");
+            sb.Append($"{indent}    snapshot = ");
+            EmitSelfAggregatingCreateCall(sb, create, "data");
+            sb.AppendLine(";");
+            sb.AppendLine($"{indent}}}");
+
+            if (apply != null)
+            {
+                sb.AppendLine($"{indent}else");
+                sb.AppendLine($"{indent}{{");
+                sb.Append($"{indent}    ");
+                EmitSelfAggregatingApplyCall(sb, apply, "data");
+                sb.AppendLine($"{indent}}}");
+            }
+
+            return;
+        }
+
+        if (apply == null) return;
+
+        if (info.HasDefaultConstructor)
+        {
+            sb.AppendLine($"{indent}snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
+            sb.Append(indent);
+            EmitSelfAggregatingApplyCall(sb, apply, "data");
+            return;
+        }
+
+        sb.AppendLine($"{indent}if (snapshot != null)");
+        sb.AppendLine($"{indent}{{");
+        sb.Append($"{indent}    ");
+        EmitSelfAggregatingApplyCall(sb, apply, "data");
+        sb.AppendLine($"{indent}}}");
     }
 
     // --- Null snapshot case generation (sync) ---


### PR DESCRIPTION
Closes #652

## Why

An event type covered by both a delete and a `Create`/`Apply` produced two arms in one `DetermineAction` switch. The delete arm's `case T data:` is unguarded, so the second was unreachable and the consumer build failed with CS8120 inside generated code it cannot edit:

```csharp
case global::Test.MyEvent data:          // ShouldDelete arm — unguarded
    if (snapshot != null && (_projection.ShouldDelete(data))) snapshot = null;
    break;
case global::Test.MyEvent data:          // CS8120: unreachable
    snapshot ??= new global::Test.SelfAgg();
    snapshot.Apply(data);
    break;
```

The shape is legitimate — "delete on this event when the predicate says so, otherwise fold it in" — and reproduces with or without `partial`, so it is independent of the candidacy gate in #650.

## Changes

The two projection dispatch shapes — the file-scoped evolver and the override injected into the user's class — carried near-identical copies of this arm emission, so it is now one `EmitDetermineActionSwitchArms` and the fix lands in both.

Delete arms own their event type. A `ShouldDelete` predicate is just that: when it returns `false` the event still has to be folded in, so the `Create`/`Apply` body moves into the arm's `else`:

```csharp
case global::Test.MyEvent data:
    if (snapshot != null && (_projection.ShouldDelete(data))) { snapshot = null; }
    else { snapshot ??= new global::Test.SelfAgg(); snapshot.Apply(data); }
    break;
```

A constructor-registered `DeleteEvent<T>()` is unconditional — mirroring the runtime's `MatchesAnyDeleteType` short circuit in `buildActionAsync` — so those event types drop their `Create`/`Apply` entirely. That also closes a second CS8120 collision that was never filtered: ctor-delete types were only checked against `ShouldDelete` types, never against `Create`/`Apply`.

**Behaviour change worth review.** The self-aggregating dispatcher avoided the collision by skipping the `Create`/`Apply` arm for any type with a `ShouldDelete`, which silently disabled the Apply instead — `ShouldDelete(E) => false` meant `Apply(E)` never ran. It now composes the two the same way as the projection paths.

## Test plan

`ShouldDeleteCompositionTests`: delete + apply compiles with one arm; a false predicate still applies the event; a ctor `DeleteEvent<T>()` suppresses the apply; delete + create compiles.

Source generator tests 38 passed; EventTests 746 on net9.0 and net10.0; EventStoreTests 114.

## Merge order

Touches `EmitDetermineActionAsOverride`, which #653 deletes — **this one before #653** is the cheaper order.
