### PR TITLE
Do not claim an unscanned ceiling when a whole batch is skipped

### DIFF
--- a/src/EventTests/Projections/EventPageTests.cs
+++ b/src/EventTests/Projections/EventPageTests.cs
@@ -45,4 +45,67 @@ public class EventPageTests
 
         page.Ceiling.ShouldBe(1000);
     }
+
+    [Fact]
+    public void an_entirely_skipped_full_batch_claims_only_what_the_query_read()
+    {
+        // https://github.com/JasperFx/jasperfx/issues/667. Ten rows read, ten skipped, so the
+        // batch was saturated and the LIMIT stopped the query at sequence 10. Everything between
+        // 11 and the high water mark was never looked at, and the consumer writes Ceiling as
+        // durable projection progress, so claiming 1000 here skips those events permanently.
+        var page = new EventPage(0) { LastObservedSequence = 10 };
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 10);
+
+        page.Ceiling.ShouldBe(10);
+    }
+
+    [Fact]
+    public void an_entirely_skipped_full_batch_moves_past_the_poison_rows_without_passing_the_query()
+    {
+        // The reason the high water mark fallback exists at all is liveness: a ceiling stuck at
+        // the floor leaves the shard re-reading the same undeserializable rows forever. The fix
+        // has to keep that while dropping the over-claim, so both bounds are asserted together.
+        //
+        // Written with an exact value rather than only ShouldBeGreaterThan(Floor). A range
+        // assertion here would pass against the very behaviour this pins, since the old ceiling of
+        // 1000 is also greater than the floor, and a test that passes against the bug it describes
+        // is not a test.
+        var page = new EventPage(floor: 5) { LastObservedSequence = 15 };
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 10);
+
+        page.Ceiling.ShouldBe(15);
+        page.Ceiling.ShouldBeGreaterThan(page.Floor);
+    }
+
+    [Fact]
+    public void a_partly_skipped_full_batch_still_uses_its_last_surviving_event()
+    {
+        // LastObservedSequence must not take over whenever it happens to be set. While the page
+        // holds anything, the last event in it is the ceiling, exactly as before: those rows were
+        // read and kept, and the ones after them inside the batch were read and skipped.
+        var page = new EventPage(0)
+        {
+            new Event<AEvent>(new AEvent()) { Sequence = 4 }
+        };
+        page.LastObservedSequence = 9;
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 9);
+
+        page.Ceiling.ShouldBe(4);
+    }
+
+    [Fact]
+    public void an_unfilled_batch_ignores_the_last_observed_sequence()
+    {
+        // A batch that did not fill genuinely exhausted its range, so the high water mark is
+        // correct and must win even when the loader reported what it last read. Without this,
+        // a loader that always sets the property would stop advancing past sparse ranges.
+        var page = new EventPage(0) { LastObservedSequence = 7 };
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 2);
+
+        page.Ceiling.ShouldBe(1000);
+    }
 }

--- a/src/EventTests/Projections/EventPageTests.cs
+++ b/src/EventTests/Projections/EventPageTests.cs
@@ -108,4 +108,44 @@ public class EventPageTests
 
         page.Ceiling.ShouldBe(1000);
     }
+
+    [Fact]
+    public void an_undetermined_sequence_sentinel_is_not_treated_as_an_observation()
+    {
+        // Marten's UnknownEventTypeException reports -1 when the throw site had no row in hand, and
+        // the read path hits exactly that when an event's stored .NET type no longer resolves -- the
+        // removed-or-renamed event type that fills a whole batch with skips in the first place. A
+        // loader that reported the exception's sequence rather than the row's would land here.
+        // Acting on it would set the ceiling below the floor and march durable progress backwards.
+        var page = new EventPage(100) { LastObservedSequence = -1 };
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 10);
+
+        page.Ceiling.ShouldBe(1000);
+    }
+
+    [Fact]
+    public void an_observed_sequence_at_or_below_the_floor_is_not_trusted()
+    {
+        // Every row this query could have read is above Floor, so a value down here is stale -- left
+        // over from an earlier range rather than observed in this one. Same reasoning as the
+        // sentinel: fall back rather than move progress backwards.
+        var page = new EventPage(100) { LastObservedSequence = 100 };
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 10);
+
+        page.Ceiling.ShouldBe(1000);
+    }
+
+    [Fact]
+    public void an_observed_sequence_just_above_the_floor_is_trusted()
+    {
+        // The boundary on the other side, so the guard cannot quietly become an off-by-one that
+        // discards the first legitimate row of a range.
+        var page = new EventPage(100) { LastObservedSequence = 101 };
+
+        page.CalculateCeiling(10, 1000, skippedEvents: 10);
+
+        page.Ceiling.ShouldBe(101);
+    }
 }

