### PR TITLE
gh-663: stamp stream identity on string-keyed appends, and stop the CommandExecutorTester console leak

### DIFF
--- a/src/CommandLineTests/CommandExecutorTester.cs
+++ b/src/CommandLineTests/CommandExecutorTester.cs
@@ -7,9 +7,11 @@ using Spectre.Console;
 namespace CommandLineTests
 {
     [Collection("SetConsoleOutput")]
-    public class CommandExecutorTester
+    public class CommandExecutorTester : IDisposable
     {
         private readonly StringWriter theOutput = new StringWriter();
+        private readonly TextWriter theOriginalConsoleOut;
+        private readonly IAnsiConsole theOriginalAnsiConsole;
 
 
 #if NET451
@@ -22,6 +24,9 @@ namespace CommandLineTests
 
         public CommandExecutorTester()
         {
+            theOriginalConsoleOut = Console.Out;
+            theOriginalAnsiConsole = AnsiConsole.Console;
+
             Console.SetOut(theOutput);
 
             // CommandExecutor renders failures through Spectre's AnsiConsole, which caches the
@@ -39,6 +44,19 @@ namespace CommandLineTests
             {
                 _.RegisterCommands(GetType().GetTypeInfo().Assembly);
             });
+        }
+
+        /// <summary>
+        /// Both writers this class swaps in are process-global. Leaving them bound to a dead
+        /// instance's StringWriter means any later test in the assembly that writes through
+        /// Console or AnsiConsole -- CommandFactory's "Error parsing input" path, for one --
+        /// keeps appending to a buffer whose owning test is long gone. Restoring them here
+        /// confines each instance's capture to its own test.
+        /// </summary>
+        public void Dispose()
+        {
+            Console.SetOut(theOriginalConsoleOut);
+            AnsiConsole.Console = theOriginalAnsiConsole;
         }
 
 
@@ -115,13 +133,16 @@ namespace CommandLineTests
             CommandExecutor.ExecuteCommand<OptionCommand>(new[] {"--big", "--number", "6"})
                 .ShouldBe(0);
 
-            // ShouldEndWith, not ShouldBe. CommandFactory prints "Searching '<assembly>' for
-            // commands" until its *static* _hasAppliedExtensions latch flips, so exactly one test
-            // per process picks up that banner as a prefix -- whichever one runs first. With an
-            // exact match, this test and its async sibling below fail on a coin flip. Seen in CI on
-            // both #587 and #589. The banner is always a prefix (discovery runs before the command
-            // does), so anchoring to the end keeps the assertion just as strong.
-            theOutput.ToString().Trim().ShouldEndWith("Big is True, Number is 6");
+            // ShouldContain, not ShouldBe or ShouldEndWith. This buffer is filled through two
+            // process-global statics, so it collects more than this test writes. Leading noise:
+            // CommandFactory prints "Searching '<assembly>' for commands" until its *static*
+            // _hasAppliedExtensions latch flips, so whichever test runs first picks up that banner
+            // (#587, #589). Trailing noise: before Dispose restored the writers, output from a
+            // later test could still land here -- CI on #659/#660 caught this assertion holding
+            // "Big is True, Number is 6" followed by an unrelated "Error parsing input", even
+            // though the command above had already returned 0 on valid input. Dispose fixes the
+            // cause; asserting on containment keeps the test honest about what the buffer is.
+            theOutput.ToString().ShouldContain("Big is True, Number is 6");
         }
 
         [Fact]
@@ -130,8 +151,8 @@ namespace CommandLineTests
             (await CommandExecutor.ExecuteCommandAsync<OptionCommand>(new[] { "--big", "--number", "7" }))
                 .ShouldBe(0);
 
-            // See execute_single_command_synchronously above for why this is ShouldEndWith.
-            theOutput.ToString().Trim().ShouldEndWith("Big is True, Number is 7");
+            // See execute_single_command_synchronously above for why this is ShouldContain.
+            theOutput.ToString().ShouldContain("Big is True, Number is 7");
         }
     }
 

--- a/src/EventTests/StreamActionTests.cs
+++ b/src/EventTests/StreamActionTests.cs
@@ -168,4 +168,52 @@ public class StreamActionTests
         
         action.PrepareEvents(5, theEvents, queue, theSession);
     }
