### PR TITLE
gh-683: let a projection storage say it cannot take concurrent slices

### DIFF
--- a/src/EventTests/Daemon/AggregationRunnerSliceConcurrencyTests.cs
+++ b/src/EventTests/Daemon/AggregationRunnerSliceConcurrencyTests.cs
@@ -41,11 +41,16 @@ public class AggregationRunnerSliceConcurrencyTests
         theProjection.Options.Returns(new AsyncOptions());
         theProjection.Scope.Returns(AggregationScope.MultiStream);
         theProjection.MatchesAnyDeleteType(Arg.Any<IReadOnlyList<IEvent>>()).Returns(false);
+        // The overlap is measured here rather than inside the storage, and it matters: this is an await,
+        // so ten concurrent applies can be in flight without ten OS threads. Measuring at a blocking call
+        // instead makes the concurrent route depend on the thread pool injecting threads, which a small CI
+        // runner does not do quickly enough -- it measured a max concurrency of 1 and failed the fan-out
+        // fact on net10.0 while passing on net9.0.
         theProjection
             .DetermineActionAsync(Arg.Any<FakeSession>(), Arg.Any<User?>(), Arg.Any<Guid>(),
                 Arg.Any<IProjectionStorage<User, Guid>>(), Arg.Any<IReadOnlyList<IEvent>>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<(User?, ActionType)>((snapshot, ActionType.Store)));
+            .Returns(_ => new ValueTask<(User?, ActionType)>(theStorage.TrackApplyAsync(snapshot)));
         theProjection
             .TryApplyMetadata(Arg.Any<IReadOnlyList<IEvent>>(), Arg.Any<User?>(), Arg.Any<Guid>(),
                 Arg.Any<IProjectionStorage<User, Guid>>())
@@ -183,14 +188,13 @@ public class AggregationRunnerSliceConcurrencyTests
     }
 
     /// <summary>
