### PR TITLE
fix(source-generator): hand the evolver the registered projection instead of a shadow

### DIFF
--- a/docs/codegen/projection-apply-dispatch.md
+++ b/docs/codegen/projection-apply-dispatch.md
@@ -31,7 +31,7 @@ The SG emits one of five shapes through `EvolverCodeEmitter`
 
 | Mode | Emits | How runtime picks it up |
 |---|---|---|
-| `PartialProjection` | Partial method on the user's projection class (`Evolve` / `EvolveAsync` / `DetermineActionAsync`) | `JasperFxAggregationProjectionBase.isOverridden(...)` returns `true` for the generated override and `_usesConventionalApplication = false` — `AggregateApplication` is never invoked for dispatch. |
+| `PartialProjection` | Standalone `file`-scoped evolver + assembly-level `[GeneratedEvolverAttribute]` carrying the projection type. When its conventional methods live on the projection instance, the evolver takes that projection through its constructor. | `tryUseAssemblyRegisteredEvolver(...)` selects the registration and `activateEvolver` builds the evolver, passing `this` when it asks for the projection, so dispatch runs on the registered instance. `_usesConventionalApplication = false` — `AggregateApplication` is never invoked for dispatch. |
 | `SelfAggregating` | Standalone evolver class implementing `IGeneratedSyncEvolver<TDoc,TId>` or `IGeneratedSyncDetermineAction<TDoc,TId>` + an assembly-level `[GeneratedEvolverAttribute]` | `JasperFxAggregationProjectionBase.tryUseAssemblyRegisteredEvolver(...)` activates and binds the evolver. |
 | `SelfAggregatingEvolve` | Standalone evolver class implementing `IGeneratedAsyncEvolver<TDoc,TId>` + `[GeneratedEvolverAttribute]` | Same as above. |
 | `EventProjection` | Partial `ApplyAsync(TOperations, IEvent, CancellationToken)` override on the user's `JasperFxEventProjectionBase<TOperations>` subclass | The override wins at vtable dispatch. `EventProjectionApplication` is only used when the base `ApplyAsync` is not overridden. |

