### PR TITLE
gh-665: a by-id load for strong-typed-identity documents

### DIFF
--- a/src/EventStoreTests/Documents/DocumentReadOperationsDefaultsTests.cs
+++ b/src/EventStoreTests/Documents/DocumentReadOperationsDefaultsTests.cs
@@ -1,0 +1,82 @@
+using System.Linq.Expressions;
+using JasperFx.Events.Documents;
+using Shouldly;
+
+namespace EventStoreTests.Documents;
+
+/// <summary>
+/// The default implementation of
+/// <see cref="IDocumentReadOperations.LoadAsync{T}(object,CancellationToken)" /> (jasperfx#665).
+/// </summary>
+/// <remarks>
+/// <see cref="InMemoryDocumentStore" /> overrides that member, as every real store will, so the
+/// compliance suites never execute the default — which is exactly why it needs its own tests. The
+/// stub below is the shape a store has on the day it takes the JasperFx bump and before it writes
+/// the override, and the behavior asserted here is what that store's consumers get in the meantime.
+/// </remarks>
+public class DocumentReadOperationsDefaultsTests
+{
+    private readonly IDocumentReadOperations theOperations = new NotYetOverriddenSession();
+
+    [Fact]
+    public async Task forwards_a_boxed_guid_to_the_guid_overload()
+    {
+        object id = Guid.NewGuid();
+
+        (await theOperations.LoadAsync<string>(id)).ShouldBe($"guid:{id}");
+    }
+
+    [Fact]
+    public async Task forwards_a_boxed_string_to_the_string_overload()
+    {
+        object id = "gadget-42";
+
+        (await theOperations.LoadAsync<string>(id)).ShouldBe("string:gadget-42");
+    }
+
+    [Fact]
+    public async Task throws_for_a_strong_typed_identity_rather_than_guessing()
+    {
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => theOperations.LoadAsync<string>(new CouponCode(Guid.NewGuid())));
+
+        // The message has to name the store, the document type and the identity type: this surfaces
+        // on the consumer's side of a contract the consumer cannot fix, so it has to point at the
+        // store that owes the override rather than merely say the shape was unrecognized.
+        ex.Message.ShouldContain(typeof(NotYetOverriddenSession).FullName!);
+        ex.Message.ShouldContain(typeof(string).FullName!);
+        ex.Message.ShouldContain(typeof(CouponCode).FullName!);
+    }
+
+    /// <remarks>
+    /// The local has to be <c>object</c>-typed to get here: a bare <c>null</c> literal is
+    /// convertible to <see cref="string" />, which is more specific than <see cref="object" />, so
+    /// <c>LoadAsync&lt;T&gt;(null)</c> binds to the string overload and never reaches this member.
+    /// </remarks>
+    [Fact]
+    public async Task throws_argument_null_for_a_null_identity()
+    {
+        object id = null!;
+
+        await Should.ThrowAsync<ArgumentNullException>(() => theOperations.LoadAsync<string>(id));
+    }
+
+    public readonly record struct CouponCode(Guid Value);
+
+    /// <summary>
+    /// Implements only what the contract has no default for, so every call to the <c>object</c>
+    /// overload lands on the default implementation.
+    /// </summary>
+    private class NotYetOverriddenSession : IDocumentReadOperations
+    {
+        public Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull
+            => Task.FromResult((T?)(object)$"guid:{id}");
+
+        public Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull
+            => Task.FromResult((T?)(object)$"string:{id}");
+
+        public IQueryable<T> Query<T>() where T : notnull => throw new NotImplementedException();
+
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
+++ b/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
@@ -75,12 +75,17 @@ public class InMemoryDocumentSession : IDocumentSessionOperations
         => Task.FromResult(load<T>(id));
 
     /// <summary>
-    /// The strong-typed-identity overload (jasperfx#665), which costs nothing here because the
-    /// storage is already keyed on the boxed identity <see cref="InMemoryDocumentStore.IdentityOf" />
-    /// pulled off the document. A real store has to route the value through its own value-type
-    /// registration; the shared assertion is only that a boxed identity of any shape resolves the
-    /// same document the typed overloads would.
+    /// The strong-typed-identity overload (jasperfx#665). Overriding the contract's default
+    /// implementation rather than inheriting it, which is the case worth demonstrating: the default
+    /// forwards a boxed <see cref="Guid" /> or <see cref="string" /> and throws on anything else, so
+    /// a store only gains the strong-typed half by writing this.
     /// </summary>
+    /// <remarks>
+    /// It costs nothing here because the storage is already keyed on the boxed identity
+    /// <see cref="InMemoryDocumentStore.IdentityOf" /> pulls off the document. A real store has to
+    /// route the value through its own value-type registration; the shared assertion is only that a
+    /// boxed identity of any shape resolves the same document the typed overloads would.
+    /// </remarks>
     public Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull
         => Task.FromResult(load<T>(id));
 

--- a/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
+++ b/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
@@ -74,6 +74,16 @@ public class InMemoryDocumentSession : IDocumentSessionOperations
     public Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull
         => Task.FromResult(load<T>(id));
 
+    /// <summary>
+    /// The strong-typed-identity overload (jasperfx#665), which costs nothing here because the
+    /// storage is already keyed on the boxed identity <see cref="InMemoryDocumentStore.IdentityOf" />
+    /// pulled off the document. A real store has to route the value through its own value-type
+    /// registration; the shared assertion is only that a boxed identity of any shape resolves the
+    /// same document the typed overloads would.
+    /// </summary>
+    public Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull
+        => Task.FromResult(load<T>(id));
+
     private T? load<T>(object id) where T : notnull
         => _store.StorageFor(typeof(T)).TryGetValue(id, out var found) ? (T)found : default;
 

--- a/src/JasperFx.Events.ComplianceTests/ComplianceDocuments.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceDocuments.cs
@@ -8,9 +8,10 @@ namespace JasperFx.Events.ComplianceTests;
 /// </summary>
 /// <remarks>
 /// Deliberately a mutable POCO with a plain <c>Id</c> property, which is the one document shape all
-/// three stores' identity conventions agree on. Strong-typed identifiers, <c>[Identity]</c>
-/// attributes and non-conventional identity members are product-specific configuration and are out
-/// of scope for the document contract.
+/// three stores' identity conventions agree on. <c>[Identity]</c> attributes and non-conventional
+/// identity members are product-specific configuration and stay out of scope for the document
+/// contract; strong-typed identifiers came into scope with jasperfx#665 and have their own document
+/// in <see cref="ComplianceCoupon" />.
 /// </remarks>
 public class ComplianceWidget
 {
@@ -29,4 +30,33 @@ public class ComplianceGadget
     public string Id { get; set; } = string.Empty;
     public string Kind { get; set; } = string.Empty;
     public int Weight { get; set; }
+}
+
+/// <summary>
+/// A strong-typed identifier wrapping a <see cref="Guid" /> — the canonical shape all three stores'
+/// value-type support agrees on.
+/// </summary>
+/// <remarks>
+/// A <c>record struct</c> over a single positional member, which is what every store's value-type
+/// detection looks for. Which primitive it wraps is a product concern and is not held to a shared
+/// definition here; what is shared is that a document keyed by a wrapper must be loadable by that
+/// wrapper.
+/// </remarks>
+public readonly record struct CouponCode(Guid Value);
+
+/// <summary>
+/// A document keyed by a strong-typed identifier, so the suites can hold
+/// <see cref="Documents.IDocumentReadOperations.LoadAsync{T}(object,System.Threading.CancellationToken)" />
+/// to a definition (jasperfx#665).
+/// </summary>
+/// <remarks>
+/// The one compliance document whose type alone is not enough to configure a store: its identity
+/// type has to be registered too, which is why <see cref="DocumentComplianceConfig.ValueTypes" />
+/// exists. A suite using this document registers both.
+/// </remarks>
+public class ComplianceCoupon
+{
+    public CouponCode Id { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public int PercentOff { get; set; }
 }

--- a/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
@@ -9,9 +9,10 @@ namespace JasperFx.Events.ComplianceTests;
 /// </summary>
 /// <remarks>
 /// Far thinner than <see cref="ComplianceStoreConfig" />, and that is the point rather than an
-/// oversight. The document contract (jasperfx#647) is seven operations, so a suite needs nothing but
-/// a schema to live in and the document types it will exercise — there is no registrar interface
-/// here because there is nothing store-specific left to register.
+/// oversight. The document contract (jasperfx#647) is eight operations, so a suite needs nothing but
+/// a schema to live in, the document types it will exercise, and the strong-typed identifiers those
+/// documents are keyed by. Still no registrar interface: unlike the event side, every one of those is
+/// expressible as a <see cref="Type" /> the fixture replays against its own options.
 /// </remarks>
 public sealed class DocumentComplianceConfig
 {
@@ -29,6 +30,24 @@ public sealed class DocumentComplianceConfig
     public DocumentComplianceConfig AddDocumentType<T>() where T : notnull
     {
         DocumentTypes.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>
+    /// Strong-typed identifier wrappers used as document identities in this configuration.
+    /// </summary>
+    /// <remarks>
+    /// Needed by <see cref="Documents.IDocumentReadOperations.LoadAsync{T}(object,System.Threading.CancellationToken)" />,
+    /// which is the only member of the document contract whose behavior depends on store
+    /// configuration the contract itself does not carry. Every Critter Stack store spells the
+    /// registration <c>StoreOptions.RegisterValueType(Type)</c>, so a fixture replays this with a
+    /// loop; stores that discover value types automatically can ignore it.
+    /// </remarks>
+    public List<Type> ValueTypes { get; } = new();
+
+    public DocumentComplianceConfig RegisterValueType<TValue>() where TValue : notnull
+    {
+        ValueTypes.Add(typeof(TValue));
         return this;
     }
 }

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -186,6 +186,13 @@ spells that `options.RegisterValueType(type)`. It is what lets `DocumentLoadAndS
 the `LoadAsync<T>(object)` overload (jasperfx#665) to a definition; a fixture that ignores it fails
 the strong-typed identity tests rather than skipping them.
 
+That overload also shows what these suites are *for*. It ships with a default implementation, so a
+store takes the JasperFx bump without a compile break — the default forwards a boxed `Guid` or
+`string` and throws on anything else. Nothing in the compiler then tells the store it has only half
+the member. `DocumentLoadAndStoreCompliance` does: a store that inherits the default fails the
+strong-typed facts. Where the contract's defaults deliberately stop breaking builds, the suite is
+what is left holding stores to the behavior.
+
 These suites are the one part of the library that is executed inside this repo as well as by its
 consumers: `EventStoreTests` enrolls an in-memory reference implementation, so the shared definition
 is known to be satisfiable before three products are held to it. That reference implementation is a

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -159,7 +159,7 @@ alongside the event store — `JasperFx.Events.Documents`:
 | Area | Suite |
 |---|---|
 | Session opening and the transaction boundary | `DocumentSessionCompliance` |
-| `Store` and `LoadAsync`, both identity styles | `DocumentLoadAndStoreCompliance` |
+| `Store` and `LoadAsync` — `Guid`, `string` and strong-typed identities | `DocumentLoadAndStoreCompliance` |
 | `Delete`, its identity overloads, and `DeleteWhere` | `DocumentDeleteCompliance` |
 | `Query<T>()`, its minimum translatable operator set, and the async terminators | `DocumentQueryCompliance` |
 
@@ -180,6 +180,11 @@ public class my_document_fixture : DocumentStorageComplianceFixture
 
 public class document_query_compliance : DocumentQueryCompliance<my_document_fixture>;
 ```
+
+`BuildStoreAsync` must honor `config.ValueTypes` as well as `config.DocumentTypes` — every store
+spells that `options.RegisterValueType(type)`. It is what lets `DocumentLoadAndStoreCompliance` hold
+the `LoadAsync<T>(object)` overload (jasperfx#665) to a definition; a fixture that ignores it fails
+the strong-typed identity tests rather than skipping them.
 
 These suites are the one part of the library that is executed inside this repo as well as by its
 consumers: `EventStoreTests` enrolls an in-memory reference implementation, so the shared definition

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentLoadAndStoreCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentLoadAndStoreCompliance.cs
@@ -84,8 +84,10 @@ public abstract class DocumentLoadAndStoreCompliance<TFixture> : DocumentStorage
     /// <remarks>
     /// The <c>object</c> overload is reached by a caller holding any identity in an
     /// <c>object</c>-typed local, not only by one holding a wrapper, so it has to resolve a boxed
-    /// canonical identity exactly as the typed overload does. An implementation that assumes every
-    /// argument here is a strong-typed wrapper passes the two tests above and fails this one.
+    /// canonical identity exactly as the typed overload does. The contract's default implementation
+    /// gets this right for free — but a store only reaches the two tests above by overriding it, and
+    /// an override that assumes every argument is a strong-typed wrapper passes those and regresses
+    /// this one.
     /// </remarks>
     [Fact]
     public async Task the_object_overload_resolves_canonical_identities_too()

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentLoadAndStoreCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentLoadAndStoreCompliance.cs
@@ -10,7 +10,7 @@ namespace JasperFx.Events.ComplianceTests;
 /// <summary>
 /// <see cref="IDocumentWriteOperations.Store{T}" /> and
 /// <see cref="IDocumentReadOperations.LoadAsync{T}(Guid,System.Threading.CancellationToken)" /> —
-/// both identity styles, the upsert semantics of <c>Store</c>, and the miss case.
+/// all three identity styles, the upsert semantics of <c>Store</c>, and the miss case.
 /// </summary>
 /// <remarks>
 /// <c>Store</c> is an upsert on every Critter Stack store, not an insert: storing an identity that
@@ -26,6 +26,8 @@ public abstract class DocumentLoadAndStoreCompliance<TFixture> : DocumentStorage
         config.SchemaName = "compliance_documents";
         config.AddDocumentType<ComplianceWidget>();
         config.AddDocumentType<ComplianceGadget>();
+        config.AddDocumentType<ComplianceCoupon>();
+        config.RegisterValueType<CouponCode>();
     };
 
     protected override Action<DocumentComplianceConfig> Configuration => _configuration;
@@ -55,6 +57,54 @@ public abstract class DocumentLoadAndStoreCompliance<TFixture> : DocumentStorage
         loaded.ShouldNotBeNull();
         loaded.Id.ShouldBe("gadget-42");
         loaded.Kind.ShouldBe("ratchet");
+    }
+
+    [Fact]
+    public async Task store_and_load_by_strong_typed_identity()
+    {
+        var id = new CouponCode(Guid.NewGuid());
+        await PersistAsync(new ComplianceCoupon { Id = id, Description = "Launch week", PercentOff = 20 });
+
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceCoupon>(id, Cancellation);
+
+        loaded.ShouldNotBeNull();
+        loaded.Id.ShouldBe(id);
+        loaded.Description.ShouldBe("Launch week");
+    }
+
+    [Fact]
+    public async Task load_returns_null_for_a_missing_strong_typed_identity()
+    {
+        await using var query = QuerySession();
+
+        (await query.LoadAsync<ComplianceCoupon>(new CouponCode(Guid.NewGuid()), Cancellation)).ShouldBeNull();
+    }
+
+    /// <remarks>
+    /// The <c>object</c> overload is reached by a caller holding any identity in an
+    /// <c>object</c>-typed local, not only by one holding a wrapper, so it has to resolve a boxed
+    /// canonical identity exactly as the typed overload does. An implementation that assumes every
+    /// argument here is a strong-typed wrapper passes the two tests above and fails this one.
+    /// </remarks>
+    [Fact]
+    public async Task the_object_overload_resolves_canonical_identities_too()
+    {
+        var widgetId = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = widgetId, Name = "Boxed" });
+        await PersistAsync(new ComplianceGadget { Id = "gadget-boxed", Kind = "spanner" });
+
+        await using var query = QuerySession();
+
+        object guidIdentity = widgetId;
+        var widget = await query.LoadAsync<ComplianceWidget>(guidIdentity, Cancellation);
+        widget.ShouldNotBeNull();
+        widget.Name.ShouldBe("Boxed");
+
+        object stringIdentity = "gadget-boxed";
+        var gadget = await query.LoadAsync<ComplianceGadget>(stringIdentity, Cancellation);
+        gadget.ShouldNotBeNull();
+        gadget.Kind.ShouldBe("spanner");
     }
 
     [Fact]

