### PR TITLE
gh-672: let a document compliance suite declare the stream identity it needs, and unseal BinaryEventAttribute

### DIFF
--- a/src/EventStoreTests/Documents/DocumentComplianceConfigTests.cs
+++ b/src/EventStoreTests/Documents/DocumentComplianceConfigTests.cs
@@ -1,0 +1,65 @@
+using JasperFx.Events;
+using JasperFx.Events.ComplianceTests;
+using Shouldly;
+
+namespace EventStoreTests.Documents;
+
+/// <summary>
+/// What a document compliance suite declares about the store it needs (jasperfx#672).
+/// </summary>
+/// <remarks>
+/// A suite whose precondition the config cannot carry is a suite that never states it, and each
+/// fixture then has to guess — at which point a store implementing the contract correctly still
+/// fails. These are cheap guards against that regressing, and they run here rather than downstream
+/// because nothing about them needs a real store.
+/// </remarks>
+public class DocumentComplianceConfigTests
+{
+    [Fact]
+    public void stream_identity_is_unset_until_a_suite_asks_for_one()
+    {
+        // Null means "leave the store on its own default", which is what every document-only suite
+        // wants. A non-null default here would push a rebuild onto fixtures that need nothing.
+        new DocumentComplianceConfig().StreamIdentity.ShouldBeNull();
+    }
+
+    /// <remarks>
+    /// The fix itself. This suite appends by stream key throughout, so it fails on any store
+    /// defaulting to Guid identity unless it says so.
+    /// </remarks>
+    [Fact]
+    public void the_document_session_events_suite_declares_string_stream_identity()
+    {
+        var config = new DocumentComplianceConfig();
+        ExposedDocumentSessionEventsCompliance.TheConfiguration(config);
+
+        config.StreamIdentity.ShouldBe(StreamIdentity.AsString);
+    }
+
+    [Fact]
+    public void a_document_only_suite_leaves_stream_identity_alone()
+    {
+        var config = new DocumentComplianceConfig();
+        ExposedDocumentSessionCompliance.TheConfiguration(config);
+
+        config.StreamIdentity.ShouldBeNull();
+    }
+
+    /// <remarks>
+    /// Not public, so xunit never collects the inherited facts — the in-memory reference store is
+    /// document-only and could not run this suite. All that is wanted is the configuration delegate.
+    /// </remarks>
+    private class ExposedDocumentSessionEventsCompliance
+        : DocumentSessionEventsCompliance<InMemoryDocumentComplianceFixture>
+    {
+        public static readonly Action<DocumentComplianceConfig> TheConfiguration =
+            new ExposedDocumentSessionEventsCompliance().Configuration;
+    }
+
+    private class ExposedDocumentSessionCompliance
+        : DocumentSessionCompliance<InMemoryDocumentComplianceFixture>
+    {
+        public static readonly Action<DocumentComplianceConfig> TheConfiguration =
+            new ExposedDocumentSessionCompliance().Configuration;
+    }
+}