--- a/src/EventTests/Projections/ProjectionInstanceBindingTests.cs
+++ b/src/EventTests/Projections/ProjectionInstanceBindingTests.cs
@@ -1,0 +1,93 @@
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests.Projections;
+
+// #653: dispatch for a projection whose conventional methods live on the instance now runs on the
+// projection the store registered. The evolver used to build its own shadow — `new TProjection()`, or
+// GetUninitializedObject when there was no public parameterless constructor — so a dependency handed
+// in by the container was null (marten#4787) and anything the real constructor set was missing.
+public partial class DiActivatedProjection : SingleStreamProjection<MyAggregate, Guid>
+{
+    private readonly ICounterSink _sink;
+
+    public DiActivatedProjection(ICounterSink sink) => _sink = sink;
+
+    public void Apply(AEvent e, MyAggregate a)
+    {
+        // Would NRE on a shadow instance built without running this constructor.
+        _sink.Record();
+        a.ACount++;
+    }
+}
+
+public interface ICounterSink
+{
+    void Record();
+}
+
+public class CounterSink : ICounterSink
+{
+    public int Count { get; private set; }
+    public void Record() => Count++;
+}
+
+// A public parameterless constructor was no reason to dispatch through a different instance either:
+// the evolver used to hold `new StatefulProjection()`, so anything the conventional method recorded
+// landed on a shadow the caller never sees.
+public partial class StatefulProjection : SingleStreamProjection<MyAggregate, Guid>
+{
+    public int Handled { get; private set; }
+
+    public void Apply(AEvent e, MyAggregate a)
+    {
+        Handled++;
+        a.ACount++;
+    }
+}
+
+public class projection_instance_binding
+{
+    [Fact]
+    public async Task dispatch_runs_on_the_registered_di_built_instance()
+    {
+        var sink = new CounterSink();
+        var projection = new DiActivatedProjection(sink);
+        projection.AssembleAndAssertValidity();
+
+        var (snapshot, action) = await projection.DetermineActionAsync(
+            new FakeSession(),
+            new MyAggregate(),
+            Guid.NewGuid(),
+            new NulloIdentitySetter<MyAggregate, Guid>(),
+            [new Event<AEvent>(new AEvent()) { Sequence = 1 }],
+            CancellationToken.None);
+
+        // The injected dependency was reachable from the conventional method...
+        sink.Count.ShouldBe(1);
+        // ...and the event was actually applied.
+        action.ShouldBe(ActionType.Store);
+        snapshot!.ACount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_projection_with_a_parameterless_constructor_dispatches_on_itself_too()
+    {
+        var projection = new StatefulProjection();
+        projection.AssembleAndAssertValidity();
+
+        await projection.DetermineActionAsync(
+            new FakeSession(),
+            new MyAggregate(),
+            Guid.NewGuid(),
+            new NulloIdentitySetter<MyAggregate, Guid>(),
+            [new Event<AEvent>(new AEvent()) { Sequence = 1 }],
+            CancellationToken.None);
+
+        // Fails against a shadow instance: the increment would land on the evolver's own copy.
+        projection.Handled.ShouldBe(1);
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -117,74 +117,6 @@ public partial class AllSync : SingleStreamProjection<MyAggregate, Guid>
     }
 
     [Fact]
-    public void di_activated_projection_without_parameterless_ctor_dispatches_through_partial_override()
-    {
-        // marten#4787: a projection registered via AddProjectionWithServices has only a constructor
-        // with injected dependencies (no parameterless ctor). The pre-fix emission built the
-        // evolver's private shadow projection via RuntimeHelpers.GetUninitializedObject — which
-        // compiled (closing the original #4185 CS7036 hole) but left injected fields null at runtime,
-        // NREing the first time a convention method dereferenced one.
-        // The fix emits a [GeneratedCode]-attributed override (Evolve / EvolveAsync /
-        // DetermineActionAsync) directly into the user's partial class. Dispatch binds to `this`
-        // (the DI-built instance), so injected fields are populated. The file-scoped Evolver and the
-        // [assembly: GeneratedEvolver(...)] attribute are NOT emitted for this case.
-        var source = @"
-using System;
-using JasperFx.Events;
-using JasperFx.Events.Aggregation;
-using JasperFx.Events.Projections;
-
-namespace Test;
-
-public class MyAggregate { public int Count { get; set; } }
-public class MyEvent { }
-public class CreateEvent { }
-public interface ISecondaryStore { }
-
-public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
-    where TDoc : notnull where TId : notnull
-{
-    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
-}
-
-public partial class DiActivated : SingleStreamProjection<MyAggregate, Guid>
-{
-    private readonly ISecondaryStore _secondaryStore;
-    public DiActivated(ISecondaryStore secondaryStore) { _secondaryStore = secondaryStore; }
-
-    public MyAggregate Create(CreateEvent e) => new MyAggregate();
-    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
-}
-";
-        var (_, generatedSources) = RunGenerator(source);
-        var generated = string.Join("\n", generatedSources);
-
-        // No shadow-instance escape hatch — the override dispatches on `this`.
-        generated.ShouldNotContain("GetUninitializedObject(typeof(global::Test.DiActivated))");
-        generated.ShouldNotContain("new global::Test.DiActivated()");
-        generated.ShouldNotContain("_projection.Create");
-        generated.ShouldNotContain("_projection.Apply");
-
-        // No file-scoped Evolver class and no GeneratedEvolver assembly attribute — the runtime
-        // selects the partial-class override via isOverridden() before tryUseAssemblyRegisteredEvolver
-        // ever runs, so the file-scoped path is unreachable for this case.
-        generated.ShouldNotContain("file sealed class");
-        generated.ShouldNotContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver");
-
-        // Partial-class override on the user's class, marked [GeneratedCode] so
-        // AssembleAndAssertValidity's isSourceGeneratedOverride() accepts it.
-        generated.ShouldContain("partial class DiActivated");
-        generated.ShouldContain("[global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        // Either Evolve (sync, no session/ShouldDelete) or EvolveAsync would do — the projection
-        // here is sync with no ShouldDelete, so expect the sync Evolve override.
-        generated.ShouldContain("public override global::Test.MyAggregate? Evolve(");
-
-        // The generated override must compile — no CS7036 "no argument for required parameter".
-        var diagnostics = CompileWithGenerator(source);
-        diagnostics.ShouldNotContain(d => d.Id == "CS7036");
-    }
-
-    [Fact]
     public void partial_projection_for_required_member_aggregate_suppresses_snapshot_fallback()
     {
         var source = @"
@@ -776,7 +708,10 @@ public class HostTests
         var (_, generatedSources) = RunGenerator(source);
         var allGenerated = string.Join("\n", generatedSources);
         allGenerated.ShouldContain("file sealed class HostTests_NestedProjectionEvolver");
-        allGenerated.ShouldContain("new global::Test.HostTests.NestedProjection()");
+        // The projection arrives through the evolver's constructor — the runtime passes the
+        // registered instance rather than the evolver building a shadow with `new`. See #653.
+        allGenerated.ShouldContain(
+            "public HostTests_NestedProjectionEvolver(global::Test.HostTests.NestedProjection projection)");
         allGenerated.ShouldContain(
             "[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.Counted), typeof(global::Test.HostTests_NestedProjectionEvolver), typeof(global::Test.HostTests.NestedProjection))]");
     }
@@ -1385,7 +1320,7 @@ public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamPr
     protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
 }
 
-// DI-only constructor forces the partial-class override path (marten#4787).
+// DI-only constructor: dispatch has to run on the registered instance (marten#4787, #653).
 public partial class CartProjection : SingleStreamProjection<Cart, Guid>
 {
     private readonly ICartPricing _pricing;
@@ -1405,7 +1340,10 @@ public partial class CartProjection : SingleStreamProjection<Cart, Guid>
 
         var (_, generatedSources) = RunGenerator(source);
         var allGenerated = string.Join("\n", generatedSources);
-        allGenerated.ShouldContain("public override global::Test.Cart? Evolve(");
+        // The dispatcher is a file-scoped evolver handed the registered projection (#653); the
+        // GetUninitializedObject below is for the AGGREGATE, which has no parameterless constructor.
+        allGenerated.ShouldContain("public global::Test.Cart? Evolve(");
+        allGenerated.ShouldContain("public CartProjectionEvolver(global::Test.CartProjection projection)");
         allGenerated.ShouldContain(
             "var s = (global::Test.Cart)global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(global::Test.Cart));");
         allGenerated.ShouldContain("return s.Apply(data);");

--- a/src/JasperFx.Events.SourceGenerator.Tests/EvolverInstanceBindingTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/EvolverInstanceBindingTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.CodeAnalysis;
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// #653: an evolver whose conventional methods live on the projection instance used to build its own
+/// shadow — `new TProjection()`, or GetUninitializedObject when there was no public parameterless
+/// constructor — so injected dependencies were null (marten#4787) and constructor state was missing.
+/// marten#4787 answered that by injecting the dispatcher into the user's partial class, the
+/// member-injection shape #462 had removed, bringing the CS0111 double-load failure back with it.
+/// The evolver now takes the projection through its constructor and the runtime passes the
+/// registered instance, so dispatch is correct AND the dispatcher stays file-scoped.
+/// </summary>
+public class EvolverInstanceBindingTests
+{
+    private const string Preamble = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Projections;
+
+namespace Test;
+
+public class MyAggregate { public int Count { get; set; } }
+public class MyEvent { }
+public class CreateEvent { }
+public interface ISecondaryStore { }
+
+public abstract class SingleStreamProjection<TDoc, TId> : JasperFxSingleStreamProjectionBase<TDoc, TId, object, object>
+    where TDoc : notnull where TId : notnull
+{
+    protected SingleStreamProjection() : base(AggregationScope.SingleStream) { }
+}
+";
+
+    [Fact]
+    public void di_activated_projection_dispatches_through_the_registered_instance()
+    {
+        var source = Preamble + @"
+public partial class DiActivated : SingleStreamProjection<MyAggregate, Guid>
+{
+    private readonly ISecondaryStore _secondaryStore;
+    public DiActivated(ISecondaryStore secondaryStore) { _secondaryStore = secondaryStore; }
+
+    public MyAggregate Create(CreateEvent e) => new MyAggregate();
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+";
+        var (_, generatedSources) = GeneratorHarness.Run(source);
+        var generated = string.Join("\n", generatedSources);
+
+        // No shadow instance of any kind.
+        generated.ShouldNotContain("GetUninitializedObject(typeof(global::Test.DiActivated))");
+        generated.ShouldNotContain("new global::Test.DiActivated()");
+
+        // The dispatcher stays a file-scoped type, registered for this projection, taking the
+        // projection through its constructor.
+        generated.ShouldContain("file sealed class DiActivated_GuidEvolver");
+        generated.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver");
+        generated.ShouldContain("public DiActivated_GuidEvolver(global::Test.DiActivated projection)");
+        generated.ShouldContain("_projection = projection;");
+        generated.ShouldContain("_projection.Create(data)");
+
+        // Nothing is written into the user's class any more.
+        generated.ShouldNotContain("partial class DiActivated");
+
+        // No CS7036 "no argument given for required parameter" — the original #4185 hole.
+        GeneratorHarness.GeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void di_activated_projection_survives_the_generator_being_loaded_twice()
+    {
+        // #462: member injection emitted the same override twice and failed with CS0111. A
+        // file-scoped evolver is local to its own generated file.
+        var source = Preamble + @"
+public partial class DiActivatedTwice : SingleStreamProjection<MyAggregate, Guid>
+{
+    private readonly ISecondaryStore _store;
+    public DiActivatedTwice(ISecondaryStore store) { _store = store; }
+
+    public void Apply(MyEvent e, MyAggregate agg) { agg.Count++; }
+}
+";
+        GeneratorHarness.DoubleLoadGeneratedCodeErrors(source).ShouldBeEmpty();
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/GeneratorHarness.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// Shared compilation harness for the generator's regression suites.
+///
+/// <para>Each issue's tests live in their own file rather than all landing at the end of
+/// AggregateEvolverGeneratorTests, so independent fixes to the generator do not collide on one test
+/// file. This type is what makes that practical — the content is deliberately identical wherever it
+/// appears, so branches that both introduce it merge without a conflict.</para>
+/// </summary>
+internal static class GeneratorHarness
+{
+    private static List<MetadataReference> References()
+    {
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IEvent).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Guid).Assembly.Location),
+        };
+
+        var runtimeDir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Runtime.dll")));
+        references.Add(MetadataReference.CreateFromFile(System.IO.Path.Combine(runtimeDir, "System.Collections.dll")));
+
+        return references;
+    }
+
+    private static CSharpCompilation Compilation(string source)
+    {
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: References(),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    /// <summary>Runs the generator and returns its diagnostics plus every generated source.</summary>
+    public static (ImmutableArray<Diagnostic> diagnostics, string[] generatedSources) Run(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver = driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out _, out var diagnostics);
+
+        var generatedSources = driver.GetRunResult().GeneratedTrees
+            .Select(t => t.GetText().ToString())
+            .ToArray();
+
+        return (diagnostics, generatedSources);
+    }
+
+    /// <summary>
+    /// Errors reported inside generated files only. The stub projection bases these fixtures use are
+    /// not valid types on their own, so an unfiltered assertion would report the harness rather than
+    /// the emission under test.
+    /// </summary>
+    public static string[] GeneratedCodeErrors(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AggregateEvolverGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Compiles with the generator loaded twice, as it is when bundled as a built-in analyzer in two
+    /// referenced packages (#462). The second copy is a distinct generator TYPE on purpose: the driver
+    /// derives generated file paths from the generator's type name, so two instances of the same type
+    /// would collide on path alone (CS0433), which is a different problem entirely.
+    /// </summary>
+    public static ImmutableArray<Diagnostic> CompileWithTwoCopies(string source)
+    {
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new AggregateEvolverGenerator().AsSourceGenerator(),
+            new SecondCopyOfTheGenerator().AsSourceGenerator());
+
+        driver.RunGeneratorsAndUpdateCompilation(Compilation(source), out var outputCompilation, out _);
+
+        return outputCompilation.GetDiagnostics();
+    }
+
+    /// <summary>Errors inside generated files after the generator ran twice over one compilation.</summary>
+    public static string[] DoubleLoadGeneratedCodeErrors(string source)
+    {
+        return CompileWithTwoCopies(source)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Where(d => (d.Location.SourceTree?.FilePath ?? "").Contains("SourceGenerator"))
+            .Select(d => d.ToString())
+            .ToArray();
+    }
+}
+
+/// <summary>
+/// Stand-in for the same generator arriving from a second referenced package (#462). Delegates to the
+/// real generator; only its type identity differs, which is what gives it its own generated file paths.
+/// </summary>
+[Generator]
+public sealed class SecondCopyOfTheGenerator : IIncrementalGenerator
+{
+    private readonly AggregateEvolverGenerator _inner = new();
+
+    public void Initialize(IncrementalGeneratorInitializationContext context) => _inner.Initialize(context);
+}

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -51,22 +51,6 @@ internal static class EvolverCodeEmitter
     /// </summary>
     public static string EmitPartialProjection(CandidateInfo info)
     {
-        // marten#4787: when a projection requires a DI-resolved instance for its conventional
-        // Apply/Create/ShouldDelete methods (it has at least one instance-on-projection handler AND
-        // no public parameterless constructor), the file-scoped Evolver dispatcher silently NREs on
-        // any deref of an injected field — its shadow projection is built via
-        // RuntimeHelpers.GetUninitializedObject, which skips the constructor. Route to the alternative
-        // emission that adds an override directly to the user's partial class so `this` (the DI-built
-        // instance) handles dispatch and injected fields are populated. Stateless / parameterless-ctor
-        // / aggregate-only / static-only projections keep the file-scoped Evolver — no perf regression
-        // for the cases that don't need DI.
-        if (NeedsProjectionInstance(info)
-            && !HasPublicParameterlessCtor(info.ClassSymbol)
-            && info.IsPartial)
-        {
-            return EmitPartialProjectionWithDIOverride(info);
-        }
-
         var sb = new StringBuilder();
         AppendGeneratedFileHeader(sb);
 
@@ -111,19 +95,23 @@ internal static class EvolverCodeEmitter
         sb.AppendLine("{");
 
         // The dispatcher invokes the projection's own instance Apply/Create/ShouldDelete methods through
-        // a private projection instance. Aggregate-side and static methods are invoked directly, so the
-        // instance is only needed (and only emitted) when at least one method lives on the projection
-        // instance — avoiding a CS0169 "field never used" warning in warnings-as-errors consumer builds.
+        // a projection instance. Aggregate-side and static methods are invoked directly, so the instance
+        // is only needed (and only emitted) when at least one method lives on the projection instance —
+        // avoiding a CS0169 "field never used" warning in warnings-as-errors consumer builds.
         //
-        // The instance is created lazily, NOT in a field initializer: the projection's own constructor
-        // resolves this very evolver (via tryUseAssemblyRegisteredEvolver), so eagerly constructing the
-        // projection here would recurse projection -> evolver -> projection -> ... and StackOverflow. By
-        // the time a handler actually runs, the evolver's own construction has long completed, so the
-        // lazy create is safe and happens once.
+        // The instance is the projection the store actually registered, handed over by the runtime's
+        // activateEvolver through this constructor. The evolver used to build its own shadow instead —
+        // `new TProjection()`, or GetUninitializedObject when there was no public parameterless
+        // constructor — which meant injected dependencies were null (marten#4787) and anything the real
+        // constructor set was missing. See #653.
         if (NeedsProjectionInstance(info))
         {
-            sb.AppendLine($"    private {projectionFullName}? _projectionInstance;");
-            sb.AppendLine($"    private {projectionFullName} _projection => _projectionInstance ??= {BuildProjectionInstanceExpression(info.ClassSymbol, projectionFullName)};");
+            sb.AppendLine($"    private readonly {projectionFullName} _projection;");
+            sb.AppendLine();
+            sb.AppendLine($"    public {evolverName}({projectionFullName} projection)");
+            sb.AppendLine("    {");
+            sb.AppendLine("        _projection = projection;");
+            sb.AppendLine("    }");
             sb.AppendLine();
         }
 
@@ -152,334 +140,6 @@ internal static class EvolverCodeEmitter
     {
         return info.Methods.Any(m => !m.IsStatic && !m.IsOnAggregate);
     }
-
-    /// <summary>
-    /// marten#4787 alternative dispatch: emit the projection's Evolve / EvolveAsync /
-    /// DetermineActionAsync as a [GeneratedCode]-attributed override directly into the user's
-    /// <em>partial</em> projection class. The body switches on event type and calls the conventional
-    /// methods bare (binding to <c>this</c>), so the DI-resolved projection instance handles
-    /// dispatch and every injected field is populated. We deliberately skip the
-    /// <c>[assembly: GeneratedEvolver(...)]</c> registration and the <c>file sealed class</c> Evolver
-    /// — the runtime's <c>isOverridden(...)</c> precedence (<c>JasperFxAggregationProjectionBase</c>
-    /// lines 82-114) prefers a user/SG override on the class over the assembly-registered Evolver,
-    /// so the dispatcher routes through this method and never recreates the shadow instance whose
-    /// null injected fields caused the regression.
-    /// </summary>
-    private static string EmitPartialProjectionWithDIOverride(CandidateInfo info)
-    {
-        var sb = new StringBuilder();
-        AppendGeneratedFileHeader(sb);
-
-        var ns = info.ClassSymbol.ContainingNamespace;
-        if (!ns.IsGlobalNamespace)
-        {
-            sb.AppendLine($"namespace {ns.ToDisplayString()};");
-            sb.AppendLine();
-        }
-
-        // Mirror EmitEventProjectionPartial: open containing-type partial declarations (handles
-        // a projection nested inside a record/class, e.g. `record Foo { partial class Projector ... }`).
-        var containingTypes = GetContainingTypes(info.ClassSymbol);
-        foreach (var container in containingTypes)
-        {
-            sb.AppendLine($"partial {ContainerKeyword(container)} {container.Name}{ContainerTypeParams(container)}");
-            sb.AppendLine("{");
-        }
-
-        var className = info.ClassSymbol.Name;
-        var typeParams = "";
-        if (info.ClassSymbol.TypeParameters.Length > 0)
-        {
-            typeParams = "<" + string.Join(", ", info.ClassSymbol.TypeParameters.Select(t => t.Name)) + ">";
-        }
-
-        sb.AppendLine($"partial class {className}{typeParams}");
-        sb.AppendLine("{");
-
-        if (info.HasShouldDelete)
-        {
-            EmitDetermineActionAsOverride(sb, info);
-        }
-        else if (info.HasAnyAsync)
-        {
-            EmitEvolveAsyncAsOverride(sb, info);
-        }
-        else
-        {
-            EmitEvolveAsOverride(sb, info);
-        }
-
-        sb.AppendLine("}");
-
-        foreach (var _ in containingTypes)
-        {
-            sb.AppendLine("}");
-        }
-
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// marten#4787: synchronous, no-ShouldDelete partial-class override. Matches the virtual at
-    /// <c>JasperFxAggregationProjectionBase.Runtime.cs:175</c>:
-    /// <c>public virtual TDoc? Evolve(TDoc? snapshot, TId id, IEvent e)</c>.
-    /// </summary>
-    private static void EmitEvolveAsOverride(StringBuilder sb, CandidateInfo info)
-    {
-        var docType = Fqn(info.AggregateType!);
-        var idType = Fqn(info.IdentityType!);
-
-        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public override {docType}? Evolve({docType}? snapshot, {idType} id, global::JasperFx.Events.IEvent e)");
-        sb.AppendLine("    {");
-
-        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
-        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
-
-        sb.AppendLine("        if (snapshot == null)");
-        sb.AppendLine("        {");
-        sb.AppendLine("            switch (e.Data)");
-        sb.AppendLine("            {");
-        EmitNullSnapshotCases(sb, info, createMethods, applyMethods, "                ", dispatchOnThis: true);
-        sb.AppendLine("                default: return null;");
-        sb.AppendLine("            }");
-        sb.AppendLine("        }");
-        sb.AppendLine();
-
-        sb.AppendLine("        switch (e.Data)");
-        sb.AppendLine("        {");
-        EmitNonNullSnapshotCases(sb, info, applyMethods, "            ", dispatchOnThis: true);
-        sb.AppendLine("            default: return snapshot;");
-        sb.AppendLine("        }");
-
-        sb.AppendLine("    }");
-    }
-
-    /// <summary>
-    /// marten#4787: async / session-using, no-ShouldDelete partial-class override. Matches the
-    /// virtual at <c>JasperFxAggregationProjectionBase.Runtime.cs:142</c>:
-    /// <c>public virtual ValueTask&lt;TDoc?&gt; EvolveAsync(TDoc? snapshot, TId id, TQuerySession session, IEvent e, CancellationToken cancellation)</c>.
-    /// The override binds the strongly-typed <c>TQuerySession</c> directly, so user handlers that
-    /// take an <c>IQuerySession</c> parameter consume <c>session</c> without a cast (no equivalent
-    /// of <see cref="EmitSessionLocalIfNeeded"/> required here).
-    /// </summary>
-    private static void EmitEvolveAsyncAsOverride(StringBuilder sb, CandidateInfo info)
-    {
-        var docType = Fqn(info.AggregateType!);
-        var idType = Fqn(info.IdentityType!);
-        var querySessionType = Fqn(info.QuerySessionType!);
-
-        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public override async global::System.Threading.Tasks.ValueTask<{docType}?> EvolveAsync(");
-        sb.AppendLine($"        {docType}? snapshot, {idType} id, {querySessionType} session, global::JasperFx.Events.IEvent e,");
-        sb.AppendLine($"        global::System.Threading.CancellationToken cancellation)");
-        sb.AppendLine("    {");
-
-        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
-        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
-
-        sb.AppendLine("        if (snapshot == null)");
-        sb.AppendLine("        {");
-        sb.AppendLine("            switch (e.Data)");
-        sb.AppendLine("            {");
-        EmitNullSnapshotCasesAsync(sb, info, createMethods, applyMethods, "                ", dispatchOnThis: true);
-        sb.AppendLine("                default: return null;");
-        sb.AppendLine("            }");
-        sb.AppendLine("        }");
-        sb.AppendLine();
-
-        sb.AppendLine("        switch (e.Data)");
-        sb.AppendLine("        {");
-        EmitNonNullSnapshotCasesAsync(sb, info, applyMethods, "            ", dispatchOnThis: true);
-        sb.AppendLine("            default: return snapshot;");
-        sb.AppendLine("        }");
-
-        sb.AppendLine("    }");
-    }
-
-    /// <summary>
-    /// marten#4787: ShouldDelete-aware partial-class override. Matches the virtual at
-    /// <c>JasperFxAggregationProjectionBase.Runtime.cs:93</c>:
-    /// <c>public virtual ValueTask&lt;(TDoc?, ActionType)&gt; DetermineActionAsync(TQuerySession session, TDoc? snapshot, TId identity, IIdentitySetter&lt;TDoc, TId&gt; identitySetter, IReadOnlyList&lt;IEvent&gt; events, CancellationToken cancellation)</c>.
-    /// Body mirrors the file-scoped <see cref="EmitDetermineActionEvolverMethod"/> verbatim, with
-    /// <c>dispatchOnThis: true</c> swapping every <c>_projection.</c> instance call for a bare call
-    /// on <c>this</c>. Per-event ApplyEventException wrapping is preserved because the runtime
-    /// dispatches DetermineActionAsync as a single call (no <c>evolveDefaultAsync</c>-style per-event
-    /// catch wrapper above us).
-    /// </summary>
-    private static void EmitDetermineActionAsOverride(StringBuilder sb, CandidateInfo info)
-    {
-        var docType = Fqn(info.AggregateType!);
-        var idType = Fqn(info.IdentityType!);
-        var querySessionType = Fqn(info.QuerySessionType!);
-        var isAsync = info.HasAnyAsync;
-        var asyncKeyword = isAsync ? "async " : "";
-
-        sb.AppendLine("    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"JasperFx.Events.SourceGenerator\", \"1.0\")]");
-        sb.AppendLine($"    public override {asyncKeyword}global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)> DetermineActionAsync(");
-        sb.AppendLine($"        {querySessionType} session,");
-        sb.AppendLine($"        {docType}? snapshot,");
-        sb.AppendLine($"        {idType} identity,");
-        sb.AppendLine($"        global::JasperFx.Events.Aggregation.IIdentitySetter<{docType}, {idType}> identitySetter,");
-        sb.AppendLine($"        global::System.Collections.Generic.IReadOnlyList<global::JasperFx.Events.IEvent> events,");
-        sb.AppendLine($"        global::System.Threading.CancellationToken cancellation)");
-        sb.AppendLine("    {");
-        sb.AppendLine("        var exists = snapshot != null;");
-        sb.AppendLine("        foreach (var e in events)");
-        sb.AppendLine("        {");
-        sb.AppendLine("            try");
-        sb.AppendLine("            {");
-        sb.AppendLine("            switch (e.Data)");
-        sb.AppendLine("            {");
-
-        var shouldDeleteMethods = info.Methods.Where(m => m.MethodName == "ShouldDelete").ToList();
-        var shouldDeleteByEventType = shouldDeleteMethods
-            .GroupBy<ConventionalMethodInfo, ITypeSymbol>(m => m.EventType, SymbolEqualityComparer.Default)
-            .OrderByDescending(g => GetTypeDepth(g.Key))
-            .ToList();
-        var shouldDeleteEventTypes = new HashSet<ITypeSymbol>(
-            shouldDeleteMethods.Select(m => m.EventType), SymbolEqualityComparer.Default);
-        var ctorDeleteEventTypes = info.ConstructorDeleteEventTypes
-            .Where(t => !shouldDeleteEventTypes.Contains(t))
-            .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
-            .OrderByDescending(t => GetTypeDepth(t))
-            .ToList();
-
-        foreach (var group in shouldDeleteByEventType)
-        {
-            var eventTypeName = Fqn(group.Key);
-            var dataVar = "data";
-            sb.AppendLine($"                case {eventTypeName} {dataVar}:");
-            sb.Append("                    if (snapshot != null && (");
-            bool first = true;
-            foreach (var method in group)
-            {
-                if (!first) sb.Append(" || ");
-                first = false;
-                EmitShouldDeleteCall(sb, method, dataVar, dispatchOnThis: true);
-            }
-            sb.AppendLine("))");
-            sb.AppendLine("                        snapshot = null;");
-            sb.AppendLine("                    break;");
-        }
-        foreach (var eventType in ctorDeleteEventTypes)
-        {
-            sb.AppendLine($"                case {Fqn(eventType)}:");
-            sb.AppendLine("                    snapshot = null;");
-            sb.AppendLine("                    break;");
-        }
-
-        var createMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Create"));
-        foreach (var method in createMethods)
-        {
-            var eventTypeName = Fqn(method.EventType);
-            sb.AppendLine($"                case {eventTypeName} data when snapshot == null:");
-            sb.Append("                    snapshot = ");
-            EmitCreateCall(sb, method, "data", "e", isAsync, dispatchOnThis: true);
-            sb.AppendLine(";");
-            sb.AppendLine("                    break;");
-        }
-
-        var applyMethods = CoalesceByEventType(info.Methods.Where(m => m.MethodName == "Apply"));
-        foreach (var method in applyMethods)
-        {
-            var eventTypeName = Fqn(method.EventType);
-            bool hasCreateForType = createMethods.Any(c =>
-                SymbolEqualityComparer.Default.Equals(c.EventType, method.EventType));
-
-            if (hasCreateForType)
-            {
-                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
-            }
-            else if (info.HasDefaultConstructor)
-            {
-                sb.AppendLine($"                case {eventTypeName} data:");
-                sb.AppendLine($"                    snapshot ??= {BuildAggregateConstructorExpression(info.AggregateType!)};");
-            }
-            else
-            {
-                sb.AppendLine($"                case {eventTypeName} data when snapshot != null:");
-            }
-
-            sb.Append("                    ");
-            EmitApplyCallStatement(sb, method, "data", "e", isAsync, dispatchOnThis: true);
-            sb.AppendLine("                    break;");
-        }
-
-        sb.AppendLine("            }");
-        sb.AppendLine("            }");
-        sb.AppendLine("            catch (global::JasperFx.Events.Daemon.ApplyEventException)");
-        sb.AppendLine("            {");
-        sb.AppendLine("                throw;");
-        sb.AppendLine("            }");
-        sb.AppendLine("            catch (global::System.Exception __ex)");
-        sb.AppendLine("                when (!global::JasperFx.Events.Projections.ProjectionExceptions.IsExceptionTransient(__ex))");
-        sb.AppendLine("            {");
-        sb.AppendLine("                throw new global::JasperFx.Events.Daemon.ApplyEventException(e, __ex);");
-        sb.AppendLine("            }");
-        sb.AppendLine("        }");
-        sb.AppendLine();
-        sb.AppendLine("        if (snapshot == null)");
-        if (!isAsync)
-        {
-            sb.AppendLine($"            return exists ? new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Delete)) : new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((null, global::JasperFx.Events.Daemon.ActionType.Nothing));");
-            sb.AppendLine($"        return new global::System.Threading.Tasks.ValueTask<({docType}?, global::JasperFx.Events.Daemon.ActionType)>((snapshot, global::JasperFx.Events.Daemon.ActionType.Store));");
-        }
-        else
-        {
-            sb.AppendLine($"            return exists ? (null, global::JasperFx.Events.Daemon.ActionType.Delete) : (null, global::JasperFx.Events.Daemon.ActionType.Nothing);");
-            sb.AppendLine($"        return (snapshot, global::JasperFx.Events.Daemon.ActionType.Store);");
-        }
-        sb.AppendLine("    }");
-    }
-
-    /// <summary>
-    /// Builds the expression that creates the evolver's private "shadow" projection instance
-    /// (used only to invoke the projection's stateless instance Apply/Create/ShouldDelete event
-    /// methods). When the projection has a public parameterless constructor we just <c>new</c> it.
-    /// A DI-activated projection (registered via <c>AddProjectionWithServices</c>) has only a
-    /// constructor with injected dependencies and therefore no parameterless ctor — <c>new T()</c>
-    /// would not compile (#4185 / CS7036). In that case instantiate without running the constructor
-    /// (mirrors the aggregate no-parameterless-ctor fallback in
-    /// <see cref="BuildAggregateConstructorExpression"/>). Note: the DI-projection path is no longer
-    /// reached for partial projections — see <see cref="EmitPartialProjectionWithDIOverride"/> for the
-    /// alternative emission used when convention methods need DI-injected dependencies at runtime
-    /// (marten#4787). This shadow-instance path is preserved only as a defensive fallback (e.g. a
-    /// non-partial projection that somehow reaches this branch) — generated dispatch through such a
-    /// shadow would still NRE on any deref of an injected service, but the new emission path
-    /// covers the supported partial-projection case correctly.
-    /// </summary>
-    private static string BuildProjectionInstanceExpression(INamedTypeSymbol projectionType, string projectionFullName)
-    {
-        if (HasPublicParameterlessCtor(projectionType))
-        {
-            return $"new {projectionFullName}()";
-        }
-
-        return $"({projectionFullName})global::System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof({projectionFullName}))";
-    }
-
-    /// <summary>
-    /// True when the projection class declares a <c>public</c> parameterless constructor (or has no
-    /// explicit constructors, so the implicit default counts). The opposite (a projection whose only
-    /// public ctor takes DI-resolved parameters) is the trigger for the partial-class override emission
-    /// path that fixes marten#4787 — dispatching events through a <c>RuntimeHelpers.GetUninitializedObject</c>
-    /// shadow leaves injected fields null and NREs the first time a convention method dereferences one.
-    /// </summary>
-    private static bool HasPublicParameterlessCtor(INamedTypeSymbol projectionType)
-    {
-        return projectionType.InstanceConstructors.Any(c =>
-            c.Parameters.Length == 0 && c.DeclaredAccessibility == Accessibility.Public);
-    }
-
-    /// <summary>
-    /// Prefix used when emitting a call to an instance convention method on the projection. Inside the
-    /// file-scoped Evolver dispatcher it's <c>_projection.</c> (the shadow instance held by the Evolver).
-    /// Inside a partial-class override on the user's projection itself it's empty — the call binds to
-    /// <c>this</c> implicitly, which is the DI-resolved instance with injected fields populated. See
-    /// <see cref="EmitPartialProjectionWithDIOverride"/> and marten#4787.
-    /// </summary>
-    private static string InstanceCallPrefix(bool dispatchOnThis) => dispatchOnThis ? string.Empty : "_projection.";
 
     /// <summary>
     /// The IGeneratedAsyncEvolver / IGeneratedAsyncDetermineAction contracts type the session as
@@ -1881,8 +1541,7 @@ internal static class EvolverCodeEmitter
     // --- Null snapshot case generation (sync) ---
 
     private static void EmitNullSnapshotCases(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent,
-        bool dispatchOnThis = false)
+        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent)
     {
         // For each event type with a Create method
         foreach (var method in createMethods)
@@ -1892,13 +1551,13 @@ internal static class EvolverCodeEmitter
             {
                 sb.AppendLine($"{indent}case {eventTypeName}:");
                 sb.Append($"{indent}    return ");
-                EmitCreateCallSync(sb, method, null, "e", dispatchOnThis);
+                EmitCreateCallSync(sb, method, null, "e");
             }
             else
             {
                 sb.AppendLine($"{indent}case {eventTypeName} data:");
                 sb.Append($"{indent}    return ");
-                EmitCreateCallSync(sb, method, "data", "e", dispatchOnThis);
+                EmitCreateCallSync(sb, method, "data", "e");
             }
 
             sb.AppendLine(";");
@@ -1932,7 +1591,7 @@ internal static class EvolverCodeEmitter
                 sb.AppendLine($"{indent}{{");
                 sb.AppendLine($"{indent}    var s = {ctorExpression};");
                 sb.Append($"{indent}    ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s", dispatchOnThis);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s");
                 sb.AppendLine(";");
                 sb.AppendLine($"{indent}    return s;");
                 sb.AppendLine($"{indent}}}");
@@ -1946,7 +1605,7 @@ internal static class EvolverCodeEmitter
                 sb.AppendLine($"{indent}{{");
                 sb.AppendLine($"{indent}    var s = {ctorExpression};");
                 sb.Append($"{indent}    return ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s", dispatchOnThis);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "s");
                 sb.AppendLine(";");
                 sb.AppendLine($"{indent}}}");
             }
@@ -1956,8 +1615,7 @@ internal static class EvolverCodeEmitter
     // --- Null snapshot case generation (async) ---
 
     private static void EmitNullSnapshotCasesAsync(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent,
-        bool dispatchOnThis = false)
+        List<ConventionalMethodInfo> createMethods, List<ConventionalMethodInfo> applyMethods, string indent)
     {
         foreach (var method in createMethods)
         {
@@ -1973,7 +1631,7 @@ internal static class EvolverCodeEmitter
                 sb.Append($"{indent}    return ");
             }
 
-            EmitCreateCall(sb, method, method.UsesIEventWrapper ? null : "data", "e", true, dispatchOnThis);
+            EmitCreateCall(sb, method, method.UsesIEventWrapper ? null : "data", "e", true);
             sb.AppendLine(";");
         }
 
@@ -1993,7 +1651,7 @@ internal static class EvolverCodeEmitter
             sb.AppendLine($"{indent}    var s = {BuildAggregateConstructorExpression(info.AggregateType!)};");
             var awaitPrefix = method.IsAsync ? "await " : "";
             sb.Append($"{indent}    {awaitPrefix}");
-            EmitApplyCallExpression(sb, method, "data", "e", true, "s", dispatchOnThis);
+            EmitApplyCallExpression(sb, method, "data", "e", true, "s");
             sb.AppendLine(";");
             sb.AppendLine($"{indent}    return s;");
             sb.AppendLine($"{indent}}}");
@@ -2003,7 +1661,7 @@ internal static class EvolverCodeEmitter
     // --- Non-null snapshot case generation (sync) ---
 
     private static void EmitNonNullSnapshotCases(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> applyMethods, string indent, bool dispatchOnThis = false)
+        List<ConventionalMethodInfo> applyMethods, string indent)
     {
         foreach (var method in applyMethods)
         {
@@ -2021,14 +1679,14 @@ internal static class EvolverCodeEmitter
             if (method.IsVoid && !method.ReturnsAggregate)
             {
                 sb.Append($"{indent}    ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "snapshot", dispatchOnThis);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "snapshot");
                 sb.AppendLine(";");
                 sb.AppendLine($"{indent}    return snapshot;");
             }
             else
             {
                 sb.Append($"{indent}    return ");
-                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "snapshot", dispatchOnThis);
+                EmitApplyCallExpression(sb, method, method.UsesIEventWrapper ? null : "data", "e", false, "snapshot");
                 sb.AppendLine(";");
             }
         }
@@ -2037,7 +1695,7 @@ internal static class EvolverCodeEmitter
     // --- Non-null snapshot case generation (async) ---
 
     private static void EmitNonNullSnapshotCasesAsync(StringBuilder sb, CandidateInfo info,
-        List<ConventionalMethodInfo> applyMethods, string indent, bool dispatchOnThis = false)
+        List<ConventionalMethodInfo> applyMethods, string indent)
     {
         foreach (var method in applyMethods)
         {
@@ -2049,13 +1707,13 @@ internal static class EvolverCodeEmitter
                 if (method.ReturnsAggregate)
                 {
                     sb.Append($"{indent}    return await ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot");
                     sb.AppendLine(";");
                 }
                 else
                 {
                     sb.Append($"{indent}    await ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot");
                     sb.AppendLine(";");
                     sb.AppendLine($"{indent}    return snapshot;");
                 }
@@ -2070,13 +1728,13 @@ internal static class EvolverCodeEmitter
                 if (method.ReturnsAggregate)
                 {
                     sb.Append($"{indent}    return ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot");
                     sb.AppendLine(";");
                 }
                 else
                 {
                     sb.Append($"{indent}    ");
-                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot", dispatchOnThis);
+                    EmitApplyCallExpression(sb, method, "data", "e", true, "snapshot");
                     sb.AppendLine(";");
                     sb.AppendLine($"{indent}    return snapshot;");
                 }
@@ -2087,8 +1745,7 @@ internal static class EvolverCodeEmitter
     // --- Call expression helpers ---
 
     private static void EmitApplyCallExpression(StringBuilder sb, ConventionalMethodInfo method,
-        string? dataVar, string eventVar, bool includeSessionAndCancellation, string aggregateVar = "snapshot",
-        bool dispatchOnThis = false)
+        string? dataVar, string eventVar, bool includeSessionAndCancellation, string aggregateVar = "snapshot")
     {
         var args = BuildApplyArgs(method, dataVar, eventVar, includeSessionAndCancellation, aggregateVar);
 
@@ -2103,16 +1760,15 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            // Instance Apply on the projection — dispatched through the evolver's held projection
-            // instance for the file-scoped dispatcher (default path, #462) or directly on `this` when
-            // the override lives on the user's partial projection class (the DI-safe path,
-            // marten#4787, see EmitPartialProjectionWithDIOverride).
-            sb.Append($"{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
+            // Instance Apply on the projection — dispatched through the projection the runtime handed
+            // the evolver at construction, which is the registered instance with its dependencies
+            // (marten#4787, #653), not a shadow built here.
+            sb.Append($"_projection.{method.MethodName}({args})");
         }
     }
 
     private static void EmitCreateCallSync(StringBuilder sb, ConventionalMethodInfo method,
-        string? dataVar, string eventVar, bool dispatchOnThis = false)
+        string? dataVar, string eventVar)
     {
         var args = BuildCreateArgs(method, dataVar, eventVar, false);
 
@@ -2129,12 +1785,12 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
+            sb.Append($"_projection.{method.MethodName}({args})");
         }
     }
 
     private static void EmitCreateCall(StringBuilder sb, ConventionalMethodInfo method,
-        string? dataVar, string eventVar, bool isAsync, bool dispatchOnThis = false)
+        string? dataVar, string eventVar, bool isAsync)
     {
         var args = BuildCreateArgs(method, dataVar, eventVar, isAsync);
         var awaitPrefix = method.IsAsync && isAsync ? "await " : "";
@@ -2151,12 +1807,12 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{awaitPrefix}{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
+            sb.Append($"{awaitPrefix}_projection.{method.MethodName}({args})");
         }
     }
 
     private static void EmitApplyCallStatement(StringBuilder sb, ConventionalMethodInfo method,
-        string dataVar, string eventVar, bool isAsync, bool dispatchOnThis = false)
+        string dataVar, string eventVar, bool isAsync)
     {
         if (method.IsAsync && isAsync)
         {
@@ -2177,12 +1833,11 @@ internal static class EvolverCodeEmitter
             }
         }
 
