### PR TITLE
gh-649: say plainly that a store's projection subclass may add required behavior

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -5,7 +5,55 @@ using JasperFx.Events.Projections;
 
 namespace JasperFx.Events.Aggregation;
 
-public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations, TQuerySession> : JasperFxAggregationProjectionBase<TDoc, TId, TOperations, TQuerySession>, IAggregatorSource<TQuerySession>, IAggregator<TDoc, TId, TQuerySession>, IInlineProjection<TOperations> 
+/// <summary>
+/// Shared implementation behind each store's own <c>SingleStreamProjection&lt;TDoc,TId&gt;</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ⚠️ <b>Derive from your store's subclass, not from this type.</b> A store's subclass may add behavior
+/// that this base deliberately omits, and nothing about taking the base instead fails at compile time —
+/// you get a projection that builds, runs, and is subtly wrong. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/649" />.
+/// </para>
+/// <para>
+/// Concretely, as of Marten 9.23 / Polecat 5.12. Polecat's <c>SingleStreamProjection&lt;TDoc,TId&gt;</c>
+/// is an empty class body, so nothing is lost there. Marten's is not — it adds two behaviors:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///     <b><c>BuildSlicer</c></b> returns a <c>TenantedEventSlicer</c> with <c>ForceSingleTenancy</c> taken
+///     from the store's <c>EventGraph.TenancyStyle</c> — the fix for
+///     <see href="https://github.com/JasperFx/wolverine/issues/2053" />. This base returns the same slicer
+///     <em>without</em> it, so taking the base changes event slicing on a single-tenanted Marten store.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     <b><c>IMartenAggregateProjection.ConfigureAggregateMapping</c></b> sets
+///     <c>mapping.UseVersionFromMatchingStream = true</c>, which changes how an aggregate's version
+///     metadata is persisted. Taking the base silently drops it — which matters most on exactly the
+///     documents someone has put optimistic-concurrency guards around.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// Both are the kind of divergence that produces a wrong answer rather than an error, and both are
+/// invisible until something downstream is already wrong, which is why this warning is here rather than
+/// left to be rediscovered. The <c>BuildSlicer</c> comment below saying the method "needs to be
+/// overridable in Marten" is the other half of the same story: it is a deliberate escape hatch for the
+/// store, not a suggestion that the base is equivalent.
+/// </para>
+/// <para>
+/// <b>If you are writing one projection to compile against several stores</b>, the routes that work today
+/// are a per-flavour alias bound to each store's own subclass, or — where the document owns its stream —
+/// a self-aggregating document registered with <c>Snapshot&lt;T&gt;()</c>, which sidesteps the question
+/// entirely because the store then constructs <em>its own</em> subclass. Note the limit on the second:
+/// a self-aggregating document has no constructor, so it cannot carry an <c>IncludeType&lt;T&gt;()</c>
+/// event allow-list, which matters when several projections slice the same stream.
+/// </para>
+/// </remarks>
+public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations, TQuerySession> : JasperFxAggregationProjectionBase<TDoc, TId, TOperations, TQuerySession>, IAggregatorSource<TQuerySession>, IAggregator<TDoc, TId, TQuerySession>, IInlineProjection<TOperations>
     where TOperations : TQuerySession, IStorageOperations where TDoc : notnull where TId : notnull
 {
     private readonly Func<IEvent,TId> _identitySource;
@@ -18,7 +66,10 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
         _streamActionSource = StreamAction.CreateAggregateIdentitySource<TId>();
     }
 