-    /// Records how many applies are in flight at once. The sleep is what makes overlap observable at all —
-    /// without it the applies are fast enough that even the ten-wide route rarely has two in flight, and the
-    /// test would pass against the bug.
+    /// Records how many applies are in flight at once, and can fail a chosen one.
     /// </summary>
     private class ConcurrencyProbeStorage: IProjectionStorage<User, Guid>
     {
         private readonly object _lock = new();
         private int _inFlight;
+        private int _stored;
 
         public bool IsThreadSafe { get; set; } = true;
         public int MaxConcurrency { get; private set; }
@@ -201,26 +205,23 @@ public class AggregationRunnerSliceConcurrencyTests
 
         public string TenantId => "foo";
 
-        public void StoreProjection(User aggregate, IEvent? lastEvent, AggregationScope scope)
+        /// <summary>
+        /// Called from the projection's apply, which awaits it. Records how many applies overlap.
+        /// </summary>
+        public async Task<(User?, ActionType)> TrackApplyAsync(User snapshot)
         {
-            int number;
-
             lock (_lock)
             {
                 _inFlight++;
                 Applied++;
-                number = Applied;
                 if (_inFlight > MaxConcurrency) MaxConcurrency = _inFlight;
             }
 
             try
             {
-                Thread.Sleep(15);
-
-                if (number == FailOnApplyNumber || number == AlsoFailOnApplyNumber)
-                {
-                    throw new DivideByZeroException($"slice {number}");
-                }
+                // Long enough that a concurrent route has every slot occupied at once, and short enough
+                // that the serial route's twenty applies still finish promptly.
+                await Task.Delay(25);
             }
             finally
             {
@@ -228,6 +229,23 @@ public class AggregationRunnerSliceConcurrencyTests
                 {
                     _inFlight--;
                 }
+            }
+
+            return (snapshot, ActionType.Store);
+        }
+
+        public void StoreProjection(User aggregate, IEvent? lastEvent, AggregationScope scope)
+        {
+            int number;
+            lock (_lock)
+            {
+                _stored++;
+                number = _stored;
+            }
+
+            if (number == FailOnApplyNumber || number == AlsoFailOnApplyNumber)
+            {
+                throw new DivideByZeroException($"slice {number}");
             }
         }
 

--- a/src/EventTests/Daemon/AggregationRunnerSliceConcurrencyTests.cs
+++ b/src/EventTests/Daemon/AggregationRunnerSliceConcurrencyTests.cs
@@ -1,0 +1,308 @@
+using EventTests.Projections;
+using JasperFx.Core;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#683: AggregationRunner applies every slice in a range through a fixed 10-wide Block, and every
+// one of them gets the SAME IProjectionStorage instance. That is what the products' own document storage is
+// built for, and it is not what an EF Core storage can take -- it wraps one DbContext per tenant/batch, and
+// a DbContext is not thread-safe (marten#5266: InvalidOperationException out of Dictionary.TryInsert,
+// NullReferenceException out of ChangeDetector.DetectChanges).
+//
+// IProjectionStorage.IsThreadSafe lets the storage say so, and the runner then applies its slices one at a
+// time. These tests observe the fan-out directly by counting how many applies are in flight at once, because
+// that is the only thing that actually changed -- what a slice DOES is identical on both routes.
+public class AggregationRunnerSliceConcurrencyTests
+{
+    private const int SliceCount = 20;
+
+    private readonly IAggregationProjection<User, Guid, FakeOperations, FakeSession> theProjection =
+        Substitute.For<IAggregationProjection<User, Guid, FakeOperations, FakeSession>>();
+
+    private readonly IEventStore<FakeOperations, FakeSession> theStore =
+        Substitute.For<IEventStore<FakeOperations, FakeSession>>();
+
+    private readonly IEventSlicer theSlicer = Substitute.For<IEventSlicer>();
+    private readonly ConcurrencyProbeStorage theStorage = new();
+    private readonly AggregationRunner<User, Guid, FakeOperations, FakeSession> theRunner;
+
+    public AggregationRunnerSliceConcurrencyTests()
+    {
+        var snapshot = new User("Beast", "Hank McCoy");
+
+        theProjection.Options.Returns(new AsyncOptions());
+        theProjection.Scope.Returns(AggregationScope.MultiStream);
+        theProjection.MatchesAnyDeleteType(Arg.Any<IReadOnlyList<IEvent>>()).Returns(false);
+        theProjection
+            .DetermineActionAsync(Arg.Any<FakeSession>(), Arg.Any<User?>(), Arg.Any<Guid>(),
+                Arg.Any<IProjectionStorage<User, Guid>>(), Arg.Any<IReadOnlyList<IEvent>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<(User?, ActionType)>((snapshot, ActionType.Store)));
+        theProjection
+            .TryApplyMetadata(Arg.Any<IReadOnlyList<IEvent>>(), Arg.Any<User?>(), Arg.Any<Guid>(),
+                Arg.Any<IProjectionStorage<User, Guid>>())
+            .Returns(((IEvent?)null, snapshot));
+
+        var batch = Substitute.For<IProjectionBatch<FakeOperations, FakeSession>>();
+        batch.SessionForTenant(Arg.Any<string>()).Returns(new FakeOperations { ProjectionStorage = theStorage });
+        theStore
+            .StartProjectionBatchAsync(Arg.Any<EventRange>(), Arg.Any<IEventDatabase>(),
+                Arg.Any<ShardExecutionMode>(), Arg.Any<AsyncOptions>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IProjectionBatch<FakeOperations, FakeSession>>(batch));
+
+        theRunner = new AggregationRunner<User, Guid, FakeOperations, FakeSession>(
+            theStore,
+            Substitute.For<IEventDatabase>(),
+            theProjection,
+            SliceBehavior.JustInTime,
+            theSlicer,
+            NullLogger.Instance);
+    }
+
+    private async Task buildBatchAsync()
+    {
+        var group = new SliceGroup<User, Guid>("foo");
+        for (var i = 0; i < SliceCount; i++)
+        {
+            var id = Guid.NewGuid();
+            group.Slices.Fill(id, new EventSlice<User, Guid>(id, "foo",
+                new IEvent[] { new Event<AEvent>(new AEvent()) }));
+        }
+
+        theSlicer.SliceAsync(Arg.Any<EventRange>())
+            .Returns(new ValueTask<IReadOnlyList<object>>(new object[] { group }));
+
+        var agent = Substitute.For<ISubscriptionAgent>();
+        agent.Metrics.Returns(Substitute.For<ISubscriptionMetrics>());
+
+        var range = new EventRange(agent, 0, 100) { BatchBehavior = BatchBehavior.Individual };
+
+        await theRunner.BuildBatchAsync(range, ShardExecutionMode.Continuous, CancellationToken.None);
+    }
+
+    /// <remarks>
+    /// The regression. One slice at a time, and nothing weaker: "fewer than ten" would still be a data race
+    /// against a DbContext.
+    /// </remarks>
+    [Fact]
+    public async Task a_storage_that_is_not_thread_safe_gets_its_slices_applied_one_at_a_time()
+    {
+        theStorage.IsThreadSafe = false;
+
+        await buildBatchAsync();
+
+        theStorage.MaxConcurrency.ShouldBe(1);
+        theStorage.Applied.ShouldBe(SliceCount);
+    }
+
+    /// <remarks>
+    /// The other half, and the reason the seam is on the storage rather than a store-wide switch: the
+    /// products' own document storage keeps the fan-out it was built for. Asserted as "more than one at
+    /// once" rather than a specific width, since the scheduler decides how many of the ten actually overlap.
+    /// </remarks>
+    [Fact]
+    public async Task a_thread_safe_storage_still_has_its_slices_applied_concurrently()
+    {
+        theStorage.IsThreadSafe = true;
+
+        await buildBatchAsync();
+
+        theStorage.MaxConcurrency.ShouldBeGreaterThan(1);
+        theStorage.Applied.ShouldBe(SliceCount);
+    }
+
+    /// <remarks>
+    /// The default is what every existing storage gets without changing a line, so it has to be the
+    /// concurrent one — the seam is additive, not a new obligation.
+    /// </remarks>
+    [Fact]
+    public void the_contract_defaults_to_thread_safe()
+    {
+        IProjectionStorage<User, Guid> storage = new PlainStorage();
+
+        storage.IsThreadSafe.ShouldBeTrue();
+    }
+
+    /// <remarks>
+    /// ⚠️ Pinned because it is a trap for the downstream adopters, all of whom are about to write tests
+    /// around this seam. NSubstitute proxies a default interface member rather than inheriting it, so a
+    /// substituted storage answers <c>default(bool)</c> — <see langword="false" /> — and silently takes the
+    /// serial route. Harmless (serial is always correct) but it means a substitute cannot be used to
+    /// exercise the concurrent route, and cannot be trusted to report what a real storage would. Every real
+    /// implementation is a concrete class and gets the <see langword="true" /> default.
+    /// </remarks>
+    [Fact]
+    public void a_substituted_storage_does_not_inherit_the_default()
+    {
+        Substitute.For<IProjectionStorage<User, Guid>>().IsThreadSafe.ShouldBeFalse();
+    }
+
+    /// <remarks>
+    /// A slice that throws must not abandon the slices after it: the range still has to mark every slice's
+    /// action, and the runner still has to surface the failure. The concurrent route got that from the
+    /// block's OnError; the serial route has to reproduce it rather than let the exception escape the loop.
+    /// </remarks>
+    [Fact]
+    public async Task a_failing_slice_on_the_serial_route_still_lets_the_rest_apply()
+    {
+        theStorage.IsThreadSafe = false;
+        theStorage.FailOnApplyNumber = 3;
+
+        var ex = await Should.ThrowAsync<DivideByZeroException>(buildBatchAsync());
+        ex.Message.ShouldBe("slice 3");
+
+        // Every slice was attempted, not just the ones before the failure.
+        theStorage.Applied.ShouldBe(SliceCount);
+        theStorage.MaxConcurrency.ShouldBe(1);
+    }
+
+    /// <remarks>
+    /// Two or more failures aggregate rather than surfacing only the first, matching what the block route
+    /// has always done.
+    /// </remarks>
+    [Fact]
+    public async Task several_failing_slices_on_the_serial_route_aggregate()
+    {
+        theStorage.IsThreadSafe = false;
+        theStorage.FailOnApplyNumber = 3;
+        theStorage.AlsoFailOnApplyNumber = 7;
+
+        var ex = await Should.ThrowAsync<AggregateException>(buildBatchAsync());
+
+        ex.InnerExceptions.Count.ShouldBe(2);
+        ex.InnerExceptions.Select(x => x.Message).ShouldBe(new[] { "slice 3", "slice 7" });
+        theStorage.Applied.ShouldBe(SliceCount);
+    }
+
+    /// <summary>
+    /// Records how many applies are in flight at once. The sleep is what makes overlap observable at all —
+    /// without it the applies are fast enough that even the ten-wide route rarely has two in flight, and the
+    /// test would pass against the bug.
+    /// </summary>
+    private class ConcurrencyProbeStorage: IProjectionStorage<User, Guid>
+    {
+        private readonly object _lock = new();
+        private int _inFlight;
+
+        public bool IsThreadSafe { get; set; } = true;
+        public int MaxConcurrency { get; private set; }
+        public int Applied { get; private set; }
+
+        public int? FailOnApplyNumber { get; set; }
+        public int? AlsoFailOnApplyNumber { get; set; }
+
+        public string TenantId => "foo";
+
+        public void StoreProjection(User aggregate, IEvent? lastEvent, AggregationScope scope)
+        {
+            int number;
+
+            lock (_lock)
+            {
+                _inFlight++;
+                Applied++;
+                number = Applied;
+                if (_inFlight > MaxConcurrency) MaxConcurrency = _inFlight;
+            }
+
+            try
+            {
+                Thread.Sleep(15);
+
+                if (number == FailOnApplyNumber || number == AlsoFailOnApplyNumber)
+                {
+                    throw new DivideByZeroException($"slice {number}");
+                }
+            }
+            finally
+            {
+                lock (_lock)
+                {
+                    _inFlight--;
+                }
+            }
+        }
+
+        public Task<IReadOnlyDictionary<Guid, User>> LoadManyAsync(Guid[] identities, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyDictionary<Guid, User>>(new Dictionary<Guid, User>());
+
+        public Task<User> LoadAsync(Guid id, CancellationToken cancellation) => Task.FromResult<User>(null!);
+
+        public void SetIdentity(User document, Guid identity)
+        {
+        }
+
+        public Guid Identity(User document) => Guid.Empty;
+
+        public void HardDelete(User snapshot)
+        {
+        }
+
+        public void UnDelete(User snapshot)
+        {
+        }
+
+        public void Store(User snapshot)
+        {
+        }
+
+        public void Delete(Guid identity)
+        {
+        }
+
+        public void HardDelete(User snapshot, string tenantId)
+        {
+        }
+
+        public void UnDelete(User snapshot, string tenantId)
+        {
+        }
+
+        public void Store(User snapshot, Guid id, string tenantId)
+        {
+        }
+
+        public void Delete(Guid identity, string tenantId)
+        {
+        }
+
+        public void ArchiveStream(Guid sliceId, string tenantId)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Implements the contract without declaring
+    /// <see cref="IProjectionStorage{TDoc,TId}.IsThreadSafe" />, so it reads the default — the shape every
+    /// store has today. It cannot subclass the probe: interface member mapping is fixed at the type that
+    /// declares the interface, so a member added further down would never be dispatched to.
+    /// </summary>
+    private class PlainStorage: IProjectionStorage<User, Guid>
+    {
+        public string TenantId => "foo";
+        public void SetIdentity(User document, Guid identity) => throw new NotSupportedException();
+        public Guid Identity(User document) => throw new NotSupportedException();
+        public void HardDelete(User snapshot) => throw new NotSupportedException();
+        public void UnDelete(User snapshot) => throw new NotSupportedException();
+        public void Store(User snapshot) => throw new NotSupportedException();
+        public void Delete(Guid identity) => throw new NotSupportedException();
+        public void HardDelete(User snapshot, string tenantId) => throw new NotSupportedException();
+        public void UnDelete(User snapshot, string tenantId) => throw new NotSupportedException();
+        public void Store(User snapshot, Guid id, string tenantId) => throw new NotSupportedException();
+        public void Delete(Guid identity, string tenantId) => throw new NotSupportedException();
+        public void ArchiveStream(Guid sliceId, string tenantId) => throw new NotSupportedException();
+        public void StoreProjection(User aggregate, IEvent? lastEvent, AggregationScope scope)
+            => throw new NotSupportedException();
+        public Task<IReadOnlyDictionary<Guid, User>> LoadManyAsync(Guid[] identities, CancellationToken token)
+            => throw new NotSupportedException();
+        public Task<User> LoadAsync(Guid id, CancellationToken cancellation) => throw new NotSupportedException();
+    }
+}

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -107,7 +107,11 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             await range.SliceAsync(Slicer);
         }
 
-        var exceptions = new List<Exception>();
+        // Concurrent because it has two writers: the block's OnError, invoked from the block's own
+        // threads, and the jasperfx#683 inline path below, invoked from this one. The block runs in the
+        // background across groups, so an inline group can be applying while a previous group's posted
+        // slices are still completing. (The block side alone was already unguarded here.)
+        var exceptions = new ConcurrentQueue<Exception>();
         var builder = new Block<EventSliceExecution>(10, async (execution, _) =>
         {
             if (cancellation.IsCancellationRequested)
@@ -119,12 +123,38 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
                 execution.Cache, cancellation);
         });
 
-        builder.OnError = (_, e) => exceptions.Add(e);
+        builder.OnError = (_, e) => exceptions.Enqueue(e);
+
+        // jasperfx#683: a storage that cannot take concurrent slices (an EF Core DbContext-backed one)
+        // gets applied inline instead of posted into the block. Both routes run the SAME handler and
+        // collect into the SAME exception list, so everything downstream of here -- MarkSliceAction, the
+        // single-vs-aggregate throw below, ApplyPendingCacheUpdates -- is unchanged either way. The
+        // block's width is fixed at construction and the storage is not known until processBatchAsync,
+        // which is why this is a routing decision rather than a width of one.
+        async Task applyInlineAsync(EventSliceExecution execution)
+        {
+            if (cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                await ApplyChangesAsync(applyMode, batch, execution.Operations, execution.Slice,
+                    execution.Storage, execution.Cache, cancellation);
+            }
+            catch (Exception e)
+            {
+                // Mirrors builder.OnError rather than propagating: a slice that throws must not abandon
+                // the slices after it, because the range's other slices still have to be marked.
+                exceptions.Enqueue(e);
+            }
+        }
 
         var groups = range.Groups.OfType<SliceGroup<TDoc, TId>>().ToArray();
         foreach (var group in groups)
         {
-            await processBatchAsync(cancellation, batch, group, builder);
+            await processBatchAsync(cancellation, batch, group, builder, applyInlineAsync);
         }
 
         await builder.WaitForCompletionAsync().ConfigureAwait(false);
@@ -139,9 +169,9 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
 
         if (exceptions.Count == 1)
         {
-            ExceptionDispatchInfo.Throw(exceptions[0]);
+            ExceptionDispatchInfo.Throw(exceptions.Single());
         }
-        else if (exceptions.Any())
+        else if (!exceptions.IsEmpty)
         {
             throw new AggregateException(exceptions);
         }
@@ -231,13 +261,18 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
     }
 
     private async Task processBatchAsync(CancellationToken cancellation, IProjectionBatch<TOperations, TQuerySession> batch, SliceGroup<TDoc, TId> group,
-        Block<EventSliceExecution> builder)
+        Block<EventSliceExecution> builder, Func<EventSliceExecution, Task> applyInlineAsync)
     {
         var operations = batch.SessionForTenant(group.TenantId);
         var cache = CacheFor(group.TenantId);
 
         var needToBeFetched = new List<EventSlice<TDoc, TId>>();
         var storage = await operations.FetchProjectionStorageAsync<TDoc, TId>(group.TenantId, cancellation);
+
+        // jasperfx#683: resolved per tenant group, so a store is free to answer differently per tenant.
+        Func<EventSliceExecution, Task> submitAsync = storage.IsThreadSafe
+            ? execution => builder.PostAsync(execution).AsTask()
+            : applyInlineAsync;
 
         group.Operations = operations;
         await Projection.EnrichEventsAsync(group, operations, cancellation);
@@ -252,14 +287,14 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             if (_deferWrites && tryFindPendingSnapshot(group.TenantId, slice.Id, out var pending))
             {
                 slice.Snapshot = pending;
-                await builder.PostAsync(new EventSliceExecution(slice, operations, storage, cache));
+                await submitAsync(new EventSliceExecution(slice, operations, storage, cache));
             }
             // If you can find the snapshot in the cache, use that
             else if (cache.TryFind(slice.Id, out var snapshot))
             {
                 slice.Snapshot = snapshot;
 
-                await builder.PostAsync(new EventSliceExecution(slice, operations, storage, cache));
+                await submitAsync(new EventSliceExecution(slice, operations, storage, cache));
             }
             else
             {
@@ -276,7 +311,7 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
                 slice.Snapshot = snapshot;
             }
 
-            await builder.PostAsync(new EventSliceExecution(slice, operations, storage, cache));
+            await submitAsync(new EventSliceExecution(slice, operations, storage, cache));
         }
     }
 