--- a/src/EventTests/BinaryEventAttributeTests.cs
+++ b/src/EventTests/BinaryEventAttributeTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using JasperFx.Events;
+using Shouldly;
+
+namespace EventTests;
+
+/// <summary>
+/// <see cref="BinaryEventAttribute" /> is deliberately unsealed (jasperfx#672).
+/// </summary>
+/// <remarks>
+/// A store that shipped its own <c>BinaryEventAttribute</c> before this one was promoted cannot
+/// delete it without breaking its users, and could not derive from a sealed one either — leaving it
+/// resolving two attribute types on every event forever. These pin the property that makes
+/// subclassing an actual fix rather than a second thing to check: a lookup for the promoted
+/// attribute has to find a derived one.
+/// </remarks>
+public class BinaryEventAttributeTests
+{
+    [Fact]
+    public void the_promoted_attribute_can_be_derived_from()
+    {
+        typeof(BinaryEventAttribute).IsSealed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void an_event_marked_with_the_promoted_attribute_is_found()
+    {
+        typeof(Shipped).GetCustomAttribute<BinaryEventAttribute>().ShouldNotBeNull();
+    }
+
+    /// <remarks>
+    /// The load-bearing one. Attribute lookup matches by assignability, so a store subclassing this
+    /// collapses its two checks back to one rather than gaining a third.
+    /// </remarks>
+    [Fact]
+    public void an_event_marked_with_a_derived_attribute_is_found_by_the_promoted_one()
+    {
+        typeof(Delivered).GetCustomAttribute<BinaryEventAttribute>().ShouldNotBeNull();
+
+        Attribute.IsDefined(typeof(Delivered), typeof(BinaryEventAttribute)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void an_unmarked_event_is_not_found()
+    {
+        typeof(Cancelled).GetCustomAttribute<BinaryEventAttribute>().ShouldBeNull();
+    }
+
+    private class StoreOwnBinaryEventAttribute : BinaryEventAttribute;
+
+    [BinaryEvent]
+    private record Shipped(string Carrier);
+
+    [StoreOwnBinaryEvent]
+    private record Delivered(string Signature);
+
+    private record Cancelled(string Reason);
+}

--- a/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
@@ -8,11 +8,21 @@ namespace JasperFx.Events.ComplianceTests;
 /// A suite fills one of these in; the fixture replays it against its own store.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Far thinner than <see cref="ComplianceStoreConfig" />, and that is the point rather than an
 /// oversight. The document contract (jasperfx#647) is eight operations, so a suite needs nothing but
 /// a schema to live in, the document types it will exercise, and the strong-typed identifiers those
 /// documents are keyed by. Still no registrar interface: unlike the event side, every one of those is
 /// expressible as a <see cref="Type" /> the fixture replays against its own options.
+/// </para>
+/// <para>
+/// Being thin is not the same as being silent, though, and jasperfx#672 is what drew the line. Every
+/// precondition a suite has on the store must be expressible here, because a precondition the config
+/// cannot carry becomes one the suite never states and each fixture has to guess — at which point a
+/// store that implements the contract correctly still fails. <see cref="StreamIdentity" /> was the
+/// first of those to surface, and it surfaced as soon as the document config had to describe
+/// anything about the event store.
+/// </para>
 /// </remarks>
 public sealed class DocumentComplianceConfig
 {
@@ -20,6 +30,33 @@ public sealed class DocumentComplianceConfig
     /// Optional schema/namespace override. When null the fixture picks its own.
     /// </summary>
     public string? SchemaName { get; set; }
+
+    /// <summary>
+    /// The stream identity style the suite needs. Null leaves the store on its own default, which is
+    /// <see cref="Events.StreamIdentity.AsGuid" /> in every current store.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A plain property rather than anything cleverer, matching
+    /// <see cref="ComplianceStoreConfig.StreamIdentity" />: the value is the shared
+    /// <see cref="Events.StreamIdentity" /> enum, but the options object it hangs off is the store's
+    /// own event graph, and the fixture is already the place that knows which.
+    /// </para>
+    /// <para>
+    /// It is here because a suite that appends by stream <em>key</em> has an undeclared precondition
+    /// otherwise, and a correctly-implemented store then fails it. That is a bug in the suite by
+    /// definition — the whole point of a shared compliance library is that implementing the contract
+    /// is sufficient to pass. See <see href="https://github.com/JasperFx/jasperfx/issues/672" />:
+    /// <see cref="DocumentSessionEventsCompliance{TFixture}" /> appends by string key throughout, so
+    /// three of its five facts failed on every store defaulting to Guid identity, with an error
+    /// naming stream identity but not the suite's requirement.
+    /// </para>
+    /// <para>
+    /// A fixture must replay this, exactly as it replays <see cref="ValueTypes" />. Ignoring it does
+    /// not make the affected suites skip — they fail.
+    /// </para>
+    /// </remarks>
+    public StreamIdentity? StreamIdentity { get; set; }
 
     /// <summary>
     /// The document types the suite will store, query and delete. Stores that create document

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -186,6 +186,14 @@ spells that `options.RegisterValueType(type)`. It is what lets `DocumentLoadAndS
 the `LoadAsync<T>(object)` overload (jasperfx#665) to a definition; a fixture that ignores it fails
 the strong-typed identity tests rather than skipping them.
 
+The same goes for `config.StreamIdentity`, which is nullable — leave the store on its own default
+when it is null, and set it when it is not. Only the event-capable document suites populate it, and
+they do so because they append by stream *key*. This is the one knob whose absence was a suite bug
+rather than a fixture's (jasperfx#672): `DocumentSessionEventsCompliance` needed string stream
+identity and had no way to say so, so three of its five facts failed on every store defaulting to
+Guid, with an error naming stream identity but nothing about the suite's requirement. A precondition
+a config cannot carry is a precondition each fixture has to guess.
+
 That overload also shows what these suites are *for*. It ships with a default implementation, so a
 store takes the JasperFx bump without a compile break — the default forwards a boxed `Guid` or
 `string` and throws on anything else. Nothing in the compiler then tells the store it has only half

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentSessionEventsCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentSessionEventsCompliance.cs
@@ -43,6 +43,14 @@ public abstract class DocumentSessionEventsCompliance<TFixture> : DocumentStorag
     private static readonly Action<DocumentComplianceConfig> _configuration = config =>
     {
         config.SchemaName = "compliance_documents";
+
+        // Every fact below appends by stream *key*, so the store has to be configured for string
+        // stream identity. Declared here rather than left to each fixture to work out: a suite with
+        // an unstated precondition fails a store that implements the contract correctly, which is a
+        // bug in the suite by definition. See jasperfx#672 -- this used to fail three of the five
+        // facts on any store defaulting to Guid identity, which is all of them.
+        config.StreamIdentity = StreamIdentity.AsString;
+
         config.AddDocumentType<ComplianceWidget>();
         config.AddEventType<KilnFired>();
         config.AddEventType<KilnCooled>();

--- a/src/JasperFx.Events/BinaryEventAttribute.cs
+++ b/src/JasperFx.Events/BinaryEventAttribute.cs
@@ -21,6 +21,22 @@ namespace JasperFx.Events;
 /// Silently falling back to JSON would write rows in a format the operator did not choose and
 /// believes they are not using.
 /// </para>
+/// <para>
+/// Deliberately <b>not</b> sealed, which is the one thing about it that is not obvious. A store that
+/// already shipped its own <c>BinaryEventAttribute</c> before this one existed cannot delete it
+/// without breaking its users, and could not derive from a sealed one either (CS0509) — so it is
+/// left resolving <em>two</em> attribute types on every event, forever. Marten is exactly that
+/// store. Unsealing lets such a store make its own attribute a subclass of this one and collapse the
+/// check back to a single lookup, because
+/// <see cref="System.Reflection.CustomAttributeExtensions.GetCustomAttribute{T}(System.Reflection.MemberInfo)" />
+/// matches a derived attribute. See <see href="https://github.com/JasperFx/jasperfx/issues/672" />.
+/// </para>
+/// <para>
+/// Stores with no pre-existing attribute of their own should use this one directly rather than
+/// subclassing it; a store-namespaced subclass would reintroduce the very thing promoting the
+/// attribute was meant to remove, which is an attribute a consumer sharing event types across stores
+/// cannot apply.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
-public sealed class BinaryEventAttribute : Attribute;
+public class BinaryEventAttribute : Attribute;


### PR DESCRIPTION
Closes #672. Takes option 1, which is the one the issue leaned toward.

## The suite bug

`DocumentSessionEventsCompliance` appends by stream **key** throughout, but `DocumentComplianceConfig` carried no `StreamIdentity` — so the suite never told the store what it needed. Three of its five facts failed on any store defaulting to Guid identity (all of them), with an error naming stream identity and nothing about the suite's requirement.

That's a bug in the suite by definition: the whole point of a shared compliance library is that implementing the contract is *sufficient* to pass it. Fisher only got past it by inferring string identity fixture-side from the presence of event types — a decision made in the fixture, not something the suite stated.

`DocumentComplianceConfig.StreamIdentity` is nullable and defaults to null, so a document-only suite leaves the store on its own default and **no existing fixture needs to change**. `DocumentSessionEventsCompliance` declares `AsString`. Mirrors `ComplianceStoreConfig.StreamIdentity` exactly, including why it's a plain property rather than anything cleverer.

The class docs now record the asymmetry that hid this: the event-side config has plenty of knobs and its suites choose identity deliberately, while `DocumentComplianceConfig` was written thin on purpose for #647 — and gaining `EventTypes` in #671 was the first time it had to describe anything about the event store at all. Thin is still right; the line drawn is that a precondition the config *cannot carry* is a precondition each fixture has to guess.

## Unsealing `BinaryEventAttribute`

Marten shipped its own before this one was promoted, can't delete it without breaking users, and couldn't derive from a sealed one (CS0509) — so `EventGraph.ResolveBinarySerializerFor` checks two attribute types indefinitely. Unsealing is non-breaking and lets it subclass instead, collapsing that back to one lookup, because attribute lookup matches by assignability.

The docs state the corollary plainly, since it's the obvious way to misuse this: a store *without* a pre-existing attribute should use this one directly. A store-namespaced subclass would reintroduce exactly what promoting the attribute removed — an attribute a consumer sharing event types across stores cannot apply.

## Tests

Both fixes get in-repo tests, since neither needs a real store and nothing caught either the first time — that the suites declare what they declare, and that a derived attribute is found by a lookup for the promoted one.

## ⚠️ Interaction with #675

`PendingStreamActionsCompliance` (added in #675) also appends by string stream key and reuses this suite's event types, so it needs the same one-line `config.StreamIdentity = StreamIdentity.AsString;`.

The two branches are independent and both cut from `main`, so whichever merges second needs that line added. Ping me and I'll push it to the trailing branch rather than leaving it for the downstream stores to rediscover — which is precisely the failure this issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)