### PR TITLE
#679: store-agnostic post-commit document session listener

### DIFF
--- a/src/EventStoreTests/Documents/InMemoryDocumentComplianceFixture.cs
+++ b/src/EventStoreTests/Documents/InMemoryDocumentComplianceFixture.cs
@@ -18,9 +18,18 @@ public class InMemoryDocumentComplianceFixture : DocumentStorageComplianceFixtur
 
     protected override Task BuildStoreAsync(DocumentComplianceConfig config)
     {
-        // Nothing to build: an in-memory store has no schema, and it creates storage for a document
-        // type on first use. Both are legitimate answers to this seam member.
-        _ = config;
+        // Nothing to build for storage: an in-memory store has no schema, and it creates storage for
+        // a document type on first use. Both are legitimate answers to this seam member.
+
+        // Commit listeners are the exception, and the reason this override is no longer empty.
+        // Registration happens when the store is built, before any session exists, so a fixture that
+        // skipped this would fail every fact in DocumentCommitListenerCompliance rather than
+        // skipping them -- a listener that was never registered is indistinguishable from a store
+        // that never invokes one. Every product spells the same replay against its own
+        // StoreOptions.Listeners.
+        _store.Listeners.Clear();
+        _store.Listeners.AddRange(config.CommitListeners);
+
         return Task.CompletedTask;
     }
 
@@ -44,3 +53,6 @@ public class in_memory_document_delete_compliance
 
 public class in_memory_document_query_compliance
     : DocumentQueryCompliance<InMemoryDocumentComplianceFixture>;
+
+public class in_memory_document_commit_listener_compliance
+    : DocumentCommitListenerCompliance<InMemoryDocumentComplianceFixture>;

--- a/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
+++ b/src/EventStoreTests/Documents/InMemoryDocumentStore.cs
@@ -25,6 +25,17 @@ public class InMemoryDocumentStore : IDocumentSessionFactory<InMemoryDocumentSes
 {
     private readonly ConcurrentDictionary<Type, ConcurrentDictionary<object, object>> _documents = new();
 
+    /// <summary>
+    /// The post-commit listeners this store raises — the reference implementation of jasperfx#679.
+    /// </summary>
+    /// <remarks>
+    /// A plain list, matching the <c>StoreOptions.Listeners</c> that all three products already
+    /// expose. The point being demonstrated is that nothing about the contract requires a store to
+    /// invent registration machinery: a collection of <see cref="IDocumentCommitListener" /> and a
+    /// loop after the commit is the whole of it.
+    /// </remarks>
+    public List<IDocumentCommitListener> Listeners { get; } = new();
+
     public InMemoryDocumentSession LightweightSession() => new(this);
 
     public InMemoryDocumentSession QuerySession() => new(this);
@@ -64,7 +75,7 @@ public class InMemoryDocumentStore : IDocumentSessionFactory<InMemoryDocumentSes
 public class InMemoryDocumentSession : IDocumentSessionOperations
 {
     private readonly InMemoryDocumentStore _store;
-    private readonly List<Action> _pending = new();
+    private readonly List<Action<InMemoryChangeSet>> _pending = new();
 
     internal InMemoryDocumentSession(InMemoryDocumentStore store) => _store = store;
 
@@ -100,7 +111,26 @@ public class InMemoryDocumentSession : IDocumentSessionOperations
         foreach (var entity in entities)
         {
             var id = InMemoryDocumentStore.IdentityOf(entity);
-            _pending.Add(() => _store.StorageFor(typeof(T))[id] = entity);
+            _pending.Add(changes =>
+            {
+                var storage = _store.StorageFor(typeof(T));
+
+                // Insert vs update is decided at commit time against what is actually stored, which
+                // is the only honest answer a store with no identity map can give. The contract
+                // deliberately does not hold products to one determination here -- only to the
+                // document landing in exactly one of the two collections.
+                var existed = storage.ContainsKey(id);
+                storage[id] = entity;
+
+                if (existed)
+                {
+                    changes.RecordUpdated(entity);
+                }
+                else
+                {
+                    changes.RecordInserted(entity);
+                }
+            });
         }
     }
 
@@ -112,12 +142,16 @@ public class InMemoryDocumentSession : IDocumentSessionOperations
     public void Delete<T>(string id) where T : notnull => deleteById<T>(id);
 
     private void deleteById<T>(object id) where T : notnull
-        => _pending.Add(() => _store.StorageFor(typeof(T)).TryRemove(id, out _));
+        => _pending.Add(changes =>
+        {
+            _store.StorageFor(typeof(T)).TryRemove(id, out _);
+            changes.RecordDeleted(typeof(T), id);
+        });
 
     public void DeleteWhere<T>(Expression<Func<T, bool>> expression) where T : notnull
     {
         var matches = expression.Compile();
-        _pending.Add(() =>
+        _pending.Add(changes =>
         {
             var storage = _store.StorageFor(typeof(T));
             foreach (var pair in storage.ToArray())
@@ -125,21 +159,39 @@ public class InMemoryDocumentSession : IDocumentSessionOperations
                 if (matches((T)pair.Value))
                 {
                     storage.TryRemove(pair.Key, out _);
+                    changes.RecordDeleted(typeof(T), pair.Key);
                 }
             }
         });
     }
 
-    public Task SaveChangesAsync(CancellationToken token = default)
+    public async Task SaveChangesAsync(CancellationToken token = default)
     {
+        // Before anything is applied, so a cancelled commit leaves the store untouched AND raises no
+        // listener. The contract's rule is that the callback happens if and only if the commit
+        // succeeded, and a store that applied first would break the second half of that.
+        token.ThrowIfCancellationRequested();
+
+        if (_pending.Count == 0)
+        {
+            // An empty unit of work raises nothing. The contract permits either answer here and the
+            // compliance suite asserts neither; this side is chosen to match Fisher.
+            return;
+        }
+
+        var changes = new InMemoryChangeSet();
+
         foreach (var change in _pending)
         {
-            change();
+            change(changes);
         }
 
         _pending.Clear();
 
-        return Task.CompletedTask;
+        foreach (var listener in _store.Listeners)
+        {
+            await listener.AfterCommitAsync(this, changes, token).ConfigureAwait(false);
+        }
     }
 
     public ValueTask DisposeAsync()
@@ -149,6 +201,41 @@ public class InMemoryDocumentSession : IDocumentSessionOperations
         return default;
     }
 }