--- a/src/JasperFx.Events/Daemon/IProjectionStorage.cs
+++ b/src/JasperFx.Events/Daemon/IProjectionStorage.cs
@@ -5,8 +5,43 @@ namespace JasperFx.Events.Daemon;
 public interface IProjectionStorage<TDoc, TId> : IIdentitySetter<TDoc, TId>
 {
     // This will wrap ProjectionUpdateBatch & the right DocumentSession
-    
+
     string TenantId { get; }
+
+    /// <summary>
+    /// Can the daemon apply several of a range's slices concurrently against this storage instance?
+    /// Return <see langword="false" /> when it cannot, and the runner applies them one at a time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// jasperfx#683. <c>AggregationRunner</c> applies every slice in a range through a fixed 10-wide
+    /// block, and every one of them gets the <em>same</em> storage instance. That is what the
+    /// products' own document storage is built for. It is not what an EF Core storage can take: it
+    /// wraps a single <c>DbContext</c> per tenant/batch, and a <c>DbContext</c> is not thread-safe.
+    /// A multi-stream projection with custom grouping fans one event out into many slices, so up to
+    /// ten of them concurrently call <c>Entry()</c> / <c>FindAsync</c> and mutate the same change
+    /// tracker — reported as an <c>InvalidOperationException</c> out of <c>Dictionary.TryInsert</c>
+    /// and a <c>NullReferenceException</c> out of <c>ChangeDetector.DetectChanges</c>
+    /// (<see href="https://github.com/JasperFx/marten/issues/5266" />).
+    /// </para>
+    /// <para>
+    /// The declaration belongs here rather than on <c>AsyncOptions</c> because the storage is the
+    /// thing that is or is not safe, and it already knows. A parallelism knob would work, but it
+    /// would make correctness a configuration problem that a user has to know they have.
+    /// </para>
+    /// <para>
+    /// ⚠️ Serializing calls <em>inside</em> a storage implementation does not substitute for this.
+    /// A lock around each storage member still leaves the aggregation on one thread mutating
+    /// entities while another thread's <c>Entry()</c> runs change detection over them, which is
+    /// exactly the reported <c>ChangeDetector</c> failure. The fan-out itself has to stop, and
+    /// nothing reachable from inside the storage can stop it.
+    /// </para>
+    /// <para>
+    /// Defaults to <see langword="true" />, so this is additive: no existing storage has to change
+    /// to stay correct.
+    /// </para>
+    /// </remarks>
+    bool IsThreadSafe => true;
     
     void HardDelete(TDoc snapshot);
     void UnDelete(TDoc snapshot);


### PR DESCRIPTION
Closes #683.

`AggregationRunner` applies every slice in a range through a fixed 10-wide `Block`, and every one of them gets the **same** `IProjectionStorage` instance. Fine for the products' own document storage. Not fine for an EF Core storage, which wraps one `DbContext` per tenant/batch — reported as marten#5266, with `InvalidOperationException` out of `Dictionary.TryInsert` and `NullReferenceException` out of `ChangeDetector.DetectChanges`.

Adds `IProjectionStorage.IsThreadSafe`, defaulted `true`, and the runner applies a storage that answers `false` one slice at a time.

## Why on the storage

Taking your reading from the issue over the `AsyncOptions.SliceParallelism` alternative: the storage is the thing that is or is not safe, and it already knows. A knob would work but makes correctness a configuration problem a user has to know they have.

The XML docs also state the thing a downstream implementer will otherwise try first: **locking inside the storage does not substitute for this.** A lock around each member still leaves the aggregation on one thread mutating entities while another thread's `Entry()` runs change detection over them — the reported `ChangeDetector` failure. The fan-out itself has to stop, and nothing reachable from inside the storage can stop it.

## What stays identical

Both routes run the same handler and collect into the same exception list, so `MarkSliceAction`, the single-vs-aggregate throw and `ApplyPendingCacheUpdates` are untouched. The inline path catches rather than propagating, mirroring `builder.OnError` — a slice that throws must not abandon the slices after it, because the range still has to mark every slice's action. Two facts pin that.

Resolved **per tenant group**, not per range, so a store may answer differently per tenant.

## One thing I changed beyond the issue

`exceptions` is now a `ConcurrentQueue<Exception>`. It already had one unguarded writer — the block's `OnError`, invoked from the block's threads — and this adds a second from the calling thread. The block runs in the background across groups, so an inline group can be applying while a previous group's posted slices are still completing. Flag if you'd rather that were a separate change.

## Tests

They observe the fan-out directly by counting applies in flight, since what a slice *does* is identical on both routes. **Verified they bite**: forcing everything back through the block fails `a_storage_that_is_not_thread_safe_gets_its_slices_applied_one_at_a_time` and `a_failing_slice_on_the_serial_route_still_lets_the_rest_apply`. Green 3/3 consecutive runs of the full suite (805 tests).

One fact is pinned specifically for the three downstream adopters, who are about to write these same tests: **NSubstitute proxies a default interface member rather than inheriting it**, so `Substitute.For<IProjectionStorage<,>>().IsThreadSafe` is `false` and silently takes the serial route. Harmless — serial is always correct — but a substitute can't be used to exercise the concurrent route, and can't be trusted to report what a real storage would. Every real implementation is a concrete class and gets the `true` default.

## Downstream

Already tracked, and each returns `false` plus a concurrency regression test: marten#5266, polecat#489, fisher#108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)