--- a/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
@@ -34,9 +34,11 @@ namespace JasperFx.Events.Documents;
 /// <see href="https://github.com/JasperFx/jasperfx/issues/647" />.
 /// </para>
 /// <para>
-/// Identity overloads are limited to <see cref="Guid" /> and <see cref="string" /> — the two the
-/// measured consumer surface uses. Numeric identities and tenant-scoped reads can be added
-/// additively later without breaking any implementer.
+/// Typed identity overloads are limited to <see cref="Guid" /> and <see cref="string" /> — the two
+/// the measured consumer surface uses — with
+/// <see cref="LoadAsync{T}(object,CancellationToken)" /> covering everything else the store can
+/// resolve, strong-typed identifiers above all. Numeric overloads and tenant-scoped reads can be
+/// added additively later without breaking any implementer.
 /// </para>
 /// </remarks>
 public interface IDocumentReadOperations : IAsyncDisposable
@@ -52,6 +54,38 @@ public interface IDocumentReadOperations : IAsyncDisposable
     /// no document exists with that identity.
     /// </summary>
     Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull;
+
+    /// <summary>
+    /// Load a single document by an identity the store resolves at runtime — the overload a
+    /// strong-typed identifier needs — or <see langword="null" /> when no document exists with that
+    /// identity.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Pass the document's own identity value, boxed. For a document keyed by
+    /// <c>record struct AlertId(string Id)</c> that means an <c>AlertId</c> and not the
+    /// <see cref="string" /> it wraps: handing over the wrapped primitive is the one mistake this
+    /// overload cannot rescue, because on the <see cref="string" /> overload it compiles cleanly and
+    /// then fails at runtime with the store's id-type mismatch.
+    /// </para>
+    /// <para>
+    /// The typed overloads stay preferred by overload resolution — a <see cref="Guid" /> or
+    /// <see cref="string" /> argument still binds to its own member, and only an argument that fits
+    /// neither lands here. Implementers should note the corollary: callers holding an identity in an
+    /// <see cref="object" />-typed local reach this overload with a boxed <see cref="Guid" /> or
+    /// <see cref="string" />, so it has to resolve those exactly as the typed overloads do rather
+    /// than assume a wrapper.
+    /// </para>
+    /// <para>
+    /// This one is here where <c>SingleOrDefaultAsync</c> and friends are not, and the distinction is
+    /// deliberate: those have a straightforward expression through what already exists, whereas
+    /// without this there is no spelling of a by-id load for a strong-typed-id document at all — a
+    /// capability cliff rather than a convenience gap, given that strong-typed identifiers are
+    /// first-class in Marten, Polecat and Fisher alike. See
+    /// <see href="https://github.com/JasperFx/jasperfx/issues/665" />.
+    /// </para>
+    /// </remarks>
+    Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull;
 
     /// <summary>
     /// Start a LINQ query over a document type.