+
+/// <summary>
+/// The reference <see cref="IDocumentChangeSet" /> — three materialized lists and nothing else.
+/// </summary>
+/// <remarks>
+/// Materialized at commit time rather than wrapping the session's pending work, which is the whole
+/// substance of the contract's snapshot rule. A store that handed out a live view would answer
+/// correctly inside the callback and empty afterwards; building the lists here is what lets a
+/// listener stash the change set and read it later, and what makes a counterpart to Marten's
+/// <c>IChangeSet.Clone()</c> unnecessary.
+/// </remarks>
+internal class InMemoryChangeSet : IDocumentChangeSet
+{
+    private readonly List<object> _inserted = new();
+    private readonly List<object> _updated = new();
+    private readonly List<IDocumentDeletion> _deleted = new();
+
+    public IReadOnlyList<object> Inserted => _inserted;
+
+    public IReadOnlyList<object> Updated => _updated;
+
+    public IReadOnlyList<IDocumentDeletion> Deleted => _deleted;
+
+    internal void RecordInserted(object document) => _inserted.Add(document);
+
+    internal void RecordUpdated(object document) => _updated.Add(document);
+
+    internal void RecordDeleted(Type documentType, object? id)
+        => _deleted.Add(new InMemoryDeletion(documentType, id));
+}
+
+/// <summary>
+/// The reference <see cref="IDocumentDeletion" /> — type and identity, no document instance.
+/// </summary>
+internal record InMemoryDeletion(Type DocumentType, object? Id) : IDocumentDeletion;
 
 /// <summary>
 /// Wraps an <see cref="IQueryable{T}" /> so that every LINQ operator applied to it keeps returning a

--- a/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentComplianceConfig.cs
@@ -105,4 +105,39 @@ public sealed class DocumentComplianceConfig
         EventTypes.Add(typeof(T));
         return this;
     }
+
+    /// <summary>
+    /// Post-commit listeners the store must invoke — <see cref="Documents.IDocumentCommitListener" />
+    /// (jasperfx#679).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The one config member that is not a <see cref="Type" />, and it has to be: a listener is
+    /// registered as an <em>instance</em> on every product (<c>StoreOptions.Listeners</c> on all
+    /// three), and the suite has to hold the same instance it registered in order to read back what
+    /// the store handed it. Nothing else in the document compliance surface needs that, which is why
+    /// this is the first departure from the "everything is a Type the fixture replays" rule.
+    /// </para>
+    /// <para>
+    /// It also has to exist at all, rather than the suite registering a listener through a session
+    /// it was handed. Registration happens when the store is <em>built</em> — before any session
+    /// exists — so without a slot here the suite for jasperfx#679 is not merely awkward to write, it
+    /// is unwritable. That is the jasperfx#672 rule restated: a precondition the config cannot carry
+    /// is one each fixture has to guess at.
+    /// </para>
+    /// <para>
+    /// A fixture replays this by adapting each entry onto its own listener type and adding it to
+    /// <c>StoreOptions.Listeners</c>. Ignoring it does not make
+    /// <c>DocumentCommitListenerCompliance</c> skip — every fact in it fails, because a listener
+    /// that was never registered never fires, which is indistinguishable from a store that does not
+    /// implement the contract.
+    /// </para>
+    /// </remarks>
+    public List<Documents.IDocumentCommitListener> CommitListeners { get; } = new();
+
+    public DocumentComplianceConfig AddCommitListener(Documents.IDocumentCommitListener listener)
+    {
+        CommitListeners.Add(listener);
+        return this;
+    }
 }

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -179,6 +179,7 @@ alongside the event store — `JasperFx.Events.Documents`:
 | `Query<T>()`, its minimum translatable operator set, and the async terminators | `DocumentQueryCompliance` |
 | The route from a session to its event store | `DocumentSessionEventsCompliance` |
 | The stream actions a session has queued but not committed | `PendingStreamActionsCompliance` |
+| Post-commit session listeners and the change set they receive | `DocumentCommitListenerCompliance` |
 
 Enrollment is deliberately much cheaper than the event side. `DocumentStorageComplianceFixture` has
 **three** abstract members — build a store, hand back an `IDocumentSessionFactory`, wipe the data —
