### PR TITLE
gh-669: an Events accessor on the document session contracts, and promote IEventBinarySerializer

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -118,6 +118,31 @@ public sealed class ComplianceStoreConfig
         return this;
     }
 
+    /// <summary>
+    /// Event types the suite asked to be stored through a binary serializer, with the serializer.
+    /// </summary>
+    public List<(Type Event, IEventBinarySerializer Serializer)> BinarySerializers { get; } = new();
+
+    /// <summary>
+    /// The store-wide fallback serializer, when the suite set one.
+    /// </summary>
+    public IEventBinarySerializer? DefaultBinarySerializer { get; private set; }
+
+    public ComplianceStoreConfig UseBinarySerializer<TEvent>(IEventBinarySerializer serializer)
+        where TEvent : notnull
+    {
+        BinarySerializers.Add((typeof(TEvent), serializer));
+        _registrations.Add(registrar => registrar.UseBinarySerializer<TEvent>(serializer));
+        return this;
+    }
+
+    public ComplianceStoreConfig SetDefaultBinarySerializer(IEventBinarySerializer serializer)
+    {
+        DefaultBinarySerializer = serializer;
+        _registrations.Add(registrar => registrar.SetDefaultBinarySerializer(serializer));
+        return this;
+    }
+
     public ComplianceStoreConfig RegisterTagType<TTag>(string tableSuffix, Type? aggregateType = null)
         where TTag : notnull
     {

--- a/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
@@ -50,4 +50,22 @@ public sealed class DocumentComplianceConfig
         ValueTypes.Add(typeof(TValue));
         return this;
     }
+
+    /// <summary>
+    /// Event types the suite will append through a session's <c>Events</c> accessor.
+    /// </summary>
+    /// <remarks>
+    /// Only <see cref="DocumentSessionEventsCompliance{TFixture}" /> populates this, and only stores
+    /// that are event stores enroll in that suite — so a fixture for a document-only store can
+    /// ignore it entirely. It is here rather than on <see cref="ComplianceStoreConfig" /> because
+    /// jasperfx#669 is precisely the seam where the two halves meet: the accessor is reached from a
+    /// <em>document</em> session, so it has to be exercised by a document fixture.
+    /// </remarks>
+    public List<Type> EventTypes { get; } = new();
+
+    public DocumentComplianceConfig AddEventType<T>() where T : notnull
+    {
+        EventTypes.Add(typeof(T));
+        return this;
+    }
 }

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -28,6 +28,29 @@ public interface IComplianceStoreRegistrar
     ITagTypeRegistration RegisterTagType<TTag>(string tableSuffix) where TTag : notnull;
 
     /// <summary>
+    /// Register a binary serializer for one event type. Maps to each store's
+    /// <c>Events.UseBinarySerializer&lt;TEvent&gt;(serializer)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Carries a throwing default because binary event serialization is an opt-in capability rather
+    /// than part of the baseline event contract — a store that has not implemented it does not
+    /// enroll in <see cref="BinaryEventSerializationCompliance{TFixture}" />, never reaches this
+    /// member, and keeps compiling against a newer compliance package.
+    /// </remarks>
+    void UseBinarySerializer<TEvent>(IEventBinarySerializer serializer) where TEvent : notnull
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement UseBinarySerializer, so it cannot run the binary event serialization compliance suite.");
+
+    /// <summary>
+    /// Set the store-wide fallback serializer used by event types marked with
+    /// <see cref="BinaryEventAttribute" /> that have no explicit per-type registration.
+    /// </summary>
+    /// <inheritdoc cref="UseBinarySerializer{TEvent}" path="/remarks" />
+    void SetDefaultBinarySerializer(IEventBinarySerializer serializer)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement SetDefaultBinarySerializer, so it cannot run the binary event serialization compliance suite.");
+
+    /// <summary>
     /// Register a single stream snapshot projection for a self-aggregating type.
     /// </summary>
     void Snapshot<TDoc>(SnapshotLifecycle lifecycle) where TDoc : notnull;