--- a/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
@@ -40,6 +40,13 @@ namespace JasperFx.Events.Documents;
 /// resolve, strong-typed identifiers above all. Numeric overloads and tenant-scoped reads can be
 /// added additively later without breaking any implementer.
 /// </para>
+/// <para>
+/// Members added after the contract first shipped carry a default implementation, so a store picks
+/// up a new JasperFx without a compile break and adopts the member when it is ready. The default is
+/// never a silent stand-in for the capability: it either answers the part that is answerable
+/// identically for every store, or throws naming the implementing type. What holds a store to the
+/// real behavior is the shared compliance suite, not the compiler.
+/// </para>
 /// </remarks>
 public interface IDocumentReadOperations : IAsyncDisposable
 {
@@ -77,6 +84,17 @@ public interface IDocumentReadOperations : IAsyncDisposable
     /// than assume a wrapper.
     /// </para>
     /// <para>
+    /// <b>The default implementation covers exactly that corollary and nothing else.</b> It unboxes a
+    /// <see cref="Guid" /> or <see cref="string" /> and forwards to the overload that already exists,
+    /// which is the only half of this member that can be answered without knowing how a store
+    /// registers value types — and it is answerable identically for every store, so there is no
+    /// reason to make three of them write it. Anything else throws
+    /// <see cref="NotSupportedException" /> naming the implementing type and the identity type,
+    /// because a strong-typed identifier can only be resolved through the store's own value-type
+    /// registration. A store overrides this member to gain that half; the shared compliance suite
+    /// asserts it directly, so the default is a starting point rather than a resting place.
+    /// </para>
+    /// <para>
     /// This one is here where <c>SingleOrDefaultAsync</c> and friends are not, and the distinction is
     /// deliberate: those have a straightforward expression through what already exists, whereas
     /// without this there is no spelling of a by-id load for a strong-typed-id document at all — a
@@ -85,7 +103,19 @@ public interface IDocumentReadOperations : IAsyncDisposable
     /// <see href="https://github.com/JasperFx/jasperfx/issues/665" />.
     /// </para>
     /// </remarks>
-    Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull;
+    /// <exception cref="NotSupportedException">
+    /// From the default implementation only, when <paramref name="id" /> is neither a
+    /// <see cref="Guid" /> nor a <see cref="string" /> and the store has not overridden this member.
+    /// </exception>
+    Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull
+        => id switch
+        {
+            null => throw new ArgumentNullException(nameof(id)),
+            Guid guid => LoadAsync<T>(guid, token),
+            string text => LoadAsync<T>(text, token),
+            _ => throw new NotSupportedException(
+                $"{GetType().FullName} does not implement {nameof(IDocumentReadOperations)}.{nameof(LoadAsync)}<T>(object), so it cannot load a document of type {typeof(T).FullName} by an identity of type {id.GetType().FullName}. The default implementation forwards only the canonical Guid and string identities to their own overloads; resolving a strong-typed identifier requires the store's own value type registration, so the store has to override this member.")
+        };
 
     /// <summary>
     /// Start a LINQ query over a document type.


### PR DESCRIPTION
Closes #665.

## The gap

`IDocumentReadOperations.LoadAsync<T>` offered `Guid` and `string` only, so a document keyed by a strong-typed identifier could not be loaded by id through the abstraction at all. Passing the wrapped primitive is not an alternative — it compiles and then throws the store's id-type mismatch at runtime — so store-agnostic code had to fall back to a LINQ query on the identity standing in for a load.

## The change

```csharp
Task<T?> LoadAsync<T>(object id, CancellationToken token = default) where T : notnull;
```

Matches the overload Marten already carries. The typed overloads stay preferred by overload resolution, so no existing call site moves; only an argument that fits neither lands on the new member.

This grows a surface #647 deliberately kept tight, and the distinction is the one the issue draws: `SingleOrDefaultAsync` and friends were left out because they have a straightforward expression through what already exists, whereas this had none.

## Not a compile break — it ships with a default implementation

The member has a default implementation, so Polecat and Fisher take the JasperFx bump without a break and adopt it on their own schedule.

The default is deliberately not a stand-in for the capability. It answers only the half that is answerable identically for every store — unbox a `Guid` or `string`, forward to the overload that already exists — and throws `NotSupportedException` naming the implementing type, the document type and the identity type for anything else, because resolving a strong-typed identifier needs the store's own value-type registration and nothing generic can guess it.

That moves enforcement from the compiler to the compliance suite, which is called out in the compliance README because it is now the only thing telling a store it has half the member.

## Compliance

`DocumentLoadAndStoreCompliance` gains `ComplianceCoupon`, keyed by a `CouponCode` record struct, and three facts — the strong-typed load, its miss case, and the one an override is most likely to get wrong: a boxed `Guid` or `string` reaching the `object` overload through an `object`-typed local has to resolve exactly as the typed overload does. A store inheriting the default passes that third fact and fails the first two.

The strong-typed facts need the identity type registered with the store, which is what the new `DocumentComplianceConfig.ValueTypes` / `RegisterValueType<T>()` is for. **Enrolling fixtures must replay it** — every store spells it `options.RegisterValueType(type)`. This is not a compile break either: the fixture builds fine without it and then fails three facts at runtime, which reads like a product bug.

The default implementation gets its own tests in `EventStoreTests`, since every real store overrides it and the compliance suites therefore never execute it. One of those pinned a resolution detail worth knowing: a bare `null` literal binds to the `string` overload rather than this one, so the null guard is only reachable through an `object`-typed local.

`EventStoreTests` is green at 121, including the in-memory reference implementation running the full document suite.

## Downstream

| | Interface member | Compliance fixture |
|---|---|---|
| **Marten** | already declares and implements `LoadAsync<T>(object)` — nothing to do | must replay `config.ValueTypes` — [marten#5241](https://github.com/JasperFx/marten/issues/5241) |
| **Polecat** | inherits the default; overrides to gain strong-typed ids — [polecat#472](https://github.com/JasperFx/polecat/issues/472) | must replay `config.ValueTypes` |
| **Fisher** | inherits the default; has `LoadAsync<T, TId>(TId)` today, which does not satisfy this — [fisher#89](https://github.com/JasperFx/fisher/issues/89) | must replay `config.ValueTypes` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