@@ -198,14 +199,38 @@ public class my_document_fixture : DocumentStorageComplianceFixture
 public class document_query_compliance : DocumentQueryCompliance<my_document_fixture>;
 ```
 
-The last two rows are opt-in: alone among the document suites they need the store to be an *event*
-store as well, so a document-only implementer simply does not enroll them. Both members they cover —
+`DocumentSessionEventsCompliance` and `PendingStreamActionsCompliance` are opt-in: alone among the
+document suites they need the store to be an *event* store as well, so a document-only implementer
+simply does not enroll them. Both members they cover —
 `IDocumentReadOperations.Events` / `IDocumentSessionOperations.Events` (jasperfx#669) and
 `IDocumentSessionOperations.PendingStreams` (jasperfx#673) — ship with throwing defaults, and both
 are reachable by a near-miss that the compiler does not catch: C# interface implementation is not
 return-type covariant, so a session already declaring a member of the same name with the product's
 own type binds to the default instead of implementing the contract. Only a test calling through a
 contract-typed session notices.
+
+`DocumentCommitListenerCompliance` (jasperfx#679) is opt-in for a different reason: it needs only
+documents, so any store implementing the document contract can enroll, but it needs `BuildStoreAsync`
+to replay `config.CommitListeners` onto the store's own listener collection — `StoreOptions.Listeners`
+on all three products. That member exists because registration happens when the store is *built*,
+before any session exists, so a suite working only through the sessions the fixture hands out could
+not register a listener at all.
+
+It is also the suite whose failure mode nothing else can reach. Neither `IDocumentCommitListener` nor
+`IDocumentChangeSet` ships a default implementation, so unlike the two members above, a store that
+declares them wrongly gets a compile error rather than a silent bind to a throwing default. What no
+compiler sees is the *wiring*: a store that declares both interfaces perfectly and never invokes the
+listener builds clean and passes every other suite here. Deleting the listener loop from this repo's
+own in-memory reference store fails 8 of the suite's 10 facts; the 2 that still pass are the two that
+assert the listener does **not** fire.
+
+Two behaviors it deliberately does not assert, because the products disagree and the contract permits
+both: an **empty unit of work** (Fisher short-circuits and raises nothing; Marten matches but never
+stated it) and a session **enlisted in a caller's ambient transaction** (Fisher does not fire, since
+the enclosing transaction rather than `SaveChangesAsync` is what makes the data durable; Marten fires
+unconditionally). The second is unreachable from a suite in any case — enlistment is spelled on each
+product's own `SessionOptions`, which `IDocumentSessionFactory` does not expose — so it belongs in
+each store's own tests.
 
 `BuildStoreAsync` must honor `config.ValueTypes` as well as `config.DocumentTypes` — every store
 spells that `options.RegisterValueType(type)`. It is what lets `DocumentLoadAndStoreCompliance` hold

--- a/src/JasperFx.Events.ComplianceTests/Suites/DocumentCommitListenerCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DocumentCommitListenerCompliance.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Records every commit it is told about, so a suite can assert on what the store handed it.
+/// </summary>
+/// <remarks>
+/// It keeps the <see cref="IDocumentChangeSet" /> itself rather than copying the three collections
+/// out of it, and that is deliberate: the contract promises the collections are snapshots, so a
+/// change set read after the session has moved on must still answer correctly. A store that handed
+/// out a live view of its unit of work — which is what Marten's <c>IChangeSet</c> natively is —
+/// fails <see cref="DocumentCommitListenerCompliance{TFixture}.the_change_set_survives_the_session_moving_on" />
+/// rather than passing quietly.
+/// </remarks>
+public class RecordingCommitListener : IDocumentCommitListener
+{
+    private readonly List<(IDocumentSessionOperations Session, IDocumentChangeSet Commit)> _commits = new();
+
+    public IReadOnlyList<(IDocumentSessionOperations Session, IDocumentChangeSet Commit)> Commits
+    {
+        get
+        {
+            lock (_commits)
+            {
+                return _commits.ToArray();
+            }
+        }
+    }
+
+    public Task AfterCommitAsync(
+        IDocumentSessionOperations session,
+        IDocumentChangeSet commit,
+        CancellationToken token)
+    {
+        lock (_commits)
+        {
+            _commits.Add((session, commit));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Clear()
+    {
+        lock (_commits)
+        {
+            _commits.Clear();
+        }
+    }
+}
+
+/// <summary>
+/// <see cref="IDocumentCommitListener" /> — the post-commit session hook and the change set it
+/// receives (jasperfx#679).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Opt-in, but for a different reason than the two event-capable document suites: it needs nothing
+/// but documents, so any store implementing the jasperfx#647 contract can enroll. What it needs
+/// instead is that the fixture <em>replay</em> <see cref="DocumentComplianceConfig.CommitListeners" />
+/// onto the store's own listener collection when it builds the store. A fixture that ignores that
+/// member fails every fact here rather than skipping them, which is correct: a listener that was
+/// never registered and a store that never invokes listeners are the same observable failure.
+/// </para>
+/// <para>
+/// ⚠️ <strong>This suite is the only thing standing between the contract and a silent no-op.</strong>
+/// Neither <see cref="IDocumentCommitListener" /> nor <see cref="IDocumentChangeSet" /> has a
+/// default implementation, so unlike jasperfx#669 there is no throwing default for a near-miss to
+/// bind to — a store that declares the interfaces wrongly gets a compile error. But a store that
+/// declares them perfectly and never calls the listener compiles clean and passes every other suite
+/// in this library. The wiring is not visible to the compiler at any point.
+/// </para>
+/// <para>
+/// <strong>Two behaviors are deliberately NOT asserted, because the contract permits both answers
+/// and a suite that picked one would fail a correct store</strong> — the jasperfx#672 rule applied to
+/// firing semantics rather than to configuration:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <strong>The empty unit of work.</strong> A <c>SaveChangesAsync</c> with nothing enlisted need not
+/// raise a commit that wrote nothing; Fisher short-circuits, and Marten's matching behavior was
+/// never stated. Asserting a fire would fail Fisher, and asserting no fire would pin an
+/// unspecified detail on the others.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <strong>A session enlisted in a caller's ambient transaction.</strong> Fisher deliberately does
+/// not fire for one, since the enclosing transaction rather than <c>SaveChangesAsync</c> is what
+/// makes the data durable; Marten fires unconditionally. It is also unreachable from here — every
+/// product spells enlistment on its own <c>SessionOptions</c>, which
+/// <see cref="IDocumentSessionFactory" /> does not expose — so it belongs in each store's own tests.
+/// </description>
+/// </item>
+/// </list>
+/// </remarks>
+public abstract class DocumentCommitListenerCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    // Static because the configuration delegate has to be a stable instance for the fixture to skip
+    // redundant rebuilds, and the suite has to hold the very instances it registered in order to read
+    // them back. Cleared per test in InitializeAsync -- xUnit runs the methods of one class
+    // sequentially, so the recordings never overlap.
+    private static readonly RecordingCommitListener _listener = new();
+    private static readonly RecordingCommitListener _second = new();
+
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_documents";
+
+        config.AddDocumentType<ComplianceWidget>();
+
+        // Two, so that "the store invoked a listener" cannot be mistaken for "the store invoked
+        // every listener" -- a store forwarding only the first registration passes with one.
+        config.AddCommitListener(_listener);
+        config.AddCommitListener(_second);
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        _listener.Clear();
+        _second.Clear();
+    }
+
+    [Fact]
+    public async Task a_listener_fires_after_a_successful_commit()
+    {
+        await PersistAsync(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Flange" });
+
+        // The whole point of the suite. A store that declares both interfaces and never wires them
+        // up reaches this line with an empty list and no compile error anywhere behind it.
+        _listener.Commits.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task every_registered_listener_is_invoked()
+    {
+        await PersistAsync(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Nacelle" });
+
+        _listener.Commits.Count.ShouldBe(1);
+        _second.Commits.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task each_commit_raises_its_own_callback()
+    {
+        await using var session = LightweightSession();
+
+        session.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "First" });
+        await session.SaveChangesAsync(Cancellation);
+
+        session.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Second" });
+        await session.SaveChangesAsync(Cancellation);
+
+        // Two commits, two callbacks -- and specifically not one callback carrying both, which is
+        // what a store accumulating across the session's lifetime would produce.
+        _listener.Commits.Count.ShouldBe(2);
+        _listener.Commits[0].Commit.Inserted.Concat(_listener.Commits[0].Commit.Updated)
+            .OfType<ComplianceWidget>().Select(x => x.Name).ShouldBe(new[] { "First" });
+        _listener.Commits[1].Commit.Inserted.Concat(_listener.Commits[1].Commit.Updated)
+            .OfType<ComplianceWidget>().Select(x => x.Name).ShouldBe(new[] { "Second" });
+    }
+
+    [Fact]
+    public async Task the_change_set_carries_the_written_document()
+    {
+        var id = Guid.NewGuid();
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Strut", Weight = 7 });
+
+        var commit = _listener.Commits.ShouldHaveSingleItem().Commit;
+
+        // Inserted or Updated -- which of the two a first write lands in is the store's own
+        // determination and is not held to a definition here. What is pinned is that it is in
+        // exactly one of them, and that the document itself is what arrives.
+        var written = commit.Inserted.Concat(commit.Updated).ShouldHaveSingleItem();
+
+        var widget = written.ShouldBeOfType<ComplianceWidget>();
+        widget.Id.ShouldBe(id);
+        widget.Name.ShouldBe("Strut");
+        widget.Weight.ShouldBe(7);
+
+        commit.Deleted.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_document_written_twice_is_reported_by_both_commits()
+    {
+        var id = Guid.NewGuid();
+
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Original" });
+        _listener.Clear();
+
+        await PersistAsync(new ComplianceWidget { Id = id, Name = "Revised" });
+
+        var commit = _listener.Commits.ShouldHaveSingleItem().Commit;
+        var written = commit.Inserted.Concat(commit.Updated).ShouldHaveSingleItem();
+
+        written.ShouldBeOfType<ComplianceWidget>().Name.ShouldBe("Revised");
+    }
+
+    [Fact]
+    public async Task a_deleted_document_is_reported_by_type_and_identity()
+    {
+        var id = Guid.NewGuid();
+        var widget = new ComplianceWidget { Id = id, Name = "Doomed" };
+
+        await PersistAsync(widget);
+        _listener.Clear();
+
+        await using (var session = LightweightSession())
+        {
+            session.Delete(widget);
+            await session.SaveChangesAsync(Cancellation);
+        }
+
+        var commit = _listener.Commits.ShouldHaveSingleItem().Commit;
+        var deletion = commit.Deleted.ShouldHaveSingleItem();
+
+        deletion.DocumentType.ShouldBe(typeof(ComplianceWidget));
+
+        // Deliberately not asserting the identity's runtime type beyond equality: a store is free to
+        // hand back the raw Guid or its own wrapped identity, and the contract only says this names
+        // the document that went.
+        deletion.Id.ShouldBe(id);
+    }
+
+    [Fact]
+    public async Task the_listener_does_not_fire_for_work_that_was_never_committed()
+    {
+        await using (var session = LightweightSession())
+        {
+            session.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Abandoned" });
+
+            // Disposed without SaveChangesAsync. This is the cheap version of the failed-commit
+            // fact below and catches the same class of mistake -- a store that raises the callback
+            // from Store(), or from a finally around the commit, fires here.
+        }
+
+        _listener.Commits.ShouldBeEmpty();
+    }
+
+    /// <remarks>
+    /// <para>
+    /// Written as a biconditional rather than as "a failed commit does not fire", because there is
+    /// no way through <see cref="IDocumentSessionFactory" /> to make a commit fail that every store
+    /// is obliged to honor. A pre-cancelled token is the closest the contract comes, and a store
+    /// that completes the commit anyway is not thereby wrong.
+    /// </para>
+    /// <para>
+    /// So the fact asserts the invariant the contract actually states — the callback happens if and
+    /// only if the commit succeeded — which is non-vacuous on both branches. A store that fires on a
+    /// rolled-back transaction fails it, and so does a store that swallows the cancellation and then
+    /// fails to report the commit it did perform. Neither branch is a free pass.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task the_listener_fires_if_and_only_if_the_commit_succeeded()
+    {
+        using var source = new CancellationTokenSource();
+        await source.CancelAsync();
+
+        await using var session = LightweightSession();
+        session.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Cancelled" });
+
+        var committed = true;
+        try
+        {
+            await session.SaveChangesAsync(source.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            committed = false;
+        }
+
+        _listener.Commits.Count.ShouldBe(committed ? 1 : 0);
+    }
+
+    [Fact]
+    public async Task the_committing_session_is_handed_to_the_listener()
+    {
+        await PersistAsync(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Cowling" });
+
+        var session = _listener.Commits.ShouldHaveSingleItem().Session;
+
+        // Not asserted to be the same instance the suite opened: a store is free to hand over a
+        // wrapper. What the contract promises is that a usable session arrives, so the listener can
+        // query or enlist further work from it.
+        session.ShouldNotBeNull();
+    }
+
+    /// <remarks>
+    /// The snapshot requirement, and the one fact here that a store can fail while doing everything
+    /// else right. Marten's <c>IChangeSet</c> <em>is</em> the session's live unit of work and is
+    /// reset immediately after the listener loop — so a store forwarding it unmaterialized answers
+    /// correctly inside the callback and empty by the time anyone reads it again. That is why
+    /// <see cref="IDocumentChangeSet" /> is declared in terms of <see cref="IReadOnlyList{T}" />
+    /// rather than <see cref="IEnumerable{T}" />, and why the shared contract needs no counterpart
+    /// to Marten's <c>IChangeSet.Clone()</c>.
+    /// </remarks>
+    [Fact]
+    public async Task the_change_set_survives_the_session_moving_on()
+    {
+        var id = Guid.NewGuid();
+
+        await using var session = LightweightSession();
+        session.Store(new ComplianceWidget { Id = id, Name = "Persistent" });
+        await session.SaveChangesAsync(Cancellation);
+
+        var commit = _listener.Commits.ShouldHaveSingleItem().Commit;
+
+        // Move the session well past the commit the listener was told about.
+        session.Store(new ComplianceWidget { Id = Guid.NewGuid(), Name = "Later" });
+        await session.SaveChangesAsync(Cancellation);
+
+        var written = commit.Inserted.Concat(commit.Updated).ShouldHaveSingleItem();
+        written.ShouldBeOfType<ComplianceWidget>().Id.ShouldBe(id);
+    }
+}

--- a/src/JasperFx.Events/Documents/IDocumentCommitListener.cs
+++ b/src/JasperFx.Events/Documents/IDocumentCommitListener.cs
@@ -1,0 +1,230 @@
+namespace JasperFx.Events.Documents;
+
+/// <summary>
+/// A callback invoked after a document session commits successfully, carrying the documents that
+/// commit wrote.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The store-agnostic counterpart to Marten's <c>DocumentSessionListenerBase</c> and to Polecat's
+/// and Fisher's <c>IDocumentSessionListener</c>. All three already declare
+/// <c>Task AfterCommitAsync(IDocumentSession, IChangeSet, CancellationToken token)</c> — the same
+/// method, differing only in the two store-local types it names. So, as with
+/// <see cref="IDocumentSessionOperations.PendingStreams" />, this closes a naming gap rather than a
+/// capability gap. Marten's being a convenience base class while the other two are interfaces is an
+/// implementation detail of Marten's base, not a real difference. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/679" />.
+/// </para>
+/// <para>
+/// <strong>This is the SESSION half only.</strong> It fires for commits made through a session the
+/// application opened. It does <em>not</em> fire for the async daemon's projection batches — JasperFx
+/// already owns that half as <see cref="Daemon.IDaemonChangeListener" />, and no store routes
+/// projection writes through its session listeners. Stated here because the failure mode is a
+/// consumer registering one listener, seeing application writes arrive, and concluding the store is
+/// dropping projection writes. A consumer that wants both registers both.
+/// </para>
+/// <para>
+/// Deliberately post-commit only. A <c>BeforeCommit</c> counterpart is not declared: no measured
+/// consumer needs one, and a pre-commit hook wanting to read what is about to be appended is already
+/// served by <see cref="IDocumentSessionOperations.PendingStreams" />. It can be added additively if
+/// a case turns up.
+/// </para>
+/// <para>
+/// <strong>Registration is the store's concern.</strong> Each product already owns a
+/// <c>Listeners</c> collection on its own <c>StoreOptions</c> and <c>SessionOptions</c>, and a store
+/// adopting this contract adapts an <see cref="IDocumentCommitListener" /> onto its own listener
+/// type from its own <c>AddMarten</c> / <c>AddPolecat</c> / <c>AddFisher</c> callback, the same way
+/// the jasperfx#647 contracts are registered. Nothing here names a container or an options type.
+/// </para>
+/// <para>
+/// ⚠️ <strong>Where the silent failure lives, and it is not where it was for
+/// <see cref="IDocumentSessionOperations.Events" />.</strong> No member of this contract has a
+/// default implementation, so the non-covariance trap of jasperfx#669 cannot bite here: a store type
+/// declaring <c>: IDocumentChangeSet</c> whose existing <c>Inserted</c> is an
+/// <c>IEnumerable&lt;object&gt;</c> rather than an <see cref="IReadOnlyList{T}" /> gets CS0535 at
+/// build time, not a member that silently binds to a throwing default. What the compiler cannot see
+/// is the <em>wiring</em>: a store that declares both interfaces perfectly and then never invokes
+/// the listener produces no error anywhere, and the consumer simply never hears about a commit. That
+/// is the failure the compliance suite exists to catch, and the reason a green build is not evidence
+/// this contract is satisfied.
+/// </para>
+/// </remarks>
+public interface IDocumentCommitListener
+{
+    /// <summary>
+    /// Called after <see cref="IDocumentSessionOperations.SaveChangesAsync" /> has committed
+    /// successfully.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>After a successful commit only.</strong> A commit that throws must not raise this —
+    /// the contract exists so a consumer can act on writes that landed, and a listener firing on a
+    /// rolled-back transaction would announce work the database never took. That is the fact a store
+    /// is most likely to get wrong by wiring the call into a <c>finally</c>, so it is pinned by the
+    /// compliance suite rather than left to the store's discretion.
+    /// </para>
+    /// <para>
+    /// ⚠️ <strong>Two cases where a store may legitimately NOT fire, and they are not uniform across
+    /// the products.</strong> Both are stated here so that neither a consumer nor a compliance suite
+    /// assumes a uniformity that does not exist:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <strong>An empty unit of work.</strong> A <c>SaveChangesAsync</c> with nothing enlisted need
+    /// not raise a commit that wrote nothing. Fisher short-circuits; Marten's behavior is the same
+    /// but was never stated. Depend on the callback for writes, never as a commit counter.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <strong>A session enlisted in a caller's ambient transaction.</strong> Fisher deliberately
+    /// does not fire for one, because the session's <c>SaveChangesAsync</c> is not the point at
+    /// which the data becomes durable — the enclosing transaction is, and the store cannot see it
+    /// commit. Marten fires unconditionally. This contract does not force either behavior, because
+    /// forcing Marten's would make the callback announce writes an outer rollback can still discard.
+    /// A consumer relying on the callback under an ambient transaction must check its store.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// One further divergence, noted so it is not mistaken for a dropped write: Marten ejects
+    /// patched document types from the change set <em>before</em> running its listener loop, so
+    /// documents modified by a patch operation are already absent from
+    /// <paramref name="commit" /> when a listener sees it.
+    /// </para>
+    /// </remarks>
+    /// <param name="session">
+    /// The session that committed. It is still usable — a listener may query through it, and may
+    /// enlist further work, though anything it enlists belongs to the <em>next</em> commit and is
+    /// not part of the transaction that just landed.
+    /// </param>
+    /// <param name="commit">What that commit wrote.</param>
+    /// <param name="token">
+    /// Named <c>token</c> deliberately and must stay that way: all three products spell it
+    /// <c>token</c>, as does <see cref="IDocumentSessionOperations.SaveChangesAsync" />.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Task" /> rather than a <see cref="ValueTask" />, matching all three products'
+    /// existing <c>AfterCommitAsync</c>. A per-commit hook is not a hot path, and a
+    /// <see cref="ValueTask" /> here would buy nothing while turning every store's forward into an
+    /// allocation-wrapping adapter.
+    /// </returns>
+    Task AfterCommitAsync(
+        IDocumentSessionOperations session,
+        IDocumentChangeSet commit,
+        CancellationToken token);
+}
+
+/// <summary>
+/// The documents written by a single committed transaction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately three collections and nothing else, on the jasperfx#647 precedent of shipping the
+/// measured surface rather than the imagined one. All three products' change sets also carry
+/// <c>GetEvents()</c> and <c>GetStreams()</c>; those are not guessed at here and can be added
+/// additively when a consumer needs them. A consumer wanting the event side of a commit today reads
+/// <see cref="IDocumentSessionOperations.PendingStreams" /> from a pre-commit position instead.
+/// </para>
+/// <para>
+/// <strong>The collections are SNAPSHOTS, and that is load-bearing rather than a nicety.</strong>
+/// They are <see cref="IReadOnlyList{T}" /> and not <see cref="IEnumerable{T}" /> because on at
+/// least one product the change set is not a value at all — Marten's <c>IChangeSet</c> <em>is</em>
+/// the session's live unit of work, and it is reset immediately after the listener loop runs. A lazy
+/// sequence handed out from it is empty or wrong by the time a listener that stashed it enumerates
+/// again. Requiring a materialized list forces each store to copy when it builds the change set,
+/// which is also why nothing here mirrors Marten's <c>IChangeSet.Clone()</c>: with the copy made at
+/// construction there is no live object left to defend against, so the shared contract needs no
+/// clone step and a consumer needs no rule about when to call one.
+/// </para>
+/// <para>
+/// Empty rather than null throughout: a commit that inserted nothing has an empty
+/// <see cref="Inserted" />. There is no null case for a consumer to guard.
+/// </para>
+/// </remarks>
+public interface IDocumentChangeSet
+{
+    /// <summary>
+    /// Documents this commit created.
+    /// </summary>
+    /// <remarks>
+    /// Whether a given <c>Store</c> counts as an insert or an update is the store's own
+    /// determination and is not held to a shared definition here — products differ on how much they
+    /// know before the write. What is pinned is that every document the commit wrote appears in
+    /// exactly one of <see cref="Inserted" /> or <see cref="Updated" />.
+    /// </remarks>
+    IReadOnlyList<object> Inserted { get; }
+
+    /// <summary>
+    /// Documents this commit overwrote.
+    /// </summary>
+    IReadOnlyList<object> Updated { get; }
+
+    /// <summary>
+    /// The deletions this commit performed, as <see cref="IDocumentDeletion" /> descriptors rather
+    /// than as document instances.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ⚠️ <strong>Descriptors, and it cannot be otherwise.</strong> Of the three products only
+    /// Marten's change set holds a deleted document instance; Polecat's and Fisher's carry
+    /// <c>{ DocumentType, Id }</c> and nothing more. A <c>Deleted</c> declared as
+    /// <c>IReadOnlyList&lt;object&gt;</c> — symmetrical with <see cref="Inserted" /> and
+    /// <see cref="Updated" />, and the obvious shape to reach for — would therefore be
+    /// unimplementable on two of the three stores, which could only ever answer it empty.
+    /// </para>
+    /// <para>
+    /// It is also the honest shape rather than merely the achievable one. Deletion by identity
+    /// (<see cref="IDocumentWriteOperations.Delete{T}(System.Guid)" />) and by criteria
+    /// (<see cref="IDocumentWriteOperations.DeleteWhere{T}" />) never loaded a document to report,
+    /// so a collection of instances would silently omit exactly the deletions a consumer is least
+    /// likely to expect to be missing.
+    /// </para>
+    /// </remarks>
+    IReadOnlyList<IDocumentDeletion> Deleted { get; }
+}
+
+/// <summary>
+/// One document removed by a committed transaction, identified by type and identity.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two members every product's change set already carries, so no store has to project anything
+/// new. Polecat's <c>Polecat.Services.IDeletion</c> and Fisher's
+/// <c>Fisher.Services.IDocumentDeletion</c> declare exactly this pair; Marten's deleted element is a
+/// live <c>Weasel.Storage.IDeletion</c> storage operation, which inherits <c>Type DocumentType</c>
+/// from <c>Weasel.Core.IStorageOperation</c> and declares <c>object Id</c>.
+/// </para>
+/// <para>
+/// Owned by JasperFx on purpose. Marten's deleted element type lives in <c>Weasel</c>, so exposing
+/// it directly would re-couple every consumer of this contract to a package it otherwise never
+/// names — the same coupling the document contracts exist to remove.
+/// </para>
+/// <para>
+/// Named for Fisher's spelling. <c>IDeletion</c> is already taken in any file that also imports
+/// <c>Weasel.Storage</c>, which is the situation inside Marten and the reason Fisher renamed it; a
+/// shared contract reintroducing that collision would have to be aliased in the one store that most
+/// needs to implement it cleanly.
+/// </para>
+/// <para>
+/// No document instance is exposed, even though Marten has one. Two of the three products cannot
+/// supply it, and a member populated on one store and empty on the others is worse than an absent
+/// one — it reads as a store bug rather than as a contract boundary. A consumer needing the deleted
+/// document reads it before the delete, or takes a dependency on a concrete store.
+/// </para>
+/// </remarks>
+public interface IDocumentDeletion
+{
+    /// <summary>
+    /// The document type that was deleted.
+    /// </summary>
+    Type DocumentType { get; }
+
+    /// <summary>
+    /// The identity of the deleted document, or <c>null</c> where the deletion was expressed as
+    /// criteria (<see cref="IDocumentWriteOperations.DeleteWhere{T}" />) and so names no single
+    /// identity.
+    /// </summary>
+    object? Id { get; }
+}


### PR DESCRIPTION
Closes #679. Refs #647, #669, #673.

**No store implements this yet.** Marten, Polecat and Fisher are all unchanged by this PR — it adds the contract, the compliance suite that holds a store to it, and the config seam the suite needs. Adoption is three follow-up PRs, one per store.

## Scope note: #678 is not in this PR

This branch was originally scoped to #678 **and** #679. #678 turns out to be a duplicate of #673, which shipped in **JasperFx 2.51.0** — the current pin in this repo and in all three stores. It landed as `IReadOnlyList<StreamAction> PendingStreams` on `IDocumentSessionOperations`, all three stores already implement it as explicit interface implementations, and `PendingStreamActionsCompliance` already pins it.

#678's proposed `IPendingStream` is strictly weaker than the shipped `StreamAction`, which already carries `Id`, `Key`, `Events` plus `ActionType` and `TenantId`. Nothing for #678 is included here; it should be closed as resolved-by-#673.

## The contract

```csharp
public interface IDocumentCommitListener
{
    Task AfterCommitAsync(
        IDocumentSessionOperations session,
        IDocumentChangeSet commit,
        CancellationToken token);
}