--- a/src/JasperFx.Events.ComplianceTests/Suites/BinaryEventSerializationCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/BinaryEventSerializationCompliance.cs
@@ -1,0 +1,248 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Binary serialization events
+
+public record ProbeLaunched(string Vehicle, string Pad);
+
+public record TelemetryBurst(string Channel, int[] Samples);
+
+/// <summary>
+/// Opted in by attribute rather than by explicit registration, so the suite can hold the
+/// <see cref="BinaryEventAttribute" /> + store-wide-default path to a definition too.
+/// </summary>
+[BinaryEvent]
+public record ProbeSeparated(int Stage);
+
+#endregion
+
+/// <summary>
+/// A deliberately non-JSON binary serializer: UTF8 JSON, gzipped.
+/// </summary>
+/// <remarks>
+/// The compression is what makes the suite's assertions mean something. A serializer that emitted
+/// plain UTF8 JSON would round-trip identically whether the store honored it or quietly fell back to
+/// its own JSON path, so every fact here would pass against a store that implemented nothing. Gzip
+/// output is not valid JSON and not valid UTF8, so a store that ignores the serializer fails loudly
+/// on write or read instead of silently agreeing.
+/// </remarks>
+public sealed class ComplianceGzipJsonSerializer : IEventBinarySerializer
+{
+    /// <summary>
+    /// Number of times <see cref="Serialize" /> has been called on this instance.
+    /// </summary>
+    public int SerializeCount { get; private set; }
+
+    /// <summary>
+    /// Number of times <see cref="Deserialize" /> has been called on this instance.
+    /// </summary>
+    public int DeserializeCount { get; private set; }
+
+    public byte[] Serialize(Type type, object data)
+    {
+        SerializeCount++;
+
+        var json = JsonSerializer.SerializeToUtf8Bytes(data, type);
+
+        using var output = new MemoryStream();
+        using (var gzip = new GZipStream(output, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            gzip.Write(json, 0, json.Length);
+        }
+
+        return output.ToArray();
+    }
+
+    public object Deserialize(Type type, byte[] data)
+    {
+        DeserializeCount++;
+
+        using var input = new MemoryStream(data);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        gzip.CopyTo(output);
+
+        return JsonSerializer.Deserialize(output.ToArray(), type)
+               ?? throw new InvalidOperationException(
+                   $"The compliance serializer deserialized a null {type.FullName}.");
+    }
+}
+
+/// <summary>
+/// Binary event serialization — per-event-type opt out of the store's JSON format
+/// (marten#4515, polecat#475, fisher#93).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Opt-in: a store that has not implemented binary event storage simply does not enroll, and the
+/// registrar members this suite drives keep their throwing defaults.
+/// </para>
+/// <para>
+/// The property worth protecting above all the others is that JSON and binary rows coexist per event
+/// type in one table — that is what makes turning a single event type binary an in-place change with
+/// no migration of existing event data. <see cref="json_and_binary_events_coexist_in_one_stream" />
+/// is the fact that pins it, and a store that got everything else right but stored a per-store or
+/// per-stream format flag would fail exactly there.
+/// </para>
+/// <para>
+/// Note what is <em>not</em> asserted: the column the bytes land in, and how a row records that it is
+/// binary. Both are genuinely per-store — Marten uses a nullable <c>bdata</c> alongside a
+/// placeholder in <c>data</c> — and pinning either here would encode Marten's schema as the contract
+/// rather than the behavior.
+/// </para>
+/// </remarks>
+public abstract class BinaryEventSerializationCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly ComplianceGzipJsonSerializer _telemetry = new();
+    private static readonly ComplianceGzipJsonSerializer _fallback = new();
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_binary_events";
+        config.AddEventType<ProbeLaunched>();
+        config.AddEventType<TelemetryBurst>();
+        config.AddEventType<ProbeSeparated>();
+
+        // TelemetryBurst is binary by explicit registration, ProbeSeparated by attribute against the
+        // store-wide default, and ProbeLaunched stays JSON — so one store carries all three routes.
+        config.UseBinarySerializer<TelemetryBurst>(_telemetry);
+        config.SetDefaultBinarySerializer(_fallback);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task a_binary_event_round_trips_through_the_registered_serializer()
+    {
+        var streamId = Guid.NewGuid();
+        var samples = new[] { 3, 1, 4, 1, 5, 9, 2, 6 };
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId, new TelemetryBurst("s-band", samples));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        var burst = events.Single().Data.ShouldBeOfType<TelemetryBurst>();
+        burst.Channel.ShouldBe("s-band");
+        burst.Samples.ShouldBe(samples);
+    }
+
+    [Fact]
+    public async Task the_registered_serializer_is_actually_the_one_that_ran()
+    {
+        var before = _telemetry.SerializeCount;
+
+        var streamId = Guid.NewGuid();
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId, new TelemetryBurst("x-band", new[] { 1 }));
+        await SaveChangesAsync(session);
+
+        // Round-tripping correctly is not by itself proof the serializer was consulted — a store
+        // that ignored it entirely and wrote its own JSON would pass the round-trip fact above.
+        _telemetry.SerializeCount.ShouldBeGreaterThan(before);
+    }
+
+    [Fact]
+    public async Task json_and_binary_events_coexist_in_one_stream()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId,
+                new ProbeLaunched("Kestrel", "LC-2"),
+                new TelemetryBurst("s-band", new[] { 7, 7, 7 }),
+                new ProbeSeparated(1));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(3);
+        events.Select(x => x.Data.GetType())
+            .ShouldBe(new[] { typeof(ProbeLaunched), typeof(TelemetryBurst), typeof(ProbeSeparated) });
+
+        events[0].Data.ShouldBeOfType<ProbeLaunched>().Vehicle.ShouldBe("Kestrel");
+        events[1].Data.ShouldBeOfType<TelemetryBurst>().Samples.ShouldBe(new[] { 7, 7, 7 });
+        events[2].Data.ShouldBeOfType<ProbeSeparated>().Stage.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task an_attribute_marked_event_uses_the_store_wide_default_serializer()
+    {
+        var before = _fallback.SerializeCount;
+
+        var streamId = Guid.NewGuid();
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId, new ProbeSeparated(2));
+            await SaveChangesAsync(session);
+        }
+
+        _fallback.SerializeCount.ShouldBeGreaterThan(before);
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Single().Data.ShouldBeOfType<ProbeSeparated>().Stage.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_binary_event_is_readable_through_live_aggregation()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId,
+                new TelemetryBurst("s-band", new[] { 1, 2 }),
+                new TelemetryBurst("x-band", new[] { 3 }));
+            await SaveChangesAsync(session);
+        }
+
+        // The deserialization path a projection or live aggregation takes is not always the one
+        // FetchStreamAsync takes; a store can read events back through more than one code path and
+        // only teach one of them about the binary column.
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Select(x => ((TelemetryBurst)x.Data).Samples.Length).Sum().ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task a_binary_payload_survives_bytes_that_are_not_valid_utf8_text()
+    {
+        // Gzip output is arbitrary bytes. A store that round-trips the payload through a text
+        // encoding somewhere in its write path -- the natural implementation if binary support is
+        // bolted onto a column that was always JSON -- corrupts it here and nowhere else.
+        var streamId = Guid.NewGuid();
+        var samples = Enumerable.Range(0, 512).ToArray();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId, new TelemetryBurst("wideband", samples));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Single().Data.ShouldBeOfType<TelemetryBurst>().Samples.ShouldBe(samples);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentSessionEventsCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentSessionEventsCompliance.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record KilnFired(string Site);
+
+public record KilnCooled(int DegreesPerHour);
+
+/// <summary>
+/// The route from a session the consumer opened to that session's event store — jasperfx#669.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Opt-in, unlike the other four document suites: it is the one that requires the store to be an
+/// event store as well as a document store. A document-only implementer (the in-memory reference
+/// store in <c>EventStoreTests</c> is the standing example) correctly leaves
+/// <see cref="IDocumentReadOperations.Events" /> on its throwing default and simply does not enroll
+/// here.
+/// </para>
+/// <para>
+/// What is under test is the <em>accessor</em>, not the event store behind it — appending, stream
+/// state, aggregation and the rest are already held to a definition by the event compliance suites,
+/// and re-asserting them here would pin the same behavior twice. So each fact does the least event
+/// work that proves the route is real: that it is reachable, that it is the same unit of work as the
+/// document session it came from, and that the read tier cannot append.
+/// </para>
+/// <para>
+/// ⚠️ The failure this suite exists to catch is silent. C# interface implementation is not
+/// return-type covariant, so a product session that already declares an <c>Events</c> property of
+/// its own event-store type does not implement the contract member — it binds to the throwing
+/// default instead, with no compile error anywhere. Nothing but a test that actually calls through
+/// the contract-typed session will notice.
+/// </para>
+/// </remarks>
+public abstract class DocumentSessionEventsCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+        config.AddDocumentType<ComplianceWidget>();
+        config.AddEventType<KilnFired>();
+        config.AddEventType<KilnCooled>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    [Fact]
+    public void a_writable_session_exposes_the_full_event_store_api()
+    {
+        // Held as the contract, never as the product's own session type — binding the local to the
+        // product type is exactly the mistake that makes the non-covariance trap invisible.
+        IDocumentSessionOperations session = LightweightSession();
+
+        session.Events.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void a_query_session_exposes_the_read_only_event_store_api()
+    {
+        IDocumentReadOperations session = QuerySession();
+
+        session.Events.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task appending_through_the_accessor_rides_the_session_unit_of_work()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+
+        IDocumentSessionOperations session = LightweightSession();
+        await using (session)
+        {
+            session.Events.StartStream<ComplianceKiln>(streamKey, new KilnFired("North Ridge"));
+
+            // The load-bearing half: uncommitted, exactly as a document Store() would be. An
+            // accessor that wrote straight through would pass every other fact here and still break
+            // any consumer that relies on the append and the document write committing together.
+            await using (var early = QuerySession())
+            {
+                var before = await early.Events.FetchStreamStateAsync(streamKey, Cancellation);
+                before.ShouldBeNull();
+            }
+
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var state = await query.Events.FetchStreamStateAsync(streamKey, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task documents_and_events_written_through_one_session_commit_together()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+        var documentId = Guid.NewGuid();
+
+        await using (var session = LightweightSession())
+        {
+            session.Store(new ComplianceWidget { Id = documentId, Name = "Nacelle" });
+            session.Events.StartStream<ComplianceKiln>(streamKey, new KilnFired("South Ridge"));
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+
+        (await query.LoadAsync<ComplianceWidget>(documentId, Cancellation)).ShouldNotBeNull();
+        (await query.Events.FetchStreamStateAsync(streamKey, Cancellation)).ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task the_accessor_reads_events_back_from_the_stream_it_appended()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+
+        await using (var session = LightweightSession())
+        {
+            session.Events.StartStream<ComplianceKiln>(streamKey,
+                new KilnFired("East Ridge"), new KilnCooled(120));
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        await using var query = QuerySession();
+        var events = await query.Events.FetchStreamAsync(streamKey, token: Cancellation);
+
+        events.Count.ShouldBe(2);
+        events.Select(x => x.Data.GetType())
+            .ShouldBe(new[] { typeof(KilnFired), typeof(KilnCooled) });
+    }
+}
+
+/// <summary>
+/// Stream marker for <see cref="DocumentSessionEventsCompliance{TFixture}" />. Never projected —
+/// the suite asserts on stream state and raw events, so no store needs a projection registered to
+/// run it.
+/// </summary>
+public class ComplianceKiln
+{
+    public Guid Id { get; set; }
+    public string Site { get; set; } = string.Empty;
+    public int DegreesPerHour { get; set; }
+}

--- a/src/JasperFx.Events/BinaryEventAttribute.cs
+++ b/src/JasperFx.Events/BinaryEventAttribute.cs
@@ -1,0 +1,26 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Marks an event type as binary-serialized: its payload is written through an
+/// <see cref="IEventBinarySerializer" /> rather than the store's JSON path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Promoted alongside <see cref="IEventBinarySerializer" /> for the same reason and at the same
+/// time. An attribute is applied to the event type itself, and event types are exactly what a
+/// consumer compiling one body of source against several stores shares — so a store-namespaced
+/// attribute is unusable in precisely the code that most wants it. Promoting the interface without
+/// the attribute would have left the feature reachable store-agnostically through registration but
+/// not through declaration.
+/// </para>
+/// <para>
+/// The attribute only marks intent. The serializer is resolved by the store at registration time,
+/// and every store that honors this attribute should resolve it the same way: an explicit per-type
+/// registration wins, a store-wide default is the fallback, and a type marked here with neither
+/// configured is a configuration error the store raises rather than a silent reversion to JSON.
+/// Silently falling back to JSON would write rows in a format the operator did not choose and
+/// believes they are not using.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class BinaryEventAttribute : Attribute;

--- a/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentReadOperations.cs
@@ -51,6 +51,48 @@ namespace JasperFx.Events.Documents;
 public interface IDocumentReadOperations : IAsyncDisposable
 {
     /// <summary>
+    /// The read-only event store API for this session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The route from a session to its event store, and the reason it is on the contract at all: a
+    /// consumer that opens its own session through <see cref="IDocumentSessionFactory" /> otherwise
+    /// has no store-agnostic way to reach events, because every product declares its own
+    /// <c>Events</c> on its own session type rather than here. The far side of the accessor already
+    /// existed — this is only the route to it. See
+    /// <see href="https://github.com/JasperFx/jasperfx/issues/669" />.
+    /// </para>
+    /// <para>
+    /// It does not bite a Wolverine handler taking a chain parameter, because wolverine#3956 fills
+    /// an <see cref="IEventStoreOperations" /> parameter from the chain's own session. It bites the
+    /// two shapes where the consumer decides when a session exists: a background or timer publisher
+    /// that opens a session and appends, and a deliberate second read session opened alongside a
+    /// chain's writing session.
+    /// </para>
+    /// <para>
+    /// Read tier deliberately, so that a <see cref="IDocumentSessionFactory.QuerySession" /> cannot
+    /// append — the write-capable narrowing lives on
+    /// <see cref="IDocumentSessionOperations.Events" />, mirroring the split the products already
+    /// draw between their own query and document sessions.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default for the same reason the <see cref="LoadAsync{T}(object,CancellationToken)" />
+    /// overload does: a store picks up a new JasperFx without a compile break and adopts the member
+    /// when it is ready. ⚠️ A store whose session already has an <c>Events</c> property of its own
+    /// product type does <em>not</em> implicitly satisfy this — C# interface implementation is not
+    /// return-type covariant, so a near-miss silently binds to this default instead of failing to
+    /// compile. A one-line explicit implementation is what closes it, and the shared compliance
+    /// suite is what proves it closed.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="NotSupportedException">
+    /// From the default implementation only, when the store has not implemented this member.
+    /// </exception>
+    IQueryEventStore Events
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement {nameof(IDocumentReadOperations)}.{nameof(Events)}, so the event store cannot be reached from a session this store opened. Note that C# interface implementation is not return-type covariant: a session declaring an Events property of the product's own event-store type does not satisfy this member, and needs a one-line explicit implementation forwarding to it.");
+
+    /// <summary>
     /// Load a single document by its <see cref="Guid" /> identity, or <see langword="null" /> when
     /// no document exists with that identity.
     /// </summary>

--- a/src/JasperFx.Events/Documents/IDocumentSessionOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentSessionOperations.cs
@@ -11,6 +11,36 @@ namespace JasperFx.Events.Documents;
 public interface IDocumentSessionOperations : IDocumentWriteOperations
 {
     /// <summary>
+    /// The full event store API for this session — read, append, and the aggregate-handler workflow.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Narrows <see cref="IDocumentReadOperations.Events" /> from <see cref="IQueryEventStore" /> to
+    /// <see cref="IEventStoreOperations" />, exactly as Marten narrows its own <c>Events</c> from
+    /// <c>IQuerySession</c> to <c>IDocumentOperations</c>. Appending belongs to the committable tier
+    /// because the append has to ride the session's unit of work: whoever can append is whoever can
+    /// <see cref="SaveChangesAsync" />.
+    /// </para>
+    /// <para>
+    /// Note that <see cref="IDocumentWriteOperations" /> — the tier a projection's
+    /// <c>RaiseSideEffects</c> receives — deliberately does <em>not</em> carry the narrowing. A
+    /// projection may write documents but must not append events or commit; the daemon owns both.
+    /// </para>
+    /// <para>
+    /// Same throwing default and the same non-covariance trap as the read tier; see
+    /// <see cref="IDocumentReadOperations.Events" />. Implementing one tier does not implement the
+    /// other — a store that satisfies only this one still throws when the session is held as
+    /// <see cref="IDocumentReadOperations" />.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="NotSupportedException">
+    /// From the default implementation only, when the store has not implemented this member.
+    /// </exception>
+    new IEventStoreOperations Events
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement {nameof(IDocumentSessionOperations)}.{nameof(Events)}, so events cannot be appended through a session this store opened. Note that C# interface implementation is not return-type covariant: a session declaring an Events property of the product's own event-store type does not satisfy this member, and needs a one-line explicit implementation forwarding to it.");
+
+    /// <summary>
     /// Commit every pending change enlisted in this session's unit of work as a single transaction.
     /// </summary>
     /// <remarks>

--- a/src/JasperFx.Events/IEventBinarySerializer.cs
+++ b/src/JasperFx.Events/IEventBinarySerializer.cs
@@ -1,0 +1,49 @@
+namespace JasperFx.Events;
+
+/// <summary>
+/// Pluggable binary serializer for event data — lets individual event types opt out of the store's
+/// JSON format in favor of a binary wire format (MessagePack, MemoryPack, compressed JSON, …).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Originated in Marten (marten#4515) and promoted here so one serializer implementation serves
+/// every Critter Stack store. A consumer that compiles the same source against more than one store —
+/// the shape the document contracts already exist for — would otherwise need a separate,
+/// per-store-namespaced copy of an identical two-method class per flavour, which is the concrete
+/// cost this move removes.
+/// </para>
+/// <para>
+/// The contract is deliberately only these two methods. Everything else about the feature is a
+/// storage concern that differs per store and stays there: which column carries the bytes, how a
+/// row records that it is binary rather than JSON, and how the serializer for a given event type is
+/// resolved at registration time.
+/// </para>
+/// <para>
+/// One property of the storage design is worth stating here because it is what makes the feature
+/// adoptable at all, and an implementing store should preserve it: JSON rows and binary rows coexist
+/// in the same event table on a per-event-type basis, keyed off whether the binary column is null.
+/// Turning a single event type binary is therefore an in-place change with no migration of existing
+/// event data — previously written JSON rows keep reading through the JSON path forever.
+/// </para>
+/// <para>
+/// ⚠️ A serializer is part of a store's read path for as long as any row it wrote still exists.
+/// Removing a registration does not make the old rows readable again — it makes them unreadable —
+/// so a serializer stays registered after the event type stops being written binary.
+/// </para>
+/// </remarks>
+public interface IEventBinarySerializer
+{
+    /// <summary>
+    /// Serialize an event data instance to bytes.
+    /// </summary>
+    /// <param name="type">The runtime CLR type of the event data.</param>
+    /// <param name="data">The event data to serialize.</param>
+    byte[] Serialize(Type type, object data);
+
+    /// <summary>
+    /// Deserialize bytes back into an event data instance.
+    /// </summary>
+    /// <param name="type">The target CLR type to deserialize into.</param>
+    /// <param name="data">The bytes previously produced by <see cref="Serialize" />.</param>
+    object Deserialize(Type type, byte[] data);
+}


### PR DESCRIPTION
Two independent changes, one per commit — happy to split into separate PRs if you'd rather review them apart. Both are additive: no existing store needs a code change to keep compiling.

Driven by CritterWatch's store decomposition (JasperFx/CritterWatch#999), and both are on the critical path for its 1.0.

---

## 1. `a4fbbee` — closes #669: an `Events` accessor on the document session contracts

A consumer that opens its own session through `IDocumentSessionFactory` had no store-agnostic route to the event store. Every product declares `Events` on **its own** session type, never on the shared contract, so the moment a consumer takes the store-agnostic route the event store becomes unreachable from the session it just opened.

The far side already existed — `IEventStoreOperations` for appends, `IQueryEventStore` for reads — so this is the route to it and nothing more.

Split across the two tiers the document contracts already draw, so a `QuerySession()` cannot append:

| tier | member |
|---|---|
| `IDocumentReadOperations` | `IQueryEventStore Events` |
| `IDocumentSessionOperations` | `new IEventStoreOperations Events` |

Deliberately **not** on `IDocumentWriteOperations` — that is the tier a projection's `RaiseSideEffects` receives, and a projection may write documents but must not append events or commit. The daemon owns both.

### Why it doesn't show up in the handler case

It doesn't bite chain parameters at all: wolverine#3956 (6.28.2) lets a handler take `IEventStoreOperations` directly and Wolverine fills it from the chain's own session. It bites the two shapes where the *consumer*, not Wolverine, decides when a session exists — a background/timer publisher that opens a session and appends, and a deliberate second read session opened alongside a chain's writing session.

### ⚠️ The trap the default creates, and why the compliance suite is the real deliverable

Both members carry the throwing default the contract established for `LoadAsync<T>(object)`, so no store breaks on upgrade. But **C# interface implementation is not return-type covariant**, so a session that already declares an `Events` property of the product's own event-store type does *not* satisfy the member — it silently binds to the throwing default instead, with **no compile error anywhere**.

Measured against the three stores as they stand today:

| store | read tier | write tier |
|---|---|---|
| Marten | `IQuerySession.Events` is already exactly `IQueryEventStore` — satisfied as-is | `IDocumentOperations.Events` is `Marten.Events.IEventStoreOperations` — needs the one-line explicit impl |
| Polecat | `IQuerySession.Events` already exactly `IQueryEventStore` — satisfied as-is | `Polecat.Events.IEventOperations` — needs the one-line explicit impl |
| Fisher | `IQuerySession` has **no** `Events` at all | `EventOperations` (a class) — needs the one-line explicit impl |

Store-side PRs follow.

`DocumentSessionEventsCompliance` is **opt-in** rather than folded into `DocumentSessionCompliance`, because it is the one document suite that requires the store to be an event store too. The in-memory reference store in `EventStoreTests` is a document-only implementer and correctly stays on the throwing default — it still passes 121/121 untouched, which is the evidence that the default does its job.

The suite asserts the *route*, not the event store behind it: reachability through a **contract-typed** local (binding the local to the product's own session type is exactly the mistake that makes the non-covariance trap invisible), that appends ride the session's unit of work rather than writing straight through, that documents and events written through one session commit together, and that events read back.

---

## 2. `d45ec16` — promote `IEventBinarySerializer` and `[BinaryEvent]` to `JasperFx.Events`

Prerequisite for JasperFx/polecat#475 and JasperFx/fisher#93.

Binary event serialization originated in Marten (JasperFx/marten#4515) and is store-namespaced, so a consumer compiling one body of source against several stores needs a separate, identical copy of every serializer per flavour. CritterWatch has exactly that today — `MessagePackEventSerializer.Marten.cs` and `CompressedJsonEventSerializer.Marten.cs` are excluded from its Polecat and Fisher flavours — so its measured **904 → 19 KB/min** win is Marten-only. Promoting the two-method interface lets one serializer serve every store.

The attribute comes along for the same reason: attributes are applied to event *types*, and event types are precisely what such a consumer shares, so a store-namespaced attribute is unusable in the code that most wants it. Promoting the interface alone would have left the feature reachable store-agnostically through registration but not through declaration.

**Marten keeps `Marten.Events.IEventBinarySerializer` deriving from this one**, so existing implementations continue to satisfy both it and any widened API — additive for every current consumer.

### The compliance suite

`BinaryEventSerializationCompliance` is the definition Polecat and Fisher implement against. Opt-in: the two new `IComplianceStoreRegistrar` members carry throwing defaults, so a store without binary storage does not enroll, never reaches them, and still compiles against this package.

Its serializer **gzips** the UTF8 JSON deliberately. A serializer emitting plain JSON would round-trip identically whether the store honored it or quietly fell back to its own JSON path, so every fact would pass against a store that implemented nothing. It also asserts the serializer was actually *called*, and that JSON and binary events coexist in one stream — the property that makes turning a single event type binary an in-place change with no data migration.

Which column carries the bytes and how a row marks itself binary are left **unasserted**: both are genuinely per-store, and pinning either would encode Marten's schema as the contract rather than the behavior.

---

## Gates

- Full `jasperfx.slnx` build: 0 errors
- `EventStoreTests`: 121/121, net9.0