### PR TITLE
gh-681: stamp the rebuild mode onto the shard states an agent publishes

### DIFF
--- a/src/EventTests/Daemon/ShardStateModeTests.cs
+++ b/src/EventTests/Daemon/ShardStateModeTests.cs
@@ -1,0 +1,217 @@
+using System.Collections.Concurrent;
+using JasperFx;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#681: ShardMode.rebuilding had no writer anywhere in the tree, so every ShardState a
+// SubscriptionAgent published claimed `continuous` -- including the ones published during a replay.
+// A subscriber watching ShardStateTracker therefore could not tell a projection catching up under a
+// rebuild from one running normally, which is the only distinction the enum exists to draw.
+//
+// The agent already knew; it just knew on a different enum (ShardExecutionMode) that was never
+// copied onto what it published. So these assert propagation, not new state -- and they assert it on
+// what comes out of the tracker rather than on the agent's own property, because the property was
+// always right and the published state was always wrong.
+public class ShardStateModeTests
+{
+    private const long HighWater = 1000;
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly RecordingObserver theObserver = new();
+    private readonly ShardStateTracker theTracker;
+
+    public ShardStateModeTests()
+    {
+        theTracker = new ShardStateTracker(NullLogger.Instance);
+        theTracker.Subscribe(theObserver);
+    }
+
+    private SubscriptionAgent agentFor()
+        => new(new ShardName("Projection1"), new AsyncOptions(), TimeProvider.System,
+            new ExhaustingEventLoader(), Substitute.For<ISubscriptionExecution>(),
+            theTracker, Substitute.For<ISubscriptionMetrics>(), NullLogger.Instance);
+
+    private static SubscriptionExecutionRequest requestFor(ShardExecutionMode mode)
+        => new(0, mode, new ErrorHandlingOptions(), new NulloDaemonRuntime());
+
+    [Fact]
+    public async Task a_continuous_start_publishes_continuous()
+    {
+        await using var agent = agentFor();
+
+        await agent.StartAsync(requestFor(ShardExecutionMode.Continuous));
+
+        (await theObserver.WaitForAsync(ShardAction.Started)).Mode.ShouldBe(ShardMode.continuous);
+    }
+
+    /// <remarks>
+    /// The distinction the issue is actually about. A shard behind the high water mark under normal
+    /// operation is still <c>continuous</c> — the number an operator is watching is lag. Only a
+    /// rebuild makes it catch-up progress instead, so only a rebuild changes the mode.
+    /// </remarks>
+    [Fact]
+    public async Task a_catch_up_start_publishes_continuous_rather_than_rebuilding()
+    {
+        await using var agent = agentFor();
+
+        await agent.StartAsync(requestFor(ShardExecutionMode.CatchUp));
+
+        (await theObserver.WaitForAsync(ShardAction.Started)).Mode.ShouldBe(ShardMode.continuous);
+    }
+
+    /// <remarks>
+    /// THE regression. Before this, the state a replay published went out with the default
+    /// <c>continuous</c>, so nothing downstream could see that a rebuild was underway.
+    /// </remarks>
+    [Fact]
+    public async Task a_replay_publishes_rebuilding()
+    {
+        await using var agent = agentFor();
+
+        var replay = agent.ReplayAsync(requestFor(ShardExecutionMode.Rebuild), HighWater, TestTimeout);
+
+        (await theObserver.WaitForAsync(ShardAction.Started)).Mode.ShouldBe(ShardMode.rebuilding);
+
+        await finishRebuildAsync(agent, replay);
+    }
+
+    // Drive the rebuild to its ceiling so ReplayAsync returns normally. Letting it time out or fault
+    // instead would leave the assertions racing the unwind, which resets Mode on its way out.
+    private static async Task finishRebuildAsync(SubscriptionAgent agent, Task replay)
+    {
+        await agent.MarkSuccessAsync(HighWater);
+        await replay.WaitAsync(TestTimeout);
+    }
+
+    /// <remarks>
+    /// Every publish in the agent runs through one stamping helper, so per-batch progress carries the
+    /// mode too. This is the one that matters most in practice: it is the state a progress display
+    /// updates on, and the one a consumer would be keying "rebuilding" off.
+    /// </remarks>
+    [Fact]
+    public async Task per_batch_progress_during_a_rebuild_publishes_rebuilding()
+    {
+        await using var agent = agentFor();
+
+        var replay = agent.ReplayAsync(requestFor(ShardExecutionMode.Rebuild), HighWater, TestTimeout);
+        await theObserver.WaitForAsync(ShardAction.Started);
+
+        await agent.MarkSuccessAsync(250);
+
+        (await theObserver.WaitForAsync(ShardAction.Updated, 250)).Mode.ShouldBe(ShardMode.rebuilding);
+
+        await finishRebuildAsync(agent, replay);
+    }
+
+    [Fact]
+    public async Task per_batch_progress_outside_a_rebuild_publishes_continuous()
+    {
+        await using var agent = agentFor();
+        await agent.StartAsync(requestFor(ShardExecutionMode.Continuous));
+
+        await agent.MarkSuccessAsync(250);
+
+        (await theObserver.WaitForAsync(ShardAction.Updated, 250)).Mode.ShouldBe(ShardMode.continuous);
+    }
+
+    /// <remarks>
+    /// The half that is easy to leave out, and worse than the original bug if you do. The teardown a
+    /// finished replay runs publishes a Stopped state; if that still said <c>rebuilding</c>, a
+    /// consumer tracking the last state it saw would latch on "rebuilding" permanently — a projection
+    /// that never stops rebuilding, from a rebuild that ended cleanly.
+    /// </remarks>
+    [Fact]
+    public async Task a_finished_replay_stops_reporting_rebuilding()
+    {
+        await using var agent = agentFor();
+
+        var replay = agent.ReplayAsync(requestFor(ShardExecutionMode.Rebuild), HighWater, TestTimeout);
+        await theObserver.WaitForAsync(ShardAction.Started);
+        await finishRebuildAsync(agent, replay);
+
+        agent.Mode.ShouldBe(ShardExecutionMode.Continuous);
+
+        // And a state published from here on says so, rather than inheriting the finished rebuild.
+        await agent.MarkSuccessAsync(900);
+        (await theObserver.WaitForAsync(ShardAction.Updated, 900)).Mode.ShouldBe(ShardMode.continuous);
+    }
+
+    /// <remarks>
+    /// A failure is exactly when an operator reads the state, and a rebuild that failed is a
+    /// materially different thing to be told about than a running projection that failed.
+    /// </remarks>
+    [Fact]
+    public async Task a_failure_during_a_rebuild_publishes_rebuilding()
+    {
+        await using var agent = agentFor();
+
+        var replay = agent.ReplayAsync(requestFor(ShardExecutionMode.Rebuild), HighWater, TestTimeout);
+        await theObserver.WaitForAsync(ShardAction.Started);
+
+        await agent.ReportCriticalFailureAsync(new DivideByZeroException("boom"));
+
+        (await theObserver.WaitForAsync(ShardAction.Paused)).Mode.ShouldBe(ShardMode.rebuilding);
+
+        // The failure faults the rebuild, which is ReplayAsync's contract (see ReplayFaultPropagationTests).
+        (await Should.ThrowAsync<DivideByZeroException>(replay.WaitAsync(TestTimeout))).Message.ShouldBe("boom");
+    }
+
+    // Returns one empty page that exhausts the whole range, so the agent stops loading and sits in
+    // Rebuild mode until the test drives it. A substituted IEventLoader returns a null page instead,
+    // which faults the agent and unwinds the replay mid-assertion.
+    private class ExhaustingEventLoader: IEventLoader
+    {
+        public Task<EventPage> LoadAsync(EventRequest request, CancellationToken token)
+        {
+            var page = new EventPage(request.Floor);
+            page.CalculateCeiling(request.BatchSize, request.HighWater);
+            return Task.FromResult(page);
+        }
+    }
+
+    private class RecordingObserver: IObserver<ShardState>
+    {
+        private readonly ConcurrentQueue<ShardState> _states = new();
+
+        public void OnNext(ShardState value) => _states.Enqueue(value);
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        /// <summary>
+        /// Wait for a matching publication rather than reading the queue as it stands.
+        /// <see cref="ShardStateTracker.PublishAsync" /> hands the state to observers off the calling
+        /// path, so an assertion that reads immediately after the awaited publish is racing the walk —
+        /// and loses often enough to be useless as a regression test.
+        /// </summary>
+        public async Task<ShardState> WaitForAsync(ShardAction action, long? sequence = null)
+        {
+            bool matches(ShardState x) => x.Action == action && (sequence == null || x.Sequence == sequence);
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            while (!_states.Any(matches))
+            {
+                if (timeout.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"No published state with Action {action}{(sequence == null ? "" : $" at sequence {sequence}")}. Saw: {string.Join(", ", _states.Select(x => $"{x.Action}@{x.Sequence}"))}");
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            }
+
+            return _states.Last(matches);
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -173,7 +173,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
             {
                 PausedTime = null;
                 Status = AgentStatus.Stopped;
-                await _tracker.PublishAsync(new ShardState(Name, LastCommitted)
+                await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)
                 {
                     Action = ShardAction.Stopped,
                     Exception = ex,
@@ -181,13 +181,13 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
                     PauseReason = failure.Detail,
                     Failure = failure,
                     LastHeartbeat = _timeProvider.GetUtcNow()
-                });
+                }));
             }
             else
             {
                 PausedTime = _timeProvider.GetUtcNow();
                 Status = AgentStatus.Paused;
-                await _tracker.PublishAsync(new ShardState(Name, LastCommitted)
+                await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)
                 {
                     Action = ShardAction.Paused,
                     Exception = ex,
@@ -195,7 +195,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
                     PauseReason = failure.Detail,
                     Failure = failure,
                     LastHeartbeat = _timeProvider.GetUtcNow()
-                });
+                }));
             }
 
             if (Mode == ShardExecutionMode.Rebuild)