public interface IDocumentChangeSet
{
    IReadOnlyList<object> Inserted { get; }
    IReadOnlyList<object> Updated { get; }
    IReadOnlyList<IDocumentDeletion> Deleted { get; }
}

public interface IDocumentDeletion
{
    Type DocumentType { get; }
    object? Id { get; }
}
```

## Three departures from the issue text, each forced by the stores

**1. `Deleted` is `IReadOnlyList<IDocumentDeletion>`, not `IReadOnlyList<object>`.** The filed shape is unimplementable on two of the three stores. Only Marten's change set holds a deleted document instance; Polecat's `IDeletion` and Fisher's `IDocumentDeletion` carry `{ Type DocumentType, object? Id }` and nothing more. Polecat and Fisher could only ever answer `IReadOnlyList<object>` empty.

It is also the honest shape rather than merely the achievable one: delete-by-id and `DeleteWhere` never loaded a document to report, so a collection of instances would silently omit exactly the deletions a consumer is least likely to expect to be missing.

The descriptor is owned by JasperFx rather than reusing Marten's element type, which is `Weasel.Storage.IDeletion` — exposing it would re-couple every consumer to a package the document contracts exist to keep out. Cost to the stores is nil: Polecat and Fisher already declare this exact pair, and Marten's `IDeletion` inherits `Type DocumentType` from `Weasel.Core.IStorageOperation` and declares `object Id`. It is named for Fisher's spelling because `IDeletion` is already taken in any file importing `Weasel.Storage`, which is the situation inside Marten.

**2. `Task`, not `ValueTask`.** All three products spell `AfterCommitAsync` returning `Task`. A per-commit hook is not a hot path, and `ValueTask` would turn every store's forward into an allocation-wrapping adapter for nothing.

**3. The collections are documented SNAPSHOTS.** Marten's `IChangeSet` *is* the session's live unit of work and is reset immediately after the listener loop — which is why Marten carries `IChangeSet.Clone()`. Declaring `IReadOnlyList` forces each store to materialize when it builds the change set, which is what lets a listener stash the change set and read it later, and is why the shared contract needs no counterpart to `Clone()`. Pinned by `the_change_set_survives_the_session_moving_on`.

## Firing semantics are documented because they are NOT uniform

This is the #672 lesson applied to behavior rather than configuration — a precondition the contract cannot carry is one every consumer and every fixture has to guess:

- **Enlisted transactions.** Fisher does not fire for a session enlisted in a caller's ambient transaction (the enclosing transaction, not `SaveChangesAsync`, is what makes the data durable). **Marten fires unconditionally.** The contract forces neither, because forcing Marten's would make the callback announce writes an outer rollback can still discard.
- **Empty unit of work.** Fisher short-circuits; Marten matches but never stated it. Permitted either way.
- **Daemon projection batches.** Neither half fires. JasperFx already owns that as `IDaemonChangeListener`, and the remarks say so explicitly — otherwise a consumer registers one listener and concludes the store is dropping projection writes.
- **Marten ejects patched types before the listener loop**, so patched documents are already absent from the change set a listener sees.

The compliance suite deliberately asserts **none** of the divergent cases, and says why in its own remarks.

## Where the silent failure lives — and it moved

Unlike #669's `Events` accessor, neither new interface has a default implementation, so the non-covariance trap cannot bite: a store declaring `: IDocumentChangeSet` whose `Inserted` is an `IEnumerable<object>` gets **CS0535 at build time**, not a member silently binding to a throwing default.

What no compiler sees is the **wiring**. A store that declares both interfaces perfectly and never invokes the listener builds clean and passes every other suite in the library. That is what `DocumentCommitListenerCompliance` exists for, and it is why a green build is not evidence this contract is satisfied.

## Compliance suite (10 facts)

`JasperFx.Events.ComplianceTests/Suites/DocumentCommitListenerCompliance.cs`:

`a_listener_fires_after_a_successful_commit` · `every_registered_listener_is_invoked` · `each_commit_raises_its_own_callback` · `the_change_set_carries_the_written_document` · `a_document_written_twice_is_reported_by_both_commits` · `a_deleted_document_is_reported_by_type_and_identity` · `the_listener_does_not_fire_for_work_that_was_never_committed` · `the_listener_fires_if_and_only_if_the_commit_succeeded` · `the_committing_session_is_handed_to_the_listener` · `the_change_set_survives_the_session_moving_on`

The failed-commit fact is written as a **biconditional** rather than as "a failed commit does not fire". There is no way through `IDocumentSessionFactory` to make a commit fail that every store is obliged to honor — a pre-cancelled token is the closest the contract comes, and a store that completes the commit anyway is not thereby wrong. Asserting "fires if and only if the commit succeeded" is non-vacuous on both branches: a store that fires on a rolled-back transaction fails it, and so does a store that swallows the cancellation and then fails to report the commit it did perform.

## New config seam

`DocumentComplianceConfig.CommitListeners` + `AddCommitListener(...)`. Registration happens when the store is **built**, before any session exists, so without this the suite is not merely awkward to write — it is unwritable. A fixture replays it onto its own `StoreOptions.Listeners`; ignoring it fails every fact rather than skipping them, which is correct, since a listener never registered and a store that never invokes one are the same observable failure.

This is the first config member that is not a `Type`, and it has to be: a listener is registered as an *instance* on every product, and the suite has to hold the same instance it registered to read back what the store handed it.

## Verification

- `dotnet build jasperfx.slnx` — **0 errors**.
- The in-memory reference store in `EventStoreTests` now implements the contract and enrols the suite, so it is executed in this repo before three products are held to it — **136 passed, 0 failed**, in 138ms with no database.
- **Mutation-checked:** deleting the listener loop from the reference store fails **8 of the 10** facts. The 2 that still pass are exactly the two asserting the listener does *not* fire.

⚠️ **No store-backed compliance suite was run.** Nothing here touched Marten, Polecat or Fisher, and the Docker/Postgres/SQL Server-backed suites were deliberately not run locally. The claims about the three products' shapes and firing semantics come from reading their sources at the current pins, not from executing them — the per-store adoption PRs are where they get proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mpctjngqnraWVnDaqWtYf
