### PR TITLE
gh-674: move IAggregateWriteCache into JasperFx.Events

### DIFF
--- a/src/EventTests/Fetching/AggregateWriteCacheTests.cs
+++ b/src/EventTests/Fetching/AggregateWriteCacheTests.cs
@@ -1,0 +1,316 @@
+using JasperFx.Events;
+using JasperFx.Events.Fetching;
+using Shouldly;
+
+namespace EventTests.Fetching;
+
+public class RecentlyUsedAggregateWriteCacheTests
+{
+    private readonly RecentlyUsedAggregateWriteCache theCache = new();
+
+    private static AggregateCacheKey keyFor(object id, string tenantId = "*default*", string database = "db-1")
+        => new(typeof(Basket), database, tenantId, id);
+
+    [Fact]
+    public void a_take_against_an_empty_cache_misses()
+    {
+        theCache.TryTake(keyFor(Guid.NewGuid()), out var aggregate, out var version).ShouldBeFalse();
+
+        aggregate.ShouldBeNull();
+        version.ShouldBe(0);
+    }
+
+    [Fact]
+    public void store_then_take_hands_back_the_same_instance_and_version()
+    {
+        var key = keyFor(Guid.NewGuid());
+        var basket = new Basket();
+
+        theCache.Store(key, basket, 12);
+
+        theCache.TryTake(key, out var aggregate, out var version).ShouldBeTrue();
+        aggregate.ShouldBeSameAs(basket);
+        version.ShouldBe(12);
+    }
+
+    /// <remarks>
+    /// Take-on-read is a contract requirement, not an implementation detail: a store folds delta
+    /// events onto the instance it is handed, so leaving the entry in place would let a second
+    /// caller mutate an aggregate someone else is already using.
+    /// </remarks>
+    [Fact]
+    public void a_take_removes_the_entry()
+    {
+        var key = keyFor(Guid.NewGuid());
+        theCache.Store(key, new Basket(), 3);
+
+        theCache.TryTake(key, out _, out _).ShouldBeTrue();
+        theCache.TryTake(key, out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void exactly_one_of_many_concurrent_takers_wins_an_entry()
+    {
+        var key = keyFor(Guid.NewGuid());
+        theCache.Store(key, new Basket(), 7);
+
+        var winners = 0;
+        Parallel.For(0, 64, i =>
+        {
+            if (theCache.TryTake(key, out _, out _))
+            {
+                Interlocked.Increment(ref winners);
+            }
+        });
+
+        winners.ShouldBe(1);
+    }
+
+    [Fact]
+    public void evict_drops_the_entry()
+    {
+        var key = keyFor(Guid.NewGuid());
+        theCache.Store(key, new Basket(), 4);
+
+        theCache.Evict(key);
+
+        theCache.TryTake(key, out _, out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void evicting_a_key_that_was_never_stored_is_a_no_op()
+    {
+        Should.NotThrow(() => theCache.Evict(keyFor(Guid.NewGuid())));
+    }
+
+    [Fact]
+    public void storing_the_same_key_twice_keeps_the_later_version()
+    {
+        var key = keyFor(Guid.NewGuid());
+        var second = new Basket();
+
+        theCache.Store(key, new Basket(), 1);
+        theCache.Store(key, second, 2);
+
+        theCache.TryTake(key, out var aggregate, out var version).ShouldBeTrue();
+        aggregate.ShouldBeSameAs(second);
+        version.ShouldBe(2);
+    }
+
+    [Fact]
+    public void hits_and_misses_are_counted()
+    {
+        var key = keyFor(Guid.NewGuid());
+        theCache.Store(key, new Basket(), 1);
+
+        theCache.TryTake(key, out _, out _);
+        theCache.TryTake(key, out _, out _);
+
+        theCache.Hits.ShouldBe(1);
+        theCache.Misses.ShouldBe(1);
+    }
+
+    [Fact]
+    public void the_size_limit_is_honored()
+    {
+        var cache = new RecentlyUsedAggregateWriteCache(5);
+
+        var keys = Enumerable.Range(0, 50).Select(_ => keyFor(Guid.NewGuid())).ToArray();
+        foreach (var key in keys)
+        {
+            cache.Store(key, new Basket(), 1);
+        }
+
+        var surviving = keys.Count(key => cache.TryTake(key, out _, out _));
+
+        // The eviction policy itself is not the contract -- only that the cache stays bounded, so
+        // an aggregate cache on a long-lived node cannot grow without limit.
+        surviving.ShouldBeLessThanOrEqualTo(5);
+    }
+
+    [Fact]
+    public void a_size_limit_with_no_room_for_an_entry_is_rejected()
+    {
+        // Silently caching nothing would look like a store that ignored the opt-in.
+        Should.Throw<ArgumentOutOfRangeException>(() => new RecentlyUsedAggregateWriteCache(0));
+    }
+
+    [Fact]
+    public void storing_a_null_aggregate_is_rejected()
+    {
+        Should.Throw<ArgumentNullException>(() => theCache.Store(keyFor(Guid.NewGuid()), null!, 1));
+    }
+}
+
+public class AggregateCacheKeyTests
+{
+    private readonly Guid theId = Guid.NewGuid();
+
+    [Fact]
+    public void the_same_four_parts_are_the_same_key()
+    {
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", theId)
+            .ShouldBe(new AggregateCacheKey(typeof(Basket), "db-1", "acme", theId));
+    }
+
+    [Fact]
+    public void a_different_tenant_is_a_different_key()
+    {
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", theId)
+            .ShouldNotBe(new AggregateCacheKey(typeof(Basket), "db-1", "globex", theId));
+    }
+
+    /// <remarks>
+    /// The database is in the key so that database-per-tenant deployments, where the same tenant id
+    /// and stream id exist in more than one physical database, cannot collide.
+    /// </remarks>
+    [Fact]
+    public void a_different_database_is_a_different_key()
+    {
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", theId)
+            .ShouldNotBe(new AggregateCacheKey(typeof(Basket), "db-2", "acme", theId));
+    }
+
+    [Fact]
+    public void a_different_document_type_is_a_different_key()
+    {
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", theId)
+            .ShouldNotBe(new AggregateCacheKey(typeof(Order), "db-1", "acme", theId));
+    }
+
+    [Fact]
+    public void a_different_identity_is_a_different_key()
+    {
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", theId)
+            .ShouldNotBe(new AggregateCacheKey(typeof(Basket), "db-1", "acme", Guid.NewGuid()));
+    }
+
+    /// <remarks>
+    /// Identity is boxed, so equality runs through <c>EqualityComparer&lt;object&gt;.Default</c>.
+    /// That is structural for the three identity shapes a store supports — Guid, string, and a
+    /// strong-typed wrapper over either — which is what makes a cache hit possible at all for a
+    /// stream fetched twice.
+    /// </remarks>
+    [Fact]
+    public void boxed_identities_compare_structurally()
+    {
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", "basket-1")
+            .ShouldBe(new AggregateCacheKey(typeof(Basket), "db-1", "acme", string.Concat("basket", "-1")));
+
+        new AggregateCacheKey(typeof(Basket), "db-1", "acme", new BasketId(theId))
+            .ShouldBe(new AggregateCacheKey(typeof(Basket), "db-1", "acme", new BasketId(theId)));
+    }
+}
+
+public class NulloAggregateWriteCacheTests
+{
+    [Fact]
+    public void never_hits_no_matter_what_was_stored()
+    {
+        var cache = NulloAggregateWriteCache.Instance;
+        var key = new AggregateCacheKey(typeof(Basket), "db-1", "acme", Guid.NewGuid());
+
+        cache.Store(key, new Basket(), 5);
+
+        cache.TryTake(key, out var aggregate, out var version).ShouldBeFalse();
+        aggregate.ShouldBeNull();
+        version.ShouldBe(0);
+    }
+}
+
+public class AggregateWriteCacheOptionsTests
+{
+    private readonly AggregateWriteCacheOptions theOptions = new();
+
+    [Fact]
+    public void caching_is_off_for_every_type_until_something_opts_in()
+    {
+        theOptions.IsEnabledForAnyType.ShouldBeFalse();
+        theOptions.IsEnabled(typeof(Basket)).ShouldBeFalse();
+        theOptions.EnabledTypes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_type_nobody_enrolled_resolves_to_the_nullo_cache()
+    {
+        theOptions.Enable(typeof(Basket));
+
+        theOptions.ResolveCache(typeof(Order)).ShouldBeOfType<NulloAggregateWriteCache>();
+    }
+
+    [Fact]
+    public void an_enrolled_type_resolves_to_the_real_cache()
+    {
+        theOptions.Enable(typeof(Basket));
+
+        theOptions.ResolveCache(typeof(Basket)).ShouldBeOfType<RecentlyUsedAggregateWriteCache>();
+    }
+
+    [Fact]
+    public void every_enrolled_type_shares_one_cache_instance()
+    {
+        theOptions.Enable(typeof(Basket));
+        theOptions.Enable(typeof(Order));
+
+        theOptions.ResolveCache(typeof(Basket)).ShouldBeSameAs(theOptions.ResolveCache(typeof(Order)));
+    }
+
+    [Fact]
+    public void a_supplied_cache_wins_over_the_default()
+    {
+        var custom = new RecentlyUsedAggregateWriteCache(3);
+        theOptions.Cache = custom;
+        theOptions.Enable(typeof(Basket));
+
+        theOptions.ResolveCache(typeof(Basket)).ShouldBeSameAs(custom);
+    }
+
+    [Fact]
+    public void enabling_a_type_twice_is_harmless()
+    {
+        theOptions.Enable(typeof(Basket));
+        theOptions.Enable(typeof(Basket));
+
+        theOptions.EnabledTypes.ShouldHaveSingleItem().ShouldBe(typeof(Basket));
+    }
+}
+
+public class EventRegistryAggregateCachingTests
+{
+    private readonly EventRegistry theRegistry = new();
+
+    [Fact]
+    public void no_aggregate_type_is_cached_by_default()
+    {
+        theRegistry.AggregateWriteCaching.IsEnabledForAnyType.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void cache_aggregates_for_writing_enrolls_exactly_one_type()
+    {
+        theRegistry.CacheAggregatesForWriting<Basket>();
+
+        theRegistry.AggregateWriteCaching.IsEnabled(typeof(Basket)).ShouldBeTrue();
+        theRegistry.AggregateWriteCaching.IsEnabled(typeof(Order)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_size_limit_argument_reaches_the_options()
+    {
+        theRegistry.CacheAggregatesForWriting<Basket>(25);
+
+        theRegistry.AggregateWriteCaching.SizeLimit.ShouldBe(25);
+    }
+}
+
+public class Basket
+{
+    public Guid Id { get; set; }
+}
+
+public class Order
+{
+    public Guid Id { get; set; }
+}
+
+public readonly record struct BasketId(Guid Value);

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Projections;
 
 namespace JasperFx.Events.ComplianceTests;
@@ -163,6 +164,30 @@ public sealed class ComplianceStoreConfig
     {
         Snapshots.Add((typeof(TDoc), lifecycle));
         _registrations.Add(registrar => registrar.Snapshot<TDoc>(lifecycle));
+        return this;
+    }
+
+    /// <summary>
+    /// Aggregate types the suite enrolled in the <c>FetchForWriting</c> snapshot cache, with the
+    /// cache instance it wants the store to use.
+    /// </summary>
+    public List<(Type Doc, IAggregateWriteCache Cache)> CachedAggregates { get; } = new();
+
+    /// <summary>
+    /// Enroll an aggregate type in the second-level <c>FetchForWriting</c> snapshot cache. Off for
+    /// every type unless asked for, which is the behavior
+    /// <see cref="AggregateWriteCacheCompliance{TFixture,TOperations,TQuerySession}" /> asserts.
+    /// </summary>
+    /// <remarks>
+    /// The cache instance is supplied by the suite rather than left to the store so the suite can
+    /// see what the store actually did with it — a store that quietly ignored the opt-in would
+    /// otherwise pass every behavioral fact, since an uncached fetch is correct by construction.
+    /// </remarks>
+    public ComplianceStoreConfig CacheAggregatesForWriting<TDoc>(IAggregateWriteCache cache)
+        where TDoc : class
+    {
+        CachedAggregates.Add((typeof(TDoc), cache));
+        _registrations.Add(registrar => registrar.CacheAggregatesForWriting<TDoc>(cache));
         return this;
     }
 

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -1,4 +1,5 @@
 using System;
+using JasperFx.Events.Fetching;
 using JasperFx.Events.Projections;
 using JasperFx.Events.Tags;
 
@@ -54,6 +55,30 @@ public interface IComplianceStoreRegistrar
     /// Register a single stream snapshot projection for a self-aggregating type.
     /// </summary>
     void Snapshot<TDoc>(SnapshotLifecycle lifecycle) where TDoc : notnull;
+
+    /// <summary>
+    /// Enroll an aggregate type in the second-level <c>FetchForWriting</c> snapshot cache, using the
+    /// supplied cache instance so the suite can observe it. Maps to the shared
+    /// <c>EventRegistry.CacheAggregatesForWriting&lt;T&gt;()</c> plus
+    /// <c>EventRegistry.AggregateWriteCaching.Cache</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both halves are on the shared <see cref="EventRegistry" />, so an implementation is two
+    /// lines. It still comes through the registrar because the fixture is the only thing that knows
+    /// which options object the store hangs its event registry off.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default for the same reason as
+    /// <see cref="UseBinarySerializer{TEvent}" />: caching is an opt-in capability rather than part
+    /// of the baseline contract, so a store that has not wired it into its fetch plans does not
+    /// enroll in <see cref="AggregateWriteCacheCompliance{TFixture,TOperations,TQuerySession}" />,
+    /// never reaches this member, and keeps compiling against a newer compliance package.
+    /// </para>
+    /// </remarks>
+    void CacheAggregatesForWriting<TDoc>(IAggregateWriteCache cache) where TDoc : class
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement CacheAggregatesForWriting, so it cannot run the aggregate write cache compliance suite.");
 
     /// <summary>
     /// Register a live aggregation for a self-aggregating type. A no-op in stores that

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -99,6 +99,20 @@ public class dcb_tag_query_and_consistency_compliance
     : DcbTagQueryAndConsistencyCompliance<MyComplianceFixture, IDocumentOperations, IQuerySession>;
 ```
 
+### Opt-in capability suites
+
+Two suites cover capabilities that are opt-in rather than part of the baseline event contract, and
+their seam members on `IComplianceStoreRegistrar` carry throwing defaults: a store that has not
+implemented the capability does not enroll, never reaches the member, and keeps compiling.
+
+`AggregateWriteCacheCompliance` (jasperfx#674) is the newer of the two. `IAggregateWriteCache` is a
+*baseline-only* cache — the stream version and every event after the cached version are still read on
+every fetch — so the suite's job is to prove that turning it on is unobservable except in latency,
+including when the cached baseline is wrong. Note the shape of the load-bearing assertion: every
+correctness fact about caching is vacuously true of a store that ignored the opt-in entirely, so the
+suite supplies its own `RecordingAggregateWriteCache` and asserts a nonzero hit count. Same reasoning
+as the gzipped serializer in `BinaryEventSerializationCompliance`.
+
 ## Capability gates
 
 Where a store genuinely cannot support a behavior, override the `virtual bool Supports...` flags on
@@ -133,6 +147,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Session correlation / causation from `Activity` | `ActivityCorrelationCompliance` |
 | String stream identity, single stream projections | `StringIdentitySingleStreamCompliance` |
 | Write handles and stream concurrency | `FetchForWritingCompliance` |
+| The second-level `FetchForWriting` snapshot cache | `AggregateWriteCacheCompliance` |
 | Stream reads, time travel, stream state | `StreamReadCompliance` |
 | The `IEvent` envelope contract | `EventMetadataCompliance` |
 | Live aggregation, including last-known | `LiveAggregationCompliance` |

--- a/src/JasperFx.Events.ComplianceTests/RecordingAggregateWriteCache.cs
+++ b/src/JasperFx.Events.ComplianceTests/RecordingAggregateWriteCache.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Events.Fetching;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// An <see cref="IAggregateWriteCache" /> that records what the store asked of it, for
+/// <see cref="AggregateWriteCacheCompliance{TFixture,TOperations,TQuerySession}" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two things it makes possible that no purely behavioral suite could do.
+/// </para>
+/// <para>
+/// First, it proves the cache was <em>consulted</em>. Every correctness fact about caching is
+/// vacuously true of a store that ignored the opt-in entirely, because an uncached fetch is correct
+/// by construction. <see cref="Hits" /> is what tells the difference. Same reasoning as the gzipped
+/// serializer in <see cref="BinaryEventSerializationCompliance{TFixture}" />.
+/// </para>
+/// <para>
+/// Second, it hands the suite a real <see cref="AggregateCacheKey" /> to poison. The key carries the
+/// store's own database identifier and tenant resolution, so a suite cannot construct one — but it
+/// can capture the one the store stored and then <see cref="Seed" /> that key with a deliberately
+/// wrong baseline.
+/// </para>
+/// <para>
+/// Take-on-read and the size bound are delegated to the real
+/// <see cref="RecentlyUsedAggregateWriteCache" /> rather than reimplemented, so a store is held to
+/// the shipped implementation's semantics and not to a test double's.
+/// </para>
+/// </remarks>
+public class RecordingAggregateWriteCache: IAggregateWriteCache
+{
+    private readonly object _locker = new();
+    private readonly List<AggregateCacheKey> _stored = new();
+    private readonly List<AggregateCacheKey> _taken = new();
+    private RecentlyUsedAggregateWriteCache _inner = new();
+    private long _hits;
+    private long _misses;
+
+    /// <summary>
+    /// Successful takes — the count that separates a store which honored the opt-in from one that
+    /// silently did not.
+    /// </summary>
+    public long Hits
+    {
+        get { lock (_locker) { return _hits; } }
+    }
+
+    public long Misses
+    {
+        get { lock (_locker) { return _misses; } }
+    }
+
+    /// <summary>
+    /// Every key the store has written, in order. Duplicates are kept — a store writing the same
+    /// key twice in one round is worth being able to see.
+    /// </summary>
+    public IReadOnlyList<AggregateCacheKey> StoredKeys
+    {
+        get { lock (_locker) { return _stored.ToArray(); } }
+    }
+
+    /// <summary>
+    /// Every key the store has successfully taken, in order.
+    /// </summary>
+    public IReadOnlyList<AggregateCacheKey> TakenKeys
+    {
+        get { lock (_locker) { return _taken.ToArray(); } }
+    }
+
+    /// <summary>
+    /// The most recent key stored for a document type, or null when the store has never cached one.
+    /// </summary>
+    public AggregateCacheKey? LastKeyFor(Type documentType)
+    {
+        lock (_locker)
+        {
+            for (var i = _stored.Count - 1; i >= 0; i--)
+            {
+                if (_stored[i].DocumentType == documentType) return _stored[i];
+            }
+
+            return null;
+        }
+    }
+
+    public bool WasStoredFor(Type documentType) => LastKeyFor(documentType).HasValue;
+
+    /// <summary>
+    /// Plant an entry directly, bypassing the counters. The suite uses this to poison a key the
+    /// store previously stored — a stale baseline, or one ahead of the stream.
+    /// </summary>
+    public void Seed(AggregateCacheKey key, object aggregate, long version)
+    {
+        _inner.Store(key, aggregate, version);
+    }
+
+    /// <summary>
+    /// Drop every entry and reset the counters. Called between arrange and act so a fact asserts on
+    /// the round it is actually testing.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_locker)
+        {
+            _inner = new RecentlyUsedAggregateWriteCache();
+            _stored.Clear();
+            _taken.Clear();
+            _hits = 0;
+            _misses = 0;
+        }
+    }
+
+    public bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version)
+    {
+        var taken = _inner.TryTake(key, out aggregate, out version);
+
+        lock (_locker)
+        {
+            if (taken)
+            {
+                _hits++;
+                _taken.Add(key);
+            }
+            else
+            {
+                _misses++;
+            }
+        }
+
+        return taken;
+    }
+
+    public void Store(AggregateCacheKey key, object aggregate, long version)
+    {
+        _inner.Store(key, aggregate, version);
+
+        lock (_locker)
+        {
+            _stored.Add(key);
+        }
+    }
+
+    public void Evict(AggregateCacheKey key)
+    {
+        _inner.Evict(key);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/AggregateWriteCacheCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AggregateWriteCacheCompliance.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Fetching;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Aggregate write cache events and aggregates
+
+public record LedgerStarted(string Owner);
+
+public record AmountPosted(decimal Amount);
+
+public record AmountReversed(decimal Amount);
+
+/// <summary>
+/// Inline-snapshotted and enrolled in the cache. The aggregate is deliberately mutable, which is the
+/// shape the take-on-read requirement exists for.
+/// </summary>
+public partial class CachedLedger
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+
+    public static CachedLedger Create(LedgerStarted e) => new() { Owner = e.Owner };
+
+    public void Apply(AmountPosted e) => Balance += e.Amount;
+
+    public void Apply(AmountReversed e) => Balance -= e.Amount;
+}
+
+/// <summary>
+/// Identical to <see cref="CachedLedger" /> and deliberately <em>not</em> enrolled. Exists so the
+/// suite can assert that caching is off unless asked for, rather than store-wide.
+/// </summary>
+public partial class UncachedLedger
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+
+    public static UncachedLedger Create(LedgerStarted e) => new() { Owner = e.Owner };
+
+    public void Apply(AmountPosted e) => Balance += e.Amount;
+
+    public void Apply(AmountReversed e) => Balance -= e.Amount;
+}
+
+/// <summary>
+/// Async-snapshotted and enrolled. The daemon is never started in this suite, which is deliberate:
+/// it means the stored snapshot always lags the stream, so every fetch has real delta events to fold
+/// onto whatever baseline it starts from. That is the harder case for a cache and it needs no
+/// timing.
+/// </summary>
+public partial class CachedJournal
+{
+    public Guid Id { get; set; }
+    public string Owner { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+
+    public static CachedJournal Create(LedgerStarted e) => new() { Owner = e.Owner };
+
+    public void Apply(AmountPosted e) => Balance += e.Amount;
+
+    public void Apply(AmountReversed e) => Balance -= e.Amount;
+}
+
+#endregion
+
+/// <summary>
+/// The second-level aggregate snapshot cache behind <c>FetchForWriting</c> — jasperfx#674.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Opt-in: a store that has not wired <see cref="IAggregateWriteCache" /> into its fetch plans does
+/// not enroll, and never reaches
+/// <see cref="IComplianceStoreRegistrar.CacheAggregatesForWriting{TDoc}" />.
+/// </para>
+/// <para>
+/// <b>What the contract actually is.</b> The cache supplies a <em>baseline</em> and nothing more.
+/// The stream version and every event after the cached version are still read from the database on
+/// every call, and the concurrency assertion on append is untouched. So the suite's job is to prove
+/// that turning caching on is <em>unobservable</em> except in latency — that a fetch off a hit is
+/// indistinguishable from a fetch off a miss, including when the cached baseline is wrong.
+/// </para>
+/// <para>
+/// ⚠️ Every one of those facts is vacuously true of a store that ignored the opt-in altogether, and
+/// that is the failure mode most likely to ship. <see cref="RecordingAggregateWriteCache.Hits" /> is
+/// what separates the two, and
+/// <see cref="the_cache_is_actually_consulted_when_a_type_opts_in" /> is the fact holding it.
+/// </para>
+/// <para>
+/// ⛔ <b>Note what is deliberately absent.</b> There is no fact that a cache hit skips the version
+/// read, because it must not: a "trusted" cache that appended blind at the cached version was
+/// measured at 0.19 ms of a 13.2 ms round and is retired. If a future implementation makes
+/// <see cref="a_cached_baseline_cannot_suppress_a_concurrency_exception" /> fail, that is the
+/// feature being reintroduced, not a test needing a gate.
+/// </para>
+/// <para>
+/// <b>When an entry is written is not pinned.</b> The two lifecycles differ — an Async snapshot can
+/// be cached at fetch time, while an Inline snapshot is mutated by the projection during commit and
+/// so can only be cached once the commit succeeds. Both are correct, and the difference is
+/// observable: a fetch that appends nothing may never warm the cache at all. Every arrange step here
+/// therefore fetches, appends and commits, so it warms the cache under either policy.
+/// </para>
+/// </remarks>
+public abstract class AggregateWriteCacheCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly RecordingAggregateWriteCache _cache = new();
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_aggregate_cache";
+        config.Snapshot<CachedLedger>(SnapshotLifecycle.Inline);
+        config.Snapshot<UncachedLedger>(SnapshotLifecycle.Inline);
+        config.Snapshot<CachedJournal>(SnapshotLifecycle.Async);
+
+        // One shared cache instance across all three types, so the "not enrolled" assertion is about
+        // the store's opt-in check rather than about which cache it happened to be handed.
+        config.CacheAggregatesForWriting<CachedLedger>(_cache);
+        config.CacheAggregatesForWriting<CachedJournal>(_cache);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    protected RecordingAggregateWriteCache TheCache => _cache;
+
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        _cache.Reset();
+    }
+
+    private async Task<Guid> anOpenVaultAsync<T>(params object[] events) where T : class
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var all = new List<object> { new LedgerStarted("Hilda") };
+        all.AddRange(events);
+        EventsFor(session).StartStream<T>(streamId, all);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    /// <summary>
+    /// Fetch, append and commit — the round that leaves an entry behind under either write-back
+    /// policy. See the note on the class.
+    /// </summary>
+    private async Task warmAsync<T>(Guid streamId, decimal amount) where T : class
+    {
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<T>(streamId, Cancellation);
+        stream.AppendOne(new AmountPosted(amount));
+        await SaveChangesAsync(session);
+    }
+
+    private async Task appendFromAnotherSessionAsync<T>(Guid streamId, decimal amount) where T : class
+    {
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<T>(streamId, Cancellation);
+        stream.AppendOne(new AmountPosted(amount));
+        await SaveChangesAsync(session);
+    }
+
+    #region The cache is real
+
+    /// <remarks>
+    /// The load-bearing fact of the whole suite. Without it, a store that dropped the opt-in on the
+    /// floor passes everything below.
+    /// </remarks>
+    [Fact]
+    public async Task the_cache_is_actually_consulted_when_a_type_opts_in()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        TheCache.WasStoredFor(typeof(CachedLedger)).ShouldBeTrue();
+
+        var hitsBefore = TheCache.Hits;
+        await warmAsync<CachedLedger>(streamId, 1);
+
+        TheCache.Hits.ShouldBeGreaterThan(hitsBefore);
+    }
+
+    /// <remarks>
+    /// Caching is per aggregate type, not store-wide. A store enabling it globally the moment any
+    /// type opts in fails here.
+    /// </remarks>
+    [Fact]
+    public async Task a_type_that_did_not_opt_in_is_never_cached()
+    {
+        var streamId = await anOpenVaultAsync<UncachedLedger>(new AmountPosted(100));
+
+        await warmAsync<UncachedLedger>(streamId, 10);
+        await warmAsync<UncachedLedger>(streamId, 5);
+
+        TheCache.WasStoredFor(typeof(UncachedLedger)).ShouldBeFalse();
+        TheCache.TakenKeys.ShouldNotContain(x => x.DocumentType == typeof(UncachedLedger));
+    }
+
+    /// <remarks>
+    /// The key carries the store's own database identifier and tenant resolution — neither of which
+    /// the suite could construct — and the aggregate identity. All three have to be filled in or two
+    /// databases, two tenants or two streams collide.
+    /// </remarks>
+    [Fact]
+    public async Task the_stored_key_identifies_the_aggregate_it_came_from()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        var key = TheCache.LastKeyFor(typeof(CachedLedger));
+
+        key.ShouldNotBeNull();
+        key.Value.DocumentType.ShouldBe(typeof(CachedLedger));
+        key.Value.Id.ShouldBe(streamId);
+        key.Value.DatabaseIdentifier.ShouldNotBeNullOrWhiteSpace();
+        key.Value.TenantId.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    /// <remarks>
+    /// Two streams of the same type must not share an entry. Trivially true of any correct key, and
+    /// cheap insurance against a store keying on the document type alone.
+    /// </remarks>
+    [Fact]
+    public async Task two_streams_of_the_same_type_get_their_own_entries()
+    {
+        var first = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        var second = await anOpenVaultAsync<CachedLedger>(new AmountPosted(7));
+
+        await warmAsync<CachedLedger>(first, 10);
+        await warmAsync<CachedLedger>(second, 1);
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedLedger>(second, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(8);
+    }
+
+    #endregion
+
+    #region A hit is indistinguishable from a miss
+
+    [Fact]
+    public async Task a_cache_hit_returns_the_state_a_cold_fetch_would_have()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedLedger>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Owner.ShouldBe("Hilda");
+        stream.Aggregate.Balance.ShouldBe(110);
+        stream.CurrentVersion.ShouldBe(3);
+        stream.StartingVersion.ShouldBe(3);
+    }
+
+    /// <remarks>
+    /// The one that matters most for correctness. A cached baseline is only a starting point — the
+    /// events another writer committed after it still have to be read and folded on. A store
+    /// returning the cached instance as-is passes every other fact here and silently loses writes.
+    /// </remarks>
+    [Fact]
+    public async Task a_cached_baseline_still_sees_events_appended_by_someone_else()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        await appendFromAnotherSessionAsync<CachedLedger>(streamId, 25);
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedLedger>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(135);
+        stream.CurrentVersion.ShouldBe(4);
+    }
+
+    /// <remarks>
+    /// A baseline planted ahead of the stream is what a database restore or a rollback produces. The
+    /// store cannot fold negative deltas onto it, so it has to notice and redo the fetch uncached
+    /// rather than hand back state the database does not have.
+    /// </remarks>
+    [Fact]
+    public async Task a_cached_baseline_ahead_of_the_stream_heals_itself()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        var key = TheCache.LastKeyFor(typeof(CachedLedger));
+        key.ShouldNotBeNull();
+
+        TheCache.Seed(key.Value, new CachedLedger { Owner = "Hilda", Balance = 9999 }, 500);
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedLedger>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(110);
+        stream.CurrentVersion.ShouldBe(3);
+    }
+
+    /// <remarks>
+    /// Dropping an entry is always sound — it is the escape hatch a store or an operator has, and
+    /// the reason <see cref="IAggregateWriteCache" /> lets an implementation evict whenever it
+    /// likes. The next fetch simply takes the uncached path.
+    /// </remarks>
+    [Fact]
+    public async Task an_evicted_entry_falls_back_to_a_correct_uncached_fetch()
+    {
+        var streamId = await anOpenVaultAsync<CachedJournal>(new AmountPosted(100));
+        await warmAsync<CachedJournal>(streamId, 10);
+
+        var key = TheCache.LastKeyFor(typeof(CachedJournal));
+        key.ShouldNotBeNull();
+
+        TheCache.Evict(key.Value);
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedJournal>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(110);
+        stream.CurrentVersion.ShouldBe(3);
+    }
+
+    #endregion
+
+    #region Optimistic concurrency is untouched
+
+    /// <remarks>
+    /// <para>
+    /// The fact the issue asked for by name: a cached baseline can never suppress a concurrency
+    /// exception that an uncached fetch would have raised.
+    /// </para>
+    /// <para>
+    /// Both writers fetch off a warm cache, then one commits and the other must still fail. Compare
+    /// <c>two_writers_racing_on_the_same_starting_version_lose_the_second_write</c> in
+    /// <see cref="FetchForWritingCompliance{TFixture,TOperations,TQuerySession}" /> — same shape,
+    /// same outcome, and that is the entire point.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_cached_baseline_cannot_suppress_a_concurrency_exception()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        await using var first = OpenSession();
+        await using var second = OpenSession();
+
+        var firstStream = await EventsFor(first).FetchForWriting<CachedLedger>(streamId, 3, Cancellation);
+        var secondStream = await EventsFor(second).FetchForWriting<CachedLedger>(streamId, 3, Cancellation);
+
+        firstStream.AppendOne(new AmountPosted(1));
+        await SaveChangesAsync(first);
+
+        secondStream.AppendOne(new AmountPosted(2));
+        await ShouldFailWithAsync<ConcurrencyException>(() => SaveChangesAsync(second));
+
+        await using var reader = OpenSession();
+        var ledger = await LoadDocumentAsync<CachedLedger>(reader, streamId);
+        ledger.ShouldNotBeNull();
+        ledger.Balance.ShouldBe(111);
+    }
+
+    [Fact]
+    public async Task a_stale_expected_version_still_fails_against_a_warm_cache()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            var stream = await EventsFor(session)
+                .FetchForWriting<CachedLedger>(streamId, 99, Cancellation);
+            stream.AppendOne(new AmountPosted(1));
+            await SaveChangesAsync(session);
+        });
+    }
+
+    /// <remarks>
+    /// The write-back's failure path. A commit that rolled back must not leave an entry describing
+    /// state the database never took — the next fetch has to see the winner's state and not the
+    /// loser's. Asserted through a fetch rather than by inspecting the cache, because a store may
+    /// legitimately leave nothing behind or leave a correct entry, and both are fine.
+    /// </remarks>
+    [Fact]
+    public async Task a_failed_commit_leaves_no_poisoned_entry_behind()
+    {
+        var streamId = await anOpenVaultAsync<CachedLedger>(new AmountPosted(100));
+        await warmAsync<CachedLedger>(streamId, 10);
+
+        await using (var first = OpenSession())
+        await using (var second = OpenSession())
+        {
+            var firstStream = await EventsFor(first).FetchForWriting<CachedLedger>(streamId, 3, Cancellation);
+            var secondStream = await EventsFor(second).FetchForWriting<CachedLedger>(streamId, 3, Cancellation);
+
+            firstStream.AppendOne(new AmountPosted(1));
+            await SaveChangesAsync(first);
+
+            secondStream.AppendOne(new AmountPosted(500));
+            await ShouldFailWithAsync<ConcurrencyException>(() => SaveChangesAsync(second));
+        }
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedLedger>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(111);
+        stream.CurrentVersion.ShouldBe(4);
+    }
+
+    #endregion
+
+    #region The async lifecycle
+
+    /// <remarks>
+    /// The daemon never runs in this suite, so the stored snapshot for
+    /// <see cref="CachedJournal" /> stays behind the stream and a fetch always has a real delta to
+    /// fold. That makes these the sharper version of the facts above rather than a repetition:
+    /// nothing here can pass by accident of the snapshot already being at the head.
+    /// </remarks>
+    [Fact]
+    public async Task an_async_snapshotted_aggregate_is_cached_too()
+    {
+        var streamId = await anOpenVaultAsync<CachedJournal>(new AmountPosted(100));
+
+        await warmAsync<CachedJournal>(streamId, 10);
+
+        TheCache.WasStoredFor(typeof(CachedJournal)).ShouldBeTrue();
+
+        var hitsBefore = TheCache.Hits;
+        await warmAsync<CachedJournal>(streamId, 1);
+
+        TheCache.Hits.ShouldBeGreaterThan(hitsBefore);
+    }
+
+    [Fact]
+    public async Task an_async_cached_baseline_folds_the_delta_after_it()
+    {
+        var streamId = await anOpenVaultAsync<CachedJournal>(new AmountPosted(100));
+        await warmAsync<CachedJournal>(streamId, 10);
+
+        await appendFromAnotherSessionAsync<CachedJournal>(streamId, 25);
+        await appendFromAnotherSessionAsync<CachedJournal>(streamId, 5);
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<CachedJournal>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Balance.ShouldBe(140);
+        stream.CurrentVersion.ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task an_async_cached_baseline_cannot_suppress_a_concurrency_exception()
+    {
+        var streamId = await anOpenVaultAsync<CachedJournal>(new AmountPosted(100));
+        await warmAsync<CachedJournal>(streamId, 10);
+
+        await using var first = OpenSession();
+        await using var second = OpenSession();
+
+        var firstStream = await EventsFor(first).FetchForWriting<CachedJournal>(streamId, 3, Cancellation);
+        var secondStream = await EventsFor(second).FetchForWriting<CachedJournal>(streamId, 3, Cancellation);
+
+        firstStream.AppendOne(new AmountPosted(1));
+        await SaveChangesAsync(first);
+
+        secondStream.AppendOne(new AmountPosted(2));
+        await ShouldFailWithAsync<ConcurrencyException>(() => SaveChangesAsync(second));
+    }
+
+    #endregion
+}

--- a/src/JasperFx.Events/Fetching/AggregateWriteCacheOptions.cs
+++ b/src/JasperFx.Events/Fetching/AggregateWriteCacheOptions.cs
@@ -1,0 +1,145 @@
+namespace JasperFx.Events.Fetching;
+
+/// <summary>
+/// Opt-in configuration for caching aggregate snapshots across <c>FetchForWriting</c> calls.
+/// <b>Off for every aggregate type by default.</b>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reached through <see cref="EventRegistry.AggregateWriteCaching" />, which every store's event
+/// options derive from; enabled per aggregate type with
+/// <see cref="EventRegistry.CacheAggregatesForWriting{T}" />. Opt-in per type rather than a
+/// store-wide switch because the win is proportional to how often one stream is fetched for writing
+/// — real on a hot aggregate under high message volume, and only overhead on an aggregate written
+/// once.
+/// </para>
+/// <para>
+/// See <see cref="IAggregateWriteCache" /> for the semantics a store owes the caller, and
+/// <see href="https://github.com/JasperFx/jasperfx/issues/674" /> for the measurements.
+/// </para>
+/// </remarks>
+public class AggregateWriteCacheOptions
+{
+    private readonly object _locker = new();
+    private readonly HashSet<Type> _enabled = new();
+    private IAggregateWriteCache? _cache;
+    private int _sizeLimit = 1000;
+
+    /// <summary>
+    /// Maximum number of cached aggregates when the default
+    /// <see cref="RecentlyUsedAggregateWriteCache" /> is built. Ignored when <see cref="Cache" /> is
+    /// supplied, and ignored after the default cache has been built.
+    /// </summary>
+    public int SizeLimit
+    {
+        get => _sizeLimit;
+        set => _sizeLimit = value;
+    }
+
+    /// <summary>
+    /// Supply your own cache implementation. When left null a
+    /// <see cref="RecentlyUsedAggregateWriteCache" /> honoring <see cref="SizeLimit" /> is built on
+    /// first use.
+    /// </summary>
+    /// <remarks>
+    /// A cache shared between two stores is shared honestly — keys carry the document type, the
+    /// database identifier and the tenant — with one exception worth knowing: two stores mapping the
+    /// same document type to different schemas within one database would collide, because a schema
+    /// is not part of the key.
+    /// </remarks>
+    public IAggregateWriteCache? Cache
+    {
+        get => _cache;
+        set
+        {
+            lock (_locker)
+            {
+                _cache = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Is any aggregate type enrolled at all? A store can use this to skip wiring up its write-back
+    /// machinery entirely on the overwhelmingly common path where nobody opted in.
+    /// </summary>
+    public bool IsEnabledForAnyType
+    {
+        get
+        {
+            lock (_locker)
+            {
+                return _enabled.Count > 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The aggregate types currently enrolled.
+    /// </summary>
+    public IReadOnlyList<Type> EnabledTypes
+    {
+        get
+        {
+            lock (_locker)
+            {
+                return _enabled.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Is snapshot caching enabled for this aggregate type?
+    /// </summary>
+    public bool IsEnabled(Type aggregateType)
+    {
+        lock (_locker)
+        {
+            return _enabled.Contains(aggregateType);
+        }
+    }
+
+    /// <summary>
+    /// Enable snapshot caching for an aggregate type.
+    /// </summary>
+    public void Enable(Type aggregateType)
+    {
+        ArgumentNullException.ThrowIfNull(aggregateType);
+
+        lock (_locker)
+        {
+            _enabled.Add(aggregateType);
+        }
+    }
+
+    /// <summary>
+    /// Resolve the cache to use, building the default
+    /// <see cref="RecentlyUsedAggregateWriteCache" /> on first use.
+    /// </summary>
+    /// <remarks>
+    /// A store should call this once when it builds its fetch plans, not per fetch. Returns
+    /// <see cref="NulloAggregateWriteCache.Instance" /> for a type nobody enrolled, so the caller
+    /// needs no branch of its own — every take misses and every store is discarded.
+    /// </remarks>
+    public IAggregateWriteCache ResolveCache(Type aggregateType)
+    {
+        return IsEnabled(aggregateType) ? ResolveCache() : NulloAggregateWriteCache.Instance;
+    }
+
+    /// <summary>
+    /// Resolve the shared cache instance regardless of which types are enrolled, building the
+    /// default <see cref="RecentlyUsedAggregateWriteCache" /> on first use.
+    /// </summary>
+    public IAggregateWriteCache ResolveCache()
+    {
+        if (_cache != null)
+        {
+            return _cache;
+        }
+
+        lock (_locker)
+        {
+            return _cache ??= new RecentlyUsedAggregateWriteCache(_sizeLimit);
+        }
+    }
+}

--- a/src/JasperFx.Events/Fetching/IAggregateWriteCache.cs
+++ b/src/JasperFx.Events/Fetching/IAggregateWriteCache.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace JasperFx.Events.Fetching;
+
+/// <summary>
+/// Identifies a single cached aggregate snapshot.
+/// </summary>
+/// <param name="DocumentType">The aggregate document type.</param>
+/// <param name="DatabaseIdentifier">
+/// Identifier of the physical database the aggregate was read from.
+/// </param>
+/// <param name="TenantId">
+/// The owning tenant, or <see cref="GlobalTenant" /> for aggregates registered as global.
+/// </param>
+/// <param name="Id">The stream / aggregate identity.</param>
+/// <remarks>
+/// <para>
+/// The database identifier is part of the key so that database-per-tenant deployments — where the
+/// very same tenant id and stream id exist in more than one physical database — cannot collide.
+/// "Global" aggregates are keyed per database for the same reason: they have one instance per
+/// database, not one per process.
+/// </para>
+/// <para>
+/// <paramref name="Id" /> is typed as <see cref="object" /> because stream identity is
+/// <see cref="Guid" />, <see cref="string" /> or a strong-typed wrapper depending on the store's
+/// configuration. Equality therefore runs through
+/// <see cref="EqualityComparer{T}.Default" />, which is structural for all three; a boxed identity
+/// that did not implement value equality would simply never produce a hit, costing a load rather
+/// than returning a wrong aggregate.
+/// </para>
+/// </remarks>
+public readonly record struct AggregateCacheKey(
+    Type DocumentType,
+    string DatabaseIdentifier,
+    string TenantId,
+    object Id)
+{
+    /// <summary>
+    /// Stand-in tenant for aggregates registered as global, which are not partitioned by tenant.
+    /// </summary>
+    public const string GlobalTenant = "*global*";
+}
+
+/// <summary>
+/// A node-local, second-level cache of aggregate snapshots that a store's <c>FetchForWriting</c>
+/// can use as a <em>baseline</em> instead of loading the stored snapshot from the database.
+/// Effectively an identity map for aggregates with a lifetime longer than a session.
+/// </summary>
+/// <remarks>
+/// <para>
+/// See <see href="https://github.com/JasperFx/jasperfx/issues/674" />. The shape originated in
+/// Marten and is declared here so Marten, Polecat and Fisher share one contract and one default
+/// implementation, rather than a consumer targeting all three reimplementing a cache per flavour.
+/// </para>
+/// <para>
+/// <b>The load-bearing property is that an implementation never has to be correct, only
+/// <em>usually</em> correct.</b> A store may use the cached instance as a starting point, but it
+/// still reads the stream version and every event after the cached version from the database on
+/// every call, and the optimistic concurrency assertion on append is untouched. A stale entry
+/// therefore costs a larger delta query — never a wrong aggregate, and never a suppressed
+/// concurrency failure. That is what makes a node-local, incoherent cache the right shape, and what
+/// rules out any coherence protocol between nodes.
+/// </para>
+/// <para>
+/// What this removes is the snapshot <em>load</em>, and nothing else. Stated as the measurement axis
+/// that matters: it reduces reads per second, where narrowing a wide document reduces bytes per
+/// read. The two compose; neither replaces the other.
+/// </para>
+/// <para>
+/// ⛔ <b>A "trusted" variant that additionally skipped the version read is explicitly retired and
+/// must not be reintroduced.</b> It was gated in advance on a measurement and failed it — 0.19 ms
+/// against a 13.2 ms round, about 1.4% — so it trades the concurrency guarantee for nothing. An
+/// implementation of this interface that lets a caller skip the version read is not implementing
+/// this interface.
+/// </para>
+/// <para>
+/// Implementations must be safe for concurrent use. Beyond that they are free to evict whenever
+/// they like: dropping an entry is always sound.
+/// </para>
+/// </remarks>
+public interface IAggregateWriteCache
+{
+    /// <summary>
+    /// Claim the cached snapshot for a key, <b>removing it from the cache in the same atomic
+    /// step</b>.
+    /// </summary>
+    /// <remarks>
+    /// Take-on-read rather than read-through, and this is a requirement rather than an
+    /// implementation detail. Aggregates are commonly mutable and a store folds delta events onto
+    /// the instance it is handed, so two callers holding the same instance would corrupt each
+    /// other's result. Exactly one caller may ever win a given entry; concurrent callers miss and
+    /// take the normal uncached path, which is always correct.
+    /// </remarks>
+    /// <param name="key">The aggregate being fetched.</param>
+    /// <param name="aggregate">The claimed snapshot, when this returns <see langword="true" />.</param>
+    /// <param name="version">
+    /// The stream version the claimed snapshot is known to be at, when this returns
+    /// <see langword="true" />; otherwise zero.
+    /// </param>
+    /// <returns><see langword="true" /> when a snapshot was claimed.</returns>
+    bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version);
+
+    /// <summary>
+    /// Store a snapshot known to be at <paramref name="version" /> of its stream.
+    /// </summary>
+    /// <remarks>
+    /// The version has to be the one the events were committed at, and a store should take it from
+    /// the committed <see cref="StreamAction" /> rather than off the document — an aggregate is free
+    /// to carry a <c>Version</c> property meaning something else entirely.
+    /// </remarks>
+    void Store(AggregateCacheKey key, object aggregate, long version);
+
+    /// <summary>
+    /// Drop any entry for this key. Always safe: the next fetch simply reloads.
+    /// </summary>
+    void Evict(AggregateCacheKey key);
+}
+
+/// <summary>
+/// The no-op <see cref="IAggregateWriteCache" />. Every take misses and nothing is ever stored.
+/// </summary>
+/// <remarks>
+/// The default for every aggregate type, and the reason a store's fetch path needs no
+/// <c>if (caching enabled)</c> branch at all.
+/// </remarks>
+public sealed class NulloAggregateWriteCache: IAggregateWriteCache
+{
+    public static readonly NulloAggregateWriteCache Instance = new();
+
+    public bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version)
+    {
+        aggregate = default;
+        version = 0;
+        return false;
+    }
+
+    public void Store(AggregateCacheKey key, object aggregate, long version)
+    {
+        // Nothing. Deliberately not even recording the key -- the point of this type is that a
+        // store on the default path allocates and retains nothing.
+    }
+
+    public void Evict(AggregateCacheKey key)
+    {
+        // Nothing to drop.
+    }
+}

--- a/src/JasperFx.Events/Fetching/RecentlyUsedAggregateWriteCache.cs
+++ b/src/JasperFx.Events/Fetching/RecentlyUsedAggregateWriteCache.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core;
+
+namespace JasperFx.Events.Fetching;
+
+/// <summary>
+/// The default <see cref="IAggregateWriteCache" />: a bounded, least-recently-used, node-local cache
+/// built on JasperFx's own <see cref="RecentlyUsedCache{TKey,TItem}" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Node-local by design rather than by omission. A cached snapshot is only ever a baseline, so
+/// coherence between nodes buys nothing that the delta read does not already provide — and an
+/// <c>IDistributedCache</c> would reintroduce exactly the round trip this exists to remove.
+/// </para>
+/// <para>
+/// Backed by <see cref="RecentlyUsedCache{TKey,TItem}" /> rather than
+/// <c>Microsoft.Extensions.Caching.Memory</c> deliberately: the prototype this was promoted from
+/// took <c>IMemoryCache</c> as a new hard dependency on core Marten and flagged that as a decision
+/// to make before graduation. Taking it here would push it onto every store and every consumer of
+/// <c>JasperFx.Events</c> instead of one of them, for an LRU with a size cap that JasperFx already
+/// has. A deployment that wants its entries in a shared <c>IMemoryCache</c> writes a small adapter
+/// implementing the three-member interface.
+/// </para>
+/// </remarks>
+public sealed class RecentlyUsedAggregateWriteCache: IAggregateWriteCache
+{
+    private readonly RecentlyUsedCache<AggregateCacheKey, Entry> _cache = new();
+    private long _hits;
+    private long _misses;
+
+    /// <param name="sizeLimit">Maximum number of cached snapshots.</param>
+    public RecentlyUsedAggregateWriteCache(int sizeLimit = 1000)
+    {
+        if (sizeLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sizeLimit),
+                "An aggregate write cache with no room for an entry would miss on every fetch. Use NulloAggregateWriteCache to turn caching off.");
+        }
+
+        _cache.Limit = sizeLimit;
+    }
+
+    /// <summary>
+    /// Number of successful takes. Diagnostics only — nothing should branch on it.
+    /// </summary>
+    public long Hits => Interlocked.Read(ref _hits);
+
+    /// <summary>
+    /// Number of failed takes. Diagnostics only.
+    /// </summary>
+    public long Misses => Interlocked.Read(ref _misses);
+
+    public bool TryTake(AggregateCacheKey key, [NotNullWhen(true)] out object? aggregate, out long version)
+    {
+        // TryFind and TryRemove are individually thread safe but not atomic together, so the claim
+        // is made on the entry itself: two callers can both find it, and exactly one can transition
+        // it from unclaimed to claimed. The loser reports a miss and takes the uncached path.
+        if (_cache.TryFind(key, out var entry) && entry.TryClaim())
+        {
+            _cache.TryRemove(key);
+
+            aggregate = entry.Aggregate;
+            version = entry.Version;
+            Interlocked.Increment(ref _hits);
+            return true;
+        }
+
+        aggregate = default;
+        version = 0;
+        Interlocked.Increment(ref _misses);
+        return false;
+    }
+
+    public void Store(AggregateCacheKey key, object aggregate, long version)
+    {
+        ArgumentNullException.ThrowIfNull(aggregate);
+
+        _cache.Store(key, new Entry(aggregate, version));
+        _cache.CompactIfNecessary();
+    }
+
+    public void Evict(AggregateCacheKey key)
+    {
+        _cache.TryRemove(key);
+    }
+
+    private sealed class Entry
+    {
+        private int _claimed;
+
+        public Entry(object aggregate, long version)
+        {
+            Aggregate = aggregate;
+            Version = version;
+        }
+
+        public object Aggregate { get; }
+        public long Version { get; }
+
+        public bool TryClaim() => Interlocked.Exchange(ref _claimed, 1) == 0;
+    }
+}

--- a/src/JasperFx.Events/IEventRegistry.cs
+++ b/src/JasperFx.Events/IEventRegistry.cs
@@ -4,6 +4,7 @@ using JasperFx.Core;
 using JasperFx.Core.Reflection;
 using JasperFx.Descriptors;
 using JasperFx.Events.Aggregation;
+using JasperFx.Events.Fetching;
 
 namespace JasperFx.Events;
 
@@ -80,6 +81,42 @@ public class EventRegistry : IEventRegistry
 
     [IgnoreDescription]
     public virtual TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+    /// <summary>
+    ///     Opt-in caching of aggregate snapshots between <c>FetchForWriting</c> calls. Disabled for
+    ///     every aggregate type by default; see <see cref="CacheAggregatesForWriting{T}" />.
+    /// </summary>
+    [IgnoreDescription]
+    public virtual AggregateWriteCacheOptions AggregateWriteCaching { get; } = new();
+
+    /// <summary>
+    ///     Keep recently fetched snapshots of <typeparamref name="T" /> in a node-local cache so that
+    ///     a subsequent <c>FetchForWriting</c> can skip loading the stored snapshot and read only the
+    ///     events after it. Effectively an identity map for aggregates with a lifetime longer than a
+    ///     session.
+    ///     <para>
+    ///     The cached snapshot is only ever a <em>baseline</em>: the stream version and any newer
+    ///     events are still read from the database on every call, and the optimistic concurrency
+    ///     assertion on append is untouched. A stale entry therefore costs a larger delta query,
+    ///     never a wrong aggregate and never a suppressed concurrency failure. See
+    ///     <see cref="IAggregateWriteCache" /> for the full semantics.
+    ///     </para>
+    ///     <para>
+    ///     Worth enabling where one stream is fetched for writing repeatedly, which is where the
+    ///     removed snapshot load is a real share of the round. On an aggregate written once it is
+    ///     only overhead, which is why this is per type rather than store-wide.
+    ///     </para>
+    /// </summary>
+    /// <param name="sizeLimit">
+    ///     Maximum number of cached aggregates, when the default cache is built. Ignored once a cache
+    ///     has been resolved, and ignored entirely when
+    ///     <see cref="AggregateWriteCacheOptions.Cache" /> is supplied.
+    /// </param>
+    public virtual void CacheAggregatesForWriting<T>(int sizeLimit = 1000) where T : class
+    {
+        AggregateWriteCaching.SizeLimit = sizeLimit;
+        AggregateWriteCaching.Enable(typeof(T));
+    }
 
     public virtual IEvent BuildEvent(object eventData)
     {


### PR DESCRIPTION
Closes #674.

Promotes the second-level `FetchForWriting` snapshot cache built on Marten's `feature/aggregate-cache-fetchforwriting` into `JasperFx.Events`, so Marten, Polecat and Fisher share one contract and one default implementation.

**Scope:** this is the JasperFx half — the contract, the registration surface, the default cache, and the compliance definition. The three store implementations follow in their own repos; the Marten one is the existing branch rebased.

## Grade 1 only, and the contract says so

`IAggregateWriteCache` documents the semantics at the top: the cached snapshot is a **baseline**, the stream version and every event after the cached version are still read from the database, and the OCC assertion on append is untouched. A stale entry costs a larger delta query — never a wrong aggregate, never a suppressed concurrency failure.

⛔ The retired "trusted" variant is named as retired *in the interface docs*, with the number that retired it (0.19 ms of a 13.2 ms round). The compliance suite carries the same note the other way round: if an implementation ever makes `a_cached_baseline_cannot_suppress_a_concurrency_exception` fail, that is the retired feature being reintroduced, not a test needing a gate.

## What ships here

| | |
|---|---|
| `IAggregateWriteCache`, `AggregateCacheKey`, `NulloAggregateWriteCache` | the contract. Keys carry document type + database identifier + tenant, so neither conjoined tenancy nor database-per-tenant collides, and a global aggregate is keyed per database because that is where it has one instance |
| `RecentlyUsedAggregateWriteCache` | the default, bounded, node-local |
| `AggregateWriteCacheOptions` | opt-in **per aggregate type, off by default** |
| `EventRegistry.CacheAggregatesForWriting<T>()` | registration, inherited by all three stores |
| `AggregateWriteCacheCompliance` | the shared definition |

Take-on-read is stated as a contract requirement rather than an implementation detail — a store folds delta events onto the instance it is handed, so exactly one caller may ever win an entry. `ResolveCache(Type)` returns the nullo cache for a type nobody enrolled, so a store's fetch path needs no enabled/disabled branch of its own.

## ⚠️ One decision worth your call: the IMemoryCache dependency

The spike's own follow-up list said *"decide the dependency question before graduation — `Microsoft.Extensions.Caching.Memory` is a new hard dependency on core Marten."*

**I decided it as: don't take it.** The default is backed by `JasperFx.Core`'s existing `RecentlyUsedCache` — a bounded LRU we already ship. Promoting the `IMemoryCache` version would push that dependency onto every store and every consumer of `JasperFx.Events` rather than one of them. A deployment that wants its entries in a shared `IMemoryCache` writes a small adapter over the three-member interface. Easy to reverse if you'd rather have the `IMemoryCache` implementation in the box.

## Compliance

The suite's subject is that turning caching on is **unobservable except in latency**: a hit is indistinguishable from a miss, including when the baseline is stale, ahead of the stream, or evicted. It carries the OCC fact the issue asked for by name, in the same shape as the uncached race in `FetchForWritingCompliance`.

The trap it exists for: every correctness fact about caching is vacuously true of a store that ignored the opt-in altogether, because an uncached fetch is correct by construction. So the suite supplies its own `RecordingAggregateWriteCache` and asserts a nonzero hit count — the same reasoning as gzipping in `BinaryEventSerializationCompliance`. The recorder also captures a *real* key, built from the store's own database identifier and tenant resolution, which is the only way the ahead-of-the-stream case can be tested at all.

Covers both lifecycles, with the daemon **deliberately never started**, so the Async aggregate's stored snapshot always lags and every fetch has a real delta to fold. When an entry is written is not pinned, because it genuinely differs — an Inline snapshot is mutated by the projection during commit and can only be cached after it succeeds. Every arrange step fetches, appends *and commits*, which warms the cache under either policy (a fetch that appends nothing never warms an Inline cache — this cost the spike two failing tests before it was understood).

Opt-in via a throwing default on `IComplianceStoreRegistrar`, so a store without the capability keeps compiling.

`EventTests/Fetching/AggregateWriteCacheTests.cs` covers the pieces directly: single-winner take under 64 concurrent takers, the size bound, key discrimination across type/database/tenant/id, and that the options are off until something opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)