### PR TITLE
gh-673: expose a session's pending stream actions on the document contract

### DIFF
--- a/src/EventStoreTests/Documents/DocumentComplianceConfigTests.cs
+++ b/src/EventStoreTests/Documents/DocumentComplianceConfigTests.cs
@@ -36,6 +36,19 @@ public class DocumentComplianceConfigTests
         config.StreamIdentity.ShouldBe(StreamIdentity.AsString);
     }
 
+    /// <remarks>
+    /// The other suite that appends by stream key, and the one most likely to be added without the
+    /// declaration — it was written before jasperfx#672 gave it anywhere to say this.
+    /// </remarks>
+    [Fact]
+    public void the_pending_stream_actions_suite_declares_string_stream_identity()
+    {
+        var config = new DocumentComplianceConfig();
+        ExposedPendingStreamActionsCompliance.TheConfiguration(config);
+
+        config.StreamIdentity.ShouldBe(StreamIdentity.AsString);
+    }
+
     [Fact]
     public void a_document_only_suite_leaves_stream_identity_alone()
     {
@@ -54,6 +67,13 @@ public class DocumentComplianceConfigTests
     {
         public static readonly Action<DocumentComplianceConfig> TheConfiguration =
             new ExposedDocumentSessionEventsCompliance().Configuration;
+    }
+
+    private class ExposedPendingStreamActionsCompliance
+        : PendingStreamActionsCompliance<InMemoryDocumentComplianceFixture>
+    {
+        public static readonly Action<DocumentComplianceConfig> TheConfiguration =
+            new ExposedPendingStreamActionsCompliance().Configuration;
     }
 
     private class ExposedDocumentSessionCompliance

--- a/src/EventStoreTests/Documents/DocumentSessionOperationsDefaultsTests.cs
+++ b/src/EventStoreTests/Documents/DocumentSessionOperationsDefaultsTests.cs
@@ -1,0 +1,62 @@
+using System.Linq.Expressions;
+using JasperFx.Events;
+using JasperFx.Events.Documents;
+using Shouldly;
+
+namespace EventStoreTests.Documents;
+
+/// <summary>
+/// The default implementation of <see cref="IDocumentSessionOperations.PendingStreams" />
+/// (jasperfx#673).
+/// </summary>
+/// <remarks>
+/// <see cref="InMemoryDocumentStore" /> is a document-only reference implementation with no event
+/// store behind it, so it leaves this member on the default and never enrolls
+/// <c>PendingStreamActionsCompliance</c> — which is exactly why the default needs its own test. What
+/// is asserted is that it throws rather than answering empty: an empty list is indistinguishable
+/// from a session with nothing pending, so a silent default would leave a consumer's work quietly
+/// discarded on a store that had not implemented the member.
+/// </remarks>
+public class DocumentSessionOperationsDefaultsTests
+{
+    private readonly IDocumentSessionOperations theSession = new NotYetOverriddenSession();
+
+    [Fact]
+    public void pending_streams_throws_rather_than_answering_with_an_empty_list()
+    {
+        var ex = Should.Throw<NotSupportedException>(() => theSession.PendingStreams);
+
+        ex.Message.ShouldContain(typeof(NotYetOverriddenSession).FullName!);
+        ex.Message.ShouldContain(nameof(IDocumentSessionOperations.PendingStreams));
+    }
+
+    /// <summary>
+    /// Implements only what the contract has no default for, so it is the shape a store has on the
+    /// day it takes the JasperFx bump and before it writes the forwarding member.
+    /// </summary>
+    private class NotYetOverriddenSession : IDocumentSessionOperations
+    {
+        public Task<T?> LoadAsync<T>(Guid id, CancellationToken token = default) where T : notnull
+            => throw new NotImplementedException();
+
+        public Task<T?> LoadAsync<T>(string id, CancellationToken token = default) where T : notnull
+            => throw new NotImplementedException();
+
+        public IQueryable<T> Query<T>() where T : notnull => throw new NotImplementedException();
+
+        public void Store<T>(params T[] entities) where T : notnull => throw new NotImplementedException();
+
+        public void Delete<T>(T entity) where T : notnull => throw new NotImplementedException();
+
+        public void Delete<T>(Guid id) where T : notnull => throw new NotImplementedException();
+
+        public void Delete<T>(string id) where T : notnull => throw new NotImplementedException();
+
+        public void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
+            => throw new NotImplementedException();
+
+        public Task SaveChangesAsync(CancellationToken token = default) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => default;
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -162,6 +162,8 @@ alongside the event store — `JasperFx.Events.Documents`:
 | `Store` and `LoadAsync` — `Guid`, `string` and strong-typed identities | `DocumentLoadAndStoreCompliance` |
 | `Delete`, its identity overloads, and `DeleteWhere` | `DocumentDeleteCompliance` |
 | `Query<T>()`, its minimum translatable operator set, and the async terminators | `DocumentQueryCompliance` |
+| The route from a session to its event store | `DocumentSessionEventsCompliance` |
+| The stream actions a session has queued but not committed | `PendingStreamActionsCompliance` |
 
 Enrollment is deliberately much cheaper than the event side. `DocumentStorageComplianceFixture` has
 **three** abstract members — build a store, hand back an `IDocumentSessionFactory`, wipe the data —
@@ -180,6 +182,15 @@ public class my_document_fixture : DocumentStorageComplianceFixture
 
 public class document_query_compliance : DocumentQueryCompliance<my_document_fixture>;
 ```
+
+The last two rows are opt-in: alone among the document suites they need the store to be an *event*
+store as well, so a document-only implementer simply does not enroll them. Both members they cover —
+`IDocumentReadOperations.Events` / `IDocumentSessionOperations.Events` (jasperfx#669) and
+`IDocumentSessionOperations.PendingStreams` (jasperfx#673) — ship with throwing defaults, and both
+are reachable by a near-miss that the compiler does not catch: C# interface implementation is not
+return-type covariant, so a session already declaring a member of the same name with the product's
+own type binds to the default instead of implementing the contract. Only a test calling through a
+contract-typed session notices.
 
 `BuildStoreAsync` must honor `config.ValueTypes` as well as `config.DocumentTypes` — every store
 spells that `options.RegisterValueType(type)`. It is what lets `DocumentLoadAndStoreCompliance` hold

--- a/src/JasperFx.Events.ComplianceTests/Suites/PendingStreamActionsCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/PendingStreamActionsCompliance.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// <see cref="IDocumentSessionOperations.PendingStreams" /> — the stream actions a session has
+/// queued but not yet committed (jasperfx#673).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Opt-in for the same reason as <see cref="DocumentSessionEventsCompliance{TFixture}" />, and it
+/// reuses that suite's event types and stream marker: there are no pending stream actions without an
+/// event store, so a document-only implementer leaves the member on its throwing default and does
+/// not enroll here. A store adopting jasperfx#669 but not yet jasperfx#673 enrolls the other suite
+/// and not this one.
+/// </para>
+/// <para>
+/// The accessor exists for code that did <em>not</em> do the appending — a listener, or a pre-commit
+/// hook deciding something from what the session is about to write. Code at the call site already
+/// has the <see cref="StreamAction" />, because <c>StartStream</c> and <c>Append</c> return it. So
+/// every fact here reads the collection through a contract-typed session, never through a return
+/// value.
+/// </para>
+/// <para>
+/// ⚠️ The first fact is the one that catches the silent failure. The contract's default throws
+/// rather than answering empty precisely because empty is indistinguishable from a session with
+/// nothing pending — a store that returned empty instead of implementing the member would pass any
+/// suite written the other way round and still drop every consumer's work.
+/// </para>
+/// </remarks>
+public abstract class PendingStreamActionsCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+        config.AddDocumentType<ComplianceWidget>();
+        config.AddEventType<KilnFired>();
+        config.AddEventType<KilnCooled>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    [Fact]
+    public async Task a_session_with_nothing_enlisted_has_no_pending_streams()
+    {
+        await using var session = LightweightSession();
+
+        // Empty, and specifically not a throw: the contract's default throws, so a store that has
+        // not implemented the member fails here rather than anywhere subtler.
+        session.PendingStreams.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task enlisting_documents_alone_does_not_produce_a_pending_stream()
+    {
+        await using var session = LightweightSession();
+        session.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Flange" });
+
+        session.PendingStreams.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_started_stream_is_pending_before_the_commit()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+
+        await using var session = LightweightSession();
+        session.Events.StartStream<ComplianceKiln>(streamKey, new KilnFired("North Ridge"));
+
+        var action = session.PendingStreams.ShouldHaveSingleItem();
+
+        action.Key.ShouldBe(streamKey);
+        action.Events.Select(x => x.Data).ShouldBe(new object[] { new KilnFired("North Ridge") });
+    }
+
+    [Fact]
+    public async Task pending_streams_carry_every_event_enlisted_for_a_stream_in_order()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+
+        await using var session = LightweightSession();
+        session.Events.StartStream<ComplianceKiln>(streamKey, new KilnFired("South Ridge"));
+        session.Events.Append(streamKey, new KilnCooled(120));
+
+        var action = session.PendingStreams.ShouldHaveSingleItem();
+
+        action.Key.ShouldBe(streamKey);
+        action.Events.Select(x => x.Data.GetType())
+            .ShouldBe(new[] { typeof(KilnFired), typeof(KilnCooled) });
+    }
+
+    [Fact]
+    public async Task several_streams_are_all_pending_together()
+    {
+        var first = Guid.NewGuid().ToString();
+        var second = Guid.NewGuid().ToString();
+
+        await using var session = LightweightSession();
+        session.Events.StartStream<ComplianceKiln>(first, new KilnFired("East Ridge"));
+        session.Events.StartStream<ComplianceKiln>(second, new KilnFired("West Ridge"));
+
+        session.PendingStreams.Select(x => x.Key).OrderBy(x => x)
+            .ShouldBe(new[] { first, second }.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task appending_to_an_existing_stream_is_pending_too()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+
+        await using (var setup = LightweightSession())
+        {
+            setup.Events.StartStream<ComplianceKiln>(streamKey, new KilnFired("Old Kiln"));
+            await setup.SaveChangesAsync(Cancellation);
+        }
+
+        await using var session = LightweightSession();
+        session.Events.Append(streamKey, new KilnCooled(90));
+
+        var action = session.PendingStreams.ShouldHaveSingleItem();
+
+        action.Key.ShouldBe(streamKey);
+        action.Events.Select(x => x.Data).ShouldBe(new object[] { new KilnCooled(90) });
+    }
+
+    [Fact]
+    public async Task committing_clears_the_pending_streams()
+    {
+        var streamKey = Guid.NewGuid().ToString();
+
+        await using var session = LightweightSession();
+        session.Events.StartStream<ComplianceKiln>(streamKey, new KilnFired("Kiln Two"));
+        session.PendingStreams.ShouldNotBeEmpty();
+
+        await session.SaveChangesAsync(Cancellation);
+
+        // A session is reusable after a commit, so a collection that still held the committed
+        // actions would double-count them on the next read.
+        session.PendingStreams.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task pending_streams_are_reported_per_session()
+    {
+        var mine = Guid.NewGuid().ToString();
+        var theirs = Guid.NewGuid().ToString();
+
+        await using var one = LightweightSession();
+        await using var two = LightweightSession();
+
+        one.Events.StartStream<ComplianceKiln>(mine, new KilnFired("Mine"));
+        two.Events.StartStream<ComplianceKiln>(theirs, new KilnFired("Theirs"));
+
+        one.PendingStreams.ShouldHaveSingleItem().Key.ShouldBe(mine);
+        two.PendingStreams.ShouldHaveSingleItem().Key.ShouldBe(theirs);
+    }
+
+    /// <remarks>
+    /// Split out from the facts above so that a store can gate it alone. Everything else here is
+    /// about which actions are present and what they carry; this is the one assertion on
+    /// <see cref="StreamActionType" />, which a consumer needs in order to tell a new stream from an
+    /// append without going back to the database.
+    /// </remarks>
+    [Fact]
+    public async Task a_pending_stream_reports_whether_it_starts_a_stream_or_appends()
+    {
+        var existing = Guid.NewGuid().ToString();
+        var fresh = Guid.NewGuid().ToString();
+
+        await using (var setup = LightweightSession())
+        {
+            setup.Events.StartStream<ComplianceKiln>(existing, new KilnFired("Existing"));
+            await setup.SaveChangesAsync(Cancellation);
+        }
+
+        await using var session = LightweightSession();
+        session.Events.StartStream<ComplianceKiln>(fresh, new KilnFired("Fresh"));
+        session.Events.Append(existing, new KilnCooled(60));
+
+        var byKey = session.PendingStreams.ToDictionary(x => x.Key!);
+
+        byKey[fresh].ActionType.ShouldBe(StreamActionType.Start);
+        byKey[existing].ActionType.ShouldBe(StreamActionType.Append);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/PendingStreamActionsCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/PendingStreamActionsCompliance.cs
@@ -39,6 +39,13 @@ public abstract class PendingStreamActionsCompliance<TFixture> : DocumentStorage
     private static readonly Action<DocumentComplianceConfig> _configuration = config =>
     {
         config.SchemaName = "compliance_documents";
+
+        // Same declaration, and for the same reason, as DocumentSessionEventsCompliance: every fact
+        // below appends by stream *key*, so the store has to be configured for string stream
+        // identity, and a suite that leaves a precondition unstated fails a store that implements
+        // the contract correctly. See jasperfx#672.
+        config.StreamIdentity = StreamIdentity.AsString;
+
         config.AddDocumentType<ComplianceWidget>();
         config.AddEventType<KilnFired>();
         config.AddEventType<KilnCooled>();

--- a/src/JasperFx.Events/Documents/IDocumentSessionOperations.cs
+++ b/src/JasperFx.Events/Documents/IDocumentSessionOperations.cs
@@ -41,6 +41,57 @@ public interface IDocumentSessionOperations : IDocumentWriteOperations
             $"{GetType().FullName} does not implement {nameof(IDocumentSessionOperations)}.{nameof(Events)}, so events cannot be appended through a session this store opened. Note that C# interface implementation is not return-type covariant: a session declaring an Events property of the product's own event-store type does not satisfy this member, and needs a one-line explicit implementation forwarding to it.");
 
     /// <summary>
+    /// The <see cref="StreamAction" />s this session has queued but not yet committed — every
+    /// <c>StartStream</c> and <c>Append</c> enlisted through <see cref="Events" /> since the last
+    /// <see cref="SaveChangesAsync" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The payload type was already shared; only the spelling of the accessor diverged — Marten's
+    /// <c>PendingChanges.Streams()</c>, Polecat's <c>PendingChanges.Streams</c>, and Fisher's
+    /// <c>Events.PendingStreams</c>, with no <c>PendingChanges</c> facade at all. So this closes a
+    /// naming gap rather than a capability gap, and each store satisfies it by forwarding to what it
+    /// already has. See <see href="https://github.com/JasperFx/jasperfx/issues/673" />.
+    /// </para>
+    /// <para>
+    /// Only the streams — deliberately not a whole unit-of-work facade. The three products' change
+    /// sets diverge well past this one collection, and the measured consumer need is to read what
+    /// the session is about to append, typically from a listener or a pre-commit hook deciding
+    /// something from the events already enlisted. Pending <em>document</em> operations are not
+    /// exposed here and are not in scope; a consumer needing those takes a dependency on a concrete
+    /// store.
+    /// </para>
+    /// <para>
+    /// Committable tier for the same reason <see cref="Events" /> is: a stream action can only be
+    /// pending in a session that can append, and appending is
+    /// <see cref="IDocumentSessionOperations" />, never
+    /// <see cref="IDocumentWriteOperations" />. A projection's <c>RaiseSideEffects</c> holds the
+    /// tier below and has no pending streams to read.
+    /// </para>
+    /// <para>
+    /// The list reflects the session at the moment it is read; a store may hand back a snapshot or a
+    /// live view, so a caller that needs stability across further appends should copy it. What is
+    /// pinned is that it is empty for a session with nothing enlisted, that it carries the actions
+    /// enlisted since the last commit, and that committing clears it.
+    /// </para>
+    /// <para>
+    /// ⚠️ Throwing default, and here the choice matters more than it did for <see cref="Events" />:
+    /// a default returning an empty list is indistinguishable from a session that genuinely has
+    /// nothing pending, so a store that had not implemented the member would silently drop whatever
+    /// the consumer derives from these actions — clean build, green tests, no events. The same
+    /// non-covariance trap applies as well: a session already declaring its own pending-streams
+    /// member of a product-specific shape does not satisfy this one, and needs an explicit
+    /// implementation forwarding to it.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="NotSupportedException">
+    /// From the default implementation only, when the store has not implemented this member.
+    /// </exception>
+    IReadOnlyList<StreamAction> PendingStreams
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement {nameof(IDocumentSessionOperations)}.{nameof(PendingStreams)}, so the stream actions queued in this session cannot be read. This member deliberately throws rather than answering with an empty list, because an empty list is indistinguishable from a session with nothing pending and would silently discard whatever the caller derives from the pending events.");
+
+    /// <summary>
     /// Commit every pending change enlisted in this session's unit of work as a single transaction.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
Closes #673.

Adds `IDocumentSessionOperations.PendingStreams` — the `StreamAction`s a session has queued but not yet committed.

## The gap

All three stores already surface the *same* `JasperFx.Events.StreamAction` collection; only the spelling of the accessor differs:

| store | spelling |
|---|---|
| Marten | `PendingChanges.Streams()` |
| Polecat | `PendingChanges.Streams` |
| Fisher | `Events.PendingStreams` (no `PendingChanges` facade) |

So each store satisfies the new member by forwarding to what it already has.

## Decisions worth reviewing

**Committable tier**, for the same reason `Events` is (#669): a stream action can only be pending in a session that can append, and `IDocumentWriteOperations` — the tier a projection's `RaiseSideEffects` receives — cannot append or commit.

**Only the streams**, deliberately not a `PendingChanges` / unit-of-work facade. The three products' change sets diverge well past this one collection, and pending *document* operations are not exposed. The measured need is reading what the session is about to append.

**Throwing default, not an empty one**, per the ⚠️ constraint on the issue. An empty default is indistinguishable from a session with nothing pending, so a store that had not implemented the member would silently drop whatever the consumer derives from these actions. Matches the `LoadAsync<T>(object)` (#665) and `Events` (#669) precedent.

The accessor is for code that did *not* do the appending — `StartStream` and `Append` already return the `StreamAction` at the call site. Every compliance fact therefore reads the collection through a contract-typed session rather than a return value.

## Compliance

`PendingStreamActionsCompliance` is what holds stores to the behavior once the compiler stops. Opt-in, and it reuses `DocumentSessionEventsCompliance`'s event types and stream marker, because there are no pending stream actions without an event store — a document-only implementer does not enroll.

The load-bearing fact is the first one: an empty collection on a fresh session, which a store still on the throwing default cannot produce. The one assertion on `StreamActionType` is split into its own fact so it can be gated alone if a store disagrees about it.

`DocumentSessionOperationsDefaultsTests` covers the default itself, which no real store executes and which the compliance suite never reaches (the in-memory reference store in `EventStoreTests` is document-only).

## Downstream

Marten, Polecat and Fisher each need a one-line forwarding member; none breaks on the bump. Same non-covariance trap as #669 — a session already declaring a pending-streams member of a product-specific shape binds to the default rather than failing to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)