@@ -247,12 +247,12 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
             _logger.LogInformation("Stopped projection agent {Name}", ProjectionShardIdentity);
             Status = AgentStatus.Stopped;
-            await _tracker.PublishAsync(new ShardState(Name, LastCommitted)
+            await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)
             {
                 Action = ShardAction.Stopped,
                 AgentStatus = "Stopped",
                 LastHeartbeat = _timeProvider.GetUtcNow()
-            });
+            }));
         }
     }
 
@@ -260,12 +260,12 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     {
         await _execution.HardStopAsync().ConfigureAwait(false);
         await DisposeAsync().ConfigureAwait(false);
-        await _tracker.PublishAsync(new ShardState(Name, LastCommitted)
+        await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)
         {
             Action = ShardAction.Stopped,
             AgentStatus = "Stopped",
             LastHeartbeat = _timeProvider.GetUtcNow()
-        });
+        }));
     }
 
     public async Task StartAsync(SubscriptionExecutionRequest request)
@@ -295,7 +295,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
         }
 
         await _commandBlock.PostAsync(Command.Started(request.StartingHighWater ?? _tracker.HighWaterMark, request.Floor));
-        await _tracker.PublishAsync(stampSideEffectGate(new ShardState(Name, request.Floor)
+        await _tracker.PublishAsync(stamp(new ShardState(Name, request.Floor)
         {
             Action = ShardAction.Started,
             AgentStatus = "Running",
@@ -314,11 +314,22 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     /// </summary>
     public bool SideEffectsSuppressed => _sideEffectsSuppressed;
 
-    // jasperfx#598/#610: stamp the warm-up window onto every state this agent publishes, so an operator
-    // watching the shard can tell "running, but not emitting side effects yet" from "running normally"
-    // — the distinction that was invisible while the warm-up hid inside the start path.
-    private ShardState stampSideEffectGate(ShardState state)
+    // Stamp what this agent knows about itself onto every state it publishes. EVERY publish in this
+    // class goes through here — a publish that skips it reports the agent's defaults rather than its
+    // actual condition, which is exactly the bug jasperfx#681 was.
+    private ShardState stamp(ShardState state)
     {
+        // jasperfx#681: ShardMode.rebuilding had no writer anywhere in the tree, so every state this
+        // agent published claimed `continuous` — including the ones published during a replay. The
+        // agent already knows better; it just knows it on a different enum. Only Rebuild maps to
+        // rebuilding: CatchUp is a shard catching up under normal operation, and telling those two
+        // apart is the whole point of the distinction.
+        state.Mode = Mode == ShardExecutionMode.Rebuild ? ShardMode.rebuilding : ShardMode.continuous;
+
+        // jasperfx#598/#610: the warm-up window, so an operator watching the shard can tell "running,
+        // but not emitting side effects yet" from "running normally" — the distinction that was
+        // invisible while the warm-up hid inside the start path.
+        //
         // Mark first, flag second: completeSideEffectGateAsync clears the flag before zeroing the mark, so
         // a publisher on another thread (MarkSuccessAsync, the heartbeat timer) racing the flip either
         // stamps a consistent pair or stamps nothing — never "suppressed, gated on 0".
@@ -355,12 +366,12 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
             "Projection agent {Name} finished its side-effect-suppressed warm-up at {Mark}; side effects are enabled from here on",
             ProjectionShardIdentity, mark);
 
-        await _tracker.PublishAsync(new ShardState(Name, LastCommitted)
+        await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)
         {
             Action = ShardAction.Updated,
             AgentStatus = Status.ToString(),
             LastHeartbeat = _timeProvider.GetUtcNow()
-        });
+        }));
     }
 
     // jasperfx#598/#610: admission to the daemon's warm-up throttle. Returns true when this agent may