-    // This actually does need to be overridable in Marten
+    // This actually does need to be overridable in Marten -- and Marten does override it, to set
+    // ForceSingleTenancy from the store's TenancyStyle (wolverine#2053). A consumer deriving from THIS type
+    // rather than from Marten's subclass gets the slicer below instead, with no compile error and no runtime
+    // failure -- just different slicing on a single-tenanted store. See jasperfx#649 and the class remarks.
     public override IEventSlicer BuildSlicer(TQuerySession session)
     {
         // Doesn't hurt anything if it's not actually tenanted

--- a/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
+++ b/src/JasperFx.Events/Projections/JasperFxEventProjectionBase.cs
@@ -9,8 +9,17 @@ using Microsoft.Extensions.Logging;
 namespace JasperFx.Events.Projections;
 
 /// <summary>
-/// Base class for adhoc projections
+/// Base class for adhoc projections, and the shared implementation behind each store's own
+/// <c>EventProjection</c>.
 /// </summary>
+/// <remarks>
+/// ⚠️ <b>Derive from your store's <c>EventProjection</c>, not from this type.</b> Same divergence, and
+/// same silence, as <see cref="Aggregation.JasperFxSingleStreamProjectionBase{TDoc,TId,TOperations,TQuerySession}" />
+/// — see that type's remarks and <see href="https://github.com/JasperFx/jasperfx/issues/649" />. As of
+/// Marten 9.23, <c>Marten.Events.Projections.EventProjection</c> adds <c>IProjectionSchemaSource</c>, the
+/// store's validation hook, and a <c>TryBuildReplayExecutor</c> override that this base does not have;
+/// taking the base instead compiles cleanly and quietly loses them.
+/// </remarks>
 /// <typeparam name="TOperations"></typeparam>
 /// <typeparam name="TQuerySession"></typeparam>
 [UnconditionalSuppressMessage("Trimming", "IL2075:DynamicallyAccessedMembers",


### PR DESCRIPTION
Addresses #649 via **option 3 only** — documenting the divergence. It does not close the gap, and I'd suggest leaving the issue open for options 1/2.

## What it says

`JasperFxSingleStreamProjectionBase` is not equivalent to the store subclasses built on it, and deriving from it instead fails nothing at compile time. Marten's `SingleStreamProjection<TDoc,TId>`:

- overrides `BuildSlicer` to set `ForceSingleTenancy` from the store's `TenancyStyle` — the wolverine#2053 fix
- implements `IMartenAggregateProjection.ConfigureAggregateMapping` to set `UseVersionFromMatchingStream = true`

Take the base instead and you get a projection that builds, runs, and slices or versions differently. A wrong answer rather than an error, and very hard to attribute later — which is exactly what your comment on the issue said about `ServiceSummary`, the one document where `UseVersionFromMatchingStream` mattered and where you'd already had to add concurrency guards.

Polecat's subclass is an empty class body, so the divergence is Marten-shaped today. That's what makes it a trap: checking one store tells you nothing.

`JasperFxEventProjectionBase` gets the same note — Marten's `EventProjection` adds `IProjectionSchemaSource`, the validation hook, and a `TryBuildReplayExecutor` override.

## Why on the type rather than just the issue

The existing comment on `BuildSlicer` — *"This actually does need to be overridable in Marten"* — reads from the outside like an implementation note, when it's really the other half of this story: a deliberate escape hatch for the store, not a sign the base is equivalent. That comment now says so.

The remarks also record the two routes that work today for a consumer compiling one projection against several stores: a per-flavour alias bound to each store's own subclass, or a self-aggregating document registered with `Snapshot<T>()`, which sidesteps it entirely because the store then constructs *its own* subclass. With the limit on the second stated, since it's what decides whether it applies — a self-aggregating document has no constructor, so it can't carry an `IncludeType<T>()` allow-list, which matters when several projections slice the same stream.

## Scope

Docs only, no behavior change, no downstream work. Options 1 and 2 — hoisting the behavior into the base, or a seam each store fills in — are what would actually let a projection compile once, and stay open.

Worth noting your comment thread moved on this: the 08-16 correction withdrew it as a CritterWatch blocker, then the 08-18 update listed it as one of exactly three items — and the other two (#678, #679) both closed that same day. So on the consumer side this is now the last one standing, even though the fix here is deliberately the cheap one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)