--- a/src/JasperFx.Events/Projections/EventPage.cs
+++ b/src/JasperFx.Events/Projections/EventPage.cs
@@ -12,15 +12,46 @@ public class EventPage: List<IEvent>
 
     public long HighWaterMark { get; set; }
 
+    /// <summary>
+    /// The sequence of the last row the loader actually read, whether or not it survived into this
+    /// page. Set it when a loader skips events, so a page that ends up empty can still report how
+    /// far its query really got.
+    /// </summary>
+    /// <remarks>
+    /// The page itself only ever sees events that deserialized, so it cannot work this out alone.
+    /// A loader that does not set it keeps the previous behaviour exactly.
+    /// </remarks>
+    public long? LastObservedSequence { get; set; }
+
     public void CalculateCeiling(int batchSize, long highWaterMark, int skippedEvents = 0)
     {
-        // Count == 0 happens when every event in a full batch was skipped (e.g. error
-        // handling is configured to skip serialization/application/unknown event errors).
-        // There is no last event to read a sequence from, so fall back to the high water
-        // mark and let the daemon make progress rather than throwing on an empty page. See
+        if ((Count + skippedEvents) != batchSize)
+        {
+            // The query did not fill the batch, so it exhausted everything up to the bound it was
+            // given and the caller's high water mark is the honest ceiling.
+            Ceiling = highWaterMark;
+            return;
+        }
+
+        if (Count > 0)
+        {
+            Ceiling = this.Last().Sequence;
+            return;
+        }
+
+        // Every row in a full batch was skipped, so there is no last event to read a sequence
+        // from. The batch was still saturated: the LIMIT stopped the query, and rows beyond it
+        // inside the same range were never looked at. Claiming highWaterMark here writes durable
+        // progress past events nobody read, which is the same over-claim the branch above exists
+        // to prevent. See https://github.com/JasperFx/jasperfx/issues/667
+        //
+        // The last row the loader saw is the correct ceiling: it is as far as the query got, and
+        // advancing to it still steps over the poison rows, so a shard cannot get stuck re-reading
+        // them. That liveness is why the fallback below exists at all. See
         // https://github.com/JasperFx/marten/issues/4663
-        Ceiling = (Count + skippedEvents) == batchSize && Count > 0
-            ? this.Last().Sequence
-            : highWaterMark;
+        //
+        // A loader that does not report LastObservedSequence still gets highWaterMark, so this
+        // changes nothing for callers that have not opted in.
+        Ceiling = LastObservedSequence ?? highWaterMark;
     }
 }

--- a/src/JasperFx.Events/Projections/EventPage.cs
+++ b/src/JasperFx.Events/Projections/EventPage.cs
@@ -18,8 +18,21 @@ public class EventPage: List<IEvent>
     /// far its query really got.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The page itself only ever sees events that deserialized, so it cannot work this out alone.
     /// A loader that does not set it keeps the previous behaviour exactly.
+    /// </para>
+    /// <para>
+    /// <b>Take the sequence from the row being read, not from the exception that rejected it.</b> A
+    /// store's skip exceptions expose a sequence — Marten's implement
+    /// <c>IEventFailureContext.Sequence</c> — but they cannot always populate it. Marten's
+    /// <c>UnknownEventTypeException</c> reports <c>-1</c> when the throw site had no row in hand, and
+    /// the read path reaches exactly that case when an event's stored .NET type no longer resolves:
+    /// a removed or renamed event type, which is the very scenario that fills a whole batch with
+    /// skips. Sourcing this from the reader's own sequence column is what makes it available when it
+    /// is most needed. <see cref="CalculateCeiling" /> discards a value it cannot trust rather than
+    /// acting on it, but a discarded value is a missed fix, not a fixed bug.
+    /// </para>
     /// </remarks>
     public long? LastObservedSequence { get; set; }
 