@@ -456,7 +467,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
             }
             else
             {
-                await _tracker.PublishAsync(new ShardState(Name, request.Floor) { Action = ShardAction.Started });
+                await _tracker.PublishAsync(stamp(new ShardState(Name, request.Floor) { Action = ShardAction.Started }));
                 await _commandBlock.PostAsync(Command.Started(highWaterMark, request.Floor));
 
                 await _rebuild.Task.TimeoutAfterAsync((int)timeout.TotalMilliseconds).ConfigureAwait(false);
@@ -469,6 +480,14 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
         }
         finally
         {
+            // jasperfx#681: drop out of Rebuild BEFORE the teardown, so the Stopped state disposal
+            // publishes does not still claim to be rebuilding. A consumer that tracks "is this shard
+            // rebuilding" off the last state it saw would otherwise latch on rebuilding forever, which
+            // is a worse failure than the one this issue reported. Safe here: everything that reads
+            // Mode to decide the rebuild's outcome (ReportCriticalFailureAsync, the RangeCompleted
+            // branch of the command loop) has already run against the completed _rebuild task.
+            Mode = ShardExecutionMode.Continuous;
+
             await DisposeAsync().ConfigureAwait(false);
         }
     }
@@ -504,7 +523,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     {
         var now = _timeProvider.GetUtcNow();
         await _commandBlock.PostAsync(Command.Completed(processedCeiling));
-        await _tracker.PublishAsync(stampSideEffectGate(new ShardState(Name, processedCeiling)
+        await _tracker.PublishAsync(stamp(new ShardState(Name, processedCeiling)
         {
             Action = ShardAction.Updated,
             LastAdvanced = now,
@@ -620,7 +639,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
                     _bufferedCeiling = LastCommitted; // jasperfx#525: keep the buffered marker >= committed
                 }
 
-                await _tracker.PublishAsync(new ShardState(Name, LastCommitted));
+                await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)));
 
                 if (LastCommitted == HighWaterMark && Mode == ShardExecutionMode.Rebuild)
                 {
@@ -766,7 +785,7 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
 
             try
             {
-                var state = stampSideEffectGate(new ShardState(Name, LastCommitted)
+                var state = stamp(new ShardState(Name, LastCommitted)
                 {
                     Action = ShardAction.Updated,
                     LastHeartbeat = _timeProvider.GetUtcNow(),

--- a/src/JasperFx.Events/Projections/ShardState.cs
+++ b/src/JasperFx.Events/Projections/ShardState.cs
@@ -2,10 +2,35 @@ using JasperFx.Events.Daemon;
 
 namespace JasperFx.Events.Projections;
 
+/// <summary>
+/// Whether the shard that published a <see cref="ShardState" /> was running normally or rebuilding.
+/// </summary>
+/// <remarks>
+/// jasperfx#681: <see cref="rebuilding" /> had no writer anywhere in the tree until then, so every
+/// state a <c>SubscriptionAgent</c> published reported <see cref="continuous" /> — including the ones
+/// published during a replay. An observer therefore could not tell a projection catching up under a
+/// rebuild from one running normally, which is the distinction this enum exists to draw.
+/// </remarks>
 public enum ShardMode
 {
+    /// <summary>
+    /// Unknown. Not published by a running agent — it is the default for a persisted progression row
+    /// that predates the mode being recorded, so it means "no mode was stored", not "idle".
+    /// </summary>
     none,
+
+    /// <summary>
+    /// Running normally. Covers ordinary catch-up as well as steady-state tailing: a shard behind the
+    /// high water mark under continuous operation is still <see cref="continuous" />, because the
+    /// number an operator is watching is lag either way.
+    /// </summary>
     continuous,
+
+    /// <summary>
+    /// Rebuilding from the beginning of the stream. The sequence on the same state is catch-up
+    /// progress toward the rebuild's ceiling, <em>not</em> lag — which is what makes this worth
+    /// telling an operator about.
+    /// </summary>
     rebuilding
 }
 


### PR DESCRIPTION
Closes #681.

`ShardMode.rebuilding` had no writer anywhere in the tree. Every `ShardState` a `SubscriptionAgent` published went out with the property's default of `continuous` — including the ones published during a replay — so a subscriber watching `ShardStateTracker` could not tell a projection catching up under a rebuild from one running normally.

The agent already knew which it was; it just knew it on a different enum (`ShardExecutionMode`) that was never copied onto what it published. Propagation, not new state.

## Two decisions beyond the literal ask

**One stamping helper, not two stamped publishes.** The issue named `ReplayAsync` and `MarkSuccessAsync`. There are **nine** publish sites in `SubscriptionAgent`, and the bug was a publish site reporting the agent's defaults instead of its condition — so all nine now route through a single `stamp(...)`, with the side-effect-gate stamping from #598/#610 folded in alongside. That is what stops the tenth from being written wrong.

**`CatchUp` maps to `continuous`, not `rebuilding`.** A shard behind the high water mark under normal operation is still `continuous`: the number an operator is watching is lag either way. Only `Rebuild` makes it catch-up progress instead, which is the distinction worth surfacing.

## The reset matters more than it looks

`ReplayAsync` drops back to `Continuous` in its `finally`, **before** the teardown. Without it the `Stopped` state that disposal publishes still claims `rebuilding`, and a consumer tracking "is this shard rebuilding" off the last state it saw latches on permanently — a projection that never stops rebuilding, from a rebuild that ended cleanly. That would be worse than the reported bug. It is safe there: everything that reads `Mode` to decide the rebuild's outcome (`ReportCriticalFailureAsync`, the `RangeCompleted` branch) has already run against the completed `_rebuild` task.

Also documents the enum, which had no stated meaning because it had no writer — including that `none` means "no mode was stored", not "idle".

## Downstream: nothing needed

Checked all three stores, since the question is whether CritterWatch gets this on a JasperFx bump alone or has to wait on a store release.

- **None of Marten, Polecat or Fisher implements `ISubscriptionAgent`** — they all use JasperFx's `SubscriptionAgent` and `ShardStateTracker` as-is, so all three pick this up on the version bump with no code change.
- **Polecat and Fisher have zero references to `ShardMode`** at all.
- **Marten has two**, and neither is affected: `EventProgressionTable` declares a `mode` column and `ShardStateSelector` reads it back. That is the *persisted* path, not the live tracker path a `IObserver<ShardState>` subscribes to.

Worth recording separately: **nothing writes Marten's `mode` column.** None of `mt_mark_event_progression.sql`, `mt_mark_event_progression_extended.sql` or `mt_mark_progression_with_skip.sql` mentions it, so it sits at its `none` default forever and a `ShardState` hydrated from the progression table always reports `none`. Pre-existing, out of scope here, and arguably honest as-is (`none` = "no mode stored"). Say the word and I'll file it against Marten.

## Tests

`ShardStateModeTests` asserts on what comes out of the tracker rather than on the agent's own property — the property was always right and the published state was always wrong. Covers: continuous start, catch-up start, replay start, per-batch progress inside and outside a rebuild, a failure during a rebuild, and that a finished replay stops reporting `rebuilding`.

Two things they need to be deterministic, both found by watching them flake:

- `ShardStateTracker.PublishAsync` hands states to observers off the publishing path, so an assertion reading the queue straight after the awaited publish loses the race often enough to be useless. Every assertion waits for its publication.
- A substituted `IEventLoader` returns a null page, which faults the agent and unwinds the replay *mid-assertion*, resetting `Mode` out from under it. The tests use a loader that exhausts its range in one empty page, and drive each rebuild to its ceiling so `ReplayAsync` returns normally.

Green 5/5 consecutive local runs of the full `EventTests` suite (799 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)