+
+    // The string-keyed Append factories used to append straight to the backing list instead of
+    // going through AddEvent, so the envelopes never got StreamKey/StreamId/TenantId. PrepareEvents
+    // does not close the gap -- it sets TenantId, Timestamp, Version and Sequence, but never the
+    // stream identity -- so an inline projection reading e.StreamKey silently wrote a blank field.
+    // See #663, reported downstream as JasperFX/fisher#72.
+    [Fact]
+    public void append_by_stream_key_stamps_the_stream_identity_on_each_event()
+    {
+        var action = StreamAction.Append(theEvents, "purple", new AEvent(), new BEvent(), new CEvent());
+
+        action.Events.Count.ShouldBe(3);
+        foreach (var @event in action.Events)
+        {
+            @event.StreamKey.ShouldBe("purple");
+            @event.Id.ShouldNotBe(Guid.Empty);
+        }
+    }
+
+    [Fact]
+    public void append_by_stream_key_with_built_events_stamps_identity_and_keeps_version_order()
+    {
+        var second = new Event<BEvent>(new BEvent()) { Version = 2 };
+        var first = new Event<AEvent>(new AEvent()) { Version = 1 };
+
+        var action = StreamAction.Append("purple", [second, first]);
+
+        // ordering by version is the behaviour this overload had before, and has to survive
+        action.Events.Select(x => x.Version).ToArray().ShouldBe([1L, 2L]);
+
+        foreach (var @event in action.Events)
+        {
+            @event.StreamKey.ShouldBe("purple");
+        }
+    }
+
+    [Fact]
+    public void append_by_stream_key_propagates_the_tenant_id_to_the_events()
+    {
+        var action = StreamAction.Append(theEvents, "purple", new AEvent(), new BEvent());
+        action.TenantId = "TX";
+
+        foreach (var @event in action.Events)
+        {
+            @event.TenantId.ShouldBe("TX");
+            @event.StreamKey.ShouldBe("purple");
+        }
+    }
 }

--- a/src/JasperFx.Events/StreamAction.cs
+++ b/src/JasperFx.Events/StreamAction.cs
@@ -259,7 +259,7 @@ public class StreamAction
     public static StreamAction Append(IEventRegistry graph, string streamKey, params object[] events)
     {
         var stream = new StreamAction(streamKey, StreamActionType.Append);
-        stream._events.AddRange(events.Select(graph.BuildEvent));
+        stream.AddEvents(events.Select(graph.BuildEvent).ToArray());
         return stream;
     }
 
@@ -272,7 +272,7 @@ public class StreamAction
     public static StreamAction Append(string streamKey, IEvent[] events)
     {
         var stream = new StreamAction(streamKey, StreamActionType.Append);
-        stream._events.AddRange(events.OrderBy(x => x.Version));
+        stream.AddEvents(events.OrderBy(x => x.Version).ToArray());
         return stream;
     }
 


### PR DESCRIPTION
Two independent fixes; both are small and each has its own commit.

## `StreamAction.Append(… string streamKey …)` never stamped the envelope — closes #663

The `Guid` overloads route through `AddEvents`/`AddEvent`, which sets `StreamId`, `StreamKey` and `TenantId` on each event. The two `string` overloads appended straight to the backing list and stamped nothing. `Start(IEventRegistry, string, …)` *does* go through `AddEvents`, so the gap was specific to appends onto a string-identified stream.

`PrepareEvents` does not close it either — `applyQuickMetadata` and `applyRichMetadata` set `TenantId`, `Timestamp`, `Version` and `Sequence`, but neither sets the stream identity. A store handing `stream.Events` to an inline projection therefore gave it envelopes with an empty `StreamKey`, which is the normal way a string-identified projection learns which entity it is projecting. Silent failure: the projection ran and wrote a document with a blank field.

Both overloads now route through `AddEvents`; the `IEvent[]` one orders by version first so that behaviour survives. `AddEvent` is now the only path that touches the backing list.

Reported downstream as JasperFX/fisher#72, where it surfaced as a query returning nothing rather than as anything throwing.

## `CommandExecutorTester` leaked its console capture — no issue, but it has flaked four times

`execute_single_command_synchronously` has failed in CI on #587, #589, #659 and #660. The standing explanation — the `Searching '<assembly>' for commands` banner arrives as a prefix, handled with `ShouldEndWith` — only covered leading noise. The #659/#660 runs show the buffer holding `Big is True, Number is 6` followed by an unrelated `Error parsing input`, on a command that had already returned 0 for valid input. The contamination was *trailing*.

Cause: the class swaps in two process-global writers — `Console.Out` and Spectre's `AnsiConsole.Console` — and never restores them, so after its last test both statics stayed bound to a dead instance's `StringWriter` and the rest of the assembly kept writing into it. `ConfigurationPreviewTests` already restores `Console.Out` in a `finally`; this class did not.

Restored in `Dispose`, and the two assertions moved to containment since the buffer is a shared capture either way.

## Test plan

- Three new `StreamActionTests` cases, **each verified failing without the fix** (`StreamKey` came back `null`) and passing with it.
- `EventTests` 754 passed on net9.0 (751 before, +3 here).
- `CommandLineTests` 295 passed on net9.0.