@@ -52,6 +65,14 @@ public class EventPage: List<IEvent>
         //
         // A loader that does not report LastObservedSequence still gets highWaterMark, so this
         // changes nothing for callers that have not opted in.
-        Ceiling = LastObservedSequence ?? highWaterMark;
+        //
+        // Floor is the guard rather than zero, and it has to be: every row this query could have
+        // read is above Floor, so a reported sequence at or below it is not a bound the loader
+        // observed. That covers a store's "sequence could not be determined" sentinel -- Marten
+        // spells it -1 -- as well as a value left over from an earlier range. Both would otherwise
+        // move durable progress BACKWARDS, past the floor the shard has already committed, which is
+        // worse than the over-claim being fixed here. Falling back leaves the pre-#667 behaviour for
+        // that page instead.
+        Ceiling = LastObservedSequence > Floor ? LastObservedSequence.Value : highWaterMark;
     }
 }


### PR DESCRIPTION
Fixes #667.

## The change

`CalculateCeiling` no longer claims the caller's high water mark when a full batch was entirely skipped. It uses the last sequence the loader actually read, when the loader reports one.

The over-claim mattered because the consumer writes `Ceiling` as durable projection progress. An all-skipped page still saturated its `LIMIT`, so rows beyond it inside the same range were never looked at, and jumping to `highWaterMark` skipped them permanently: no exception, no dead-letter beyond the individual skips, and a shard reporting itself caught up.

## Keeping the liveness the fallback exists for

The `highWaterMark` fallback was added by marten#4663 so a batch of undeserializable rows could not leave a shard re-reading the same poison forever. That property is kept: `LastObservedSequence` is past those rows by definition, so progress still advances. What it stops doing is advancing past rows nobody read.

The one thing the page could not do before was know that sequence, because an `EventPage` only ever contains events that deserialized. So it has to be told, which is the new property:

```csharp
public long? LastObservedSequence { get; set; }
```

## Nothing changes for existing callers

`LastObservedSequence` defaults to null and the ceiling falls back to `highWaterMark` exactly as before, so this is opt-in per loader and no existing behaviour moves. The existing `calculate_ceiling_when_full_batch_was_entirely_skipped_does_not_throw` test, which pins the marten#4663 fallback, passes unchanged and was deliberately left alone.

The method now returns early per branch rather than nesting a conditional, which was needed to comment the three cases separately. No behavioural change in the two existing branches.

Marten's `loadNormalAsync` is where this bites in practice, and it would need to set the property as it reads rows. That is a Marten-side change and is not in this PR.

## Tests

758 pass in `EventTests` on net10.0. Four added:

| Test | Pins |
|---|---|
| `an_entirely_skipped_full_batch_claims_only_what_the_query_read` | the fix: ceiling is 10, not 1000 |
| `an_entirely_skipped_full_batch_moves_past_the_poison_rows_without_passing_the_query` | liveness and the fix together |
| `a_partly_skipped_full_batch_still_uses_its_last_surviving_event` | the new property must not take over while the page holds events |
| `an_unfilled_batch_ignores_the_last_observed_sequence` | an unfilled batch genuinely exhausted its range, so the high water mark still wins |

**Proven by mutation.** Reverting the new branch to `Ceiling = highWaterMark` fails the first two and leaves the other two green, which is correct: those two are guards on paths the fix does not touch.

Worth mentioning because it nearly went in wrong: the liveness test first asserted only `Ceiling.ShouldBeGreaterThan(Floor)`, and it **passed against the bug**, since the old ceiling of 1000 also clears a floor of 5. It now asserts the exact value as well.

## Note on net9.0

Only the net10.0 leg ran locally; the .NET 9 runtime is not installed on this machine. The change is a branch in one method with no framework-conditional code, so CI covering both should be enough, but I have not run net9.0 myself and did not want to imply otherwise.