-        EmitApplyCallExpression(sb, method, dataVar, eventVar, isAsync, dispatchOnThis: dispatchOnThis);
+        EmitApplyCallExpression(sb, method, dataVar, eventVar, isAsync);
         sb.AppendLine(";");
     }
 
-    private static void EmitShouldDeleteCall(StringBuilder sb, ConventionalMethodInfo method, string dataVar,
-        bool dispatchOnThis = false)
+    private static void EmitShouldDeleteCall(StringBuilder sb, ConventionalMethodInfo method, string dataVar)
     {
         var args = BuildShouldDeleteArgs(method, dataVar);
         var awaitKeyword = method.IsAsync ? "await " : "";
@@ -2197,7 +1852,7 @@ internal static class EvolverCodeEmitter
         }
         else
         {
-            sb.Append($"{awaitKeyword}{InstanceCallPrefix(dispatchOnThis)}{method.MethodName}({args})");
+            sb.Append($"{awaitKeyword}_projection.{method.MethodName}({args})");
         }
     }
 

--- a/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxAggregationProjectionBase.cs
@@ -255,7 +255,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
             var syncEvolverInterface = typeof(IGeneratedSyncEvolver<TDoc, TId>);
             if (!hasShouldDelete && syncEvolverInterface.IsAssignableFrom(evolverType))
             {
-                var evolver = (IGeneratedSyncEvolver<TDoc, TId>)Activator.CreateInstance(evolverType)!;
+                var evolver = (IGeneratedSyncEvolver<TDoc, TId>)activateEvolver(evolverType);
                 _generatedEvolverEventTypes = evolver.EventTypes;
                 _evolve = (snapshot, id, _, events, _) =>
                 {
@@ -287,7 +287,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
             var determineActionInterface = typeof(IGeneratedSyncDetermineAction<TDoc, TId>);
             if (determineActionInterface.IsAssignableFrom(evolverType))
             {
-                var evolver = (IGeneratedSyncDetermineAction<TDoc, TId>)Activator.CreateInstance(evolverType)!;
+                var evolver = (IGeneratedSyncDetermineAction<TDoc, TId>)activateEvolver(evolverType);
                 _generatedEvolverEventTypes = evolver.EventTypes;
                 _buildAction = (_, snapshot, id, _, events, _) =>
                 {
@@ -335,7 +335,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
             var asyncDetermineActionInterface = typeof(IGeneratedAsyncDetermineAction<TDoc, TId>);
             if (asyncDetermineActionInterface.IsAssignableFrom(evolverType))
             {
-                var evolver = (IGeneratedAsyncDetermineAction<TDoc, TId>)Activator.CreateInstance(evolverType)!;
+                var evolver = (IGeneratedAsyncDetermineAction<TDoc, TId>)activateEvolver(evolverType);
                 _generatedEvolverEventTypes = evolver.EventTypes;
                 _buildAction = (session, snapshot, id, _, events, ct) =>
                     evolver.DetermineActionAsync(snapshot, id, events, session!, ct);
@@ -347,7 +347,7 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
             var asyncEvolverInterface = typeof(IGeneratedAsyncEvolver<TDoc, TId>);
             if (!hasShouldDelete && asyncEvolverInterface.IsAssignableFrom(evolverType))
             {
-                var evolver = (IGeneratedAsyncEvolver<TDoc, TId>)Activator.CreateInstance(evolverType)!;
+                var evolver = (IGeneratedAsyncEvolver<TDoc, TId>)activateEvolver(evolverType);
                 _generatedEvolverEventTypes = evolver.EventTypes;
                 _evolve = async (snapshot, id, session, events, ct) =>
                 {
@@ -378,6 +378,38 @@ public abstract partial class JasperFxAggregationProjectionBase<TDoc, TId, TOper
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Builds a generated evolver, handing it this projection when it asks for one.
+    ///
+    /// <para>An evolver that dispatches to conventional methods living on the projection instance —
+    /// rather than on the aggregate or a static — needs an instance to call them on. It used to build
+    /// its own: <c>new TProjection()</c>, or <c>RuntimeHelpers.GetUninitializedObject</c> when there was
+    /// no public parameterless constructor. Both are shadows of the projection the store actually
+    /// registered, so anything the real constructor or the container supplied was missing — null for an
+    /// injected dependency (marten#4787), default for anything set in the constructor.</para>
+    ///
+    /// <para>The generator therefore emits a constructor taking the projection type on any evolver that
+    /// needs an instance, and we pass <c>this</c>. Evolvers that need nothing from the projection
+    /// (aggregate-side or static conventional methods) keep their parameterless constructor, as do
+    /// evolvers generated before this change, so the fallback below is the compatible path rather than
+    /// an error case. See #653.</para>
+    /// </summary>
+    private object activateEvolver(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        Type evolverType)
+    {
+        var boundConstructor = evolverType.GetConstructors()
+            .FirstOrDefault(c => c.GetParameters().Length == 1
+                                 && c.GetParameters()[0].ParameterType.IsInstanceOfType(this));
+
+        if (boundConstructor != null)
+        {
+            return boundConstructor.Invoke([this]);
+        }
+
+        return Activator.CreateInstance(evolverType)!;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #653

## Why

An evolver whose conventional methods live on the projection instance had to get an instance from somewhere, and it built its own: `new TProjection()`, or `RuntimeHelpers.GetUninitializedObject` when there was no public parameterless constructor. Both are shadows of the projection the store actually registered, so injected dependencies were null (marten#4787) and anything the real constructor set was missing.

marten#4787 addressed the DI half by emitting the dispatcher as an override injected into the user's partial class — the member-injection shape #462 had just removed — and with it came back the CS0111 failure when the generator is bundled in two referenced packages and loads twice.

## Changes

Remove the need for member injection rather than patch it. The evolver declares a constructor taking the projection type, and the runtime passes `this`:

```csharp
private object activateEvolver(Type evolverType)
{
    var boundConstructor = evolverType.GetConstructors()
        .FirstOrDefault(c => c.GetParameters().Length == 1
                             && c.GetParameters()[0].ParameterType.IsInstanceOfType(this));

    return boundConstructor != null ? boundConstructor.Invoke([this]) : Activator.CreateInstance(evolverType)!;
}
```

Dispatch runs on the registered instance in every case, the dispatcher stays a file-scoped type two loaded copies cannot collide over, and the injected-override emission — along with its `Evolve`/`EvolveAsync`/`DetermineActionAsync` override emitters and the `dispatchOnThis` plumbing — is gone. Evolvers that need nothing from the projection keep their parameterless constructor, which is also the fallback for evolvers generated before this change.

## Version coupling

The generator and the `JasperFx.Events` runtime now have to move together: an evolver with only the projection constructor cannot be activated by a runtime without `activateEvolver`. They ship as a matched pair (Marten bundles the analyzer matching its `JasperFx.Events` pin), but it is a coupling worth stating explicitly.

## Test plan

- `ProjectionInstanceBindingTests` (runtime): a DI-built projection's injected dependency is reachable during dispatch; and `a_projection_with_a_parameterless_constructor_dispatches_on_itself_too` **fails on `main`** — the shadow absorbs the mutation — and passes here. Verified both directions. The DI test alone would not discriminate, since member injection also dispatched on the real instance.
- `EvolverInstanceBindingTests` (generator): the DI shape emits a file-scoped evolver taking the projection through its constructor with no shadow and nothing written into the user's class; and it survives the generator being loaded twice.
- Source generator tests 35 passed; EventTests 748 on net9.0 and net10.0; EventStoreTests 114.
- Marten 9.23.0's `src/EventSourcingTests` builds clean with this generator swapped in for the published analyzer.

## Merge order

This deletes `EmitPartialProjectionWithDIOverride` and its three override emitters. #650/#651 routes generic and non-visible projections *to* that emitter, and #652 refactors one of the three — so this should land **last**, and rebases to keep the emitter for the naming-constrained shapes only if #651 lands first.
