### PR TITLE
gh-687: Event Modeling semantic model v2, the overlay API and the discovery bridge (+ gh-689)

### DIFF
--- a/src/EventTests/EventModeling/EventModelBuilderTests.cs
+++ b/src/EventTests/EventModeling/EventModelBuilderTests.cs
@@ -4,88 +4,127 @@ using Shouldly;
 
 namespace EventTests.EventModeling;
 
+// jasperfx#687 (reshaped 2026-08-20): the fluent API is an OVERLAY. It names, groups,
+// annotates and links; it never declares a role. Roles come from derived sources and the
+// one documented escape hatch.
 public class EventModelBuilderTests
 {
     [Fact]
-    public void smoke_test_exercises_every_chain_method()
+    public void overlay_names_groups_annotates_and_links()
     {
-        var definition = new SampleDefinition();
-        var builder = new EventModelBuilder { Name = "Sample" };
-
-        definition.Configure(builder);
+        var builder = new EventModelBuilder { Name = "Orders" };
+        new SampleOverlay().Configure(builder);
 
         var slices = builder.BuildSlices();
-        slices.Count.ShouldBe(1);
+        slices.Count.ShouldBe(2);
 
-        var slice = slices[0];
-        slice.Name.ShouldBe("Place order");
-        slice.TriggerLabel.ShouldBe("User clicks Place Order");
-        slice.TriggerType.ShouldBe(TypeDescriptor.For(typeof(SampleTrigger)));
-        slice.CommandType.ShouldBe(TypeDescriptor.For(typeof(SampleCommand)));
-        slice.HandlerType.ShouldBe(TypeDescriptor.For(typeof(SampleHandler)));
-        slice.EmittedEvents.ShouldContain(TypeDescriptor.For(typeof(SampleEvent)));
-        slice.ProjectionTypes.ShouldContain(TypeDescriptor.For(typeof(SampleProjection)));
-        slice.ReadModelTypes.ShouldContain(TypeDescriptor.For(typeof(SampleReadModel)));
+        var place = slices[0];
+        place.Name.ShouldBe("PlaceOrder");
+        place.Domain.ShouldBe("Orders");
+        place.TriggerLabel.ShouldBe("User clicks Place Order");
+        place.Specifications.Select(x => x.Identity).ShouldBe(new[] { "Place Order/Place an order" });
+
+        // and nothing role-shaped was declared
+        place.Pattern.ShouldBeNull();
+        place.TriggerKind.ShouldBeNull();
+        place.CommandType.ShouldBeNull();
+        place.HandlerType.ShouldBeNull();
+        place.EmittedEvents.ShouldBeEmpty();
+        place.AggregateTypes.ShouldBeEmpty();
+        place.ProjectionTypes.ShouldBeEmpty();
+        place.ReadModelTypes.ShouldBeEmpty();
+
+        var ship = slices[1];
+        ship.Domain.ShouldBe("Fulfilment"); // slice-level InDomain overrides the builder default
+    }
+
+    [Fact]
+    public void builder_level_domain_applies_to_slices_opened_after_it()
+    {
+        var builder = new EventModelBuilder();
+        builder.Slice("before");
+        builder.InDomain("Billing");
+        builder.Slice("after");
+
+        var slices = builder.BuildSlices();
+        slices[0].Domain.ShouldBeNull();
+        slices[1].Domain.ShouldBe("Billing");
     }
 
     [Fact]
     public void multiple_slices_are_kept_in_declaration_order()
     {
         var builder = new EventModelBuilder();
-        builder.Slice("first").Command<SampleCommand>();
-        builder.Slice("second").Command<SampleOtherCommand>();
+        builder.Slice("first");
+        builder.Slice("second");
 
-        var slices = builder.BuildSlices();
-
-        slices.Select(s => s.Name).ShouldBe(new[] { "first", "second" });
+        builder.BuildSlices().Select(s => s.Name).ShouldBe(new[] { "first", "second" });
     }
 
     [Fact]
-    public void emits_supports_multiple_event_types()
+    public void build_uses_the_fallback_name_when_unset()
     {
         var builder = new EventModelBuilder();
-        builder.Slice("multi")
-            .Emits<SampleEvent>()
-            .Emits<SampleOtherEvent>();
+        builder.Slice("x");
 
-        var slice = builder.BuildSlices().Single();
-        slice.EmittedEvents.Count.ShouldBe(2);
+        builder.Build("Fallback").Name.ShouldBe("Fallback");
+        new EventModelBuilder { Name = "Explicit" }.Build("Fallback").Name.ShouldBe("Explicit");
     }
 
     [Fact]
-    public void event_model_descriptor_round_trips_through_builder()
+    public void escape_hatch_declares_roles_for_a_flow_not_owned_here()
     {
-        var builder = new EventModelBuilder { Name = "Sample" };
-        builder.Slice("x").Command<SampleCommand>().Emits<SampleEvent>();
+        var builder = new EventModelBuilder();
+        builder.Slice("PartnerRefund")
+            .TriggeredBy("Partner posts a refund")
+            .ForFlowNotOwnedHere(roles => roles
+                .Pattern(SlicePattern.Translation)
+                .TriggeredBy<PartnerRefundRequest>(TriggerKind.External)
+                .Command<RefundOrder>()
+                .HandledBy<RefundHandler>()
+                .UsesAggregate<Order>()
+                .Emits<OrderRefunded>()
+                .Publishes<NotifyAccounting>()
+                .Projects<OrderProjection>()
+                .Reads<OrderSummary>()
+                .ExternalSystem("Partner", ExternalSystemDirection.Inbound, "rabbitmq://queue/partner"));
 
-        var descriptor = new EventModelDescriptor(builder.Name!, builder.BuildSlices());
-
-        descriptor.Name.ShouldBe("Sample");
-        descriptor.Slices.Count.ShouldBe(1);
-        descriptor.Slices[0].EmittedEvents.Count.ShouldBe(1);
+        var slice = builder.BuildSlices().Single();
+        slice.TriggerLabel.ShouldBe("Partner posts a refund");
+        slice.Pattern.ShouldBe(SlicePattern.Translation);
+        slice.TriggerKind.ShouldBe(TriggerKind.External);
+        slice.TriggerType.ShouldBe(TypeDescriptor.For(typeof(PartnerRefundRequest)));
+        slice.CommandType.ShouldBe(TypeDescriptor.For(typeof(RefundOrder)));
+        slice.HandlerType.ShouldBe(TypeDescriptor.For(typeof(RefundHandler)));
+        slice.AggregateTypes.ShouldBe(new[] { TypeDescriptor.For(typeof(Order)) });
+        slice.EmittedEvents.ShouldBe(new[] { TypeDescriptor.For(typeof(OrderRefunded)) });
+        slice.PublishedMessages.ShouldBe(new[] { TypeDescriptor.For(typeof(NotifyAccounting)) });
+        slice.ProjectionTypes.ShouldBe(new[] { TypeDescriptor.For(typeof(OrderProjection)) });
+        slice.ReadModelTypes.ShouldBe(new[] { TypeDescriptor.For(typeof(OrderSummary)) });
+        slice.ExternalSystems.Single().ShouldBe(new ExternalSystemDescriptor("Partner", ExternalSystemDirection.Inbound, "rabbitmq://queue/partner"));
     }
 
-    public class SampleDefinition : EventModelDefinition
+    public class SampleOverlay : EventModelDefinition
     {
         public override void Configure(EventModelBuilder builder)
         {
-            builder.Slice("Place order")
+            builder.InDomain("Orders");
+
+            builder.Slice("PlaceOrder")
                 .TriggeredBy("User clicks Place Order")
-                .TriggeredBy<SampleTrigger>()
-                .Command<SampleCommand>()
-                .HandledBy<SampleHandler>()
-                .Emits<SampleEvent>()
-                .Projects<SampleProjection>()
-                .Reads<SampleReadModel>();
+                .LinksToSpecification("Place Order/Place an order");
+
+            builder.Slice("ShipOrder")
+                .InDomain("Fulfilment");
         }
     }
 
-    public class SampleTrigger { }
-    public class SampleCommand { }
-    public class SampleOtherCommand { }
-    public class SampleHandler { }
-    public class SampleEvent { }
-    public class SampleOtherEvent { }
-    public class SampleProjection { }
-    public class SampleReadModel { }
+    public class PartnerRefundRequest { }
+    public class RefundOrder { }
+    public class RefundHandler { }
+    public class Order { }
+    public class OrderRefunded { }
+    public class NotifyAccounting { }
+    public class OrderProjection { }
+    public class OrderSummary { }
 }

--- a/src/EventTests/EventModeling/EventModelDiscoveryTests.cs
+++ b/src/EventTests/EventModeling/EventModelDiscoveryTests.cs
@@ -1,0 +1,212 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+// jasperfx#687 §3: the discovery / registration bridge. Before this, IEventModelDefinitionSource
+// had zero implementations anywhere.
+public class EventModelDiscoveryTests
+{
+    private static TypeDescriptor T<TType>() => TypeDescriptor.For(typeof(TType));
+
+    [Fact]
+    public void a_definition_type_becomes_a_source_with_an_event_model_subject()
+    {
+        var source = EventModelDefinitionSource.For<OrdersOverlay>();
+        source.Subject.ShouldBe(new Uri("event-model://OrdersOverlay"));
+    }
+
+    [Fact]
+    public void a_named_definition_is_addressed_by_its_name()
+    {
+        EventModelDefinitionSource.For(new NamedOverlay()).Subject.ShouldBe(new Uri("event-model://Orders"));
+        EventModelDefinitionSource.For("Orders", _ => { }).Subject.ShouldBe(new Uri("event-model://Orders"));
+    }
+
+    [Fact]
+    public void an_abstract_or_unrelated_type_is_rejected()
+    {
+        Should.Throw<ArgumentException>(() => EventModelDefinitionSource.For(typeof(EventModelDefinition)));
+        Should.Throw<ArgumentException>(() => EventModelDefinitionSource.For(typeof(string)));
+    }
+
+    [Fact]
+    public async Task a_subclass_is_instantiated_configured_and_snapshotted()
+    {
+        var services = new ServiceCollection().AddEventModel<OrdersOverlay>().BuildServiceProvider();
+
+        var descriptors = await EventModelDiscovery.DiscoverAsync(services);
+
+        var model = descriptors.Single();
+        model.Name.ShouldBe("OrdersOverlay");
+        model.Slices.Single().Name.ShouldBe("PlaceOrder");
+        model.Slices.Single().Domain.ShouldBe("Orders");
+    }
+
+    [Fact]
+    public async Task a_subclass_with_dependencies_gets_them_from_di()
+    {
+        var services = new ServiceCollection()
+            .AddSingleton(new SliceNames("FromDi"))
+            .AddEventModel(typeof(DependentOverlay))
+            .BuildServiceProvider();
+
+        var model = (await EventModelDiscovery.DiscoverAsync(services)).Single();
+        model.Slices.Single().Name.ShouldBe("FromDi");
+    }
+
+    [Fact]
+    public async Task a_subclass_registered_in_di_is_resolved_rather_than_constructed()
+    {
+        var instance = new OrdersOverlay();
+        var services = new ServiceCollection()
+            .AddSingleton(instance)
+            .AddEventModel<OrdersOverlay>()
+            .BuildServiceProvider();
+
+        await EventModelDiscovery.DiscoverAsync(services);
+        instance.Configured.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task an_inline_lambda_is_a_source_too()
+    {
+        var services = new ServiceCollection()
+            .AddEventModel("Orders", model => model.Slice("PlaceOrder").TriggeredBy("User clicks Place Order"))
+            .BuildServiceProvider();
+
+        var model = (await EventModelDiscovery.DiscoverAsync(services)).Single();
+        model.Name.ShouldBe("Orders");
+        model.Slices.Single().TriggerLabel.ShouldBe("User clicks Place Order");
+    }
+
+    [Fact]
+    public async Task an_instance_is_a_source_too()
+    {
+        var services = new ServiceCollection().AddEventModel(new NamedOverlay()).BuildServiceProvider();
+        (await EventModelDiscovery.DiscoverAsync(services)).Single().Name.ShouldBe("Orders");
+    }
+
+    [Fact]
+    public async Task every_concrete_definition_in_an_assembly_can_be_registered()
+    {
+        var services = new ServiceCollection()
+            .AddSingleton(new SliceNames("x"))
+            .AddEventModelsFromAssembly(typeof(EventModelDiscoveryTests).Assembly)
+            .BuildServiceProvider();
+
+        var names = (await EventModelDiscovery.DiscoverAsync(services)).Select(x => x.Name).ToList();
+        names.ShouldContain("OrdersOverlay");
+        names.ShouldContain("Orders");       // NamedOverlay
+        names.ShouldContain("DependentOverlay");
+        names.ShouldNotContain(nameof(AbstractOverlay));
+    }
+
+    [Fact]
+    public async Task a_source_that_returns_null_is_skipped()
+    {
+        var services = new ServiceCollection()
+            .AddEventModelSource(new NullSource())
+            .AddEventModel<OrdersOverlay>()
+            .BuildServiceProvider();
+
+        (await EventModelDiscovery.DiscoverAsync(services)).Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task assemble_folds_the_overlay_onto_a_derived_source_by_model_and_slice_name()
+    {
+        // A derived source — what Wolverine (wolverine#3988) or the Bobcat generator (bobcat#106)
+        // will register — first, then the overlay. Registration order is merge order.
+        var services = new ServiceCollection()
+            .AddEventModelSource(new DerivedSource())
+            .AddEventModel<OrdersOverlay>()            // model name "OrdersOverlay" — a second model
+            .AddEventModel("Orders", model =>          // model name "Orders" — folds onto the derived one
+            {
+                model.Slice("PlaceOrder").InDomain("Orders").TriggeredBy("User clicks Place Order");
+                model.Slice("CancelOrder").InDomain("Orders");
+            })
+            .BuildServiceProvider();
+
+        var models = await EventModelDiscovery.AssembleAsync(services);
+
+        models.Select(m => m.Name).ShouldBe(new[] { "Orders", "OrdersOverlay" });
+
+        var orders = models[0];
+        orders.Slices.Select(s => s.Name).ShouldBe(new[] { "PlaceOrder", "CancelOrder" });
+        var place = orders.Slices[0];
+        place.CommandType.ShouldBe(T<PlaceOrder>());                // derived role survives
+        place.Pattern.ShouldBe(SlicePattern.Command);
+        place.TriggerLabel.ShouldBe("User clicks Place Order");     // overlay annotation lands
+        place.Domain.ShouldBe("Orders");
+        place.Specifications.Single().Identity.ShouldBe("Place Order/Place an order");
+        orders.Slices[1].CommandType.ShouldBeNull();                // overlay-only slice: named, not derived
+        orders.Aggregates.Single().Type.ShouldBe(T<Order>());
+    }
+
+    public class OrdersOverlay : EventModelDefinition
+    {
+        public int Configured { get; private set; }
+
+        public override void Configure(EventModelBuilder builder)
+        {
+            Configured++;
+            builder.InDomain("Orders");
+            builder.Slice("PlaceOrder");
+        }
+    }
+
+    public class NamedOverlay : EventModelDefinition
+    {
+        public override string Name => "Orders";
+        public override void Configure(EventModelBuilder builder) => builder.Slice("ShipOrder");
+    }
+
+    public record SliceNames(string Name);
+
+    public class DependentOverlay : EventModelDefinition
+    {
+        private readonly SliceNames _names;
+        public DependentOverlay(SliceNames names) => _names = names;
+        public override void Configure(EventModelBuilder builder) => builder.Slice(_names.Name);
+    }
+
+    public abstract class AbstractOverlay : EventModelDefinition
+    {
+    }
+
+    private sealed class NullSource : IEventModelDefinitionSource
+    {
+        public Uri Subject => new("event-model://null");
+        public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+            => Task.FromResult<EventModelDescriptor?>(null);
+    }
+
+    private sealed class DerivedSource : IEventModelDefinitionSource
+    {
+        public Uri Subject => new("event-model://derived");
+
+        public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+            => Task.FromResult<EventModelDescriptor?>(new EventModelDescriptor("Orders", new[]
+            {
+                new EventModelSliceDescriptor("PlaceOrder", null, null, T<PlaceOrder>(), T<OrderHandler>(),
+                    new[] { T<OrderPlaced>() }, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>())
+                {
+                    Pattern = SlicePattern.Command,
+                    TriggerKind = TriggerKind.Http,
+                    AggregateTypes = new[] { T<Order>() },
+                    Specifications = new[] { new SpecificationDescriptor("Place Order/Place an order", new[] { T<PlaceOrder>(), T<OrderPlaced>() }) },
+                },
+            })
+            {
+                Aggregates = new[] { new AggregateDescriptor(T<Order>(), AggregateKind.WriteAggregate, new[] { T<OrderPlaced>() }) },
+            });
+    }
+
+    public class PlaceOrder { }
+    public class OrderHandler { }
+    public class Order { }
+    public class OrderPlaced { }
+}

--- a/src/EventTests/EventModeling/EventModelSliceDescriptorTests.cs
+++ b/src/EventTests/EventModeling/EventModelSliceDescriptorTests.cs
@@ -1,0 +1,254 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+public class EventModelSliceDescriptorTests
+{
+    private static TypeDescriptor T<TType>() => TypeDescriptor.For(typeof(TType));
+
+    [Fact]
+    public void original_positional_shape_still_compiles_and_the_additive_slots_default_safely()
+    {
+        // The 2.x positional constructor is what CritterWatch and the source generator call.
+        // Every jasperfx#687 addition must default to "not derived" so precompiled callers and
+        // older JSON payloads keep working.
+        var slice = new EventModelSliceDescriptor("place", null, null, T<PlaceOrder>(), T<OrderHandler>(),
+            new[] { T<OrderPlaced>() }, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>());
+
+        slice.Pattern.ShouldBeNull();
+        slice.TriggerKind.ShouldBeNull();
+        slice.TriggerOrigin.ShouldBeNull();
+        slice.AggregateTypes.ShouldBeEmpty();
+        slice.PublishedMessages.ShouldBeEmpty();
+        slice.ExternalSystems.ShouldBeEmpty();
+        slice.Hotspots.ShouldBeEmpty();
+        slice.Specifications.ShouldBeEmpty();
+        slice.Domain.ShouldBeNull();
+    }
+
+    [Fact]
+    public void named_is_an_empty_slice()
+    {
+        var slice = EventModelSliceDescriptor.Named("x");
+        slice.Name.ShouldBe("x");
+        slice.Elements.ShouldBeEmpty();
+        slice.Edges.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void command_slice_renders_every_element_with_id_kind_and_lane_and_directed_edges()
+    {
+        var slice = new EventModelSliceDescriptor("PlaceOrder", "User clicks Place Order", null,
+                T<PlaceOrder>(), T<OrderHandler>(),
+                new[] { T<OrderPlaced>() }, new[] { T<OrderProjection>() }, new[] { T<OrderSummary>() })
+        {
+            Pattern = SlicePattern.Command,
+            TriggerKind = TriggerKind.Human,
+            AggregateTypes = new[] { T<Order>() },
+            PublishedMessages = new[] { T<NotifyWarehouse>() },
+            ExternalSystems = new[] { new ExternalSystemDescriptor("Warehouse", ExternalSystemDirection.Outbound) },
+            Hotspots = new[] { HotspotDescriptor.PendingSpecification("Place Order/Rejects empty cart") },
+        };
+
+        var elements = slice.Elements;
+
+        // one element per role, each with the canonical lane
+        elements.Select(e => e.Kind).ShouldBe(new[]
+        {
+            EventModelElementKind.Trigger,
+            EventModelElementKind.Hotspot,
+            EventModelElementKind.Command,
+            EventModelElementKind.Handler,
+            EventModelElementKind.Aggregate,
+            EventModelElementKind.Event,
+            EventModelElementKind.Message,
+            EventModelElementKind.Projection,
+            EventModelElementKind.ReadModel,
+            EventModelElementKind.ExternalSystem,
+        });
+
+        elements.Single(e => e.Kind == EventModelElementKind.Trigger).Lane.ShouldBe(EventModelLane.Wireframe);
+        elements.Single(e => e.Kind == EventModelElementKind.Hotspot).Lane.ShouldBe(EventModelLane.Wireframe);
+        elements.Single(e => e.Kind == EventModelElementKind.Command).Lane.ShouldBe(EventModelLane.Command);
+        elements.Single(e => e.Kind == EventModelElementKind.Handler).Lane.ShouldBe(EventModelLane.Command);
+        elements.Single(e => e.Kind == EventModelElementKind.Aggregate).Lane.ShouldBe(EventModelLane.Command);
+        elements.Single(e => e.Kind == EventModelElementKind.Event).Lane.ShouldBe(EventModelLane.EventStream);
+        elements.Single(e => e.Kind == EventModelElementKind.Message).Lane.ShouldBe(EventModelLane.EventStream);
+        elements.Single(e => e.Kind == EventModelElementKind.Projection).Lane.ShouldBe(EventModelLane.ReadModel);
+        elements.Single(e => e.Kind == EventModelElementKind.ReadModel).Lane.ShouldBe(EventModelLane.ReadModel);
+
+        // ids are stable and unique within the slice, and carry the type identity for drift matching
+        elements.Select(e => e.Id).Distinct().Count().ShouldBe(elements.Count);
+        var command = elements.Single(e => e.Kind == EventModelElementKind.Command);
+        command.Id.ShouldBe($"PlaceOrder/Command/{typeof(PlaceOrder).FullName}");
+        command.Type.ShouldBe(T<PlaceOrder>());
+        command.Label.ShouldBe(nameof(PlaceOrder));
+
+        // directed edges, by id
+        string id(EventModelElementKind kind) => elements.Single(e => e.Kind == kind).Id;
+        slice.Edges.ShouldBe(new[]
+        {
+            new EventModelEdge(id(EventModelElementKind.Trigger), id(EventModelElementKind.Command)),
+            new EventModelEdge(id(EventModelElementKind.Command), id(EventModelElementKind.Handler)),
+            new EventModelEdge(id(EventModelElementKind.Handler), id(EventModelElementKind.Aggregate)),
+            new EventModelEdge(id(EventModelElementKind.Handler), id(EventModelElementKind.Event)),
+            new EventModelEdge(id(EventModelElementKind.Handler), id(EventModelElementKind.Message)),
+            new EventModelEdge(id(EventModelElementKind.Message), id(EventModelElementKind.ExternalSystem)),
+            new EventModelEdge(id(EventModelElementKind.Event), id(EventModelElementKind.Projection)),
+            new EventModelEdge(id(EventModelElementKind.Projection), id(EventModelElementKind.ReadModel)),
+        });
+
+        // the rendering contract is computed, so it can never disagree with the typed roles
+        (slice with { EmittedEvents = Array.Empty<TypeDescriptor>() }).Elements
+            .ShouldNotContain(e => e.Kind == EventModelElementKind.Event);
+    }
+
+    [Fact]
+    public void events_link_straight_to_read_models_when_there_is_no_projection()
+    {
+        var slice = EventModelSliceDescriptor.Named("x") with
+        {
+            EmittedEvents = new[] { T<OrderPlaced>() },
+            ReadModelTypes = new[] { T<OrderSummary>() },
+        };
+
+        slice.Edges.Single().ShouldBe(new EventModelEdge(
+            $"x/Event/{typeof(OrderPlaced).FullName}",
+            $"x/ReadModel/{typeof(OrderSummary).FullName}"));
+    }
+
+    [Fact]
+    public void inbound_external_system_is_the_trigger_of_a_translation_slice()
+    {
+        var slice = EventModelSliceDescriptor.Named("Import") with
+        {
+            Pattern = SlicePattern.Translation,
+            TriggerKind = TriggerKind.External,
+            HandlerType = T<OrderHandler>(),
+            EmittedEvents = new[] { T<OrderPlaced>() },
+            ExternalSystems = new[] { new ExternalSystemDescriptor("Legacy", ExternalSystemDirection.Inbound, "rabbitmq://queue/legacy") },
+        };
+
+        slice.Edges.ShouldBe(new[]
+        {
+            new EventModelEdge("Import/ExternalSystem/Legacy", $"Import/Handler/{typeof(OrderHandler).FullName}"),
+            new EventModelEdge($"Import/Handler/{typeof(OrderHandler).FullName}", $"Import/Event/{typeof(OrderPlaced).FullName}"),
+        });
+    }
+
+    [Fact]
+    public void trigger_origin_label_stands_in_for_a_missing_trigger()
+    {
+        var slice = EventModelSliceDescriptor.Named("x") with
+        {
+            CommandType = T<PlaceOrder>(),
+            TriggerKind = TriggerKind.Http,
+            TriggerOrigin = new PublisherOrigin { HttpMethod = "POST", HttpRoute = "/orders", Label = "POST /orders" },
+        };
+
+        var trigger = slice.Elements.Single(e => e.Kind == EventModelElementKind.Trigger);
+        trigger.Label.ShouldBe("POST /orders");
+        trigger.Type.ShouldBeNull();
+    }
+
+    [Fact]
+    public void every_element_kind_has_a_lane_and_a_palette_colour()
+    {
+        foreach (var kind in Enum.GetValues<EventModelElementKind>())
+        {
+            Enum.IsDefined(EventModelElement.LaneFor(kind)).ShouldBeTrue();
+            EventModelPalette.ColorFor(kind).ShouldStartWith("#");
+        }
+    }
+
+    [Fact]
+    public void merge_lets_the_first_slice_win_scalars_and_unions_lists_by_identity()
+    {
+        var derived = new EventModelSliceDescriptor("PlaceOrder", null, null, T<PlaceOrder>(), T<OrderHandler>(),
+                new[] { T<OrderPlaced>() }, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>())
+        {
+            Pattern = SlicePattern.Command,
+            TriggerKind = TriggerKind.Http,
+            AggregateTypes = new[] { T<Order>() },
+            Specifications = new[] { new SpecificationDescriptor("Place Order/Place an order", new[] { T<PlaceOrder>(), T<OrderPlaced>() }) },
+        };
+
+        var overlay = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            TriggerLabel = "User clicks Place Order",
+            Domain = "Orders",
+            // the same spec linked by identity only — must not duplicate
+            Specifications = new[] { new SpecificationDescriptor("Place Order/Place an order"), new SpecificationDescriptor("Place Order/Rejects empty cart") },
+            EmittedEvents = new[] { T<OrderPlaced>(), T<OrderConfirmed>() },
+            Hotspots = new[] { HotspotDescriptor.PendingSpecification("Place Order/Rejects empty cart") },
+        };
+
+        var merged = derived.Merge(overlay);
+
+        merged.CommandType.ShouldBe(T<PlaceOrder>());
+        merged.Pattern.ShouldBe(SlicePattern.Command);
+        merged.TriggerKind.ShouldBe(TriggerKind.Http);
+        merged.TriggerLabel.ShouldBe("User clicks Place Order");
+        merged.Domain.ShouldBe("Orders");
+        merged.EmittedEvents.ShouldBe(new[] { T<OrderPlaced>(), T<OrderConfirmed>() });
+        merged.AggregateTypes.ShouldBe(new[] { T<Order>() });
+        merged.Specifications.Select(x => x.Identity).ShouldBe(new[] { "Place Order/Place an order", "Place Order/Rejects empty cart" });
+        // the derived spec (with resolved types) wins over the identity-only link
+        merged.Specifications[0].ResolvedTypes.Count.ShouldBe(2);
+        merged.Hotspots.Single().Origin.ShouldBe(HotspotOrigin.PendingSpecification);
+    }
+
+    [Fact]
+    public void merge_refuses_a_different_slice()
+    {
+        Should.Throw<ArgumentException>(() =>
+            EventModelSliceDescriptor.Named("a").Merge(EventModelSliceDescriptor.Named("b")));
+    }
+
+    [Fact]
+    public void model_merge_folds_slices_by_name_across_descriptors_and_unions_aggregates()
+    {
+        var order = new AggregateDescriptor(T<Order>(), AggregateKind.WriteAggregate, new[] { T<OrderPlaced>() });
+
+        var derived = new EventModelDescriptor("Orders", new[]
+        {
+            new EventModelSliceDescriptor("PlaceOrder", null, null, T<PlaceOrder>(), T<OrderHandler>(),
+                new[] { T<OrderPlaced>() }, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>()) { Pattern = SlicePattern.Command },
+            EventModelSliceDescriptor.Named("ShipOrder") with { Pattern = SlicePattern.Command },
+        }) { Aggregates = new[] { order } };
+
+        var overlay = new EventModelDescriptor("Orders", new[]
+        {
+            EventModelSliceDescriptor.Named("ShipOrder") with { Domain = "Fulfilment" },
+            EventModelSliceDescriptor.Named("PlaceOrder") with { Domain = "Orders" },
+            EventModelSliceDescriptor.Named("CancelOrder") with { Domain = "Orders" },
+        }) { Aggregates = new[] { order } };
+
+        var merged = EventModelDescriptor.Merge("Orders", new[] { derived, overlay });
+
+        merged.Name.ShouldBe("Orders");
+        merged.Slices.Select(s => s.Name).ShouldBe(new[] { "PlaceOrder", "ShipOrder", "CancelOrder" });
+        merged.Slices[0].CommandType.ShouldBe(T<PlaceOrder>());
+        merged.Slices[0].Domain.ShouldBe("Orders");
+        merged.Slices[1].Domain.ShouldBe("Fulfilment");
+        merged.Slices[2].Pattern.ShouldBeNull(); // overlay-only slice — named, not derived
+        merged.Aggregates.ShouldBe(new[] { order });
+    }
+
+    [Fact]
+    public void model_descriptor_positional_shape_still_compiles_and_aggregates_default_empty()
+    {
+        new EventModelDescriptor("m", Array.Empty<EventModelSliceDescriptor>()).Aggregates.ShouldBeEmpty();
+    }
+
+    public class PlaceOrder { }
+    public class OrderHandler { }
+    public class Order { }
+    public class OrderPlaced { }
+    public class OrderConfirmed { }
+    public class NotifyWarehouse { }
+    public class OrderProjection { }
+    public class OrderSummary { }
+}

--- a/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
+++ b/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
@@ -1,0 +1,224 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+// jasperfx#687 acceptance: everything round-trips through the wire descriptor. CritterWatch
+// serialises with System.Text.Json camelCase + JsonStringEnumConverter (camelCase), so that
+// is the shape under test alongside the STJ defaults.
+public class EventModelWireRoundTripTests
+{
+    private static TypeDescriptor T<TType>() => TypeDescriptor.For(typeof(TType));
+
+    private static readonly JsonSerializerOptions CritterWatchWire = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    private static readonly JsonSerializerOptions Defaults = new();
+
+    public static IEnumerable<object[]> Options() =>
+    [
+        [CritterWatchWire],
+        [Defaults],
+    ];
+
+    private static EventModelDescriptor fullModel() => new("Orders", new[]
+    {
+        new EventModelSliceDescriptor("PlaceOrder", "User clicks Place Order", T<PlaceOrderRequest>(), T<PlaceOrder>(), T<OrderHandler>(),
+            new[] { T<OrderPlaced>() }, new[] { T<OrderProjection>() }, new[] { T<OrderSummary>() })
+        {
+            Pattern = SlicePattern.Command,
+            TriggerKind = TriggerKind.Http,
+            TriggerOrigin = new PublisherOrigin { HttpMethod = "POST", HttpRoute = "/orders", Label = "POST /orders" },
+            AggregateTypes = new[] { T<Order>() },
+            PublishedMessages = new[] { T<NotifyWarehouse>() },
+            ExternalSystems = new[] { new ExternalSystemDescriptor("Warehouse", ExternalSystemDirection.Outbound, "rabbitmq://queue/warehouse") },
+            Hotspots = new[]
+            {
+                HotspotDescriptor.PendingSpecification("Place Order/Rejects empty cart"),
+                HotspotDescriptor.Prose("Refund policy unclear when partially shipped"),
+            },
+            Specifications = new[]
+            {
+                new SpecificationDescriptor("Place Order/Place an order", new[] { T<PlaceOrder>(), T<OrderPlaced>() }),
+                new SpecificationDescriptor("Place Order/Rejects empty cart"),
+            },
+            Domain = "Orders",
+        },
+        EventModelSliceDescriptor.Named("OrderList") with
+        {
+            Pattern = SlicePattern.View,
+            TriggerKind = TriggerKind.Human,
+            TriggerLabel = "Orders screen",
+            ReadModelTypes = new[] { T<OrderSummary>() },
+        },
+        EventModelSliceDescriptor.Named("NotifyOnPlaced") with
+        {
+            Pattern = SlicePattern.Automation,
+            TriggerKind = TriggerKind.JobScheduler,
+            HandlerType = T<OrderHandler>(),
+            PublishedMessages = new[] { T<NotifyWarehouse>() },
+        },
+        EventModelSliceDescriptor.Named("ImportLegacy") with
+        {
+            Pattern = SlicePattern.Translation,
+            TriggerKind = TriggerKind.External,
+            ExternalSystems = new[] { new ExternalSystemDescriptor("Legacy", ExternalSystemDirection.Inbound) },
+            EmittedEvents = new[] { T<OrderPlaced>() },
+        },
+        EventModelSliceDescriptor.Named("GrpcPlace") with { TriggerKind = TriggerKind.Grpc, Pattern = SlicePattern.Command },
+        EventModelSliceDescriptor.Named("BusPlace") with { TriggerKind = TriggerKind.MessageHandler, Pattern = SlicePattern.Command },
+    })
+    {
+        Aggregates = new[] { new AggregateDescriptor(T<Order>(), AggregateKind.WriteAggregate, new[] { T<OrderPlaced>() }) },
+    };
+
+    [Theory]
+    [MemberData(nameof(Options))]
+    public void every_role_and_element_round_trips(JsonSerializerOptions options)
+    {
+        var model = fullModel();
+
+        var json = JsonSerializer.Serialize(model, options);
+        var back = JsonSerializer.Deserialize<EventModelDescriptor>(json, options)!;
+
+        // record equality covers every positional + init slot; Elements/Edges are computed, so
+        // comparing them proves the typed roles came back whole
+        back.Name.ShouldBe(model.Name);
+        // AggregateDescriptor / SpecificationDescriptor carry lists, and record equality compares
+        // lists by reference — so compare those member-wise
+        back.Aggregates.Count.ShouldBe(model.Aggregates.Count);
+        for (var i = 0; i < model.Aggregates.Count; i++)
+        {
+            back.Aggregates[i].Type.ShouldBe(model.Aggregates[i].Type);
+            back.Aggregates[i].Kind.ShouldBe(model.Aggregates[i].Kind);
+            back.Aggregates[i].AppliedEvents.ShouldBe(model.Aggregates[i].AppliedEvents);
+        }
+        back.Slices.Count.ShouldBe(model.Slices.Count);
+        for (var i = 0; i < model.Slices.Count; i++)
+        {
+            var expected = model.Slices[i];
+            var actual = back.Slices[i];
+
+            actual.Name.ShouldBe(expected.Name);
+            actual.Pattern.ShouldBe(expected.Pattern);
+            actual.TriggerKind.ShouldBe(expected.TriggerKind);
+            actual.TriggerLabel.ShouldBe(expected.TriggerLabel);
+            actual.TriggerType.ShouldBe(expected.TriggerType);
+            actual.TriggerOrigin.ShouldBe(expected.TriggerOrigin);
+            actual.CommandType.ShouldBe(expected.CommandType);
+            actual.HandlerType.ShouldBe(expected.HandlerType);
+            actual.AggregateTypes.ShouldBe(expected.AggregateTypes);
+            actual.EmittedEvents.ShouldBe(expected.EmittedEvents);
+            actual.PublishedMessages.ShouldBe(expected.PublishedMessages);
+            actual.ProjectionTypes.ShouldBe(expected.ProjectionTypes);
+            actual.ReadModelTypes.ShouldBe(expected.ReadModelTypes);
+            actual.ExternalSystems.ShouldBe(expected.ExternalSystems);
+            actual.Hotspots.ShouldBe(expected.Hotspots);
+            actual.Specifications.Count.ShouldBe(expected.Specifications.Count);
+            for (var j = 0; j < expected.Specifications.Count; j++)
+            {
+                actual.Specifications[j].Identity.ShouldBe(expected.Specifications[j].Identity);
+                actual.Specifications[j].ResolvedTypes.ShouldBe(expected.Specifications[j].ResolvedTypes);
+            }
+            actual.Domain.ShouldBe(expected.Domain);
+
+            actual.Elements.ShouldBe(expected.Elements);
+            actual.Edges.ShouldBe(expected.Edges);
+        }
+    }
+
+    [Fact]
+    public void the_wire_carries_the_rendering_contract_in_camel_case_with_string_enums()
+    {
+        var json = JsonSerializer.Serialize(fullModel(), CritterWatchWire);
+        using var doc = JsonDocument.Parse(json);
+
+        var slice = doc.RootElement.GetProperty("slices")[0];
+        slice.GetProperty("pattern").GetString().ShouldBe("command");
+        slice.GetProperty("triggerKind").GetString().ShouldBe("http");
+        slice.GetProperty("domain").GetString().ShouldBe("Orders");
+        slice.GetProperty("aggregateTypes").GetArrayLength().ShouldBe(1);
+        slice.GetProperty("specifications")[0].GetProperty("identity").GetString().ShouldBe("Place Order/Place an order");
+        slice.GetProperty("hotspots")[0].GetProperty("origin").GetString().ShouldBe("pendingSpecification");
+        slice.GetProperty("hotspots")[0].GetProperty("specificationIdentity").GetString().ShouldBe("Place Order/Rejects empty cart");
+        slice.GetProperty("externalSystems")[0].GetProperty("direction").GetString().ShouldBe("outbound");
+
+        // the computed rendering contract is ON the wire — a viewer needs no second transform
+        var elements = slice.GetProperty("elements");
+        elements.GetArrayLength().ShouldBeGreaterThan(0);
+        var first = elements[0];
+        first.GetProperty("id").GetString().ShouldNotBeNullOrEmpty();
+        first.GetProperty("kind").GetString().ShouldBe("trigger");
+        first.GetProperty("lane").GetString().ShouldBe("wireframe");
+        slice.GetProperty("edges")[0].GetProperty("fromId").GetString().ShouldNotBeNullOrEmpty();
+
+        // the model-level aggregate element
+        doc.RootElement.GetProperty("aggregates")[0].GetProperty("kind").GetString().ShouldBe("writeAggregate");
+    }
+
+    [Theory]
+    [MemberData(nameof(Options))]
+    public void a_payload_from_before_687_still_deserializes(JsonSerializerOptions options)
+    {
+        // Exactly the 2.x positional shape and nothing else — what a 2.53 producer sends.
+        var old = new EventModelDescriptor("m", new[]
+        {
+            new EventModelSliceDescriptor("place", null, null, T<PlaceOrder>(), T<OrderHandler>(),
+                new[] { T<OrderPlaced>() }, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>()),
+        });
+
+        var json = JsonSerializer.Serialize(old, options);
+        using (var doc = JsonDocument.Parse(json))
+        {
+            // prove the serializer wrote the new slots too (additive on the wire)...
+            doc.RootElement.GetProperty(options.PropertyNamingPolicy is null ? "Slices" : "slices")[0]
+                .TryGetProperty(options.PropertyNamingPolicy is null ? "Pattern" : "pattern", out _).ShouldBeTrue();
+        }
+
+        // ...and that a payload WITHOUT them deserializes to the same defaults
+        var stripped = options.PropertyNamingPolicy is null
+            ? """{"Name":"m","Slices":[{"Name":"place","TriggerLabel":null,"TriggerType":null,"CommandType":{"Name":"PlaceOrder","FullName":"x.PlaceOrder","AssemblyName":"x"},"HandlerType":null,"EmittedEvents":[],"ProjectionTypes":[],"ReadModelTypes":[]}]}"""
+            : """{"name":"m","slices":[{"name":"place","triggerLabel":null,"triggerType":null,"commandType":{"name":"PlaceOrder","fullName":"x.PlaceOrder","assemblyName":"x"},"handlerType":null,"emittedEvents":[],"projectionTypes":[],"readModelTypes":[]}]}""";
+
+        var back = JsonSerializer.Deserialize<EventModelDescriptor>(stripped, options)!;
+        back.Aggregates.ShouldBeEmpty();
+        var slice = back.Slices.Single();
+        slice.CommandType!.FullName.ShouldBe("x.PlaceOrder");
+        slice.Pattern.ShouldBeNull();
+        slice.TriggerKind.ShouldBeNull();
+        slice.AggregateTypes.ShouldBeEmpty();
+        slice.Specifications.ShouldBeEmpty();
+        slice.Hotspots.ShouldBeEmpty();
+        slice.Elements.Select(e => e.Kind).ShouldBe(new[] { EventModelElementKind.Command });
+    }
+
+    [Fact]
+    public void specification_feature_and_scenario_are_derived_and_not_on_the_wire()
+    {
+        var spec = new SpecificationDescriptor("Place Order/Place an order");
+        spec.Feature.ShouldBe("Place Order");
+        spec.Scenario.ShouldBe("Place an order");
+        new SpecificationDescriptor("Loose").Feature.ShouldBe("Loose");
+        new SpecificationDescriptor("Loose").Scenario.ShouldBeNull();
+
+        var json = JsonSerializer.Serialize(spec, CritterWatchWire);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.TryGetProperty("feature", out _).ShouldBeFalse();
+        doc.RootElement.TryGetProperty("scenario", out _).ShouldBeFalse();
+    }
+
+    public class PlaceOrderRequest { }
+    public class PlaceOrder { }
+    public class OrderHandler { }
+    public class Order { }
+    public class OrderPlaced { }
+    public class NotifyWarehouse { }
+    public class OrderProjection { }
+    public class OrderSummary { }
+}

--- a/src/EventTests/EventModeling/HandlerRelationshipFoldTests.cs
+++ b/src/EventTests/EventModeling/HandlerRelationshipFoldTests.cs
@@ -1,0 +1,83 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+// jasperfx#687: HandlerRelationshipDescriptor / PublisherKind / PublisherOrigin fold into the
+// slice vocabulary. The type stays (the CritterWatch source generator still emits it);
+// ToSliceDescriptor is the fold.
+public class HandlerRelationshipFoldTests
+{
+    private static TypeDescriptor T<TType>() => TypeDescriptor.For(typeof(TType));
+
+    private static HandlerRelationshipDescriptor relationship(PublisherKind kind, PublisherOrigin? origin = null)
+        => new(T<OrderHandler>(), T<PlaceOrder>(), new[] { T<OrderPlaced>() }, T<Order>()) { Kind = kind, Origin = origin };
+
+    [Fact]
+    public void a_message_handler_is_a_command_slice_named_after_the_message()
+    {
+        var slice = relationship(PublisherKind.Handler).ToSliceDescriptor();
+
+        slice.Name.ShouldBe(nameof(PlaceOrder));
+        slice.Pattern.ShouldBe(SlicePattern.Command);
+        slice.TriggerKind.ShouldBe(TriggerKind.MessageHandler);
+        slice.CommandType.ShouldBe(T<PlaceOrder>());
+        slice.HandlerType.ShouldBe(T<OrderHandler>());
+        slice.AggregateTypes.ShouldBe(new[] { T<Order>() });
+        slice.EmittedEvents.ShouldBe(new[] { T<OrderPlaced>() });
+        slice.TriggerOrigin.ShouldBeNull();
+        slice.TriggerLabel.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_stateless_handler_has_no_aggregate()
+    {
+        var slice = new HandlerRelationshipDescriptor(T<OrderHandler>(), T<PlaceOrder>(), Array.Empty<TypeDescriptor>(), null)
+            .ToSliceDescriptor("custom");
+
+        slice.Name.ShouldBe("custom");
+        slice.AggregateTypes.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(PublisherKind.HttpEndpoint, SlicePattern.Command, TriggerKind.Http)]
+    [InlineData(PublisherKind.GrpcEndpoint, SlicePattern.Command, TriggerKind.Grpc)]
+    [InlineData(PublisherKind.DirectBusCall, SlicePattern.Command, TriggerKind.MessageHandler)]
+    [InlineData(PublisherKind.Scheduled, SlicePattern.Automation, TriggerKind.JobScheduler)]
+    [InlineData(PublisherKind.External, SlicePattern.Translation, TriggerKind.External)]
+    public void publisher_kinds_fold_to_pattern_and_trigger_kind(PublisherKind kind, SlicePattern pattern, TriggerKind trigger)
+    {
+        var slice = relationship(kind).ToSliceDescriptor();
+        slice.Pattern.ShouldBe(pattern);
+        slice.TriggerKind.ShouldBe(trigger);
+    }
+
+    [Fact]
+    public void a_projection_side_effect_is_an_automation_with_no_trigger_kind()
+    {
+        var origin = new PublisherOrigin { ProjectionType = T<OrderProjection>() };
+        var slice = relationship(PublisherKind.ProjectionSideEffect, origin).ToSliceDescriptor();
+
+        slice.Pattern.ShouldBe(SlicePattern.Automation);
+        slice.TriggerKind.ShouldBeNull();
+        slice.TriggerOrigin.ShouldBe(origin);
+    }
+
+    [Fact]
+    public void the_origin_is_carried_whole_and_its_label_becomes_the_trigger_label()
+    {
+        var origin = new PublisherOrigin { HttpMethod = "POST", HttpRoute = "/orders", Label = "POST /orders" };
+        var slice = relationship(PublisherKind.HttpEndpoint, origin).ToSliceDescriptor();
+
+        slice.TriggerOrigin.ShouldBe(origin);
+        slice.TriggerLabel.ShouldBe("POST /orders");
+        slice.Elements.Single(e => e.Kind == EventModelElementKind.Trigger).Label.ShouldBe("POST /orders");
+    }
+
+    public class PlaceOrder { }
+    public class OrderHandler { }
+    public class Order { }
+    public class OrderPlaced { }
+    public class OrderProjection { }
+}

--- a/src/EventTests/EventModeling/HotspotDescriptorTests.cs
+++ b/src/EventTests/EventModeling/HotspotDescriptorTests.cs
@@ -1,0 +1,44 @@
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+// jasperfx#689: a pending specification is a hotspot.
+public class HotspotDescriptorTests
+{
+    [Fact]
+    public void pending_specification_carries_the_spec_identity_as_origin_and_text()
+    {
+        var hotspot = HotspotDescriptor.PendingSpecification("Place Order/Rejects empty cart");
+
+        hotspot.Origin.ShouldBe(HotspotOrigin.PendingSpecification);
+        hotspot.SpecificationIdentity.ShouldBe("Place Order/Rejects empty cart");
+        hotspot.Text.ShouldBe("Place Order/Rejects empty cart");
+    }
+
+    [Fact]
+    public void prose_is_the_reserved_form_with_no_spec_identity()
+    {
+        var hotspot = HotspotDescriptor.Prose("Refund policy unclear");
+
+        hotspot.Origin.ShouldBe(HotspotOrigin.Prose);
+        hotspot.SpecificationIdentity.ShouldBeNull();
+        hotspot.Text.ShouldBe("Refund policy unclear");
+    }
+
+    [Fact]
+    public void a_pending_spec_hotspot_renders_on_the_slice_it_binds_to_in_the_hotspot_colour()
+    {
+        var slice = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            Specifications = new[] { new SpecificationDescriptor("Place Order/Rejects empty cart") },
+            Hotspots = new[] { HotspotDescriptor.PendingSpecification("Place Order/Rejects empty cart") },
+        };
+
+        var element = slice.Elements.Single(e => e.Kind == EventModelElementKind.Hotspot);
+        element.Id.ShouldBe("PlaceOrder/Hotspot/Place Order/Rejects empty cart");
+        element.Lane.ShouldBe(EventModelLane.Wireframe);
+        element.Type.ShouldBeNull();
+        EventModelPalette.ColorFor(element.Kind).ShouldBe("#E91E63");
+    }
+}

--- a/src/JasperFx.Events/EventModeling/EventModelBuilder.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelBuilder.cs
@@ -1,42 +1,59 @@
-using JasperFx.Descriptors;
-
 namespace JasperFx.Events.EventModeling;
 
 /// <summary>
-/// Fluent root used by an <see cref="EventModelDefinition"/> to declare
-/// the slices that make up an Event Modeling topology. Each call to
-/// <see cref="Slice"/> opens a new lane the author can populate via
-/// <see cref="EventModelSliceBuilder"/>.
+/// Fluent root used by an <see cref="EventModelDefinition"/> (or an inline
+/// <c>services.AddEventModel(name, configure)</c> lambda) to lay the overlay on an
+/// Event Model: name slices, group them by domain, label triggers and link
+/// specifications. Each call to <see cref="Slice"/> opens one slice.
 /// </summary>
 public class EventModelBuilder
 {
     private readonly List<EventModelSliceBuilder> _slices = new();
+    private string? _defaultDomain;
 
     /// <summary>
-    /// Optional friendly name of the event model. When unset, the
-    /// discovery layer falls back to the defining type's name.
+    /// Optional friendly name of the event model. When unset, the discovery layer falls back to
+    /// the defining type's name.
     /// </summary>
     public string? Name { get; set; }
 
     /// <summary>
-    /// Begin declaring a slice. Returns the per-slice builder so the
-    /// caller can chain trigger / command / handler / events / projection
-    /// / read-model entries onto it.
+    /// Domain / bounded context applied to every slice opened after this call that does not set
+    /// its own with <see cref="EventModelSliceBuilder.InDomain"/>.
+    /// </summary>
+    /// <param name="domain">Domain / bounded-context name.</param>
+    /// <returns>This builder for chaining.</returns>
+    public EventModelBuilder InDomain(string domain)
+    {
+        _defaultDomain = domain;
+        return this;
+    }
+
+    /// <summary>
+    /// Open a slice. The <paramref name="sliceName"/> is the key the overlay merges onto the
+    /// derived model by, so it should match the derived slice's name — by convention the
+    /// command's short name.
     /// </summary>
     /// <param name="sliceName">Display name of the slice.</param>
     public EventModelSliceBuilder Slice(string sliceName)
     {
-        var slice = new EventModelSliceBuilder(sliceName);
+        var slice = new EventModelSliceBuilder(sliceName, _defaultDomain);
         _slices.Add(slice);
         return slice;
     }
 
     /// <summary>
-    /// Snapshot the configured slices as descriptor records. Called by
-    /// the discovery layer once <see cref="EventModelDefinition.Configure"/>
-    /// returns.
+    /// Snapshot the configured slices as descriptor records. Called by the discovery layer once
+    /// <see cref="EventModelDefinition.Configure"/> returns.
     /// </summary>
     /// <returns>A read-only list of slice descriptors in declaration order.</returns>
     public IReadOnlyList<EventModelSliceDescriptor> BuildSlices()
         => _slices.Select(x => x.Build()).ToList();
+
+    /// <summary>
+    /// Snapshot the whole overlay as an <see cref="EventModelDescriptor"/>.
+    /// </summary>
+    /// <param name="fallbackName">Name used when <see cref="Name"/> is unset.</param>
+    public EventModelDescriptor Build(string fallbackName)
+        => new(Name ?? fallbackName, BuildSlices());
 }

--- a/src/JasperFx.Events/EventModeling/EventModelDefinition.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelDefinition.cs
@@ -1,19 +1,41 @@
 namespace JasperFx.Events.EventModeling;
 
 /// <summary>
-/// Base class application authors derive from to declare an Event
-/// Modeling topology — the swim-lane / slice description that
-/// CritterWatch and other operator tooling renders. Override
-/// <see cref="Configure"/> to populate the supplied
-/// <see cref="EventModelBuilder"/> with slices and their members.
+/// Base class application authors derive from to lay an <em>overlay</em> on the
+/// Event Model — names for slices, domain grouping, trigger labels and links to
+/// specifications. Override <see cref="Configure"/> to populate the supplied
+/// <see cref="EventModelBuilder"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Declare only what code cannot express</b> (jasperfx#687 reshape, 2026-08-20). Roles —
+/// command, handler, aggregates, emitted events, published messages, projections, read models,
+/// trigger kind, slice pattern — are <em>derived</em> by the sources that can see them:
+/// Wolverine from its handler / HTTP / gRPC chains, the Bobcat generator from Gherkin with
+/// shipped grammars. The overlay never declares them; it is folded onto the derived model by
+/// <see cref="EventModelDescriptor.Merge"/> with the derived sources first, so it cannot
+/// overwrite a derived role. The one exception is
+/// <see cref="EventModelSliceBuilder.ForFlowNotOwnedHere"/> — an explicit escape hatch for flows
+/// whose code this host does not own.
+/// </para>
+/// <para>
+/// Register a definition with <c>services.AddEventModel&lt;TDefinition&gt;()</c> (or an inline
+/// lambda via <c>services.AddEventModel(name, configure)</c>); it is surfaced as an
+/// <see cref="IEventModelDefinitionSource"/> and enumerated by <see cref="EventModelDiscovery"/>.
+/// </para>
+/// </remarks>
 public abstract class EventModelDefinition
 {
     /// <summary>
-    /// Populate <paramref name="builder"/> with the slices that make up
-    /// this event-model definition. Called once by the discovery layer
-    /// when assembling the topology.
+    /// Name of the model this overlay contributes to. Defaults to the defining type's name;
+    /// override to contribute to a named model (the merge assembles all sources by model).
     /// </summary>
-    /// <param name="builder">Builder that accumulates slices into a definition.</param>
+    public virtual string Name => GetType().Name;
+
+    /// <summary>
+    /// Populate <paramref name="builder"/> with the overlay — slice names, domains, trigger
+    /// labels, specification links. Called once by the discovery layer.
+    /// </summary>
+    /// <param name="builder">Builder that accumulates the overlay.</param>
     public abstract void Configure(EventModelBuilder builder);
 }

--- a/src/JasperFx.Events/EventModeling/EventModelDefinitionSource.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelDefinitionSource.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// The discovery bridge for overlays: adapts an <see cref="EventModelDefinition"/> — a
+/// registered subclass, a ready instance, or an inline lambda — to
+/// <see cref="IEventModelDefinitionSource"/> (jasperfx#687 §3). Instantiates the definition
+/// (from DI when it is a type), runs <see cref="EventModelDefinition.Configure"/>, and
+/// snapshots the result as an <see cref="EventModelDescriptor"/>.
+/// </summary>
+public sealed class EventModelDefinitionSource : IEventModelDefinitionSource
+{
+    /// <summary>URI scheme for overlay sources: <c>event-model://{name}</c>.</summary>
+    public const string Scheme = "event-model";
+
+    private readonly string _name;
+    private readonly Func<IServiceProvider, EventModelDefinition?> _resolve;
+
+    private EventModelDefinitionSource(string name, Func<IServiceProvider, EventModelDefinition?> resolve)
+    {
+        _name = name;
+        _resolve = resolve;
+        Subject = new Uri($"{Scheme}://{Uri.EscapeDataString(name)}");
+    }
+
+    /// <summary>Wrap a ready definition instance.</summary>
+    public static EventModelDefinitionSource For(EventModelDefinition definition)
+        => new(definition.Name, _ => definition);
+
+    /// <summary>
+    /// Wrap a definition type. Resolved from the service provider if registered there, otherwise
+    /// constructed through <see cref="ActivatorUtilities"/> so constructor dependencies still
+    /// come from DI.
+    /// </summary>
+    public static EventModelDefinitionSource For(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type definitionType)
+    {
+        if (!typeof(EventModelDefinition).IsAssignableFrom(definitionType) || definitionType.IsAbstract)
+        {
+            throw new ArgumentException(
+                $"{definitionType.FullName} is not a concrete {nameof(EventModelDefinition)} subclass",
+                nameof(definitionType));
+        }
+
+        return new EventModelDefinitionSource(definitionType.Name, services =>
+            (services.GetService(definitionType) ?? ActivatorUtilities.CreateInstance(services, definitionType))
+            as EventModelDefinition);
+    }
+
+    /// <summary>Wrap a definition type.</summary>
+    public static EventModelDefinitionSource For<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDefinition>()
+        where TDefinition : EventModelDefinition
+        => For(typeof(TDefinition));
+
+    /// <summary>Wrap an inline overlay.</summary>
+    public static EventModelDefinitionSource For(string name, Action<EventModelBuilder> configure)
+        => new(name, _ => new LambdaDefinition(name, configure));
+
+    /// <inheritdoc />
+    public Uri Subject { get; }
+
+    /// <inheritdoc />
+    public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+    {
+        var definition = _resolve(services);
+        if (definition is null) return Task.FromResult<EventModelDescriptor?>(null);
+
+        var builder = new EventModelBuilder();
+        definition.Configure(builder);
+        return Task.FromResult<EventModelDescriptor?>(builder.Build(definition.Name));
+    }
+
+    private sealed class LambdaDefinition : EventModelDefinition
+    {
+        private readonly Action<EventModelBuilder> _configure;
+
+        public LambdaDefinition(string name, Action<EventModelBuilder> configure)
+        {
+            Name = name;
+            _configure = configure;
+        }
+
+        public override string Name { get; }
+
+        public override void Configure(EventModelBuilder builder) => _configure(builder);
+    }
+}

--- a/src/JasperFx.Events/EventModeling/EventModelElement.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelElement.cs
@@ -1,0 +1,144 @@
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Kind of a rendered element on the Event Modeling canvas. Maps 1:1 to the
+/// canonical Event Modeling / Event Storming sticky-note colour (see
+/// <see cref="EventModelPalette"/>) so any viewer — the Bobcat viewer,
+/// CritterWatch, a standalone page — colours the same descriptor the same way.
+/// </summary>
+public enum EventModelElementKind
+{
+    /// <summary>A UI / wireframe or other human or external trigger. White.</summary>
+    Trigger,
+
+    /// <summary>The inbound command / message type. Blue.</summary>
+    Command,
+
+    /// <summary>The handler (Wolverine handler or endpoint method) that processes the command. Blue, outlined.</summary>
+    Handler,
+
+    /// <summary>An aggregate / projected write model the handler loads or decides against. Pale yellow.</summary>
+    Aggregate,
+
+    /// <summary>An emitted domain event. Orange.</summary>
+    Event,
+
+    /// <summary>A published (non-event) message — a cascaded command or integration message. Blue, dashed.</summary>
+    Message,
+
+    /// <summary>A projection that folds events into a read model. Green, outlined.</summary>
+    Projection,
+
+    /// <summary>A read model / view. Green.</summary>
+    ReadModel,
+
+    /// <summary>An external system on either end of a translation. Pink.</summary>
+    ExternalSystem,
+
+    /// <summary>A hotspot — an open question, conflict, or pending specification. Magenta / red.</summary>
+    Hotspot,
+}
+
+/// <summary>
+/// Swim lane an element is rendered in. The four lanes of a standard Event
+/// Modeling canvas, top to bottom (jasperfx#687 decision 9).
+/// </summary>
+public enum EventModelLane
+{
+    /// <summary>Top lane: wireframes, UI, human and external triggers, hotspots.</summary>
+    Wireframe,
+
+    /// <summary>Second lane: commands, handlers, aggregates, automations — the "timeline" of decisions.</summary>
+    Command,
+
+    /// <summary>Third lane: the event stream — emitted events and published messages.</summary>
+    EventStream,
+
+    /// <summary>Bottom lane: projections and read models.</summary>
+    ReadModel,
+}
+
+/// <summary>
+/// One rendered element of a slice — the rendering contract every viewer can
+/// draw from without a second transform (jasperfx#687 decision 9).
+/// </summary>
+/// <param name="Id">
+///     Stable id, unique within the slice and deterministic across runs:
+///     <c>{slice name}/{kind}/{type full name or label}</c>. Edges reference elements by this id,
+///     and drift colouring matches declared vs. implemented elements by the <see cref="Type"/>
+///     identity underneath it.
+/// </param>
+/// <param name="Kind">Element kind → canonical colour.</param>
+/// <param name="Lane">Swim lane the element renders in.</param>
+/// <param name="Label">Display text — the CLR type's short name, or the free-form label for typeless triggers / hotspots.</param>
+/// <param name="Type">The CLR type identity underneath the element, when there is one. Null for labelled triggers, external systems and hotspots.</param>
+public sealed record EventModelElement(
+    string Id,
+    EventModelElementKind Kind,
+    EventModelLane Lane,
+    string Label,
+    TypeDescriptor? Type)
+{
+    /// <summary>
+    /// Compose the deterministic element id for <paramref name="kind"/> inside <paramref name="sliceName"/>.
+    /// </summary>
+    public static string IdFor(string sliceName, EventModelElementKind kind, string identity)
+        => $"{sliceName}/{kind}/{identity}";
+
+    /// <summary>Build the element for a CLR-typed role.</summary>
+    public static EventModelElement ForType(string sliceName, EventModelElementKind kind, TypeDescriptor type)
+        => new(IdFor(sliceName, kind, type.FullName), kind, LaneFor(kind), type.Name, type);
+
+    /// <summary>Build the element for a labelled, typeless role (a trigger label, an external system, a hotspot).</summary>
+    public static EventModelElement ForLabel(string sliceName, EventModelElementKind kind, string label)
+        => new(IdFor(sliceName, kind, label), kind, LaneFor(kind), label, null);
+
+    /// <summary>The canonical lane for an element kind.</summary>
+    public static EventModelLane LaneFor(EventModelElementKind kind) => kind switch
+    {
+        EventModelElementKind.Trigger => EventModelLane.Wireframe,
+        EventModelElementKind.ExternalSystem => EventModelLane.Wireframe,
+        EventModelElementKind.Hotspot => EventModelLane.Wireframe,
+        EventModelElementKind.Command => EventModelLane.Command,
+        EventModelElementKind.Handler => EventModelLane.Command,
+        EventModelElementKind.Aggregate => EventModelLane.Command,
+        EventModelElementKind.Event => EventModelLane.EventStream,
+        EventModelElementKind.Message => EventModelLane.EventStream,
+        EventModelElementKind.Projection => EventModelLane.ReadModel,
+        EventModelElementKind.ReadModel => EventModelLane.ReadModel,
+        _ => EventModelLane.Command,
+    };
+}
+
+/// <summary>
+/// A directed relationship between two elements of a slice, by element id.
+/// </summary>
+/// <param name="FromId">Id of the source element.</param>
+/// <param name="ToId">Id of the target element.</param>
+public sealed record EventModelEdge(string FromId, string ToId);
+
+/// <summary>
+/// The canonical Event Modeling / Event Storming sticky-note colours, keyed by
+/// <see cref="EventModelElementKind"/>. Viewers are free to theme, but this is
+/// the shared reference so two viewers of one descriptor agree on what a colour means.
+/// </summary>
+public static class EventModelPalette
+{
+    /// <summary>Hex colour for an element kind.</summary>
+    public static string ColorFor(EventModelElementKind kind) => kind switch
+    {
+        EventModelElementKind.Trigger => "#FFFFFF",        // wireframe / UI — white
+        EventModelElementKind.Command => "#5B9BD5",        // command — blue
+        EventModelElementKind.Handler => "#5B9BD5",        // handler — blue (drawn outlined)
+        EventModelElementKind.Aggregate => "#FFF2A8",      // aggregate — pale yellow
+        EventModelElementKind.Event => "#F5A623",          // event — orange
+        EventModelElementKind.Message => "#5B9BD5",        // message — blue (drawn dashed)
+        EventModelElementKind.Projection => "#7ED321",     // projection — green (drawn outlined)
+        EventModelElementKind.ReadModel => "#7ED321",      // read model — green
+        EventModelElementKind.ExternalSystem => "#F8BBD0", // external system — pink
+        EventModelElementKind.Hotspot => "#E91E63",        // hotspot — magenta
+        _ => "#CCCCCC",
+    };
+}

--- a/src/JasperFx.Events/EventModeling/EventModelServiceCollectionExtensions.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelServiceCollectionExtensions.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Registration API for Event Model sources (jasperfx#687 §3). Every registration is an
+/// <see cref="IEventModelDefinitionSource"/> singleton; <see cref="EventModelDiscovery"/>
+/// enumerates them.
+/// </summary>
+public static class EventModelServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register an <see cref="EventModelDefinition"/> subclass as an overlay source. The type is
+    /// resolved from DI at discovery time (or constructed with its dependencies from DI).
+    /// </summary>
+    public static IServiceCollection AddEventModel<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TDefinition>(
+        this IServiceCollection services)
+        where TDefinition : EventModelDefinition
+        => services.AddEventModelSource(EventModelDefinitionSource.For<TDefinition>());
+
+    /// <summary>
+    /// Register a discovered <see cref="EventModelDefinition"/> subclass as an overlay source.
+    /// </summary>
+    public static IServiceCollection AddEventModel(
+        this IServiceCollection services,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type definitionType)
+        => services.AddEventModelSource(EventModelDefinitionSource.For(definitionType));
+
+    /// <summary>Register a ready definition instance as an overlay source.</summary>
+    public static IServiceCollection AddEventModel(this IServiceCollection services, EventModelDefinition definition)
+        => services.AddEventModelSource(EventModelDefinitionSource.For(definition));
+
+    /// <summary>Register an inline overlay.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="name">Name of the model the overlay contributes to.</param>
+    /// <param name="configure">The overlay.</param>
+    public static IServiceCollection AddEventModel(this IServiceCollection services, string name, Action<EventModelBuilder> configure)
+        => services.AddEventModelSource(EventModelDefinitionSource.For(name, configure));
+
+    /// <summary>
+    /// Register every concrete <see cref="EventModelDefinition"/> subclass exported by
+    /// <paramref name="assembly"/>.
+    /// </summary>
+    [RequiresUnreferencedCode("Enumerates Assembly.ExportedTypes to find EventModelDefinition subclasses. AOT-publishing apps should register each definition explicitly with AddEventModel<T>().")]
+    public static IServiceCollection AddEventModelsFromAssembly(this IServiceCollection services, Assembly assembly)
+    {
+        foreach (var type in assembly.GetExportedTypes())
+        {
+            if (type.IsAbstract || !typeof(EventModelDefinition).IsAssignableFrom(type)) continue;
+            services.AddEventModel(type);
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Register any <see cref="IEventModelDefinitionSource"/> — an overlay adapter, a generated
+    /// source, a Wolverine-derived source — so <see cref="EventModelDiscovery"/> sees it.
+    /// </summary>
+    public static IServiceCollection AddEventModelSource(this IServiceCollection services, IEventModelDefinitionSource source)
+    {
+        services.AddSingleton(source);
+        return services;
+    }
+
+    /// <summary>
+    /// Register an <see cref="IEventModelDefinitionSource"/> implementation type.
+    /// </summary>
+    public static IServiceCollection AddEventModelSource<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TSource>(
+        this IServiceCollection services)
+        where TSource : class, IEventModelDefinitionSource
+    {
+        services.AddSingleton<IEventModelDefinitionSource, TSource>();
+        return services;
+    }
+}
+
+/// <summary>
+/// The enumeration path (jasperfx#687 §3): walk every registered
+/// <see cref="IEventModelDefinitionSource"/> and assemble the full picture.
+/// </summary>
+public static class EventModelDiscovery
+{
+    /// <summary>
+    /// Ask every registered source for its descriptor. Sources that return null are skipped.
+    /// Returned in registration order — derived sources should be registered before overlays so
+    /// <see cref="Assemble"/> lets derived roles win.
+    /// </summary>
+    public static async Task<IReadOnlyList<EventModelDescriptor>> DiscoverAsync(IServiceProvider services, CancellationToken token = default)
+    {
+        var descriptors = new List<EventModelDescriptor>();
+        foreach (var source in services.GetServices<IEventModelDefinitionSource>())
+        {
+            var descriptor = await source.TryCreateAsync(services, token).ConfigureAwait(false);
+            if (descriptor is not null) descriptors.Add(descriptor);
+        }
+
+        return descriptors;
+    }
+
+    /// <summary>
+    /// Fold the discovered descriptors into one model per name — overlays onto derived sources,
+    /// slices by name — and return them in first-appearance order.
+    /// </summary>
+    public static IReadOnlyList<EventModelDescriptor> Assemble(IEnumerable<EventModelDescriptor> descriptors)
+    {
+        var order = new List<string>();
+        var byName = new Dictionary<string, List<EventModelDescriptor>>(StringComparer.Ordinal);
+        foreach (var descriptor in descriptors)
+        {
+            if (!byName.TryGetValue(descriptor.Name, out var list))
+            {
+                list = new List<EventModelDescriptor>();
+                byName[descriptor.Name] = list;
+                order.Add(descriptor.Name);
+            }
+
+            list.Add(descriptor);
+        }
+
+        return order.Select(name => EventModelDescriptor.Merge(name, byName[name])).ToList();
+    }
+
+    /// <summary>
+    /// <see cref="DiscoverAsync"/> then <see cref="Assemble"/>: the full picture, one descriptor
+    /// per model name.
+    /// </summary>
+    public static async Task<IReadOnlyList<EventModelDescriptor>> AssembleAsync(IServiceProvider services, CancellationToken token = default)
+        => Assemble(await DiscoverAsync(services, token).ConfigureAwait(false));
+}

--- a/src/JasperFx.Events/EventModeling/EventModelSliceBuilder.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelSliceBuilder.cs
@@ -3,35 +3,45 @@ using JasperFx.Descriptors;
 namespace JasperFx.Events.EventModeling;
 
 /// <summary>
-/// Per-slice fluent builder. Each method describes one role inside a
-/// slice (trigger, command, handler, emitted events, projections,
-/// read models) and returns <c>this</c> so the author can chain them
-/// into a single declarative block.
+/// Per-slice overlay builder. The methods here <em>name, group, annotate and link</em> —
+/// they never declare a role. Roles are derived by the sources that can see them and the
+/// overlay is merged onto the derived slice by name (jasperfx#687 reshape).
 /// </summary>
 public class EventModelSliceBuilder
 {
     private readonly string _sliceName;
+    private string? _domain;
     private string? _triggerLabel;
-    private TypeDescriptor? _triggerType;
-    private TypeDescriptor? _commandType;
-    private TypeDescriptor? _handlerType;
-    private readonly List<TypeDescriptor> _emittedEvents = new();
-    private readonly List<TypeDescriptor> _projectionTypes = new();
-    private readonly List<TypeDescriptor> _readModelTypes = new();
+    private readonly List<SpecificationDescriptor> _specifications = new();
+    private ExternallyOwnedRoles? _externallyOwned;
 
     /// <summary>
-    /// Create a slice builder. The discovery layer wires this up — author
+    /// Create a slice builder. <see cref="EventModelBuilder.Slice"/> wires this up — author
     /// code never instantiates it directly.
     /// </summary>
     /// <param name="sliceName">Display name of the slice.</param>
-    public EventModelSliceBuilder(string sliceName)
+    /// <param name="domain">Domain inherited from <see cref="EventModelBuilder.InDomain"/>, if any.</param>
+    public EventModelSliceBuilder(string sliceName, string? domain = null)
     {
         _sliceName = sliceName;
+        _domain = domain;
     }
 
     /// <summary>
-    /// Declare a free-form trigger label (e.g. "User clicks Save"). Use
-    /// when the trigger is not represented by a CLR type.
+    /// Group this slice under a domain / bounded context (overrides the builder-level default).
+    /// </summary>
+    /// <param name="domain">Domain / bounded-context name.</param>
+    /// <returns>This builder for chaining.</returns>
+    public EventModelSliceBuilder InDomain(string domain)
+    {
+        _domain = domain;
+        return this;
+    }
+
+    /// <summary>
+    /// Annotate the trigger with a human-readable label (e.g. "User clicks Place Order") —
+    /// the one thing about a trigger code cannot express. The trigger's <em>kind</em> and type
+    /// are derived.
     /// </summary>
     /// <param name="label">Display label for the trigger.</param>
     /// <returns>This builder for chaining.</returns>
@@ -42,83 +52,159 @@ public class EventModelSliceBuilder
     }
 
     /// <summary>
-    /// Declare a CLR-typed trigger (e.g. an inbound HTTP request DTO).
+    /// Link a specification to this slice by identity (<c>{Feature}/{Scenario}</c>). Use this
+    /// only for a spec the binding source cannot stamp itself — a spec that lives outside the
+    /// compilation (a manual test plan, a partner's acceptance suite). Specs the Bobcat generator
+    /// or a code-first runner can see are bound by them, with resolved types, and never re-typed here.
     /// </summary>
-    /// <typeparam name="T">CLR trigger type.</typeparam>
+    /// <param name="specificationIdentity">The <c>{Feature}/{Scenario}</c> identity.</param>
     /// <returns>This builder for chaining.</returns>
-    public EventModelSliceBuilder TriggeredBy<T>()
+    public EventModelSliceBuilder LinksToSpecification(string specificationIdentity)
     {
-        _triggerType = TypeDescriptor.For(typeof(T));
+        _specifications.Add(new SpecificationDescriptor(specificationIdentity));
         return this;
     }
 
     /// <summary>
-    /// Declare the command type that this slice dispatches.
+    /// <b>Escape hatch.</b> Declare roles for a flow whose code this host does <em>not</em> own —
+    /// a partner system's command and the events it emits, a legacy service with no Wolverine
+    /// chain to derive from. For anything this host's own code implements, do not use this:
+    /// roles are derived from the code and a declaration here would only drift from it.
     /// </summary>
-    /// <typeparam name="T">CLR command type.</typeparam>
+    /// <param name="configure">Declares the externally-owned roles.</param>
     /// <returns>This builder for chaining.</returns>
-    public EventModelSliceBuilder Command<T>()
+    public EventModelSliceBuilder ForFlowNotOwnedHere(Action<ExternallyOwnedRoles> configure)
+    {
+        _externallyOwned ??= new ExternallyOwnedRoles();
+        configure(_externallyOwned);
+        return this;
+    }
+
+    internal EventModelSliceDescriptor Build()
+    {
+        var overlay = EventModelSliceDescriptor.Named(_sliceName) with
+        {
+            TriggerLabel = _triggerLabel,
+            Domain = _domain,
+            Specifications = _specifications.ToList(),
+        };
+
+        return _externallyOwned is null ? overlay : overlay.Merge(_externallyOwned.ToSlice(_sliceName));
+    }
+}
+
+/// <summary>
+/// Roles declared through <see cref="EventModelSliceBuilder.ForFlowNotOwnedHere"/> — the
+/// explicitly-documented escape hatch for flows this host's code does not implement and no
+/// source can therefore derive. Everything here is a role a source would otherwise stamp.
+/// </summary>
+public sealed class ExternallyOwnedRoles
+{
+    private SlicePattern? _pattern;
+    private TriggerKind? _triggerKind;
+    private TypeDescriptor? _triggerType;
+    private TypeDescriptor? _commandType;
+    private TypeDescriptor? _handlerType;
+    private readonly List<TypeDescriptor> _aggregateTypes = new();
+    private readonly List<TypeDescriptor> _emittedEvents = new();
+    private readonly List<TypeDescriptor> _publishedMessages = new();
+    private readonly List<TypeDescriptor> _projectionTypes = new();
+    private readonly List<TypeDescriptor> _readModelTypes = new();
+    private readonly List<ExternalSystemDescriptor> _externalSystems = new();
+
+    /// <summary>Which of the four canonical patterns the flow is.</summary>
+    public ExternallyOwnedRoles Pattern(SlicePattern pattern)
+    {
+        _pattern = pattern;
+        return this;
+    }
+
+    /// <summary>What starts the flow.</summary>
+    public ExternallyOwnedRoles TriggeredBy(TriggerKind kind)
+    {
+        _triggerKind = kind;
+        return this;
+    }
+
+    /// <summary>A CLR-typed trigger (e.g. an inbound request DTO).</summary>
+    public ExternallyOwnedRoles TriggeredBy<T>(TriggerKind kind)
+    {
+        _triggerKind = kind;
+        _triggerType = TypeDescriptor.For(typeof(T));
+        return this;
+    }
+
+    /// <summary>The command / inbound message type.</summary>
+    public ExternallyOwnedRoles Command<T>()
     {
         _commandType = TypeDescriptor.For(typeof(T));
         return this;
     }
 
-    /// <summary>
-    /// Declare the handler / aggregate type that processes the slice's
-    /// command.
-    /// </summary>
-    /// <typeparam name="T">CLR handler type.</typeparam>
-    /// <returns>This builder for chaining.</returns>
-    public EventModelSliceBuilder HandledBy<T>()
+    /// <summary>The handler type, distinct from the aggregate(s).</summary>
+    public ExternallyOwnedRoles HandledBy<T>()
     {
         _handlerType = TypeDescriptor.For(typeof(T));
         return this;
     }
 
-    /// <summary>
-    /// Declare an event type that this slice emits. Call once per emitted
-    /// event.
-    /// </summary>
-    /// <typeparam name="T">CLR event type.</typeparam>
-    /// <returns>This builder for chaining.</returns>
-    public EventModelSliceBuilder Emits<T>()
+    /// <summary>An aggregate / projected write model the handler decides against. Call once per aggregate.</summary>
+    public ExternallyOwnedRoles UsesAggregate<T>()
+    {
+        _aggregateTypes.Add(TypeDescriptor.For(typeof(T)));
+        return this;
+    }
+
+    /// <summary>An event the flow emits. Call once per event type.</summary>
+    public ExternallyOwnedRoles Emits<T>()
     {
         _emittedEvents.Add(TypeDescriptor.For(typeof(T)));
         return this;
     }
 
-    /// <summary>
-    /// Declare a projection that consumes events from this slice. Call
-    /// once per projection.
-    /// </summary>
-    /// <typeparam name="T">CLR projection type.</typeparam>
-    /// <returns>This builder for chaining.</returns>
-    public EventModelSliceBuilder Projects<T>()
+    /// <summary>A non-event message the flow publishes. Call once per message type.</summary>
+    public ExternallyOwnedRoles Publishes<T>()
+    {
+        _publishedMessages.Add(TypeDescriptor.For(typeof(T)));
+        return this;
+    }
+
+    /// <summary>A projection that consumes the flow's events. Call once per projection.</summary>
+    public ExternallyOwnedRoles Projects<T>()
     {
         _projectionTypes.Add(TypeDescriptor.For(typeof(T)));
         return this;
     }
 
-    /// <summary>
-    /// Declare a read model that this slice reads from. Call once per
-    /// read model.
-    /// </summary>
-    /// <typeparam name="T">CLR read-model type.</typeparam>
-    /// <returns>This builder for chaining.</returns>
-    public EventModelSliceBuilder Reads<T>()
+    /// <summary>A read model the flow reads from or produces. Call once per read model.</summary>
+    public ExternallyOwnedRoles Reads<T>()
     {
         _readModelTypes.Add(TypeDescriptor.For(typeof(T)));
         return this;
     }
 
-    internal EventModelSliceDescriptor Build()
+    /// <summary>An external system on one end of the flow.</summary>
+    public ExternallyOwnedRoles ExternalSystem(string name, ExternalSystemDirection direction, string? endpointUri = null)
+    {
+        _externalSystems.Add(new ExternalSystemDescriptor(name, direction, endpointUri));
+        return this;
+    }
+
+    internal EventModelSliceDescriptor ToSlice(string sliceName)
         => new(
-            _sliceName,
-            _triggerLabel,
+            sliceName,
+            null,
             _triggerType,
             _commandType,
             _handlerType,
             _emittedEvents.ToList(),
             _projectionTypes.ToList(),
-            _readModelTypes.ToList());
+            _readModelTypes.ToList())
+        {
+            Pattern = _pattern,
+            TriggerKind = _triggerKind,
+            AggregateTypes = _aggregateTypes.ToList(),
+            PublishedMessages = _publishedMessages.ToList(),
+            ExternalSystems = _externalSystems.ToList(),
+        };
 }

--- a/src/JasperFx.Events/EventModeling/EventModelSliceDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelSliceDescriptor.cs
@@ -3,18 +3,37 @@ using JasperFx.Descriptors;
 namespace JasperFx.Events.EventModeling;
 
 /// <summary>
-/// Diagnostic descriptor for a single slice in an Event Modeling
-/// definition. Snapshot of what an <see cref="EventModelSliceBuilder"/>
-/// captured, ready for transport over the wire to operator tooling.
+/// Wire descriptor for a single slice of an Event Model — the one vocabulary every
+/// source writes into (Wolverine chains, the Bobcat generator, the CritterWatch
+/// source generator via <see cref="HandlerRelationshipDescriptor.ToSliceDescriptor"/>,
+/// and the naming / grouping / linking overlay) and every viewer reads from.
 /// </summary>
-/// <param name="Name">Display name of the slice.</param>
+/// <remarks>
+/// <para>
+/// <b>Shape.</b> The positional constructor is the original 2.x shape and is kept
+/// source- and binary-compatible; everything jasperfx#687 added is an <c>init</c>
+/// property with a safe default, so precompiled callers and older JSON payloads keep
+/// working. <see cref="Elements"/> and <see cref="Edges"/> are <em>computed</em> from the
+/// typed roles on every read, so the wire carries the rendering contract without the two
+/// ever disagreeing; a deserializer simply ignores them and recomputes.
+/// </para>
+/// <para>
+/// <b>Roles are derived, not declared</b> (jasperfx#687 reshape, 2026-08-20): the command,
+/// handler, aggregates, emitted events, published messages, projections, read models,
+/// trigger kind and slice pattern are stamped by the source that can see them. The overlay
+/// (<see cref="EventModelDefinition"/>) only names, groups, annotates and links. Two slices
+/// with the same <see cref="Name"/> from different sources are folded into one by
+/// <see cref="Merge"/>.
+/// </para>
+/// </remarks>
+/// <param name="Name">Display name of the slice; also the merge key across sources.</param>
 /// <param name="TriggerLabel">Free-form trigger label, when one was supplied.</param>
-/// <param name="TriggerType">CLR trigger type, when one was supplied.</param>
-/// <param name="CommandType">CLR command type dispatched by the slice, when one was declared.</param>
-/// <param name="HandlerType">CLR handler / aggregate type for the command, when one was declared.</param>
-/// <param name="EmittedEvents">CLR event types emitted by the slice, in declaration order.</param>
-/// <param name="ProjectionTypes">CLR projection types that consume the slice's events.</param>
-/// <param name="ReadModelTypes">CLR read-model types the slice reads from.</param>
+/// <param name="TriggerType">CLR trigger type, when one was supplied (e.g. an inbound HTTP request DTO).</param>
+/// <param name="CommandType">The inbound message type — the command — when one was derived.</param>
+/// <param name="HandlerType">The handler / endpoint type that processes the command. Distinct from the aggregate(s).</param>
+/// <param name="EmittedEvents">Event types emitted by the slice, in declaration order.</param>
+/// <param name="ProjectionTypes">Projection types that consume the slice's events.</param>
+/// <param name="ReadModelTypes">Read-model types the slice reads from or produces.</param>
 public sealed record EventModelSliceDescriptor(
     string Name,
     string? TriggerLabel,
@@ -23,15 +42,304 @@ public sealed record EventModelSliceDescriptor(
     TypeDescriptor? HandlerType,
     IReadOnlyList<TypeDescriptor> EmittedEvents,
     IReadOnlyList<TypeDescriptor> ProjectionTypes,
-    IReadOnlyList<TypeDescriptor> ReadModelTypes);
+    IReadOnlyList<TypeDescriptor> ReadModelTypes)
+{
+    /// <summary>A slice with nothing but a name — what the overlay starts from.</summary>
+    public static EventModelSliceDescriptor Named(string name)
+        => new(name, null, null, null, null, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>());
+
+    /// <summary>
+    /// Which of the four canonical Event Modeling patterns this slice is. Null until a source
+    /// derives it.
+    /// </summary>
+    public SlicePattern? Pattern { get; init; }
+
+    /// <summary>What starts the slice. Null until a source derives it.</summary>
+    public TriggerKind? TriggerKind { get; init; }
+
+    /// <summary>
+    /// Structured detail of the trigger for the kinds that have it — HTTP route + verb, gRPC
+    /// service + method, the projection raising a side effect, or a display label. Shares the
+    /// <see cref="PublisherOrigin"/> shape with <see cref="HandlerRelationshipDescriptor.Origin"/>
+    /// so the two fold into one vocabulary.
+    /// </summary>
+    public PublisherOrigin? TriggerOrigin { get; init; }
+
+    /// <summary>
+    /// The aggregate(s) / projected write model(s) the handler decides against — a list, because one
+    /// Critter Stack command handler may load several projected models. Distinct from
+    /// <see cref="HandlerType"/>. The aggregate <em>elements</em> themselves (kind, applied events)
+    /// live on <see cref="EventModelDescriptor.Aggregates"/>; this is the reference by type.
+    /// </summary>
+    public IReadOnlyList<TypeDescriptor> AggregateTypes { get; init; } = Array.Empty<TypeDescriptor>();
+
+    /// <summary>
+    /// Non-event messages the slice publishes — cascaded commands, integration messages. Kept
+    /// apart from <see cref="EmittedEvents"/> so the event stream lane shows only events.
+    /// </summary>
+    public IReadOnlyList<TypeDescriptor> PublishedMessages { get; init; } = Array.Empty<TypeDescriptor>();
+
+    /// <summary>External systems on either end of this slice (translation edges).</summary>
+    public IReadOnlyList<ExternalSystemDescriptor> ExternalSystems { get; init; } = Array.Empty<ExternalSystemDescriptor>();
+
+    /// <summary>Hotspots attached to this slice — primarily pending specifications (jasperfx#689).</summary>
+    public IReadOnlyList<HotspotDescriptor> Hotspots { get; init; } = Array.Empty<HotspotDescriptor>();
+
+    /// <summary>
+    /// Specifications bound to this slice by identity + resolved types. Stamped by sources, never
+    /// hand-typed. Empty means "no spec" — the orange of drift colouring.
+    /// </summary>
+    public IReadOnlyList<SpecificationDescriptor> Specifications { get; init; } = Array.Empty<SpecificationDescriptor>();
+
+    /// <summary>
+    /// Domain / bounded context the slice belongs to, so large models can collapse into
+    /// sub-diagrams. Null when ungrouped.
+    /// </summary>
+    public string? Domain { get; init; }
+
+    /// <summary>
+    /// The rendering contract — every element of the slice with a stable id, a kind (→ colour)
+    /// and a lane. Computed from the typed roles on each read.
+    /// </summary>
+    public IReadOnlyList<EventModelElement> Elements => buildGraph().elements;
+
+    /// <summary>
+    /// The explicit, directed relationships between <see cref="Elements"/>, by element id.
+    /// Computed from the typed roles on each read.
+    /// </summary>
+    public IReadOnlyList<EventModelEdge> Edges => buildGraph().edges;
+
+    /// <summary>
+    /// Fold another source's view of the <em>same</em> slice into this one. Scalars keep the
+    /// first non-null value (this instance wins); lists are unioned in order, deduplicated by
+    /// identity. The overlay is typically merged <em>onto</em> the derived slice so derived roles
+    /// are never overwritten by a name-only declaration.
+    /// </summary>
+    public EventModelSliceDescriptor Merge(EventModelSliceDescriptor other)
+    {
+        if (!string.Equals(Name, other.Name, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Cannot merge slice '{other.Name}' into slice '{Name}'; slices merge by name.",
+                nameof(other));
+        }
+
+        return new EventModelSliceDescriptor(
+            Name,
+            TriggerLabel ?? other.TriggerLabel,
+            TriggerType ?? other.TriggerType,
+            CommandType ?? other.CommandType,
+            HandlerType ?? other.HandlerType,
+            unionTypes(EmittedEvents, other.EmittedEvents),
+            unionTypes(ProjectionTypes, other.ProjectionTypes),
+            unionTypes(ReadModelTypes, other.ReadModelTypes))
+        {
+            Pattern = Pattern ?? other.Pattern,
+            TriggerKind = TriggerKind ?? other.TriggerKind,
+            TriggerOrigin = TriggerOrigin ?? other.TriggerOrigin,
+            AggregateTypes = unionTypes(AggregateTypes, other.AggregateTypes),
+            PublishedMessages = unionTypes(PublishedMessages, other.PublishedMessages),
+            ExternalSystems = union(ExternalSystems, other.ExternalSystems, x => $"{x.Direction}:{x.Name}"),
+            Hotspots = union(Hotspots, other.Hotspots, x => $"{x.Origin}:{x.Text}"),
+            Specifications = union(Specifications, other.Specifications, x => x.Identity),
+            Domain = Domain ?? other.Domain,
+        };
+    }
+
+    private static IReadOnlyList<TypeDescriptor> unionTypes(IReadOnlyList<TypeDescriptor> first, IReadOnlyList<TypeDescriptor> second)
+        => union(first, second, x => x.FullName);
+
+    private static IReadOnlyList<T> union<T>(IReadOnlyList<T> first, IReadOnlyList<T> second, Func<T, string> key)
+    {
+        if (second.Count == 0) return first;
+        if (first.Count == 0) return second;
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var list = new List<T>(first.Count + second.Count);
+        foreach (var item in first.Concat(second))
+        {
+            if (seen.Add(key(item))) list.Add(item);
+        }
+
+        return list;
+    }
+
+    private (IReadOnlyList<EventModelElement> elements, IReadOnlyList<EventModelEdge> edges) buildGraph()
+    {
+        var elements = new List<EventModelElement>();
+        var edges = new List<EventModelEdge>();
+
+        EventModelElement add(EventModelElement element)
+        {
+            elements.Add(element);
+            return element;
+        }
+
+        void link(EventModelElement? from, EventModelElement? to)
+        {
+            if (from is null || to is null) return;
+            edges.Add(new EventModelEdge(from.Id, to.Id));
+        }
+
+        // Wireframe lane: the trigger, inbound external systems, hotspots
+        EventModelElement? trigger = null;
+        if (TriggerType is not null)
+        {
+            trigger = add(EventModelElement.ForType(Name, EventModelElementKind.Trigger, TriggerType));
+        }
+        else if (TriggerLabel is not null)
+        {
+            trigger = add(EventModelElement.ForLabel(Name, EventModelElementKind.Trigger, TriggerLabel));
+        }
+        else if (TriggerOrigin?.Label is not null)
+        {
+            trigger = add(EventModelElement.ForLabel(Name, EventModelElementKind.Trigger, TriggerOrigin.Label));
+        }
+
+        var inboundSystems = ExternalSystems
+            .Where(x => x.Direction == ExternalSystemDirection.Inbound)
+            .Select(x => add(EventModelElement.ForLabel(Name, EventModelElementKind.ExternalSystem, x.Name)))
+            .ToList();
+
+        foreach (var hotspot in Hotspots)
+        {
+            add(EventModelElement.ForLabel(Name, EventModelElementKind.Hotspot, hotspot.Text));
+        }
+
+        // Command lane: command, handler, aggregates
+        var command = CommandType is null ? null : add(EventModelElement.ForType(Name, EventModelElementKind.Command, CommandType));
+        var handler = HandlerType is null ? null : add(EventModelElement.ForType(Name, EventModelElementKind.Handler, HandlerType));
+        var aggregates = AggregateTypes.Select(x => add(EventModelElement.ForType(Name, EventModelElementKind.Aggregate, x))).ToList();
+
+        // Event stream lane: emitted events, published messages
+        var events = EmittedEvents.Select(x => add(EventModelElement.ForType(Name, EventModelElementKind.Event, x))).ToList();
+        var messages = PublishedMessages.Select(x => add(EventModelElement.ForType(Name, EventModelElementKind.Message, x))).ToList();
+
+        // Read model lane: projections, read models
+        var projections = ProjectionTypes.Select(x => add(EventModelElement.ForType(Name, EventModelElementKind.Projection, x))).ToList();
+        var readModels = ReadModelTypes.Select(x => add(EventModelElement.ForType(Name, EventModelElementKind.ReadModel, x))).ToList();
+
+        var outboundSystems = ExternalSystems
+            .Where(x => x.Direction == ExternalSystemDirection.Outbound)
+            .Select(x => add(EventModelElement.ForLabel(Name, EventModelElementKind.ExternalSystem, x.Name)))
+            .ToList();
+
+        // Edges. The "processor" is the handler when there is one, else the command.
+        var entry = command ?? handler;
+        var processor = handler ?? command;
+
+        link(trigger, entry);
+        foreach (var system in inboundSystems) link(system, entry);
+        link(command, handler);
+        foreach (var aggregate in aggregates) link(processor, aggregate);
+        foreach (var evt in events) link(processor, evt);
+        foreach (var message in messages) link(processor, message);
+        foreach (var message in messages)
+        foreach (var system in outboundSystems)
+        {
+            link(message, system);
+        }
+
+        if (messages.Count == 0)
+        {
+            foreach (var evt in events)
+            foreach (var system in outboundSystems)
+            {
+                link(evt, system);
+            }
+        }
+
+        if (projections.Count > 0)
+        {
+            foreach (var evt in events)
+            foreach (var projection in projections)
+            {
+                link(evt, projection);
+            }
+
+            foreach (var projection in projections)
+            foreach (var readModel in readModels)
+            {
+                link(projection, readModel);
+            }
+        }
+        else
+        {
+            foreach (var evt in events)
+            foreach (var readModel in readModels)
+            {
+                link(evt, readModel);
+            }
+        }
+
+        // A view slice with no events of its own reads straight from its read models
+        if (events.Count == 0 && processor is null && trigger is not null)
+        {
+            foreach (var readModel in readModels) link(readModel, trigger);
+        }
+
+        return (elements, edges);
+    }
+}
 
 /// <summary>
-/// Diagnostic descriptor for an entire Event Modeling definition.
-/// Carries the slice list produced by an
-/// <see cref="EventModelDefinition"/> after configuration runs.
+/// Wire descriptor for an entire Event Model — every slice, plus the model-level
+/// aggregate elements the slices reference by type.
 /// </summary>
+/// <remarks>
+/// The positional constructor is the original 2.x shape and is kept source- and
+/// binary-compatible; <see cref="Aggregates"/> is an additive <c>init</c> property.
+/// Use <see cref="Merge"/> to assemble the full picture from several sources.
+/// </remarks>
 /// <param name="Name">Display name of the model.</param>
 /// <param name="Slices">Slices that make up the model, in declaration order.</param>
 public sealed record EventModelDescriptor(
     string Name,
-    IReadOnlyList<EventModelSliceDescriptor> Slices);
+    IReadOnlyList<EventModelSliceDescriptor> Slices)
+{
+    /// <summary>
+    /// The aggregate elements of the model — one per aggregate-shaped CLR type, with its kind and
+    /// applied events. Slices point at these through
+    /// <see cref="EventModelSliceDescriptor.AggregateTypes"/>.
+    /// </summary>
+    public IReadOnlyList<AggregateDescriptor> Aggregates { get; init; } = Array.Empty<AggregateDescriptor>();
+
+    /// <summary>
+    /// Assemble one model from several sources' descriptors. Slices with the same name are
+    /// folded with <see cref="EventModelSliceDescriptor.Merge"/> in the order the descriptors
+    /// are given (earlier wins on scalars — put derived sources before the overlay); aggregates
+    /// are unioned by type. Slice order is first appearance.
+    /// </summary>
+    /// <param name="name">Name of the assembled model.</param>
+    /// <param name="descriptors">Descriptors to fold, derived sources first.</param>
+    public static EventModelDescriptor Merge(string name, IEnumerable<EventModelDescriptor> descriptors)
+    {
+        var slices = new List<EventModelSliceDescriptor>();
+        var indexByName = new Dictionary<string, int>(StringComparer.Ordinal);
+        var aggregates = new List<AggregateDescriptor>();
+        var aggregateNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var descriptor in descriptors)
+        {
+            foreach (var slice in descriptor.Slices)
+            {
+                if (indexByName.TryGetValue(slice.Name, out var index))
+                {
+                    slices[index] = slices[index].Merge(slice);
+                }
+                else
+                {
+                    indexByName[slice.Name] = slices.Count;
+                    slices.Add(slice);
+                }
+            }
+
+            foreach (var aggregate in descriptor.Aggregates)
+            {
+                if (aggregateNames.Add(aggregate.Type.FullName)) aggregates.Add(aggregate);
+            }
+        }
+
+        return new EventModelDescriptor(name, slices) { Aggregates = aggregates };
+    }
+}

--- a/src/JasperFx.Events/EventModeling/ExternalSystemDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/ExternalSystemDescriptor.cs
@@ -1,0 +1,27 @@
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Which way messages flow between the model and an external system.
+/// </summary>
+public enum ExternalSystemDirection
+{
+    /// <summary>The external system pushes into the model — it is the slice's trigger (translation in).</summary>
+    Inbound,
+
+    /// <summary>The model pushes out to the external system — it receives the slice's published messages (translation out).</summary>
+    Outbound,
+}
+
+/// <summary>
+/// An external system on one end of an integration edge (jasperfx#687 decision 5).
+/// The <em>edge</em> is derived from the Wolverine endpoint the messages travel
+/// over; only the <see cref="Name"/> is ever declared, and it is declared on that
+/// endpoint's configuration (wolverine#3989), not through the overlay here.
+/// </summary>
+/// <param name="Name">Display name of the external system (e.g. "Stripe", "Legacy ERP").</param>
+/// <param name="Direction">Whether the system feeds the slice or is fed by it.</param>
+/// <param name="EndpointUri">The Wolverine endpoint URI the edge was derived from, when known.</param>
+public sealed record ExternalSystemDescriptor(
+    string Name,
+    ExternalSystemDirection Direction,
+    string? EndpointUri = null);

--- a/src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/HandlerRelationshipDescriptor.cs
@@ -9,6 +9,15 @@ namespace JasperFx.Events.EventModeling;
 /// between commands, handlers, aggregates, and downstream events.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>Superseded as a vocabulary by <see cref="EventModelSliceDescriptor"/></b> (jasperfx#687,
+/// 2026-08-20): a handler relationship is a command slice, and
+/// <see cref="ToSliceDescriptor"/> is the fold — <see cref="Kind"/> / <see cref="Origin"/> become
+/// the slice's pattern, trigger kind and trigger origin, <see cref="TargetAggregate"/> its
+/// aggregate types. The type stays because the CritterWatch source generator still emits it
+/// (it is the only thing that can see imperative appends in handler bodies); new sources should
+/// produce slices directly.
+/// </para>
 /// One descriptor per handler chain the CritterWatch source generator
 /// (CritterWatch#144) discovers via the standard Wolverine handler-discovery
 /// conventions, plus the saga-subclass + <c>yield return new SomeEvent(...)</c>
@@ -61,4 +70,41 @@ public sealed record HandlerRelationshipDescriptor(
     /// trigger is the <see cref="MessageType"/>.
     /// </summary>
     public PublisherOrigin? Origin { get; init; }
+
+    /// <summary>
+    /// Fold this relationship into the one slice vocabulary (jasperfx#687). The slice is named
+    /// after the message type's short name — the drift-comparison key CritterWatch already uses —
+    /// unless <paramref name="sliceName"/> says otherwise.
+    /// </summary>
+    /// <param name="sliceName">Slice name; defaults to <c>MessageType.Name</c>.</param>
+    public EventModelSliceDescriptor ToSliceDescriptor(string? sliceName = null)
+    {
+        var (pattern, triggerKind) = Kind switch
+        {
+            PublisherKind.Handler => (SlicePattern.Command, (TriggerKind?)EventModeling.TriggerKind.MessageHandler),
+            PublisherKind.HttpEndpoint => (SlicePattern.Command, EventModeling.TriggerKind.Http),
+            PublisherKind.GrpcEndpoint => (SlicePattern.Command, EventModeling.TriggerKind.Grpc),
+            PublisherKind.DirectBusCall => (SlicePattern.Command, EventModeling.TriggerKind.MessageHandler),
+            PublisherKind.ProjectionSideEffect => (SlicePattern.Automation, null),
+            PublisherKind.Scheduled => (SlicePattern.Automation, EventModeling.TriggerKind.JobScheduler),
+            PublisherKind.External => (SlicePattern.Translation, EventModeling.TriggerKind.External),
+            _ => (SlicePattern.Command, null),
+        };
+
+        return new EventModelSliceDescriptor(
+            sliceName ?? MessageType.Name,
+            Origin?.Label,
+            null,
+            MessageType,
+            HandlerType,
+            EmittedEvents,
+            Array.Empty<TypeDescriptor>(),
+            Array.Empty<TypeDescriptor>())
+        {
+            Pattern = pattern,
+            TriggerKind = triggerKind,
+            TriggerOrigin = Origin,
+            AggregateTypes = TargetAggregate is null ? Array.Empty<TypeDescriptor>() : new[] { TargetAggregate },
+        };
+    }
 }

--- a/src/JasperFx.Events/EventModeling/HotspotDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/HotspotDescriptor.cs
@@ -1,0 +1,48 @@
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// Where a hotspot came from.
+/// </summary>
+public enum HotspotOrigin
+{
+    /// <summary>
+    /// A specification bound to the slice is pending — it cannot pass yet, or has no bound
+    /// steps. The primary hotspot mechanism (jasperfx#689): an open question in a spec-driven
+    /// flow <em>is</em> a pending spec, so the hotspot comes from the spec, not from a builder call.
+    /// </summary>
+    PendingSpecification,
+
+    /// <summary>
+    /// Free-text prose declared through the overlay. Reserved form — the overlay surface for it
+    /// is a later stage (jasperfx#690); sources may still emit it.
+    /// </summary>
+    Prose,
+}
+
+/// <summary>
+/// A hotspot attached to a slice — an open question, a conflict, or (primarily) a
+/// specification that is still pending. Renders in the canonical hotspot colour
+/// on the slice it is attached to (jasperfx#687 decision 6, jasperfx#689).
+/// </summary>
+/// <param name="Origin">Whether this hotspot is a pending specification or prose.</param>
+/// <param name="Text">
+///     Display text. For a pending specification this is the spec identity
+///     (<c>{Feature}/{Scenario}</c>); for prose it is the note itself.
+/// </param>
+/// <param name="SpecificationIdentity">
+///     The <c>{Feature}/{Scenario}</c> identity of the pending specification, when
+///     <see cref="Origin"/> is <see cref="HotspotOrigin.PendingSpecification"/>; otherwise null.
+/// </param>
+public sealed record HotspotDescriptor(
+    HotspotOrigin Origin,
+    string Text,
+    string? SpecificationIdentity = null)
+{
+    /// <summary>A hotspot for a specification that is pending (jasperfx#689).</summary>
+    public static HotspotDescriptor PendingSpecification(string specificationIdentity)
+        => new(HotspotOrigin.PendingSpecification, specificationIdentity, specificationIdentity);
+
+    /// <summary>A prose hotspot. Reserved form — see <see cref="HotspotOrigin.Prose"/>.</summary>
+    public static HotspotDescriptor Prose(string text)
+        => new(HotspotOrigin.Prose, text);
+}

--- a/src/JasperFx.Events/EventModeling/PublisherOrigin.cs
+++ b/src/JasperFx.Events/EventModeling/PublisherOrigin.cs
@@ -3,7 +3,10 @@ using JasperFx.Descriptors;
 namespace JasperFx.Events.EventModeling;
 
 /// <summary>
-/// Polymorphic trigger origin for a <see cref="HandlerRelationshipDescriptor"/> whose
+/// Structured trigger detail shared by <see cref="EventModelSliceDescriptor.TriggerOrigin"/>
+/// and <see cref="HandlerRelationshipDescriptor.Origin"/> — one shape for both so the two
+/// descriptors fold into one vocabulary (jasperfx#687). Historically: the polymorphic trigger
+/// origin for a <see cref="HandlerRelationshipDescriptor"/> whose
 /// <see cref="HandlerRelationshipDescriptor.Kind"/> is not
 /// <see cref="PublisherKind.Handler"/> — i.e. publishers initiated by something other
 /// than an inbound message (an HTTP route, a gRPC method, a projection side-effect,

--- a/src/JasperFx.Events/EventModeling/SlicePattern.cs
+++ b/src/JasperFx.Events/EventModeling/SlicePattern.cs
@@ -1,0 +1,37 @@
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// The four canonical Event Modeling slice patterns. Every slice in an
+/// <see cref="EventModelDescriptor"/> is one of these once a source has
+/// derived it (jasperfx#687 decision 1). The pattern drives lane rendering
+/// and tells a viewer which roles to expect on the slice.
+/// </summary>
+/// <remarks>
+/// The pattern is <em>derived</em> by the source that produced the slice —
+/// Wolverine from its handler / HTTP / gRPC chains, the Bobcat generator from a
+/// feature's tags — never hand-declared through the overlay. A slice whose
+/// pattern has not been derived yet carries <see langword="null"/>.
+/// </remarks>
+public enum SlicePattern
+{
+    /// <summary>
+    /// A state change: trigger → command → handler (with its aggregate(s)) → emitted events.
+    /// </summary>
+    Command,
+
+    /// <summary>
+    /// A read: events → projection → read model, consumed by a UI or another slice.
+    /// </summary>
+    View,
+
+    /// <summary>
+    /// A reaction with no human in the loop: events or a schedule → processor → command / message.
+    /// </summary>
+    Automation,
+
+    /// <summary>
+    /// An integration edge: an external system's messages translated into the model's
+    /// events, or the model's events translated out to an external system.
+    /// </summary>
+    Translation,
+}

--- a/src/JasperFx.Events/EventModeling/SpecificationDescriptor.cs
+++ b/src/JasperFx.Events/EventModeling/SpecificationDescriptor.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// A specification bound to a slice — the typed <c>Specification</c> slot of
+/// jasperfx#687. Stamped by the source that owns the binding (the Bobcat
+/// generator, a code-first spec runner), <em>never hand-typed</em>: the identity
+/// plus the CLR types the spec's steps resolved is what lets drift colouring read
+/// real evidence (no spec → orange, passing → green, failing → red, a spec
+/// touching undeclared types → yellow).
+/// </summary>
+/// <param name="Identity">
+///     Stable spec identity in the form <c>{Feature}/{Scenario}</c> — the same key Bobcat
+///     publishes on <c>scenario_finished</c>, so run evidence joins on it.
+/// </param>
+/// <param name="ResolvedTypes">
+///     CLR types the specification's steps resolved against the compilation (commands sent,
+///     events expected, read models asserted on), in step order, deduplicated. Empty when the
+///     binding source cannot resolve types (e.g. a spec bound by identity only).
+/// </param>
+[method: JsonConstructor]
+public sealed record SpecificationDescriptor(
+    string Identity,
+    IReadOnlyList<TypeDescriptor> ResolvedTypes)
+{
+    /// <summary>Bind by identity only, with no resolved types.</summary>
+    public SpecificationDescriptor(string identity) : this(identity, Array.Empty<TypeDescriptor>())
+    {
+    }
+
+    /// <summary>The <c>{Feature}</c> half of <see cref="Identity"/>, or the whole identity when it has no separator.</summary>
+    [JsonIgnore]
+    public string Feature
+    {
+        get
+        {
+            var index = Identity.IndexOf('/');
+            return index < 0 ? Identity : Identity[..index];
+        }
+    }
+
+    /// <summary>The <c>{Scenario}</c> half of <see cref="Identity"/>, or null when it has no separator.</summary>
+    [JsonIgnore]
+    public string? Scenario
+    {
+        get
+        {
+            var index = Identity.IndexOf('/');
+            return index < 0 ? null : Identity[(index + 1)..];
+        }
+    }
+}

--- a/src/JasperFx.Events/EventModeling/TriggerKind.cs
+++ b/src/JasperFx.Events/EventModeling/TriggerKind.cs
@@ -1,0 +1,34 @@
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// What starts a slice (jasperfx#687 decision 8). Finer-grained than the
+/// "human / external" split of textbook Event Modeling because the Critter
+/// Stack can tell its own trigger kinds apart statically.
+/// </summary>
+/// <remarks>
+/// Derived by the producing source, never declared through the overlay. A slice
+/// whose trigger kind has not been derived carries <see langword="null"/>.
+/// </remarks>
+public enum TriggerKind
+{
+    /// <summary>An HTTP endpoint (e.g. a Wolverine.Http route). Route and verb live on the slice's trigger origin.</summary>
+    Http,
+
+    /// <summary>A gRPC service method. Service and method live on the slice's trigger origin.</summary>
+    Grpc,
+
+    /// <summary>An inbound message handled by a Wolverine message handler; the command type is the trigger.</summary>
+    MessageHandler,
+
+    /// <summary>
+    /// A scheduled or recurring job. Reserved ahead of the Critter Stack job scheduler landing;
+    /// sources may stamp it today for cron-style / scheduled publishers.
+    /// </summary>
+    JobScheduler,
+
+    /// <summary>A person acting through a UI / wireframe.</summary>
+    Human,
+
+    /// <summary>An external system pushing into the model (the inbound half of a translation slice).</summary>
+    External,
+}


### PR DESCRIPTION
Closes #687. Closes #689.

Implements the **reshaped** #687 (2026-08-20, cross-stack SDD master JasperFx/stoat#9) and folds in #689, which is the shape of the Hotspot element.

## The one vocabulary: `EventModelSliceDescriptor` v2

Kept **source- and binary-compatible** — the 2.x positional constructor is untouched (CritterWatch and its source generator call it; `LifecycleAssemblerTests.cs:227` uses the 8-arg form), and every addition is an `init` property with a safe default. Older JSON payloads deserialise to the same defaults (test: `a_payload_from_before_687_still_deserializes`).

Added on the slice:
- `SlicePattern? Pattern` — `Command | View | Automation | Translation`
- `TriggerKind? TriggerKind` — `Http | Grpc | MessageHandler | JobScheduler | Human | External`
- `PublisherOrigin? TriggerOrigin` — the same shape `HandlerRelationshipDescriptor.Origin` uses, so the two fold into one vocabulary
- `AggregateTypes` (a **list**; one handler may load several projected models), `PublishedMessages`, `ExternalSystems`, `Hotspots`, `Specifications`, `Domain`
- **The rendering contract**: `Elements` (stable id `{slice}/{kind}/{identity}`, `Kind` → canonical colour via `EventModelPalette`, `Lane` = Wireframe · Command · EventStream · ReadModel) and `Edges` (directed, by id). Both are *computed from the typed roles on every read* — the wire carries them (a viewer needs no second transform) and they can never disagree with the roles.
- `Merge(other)` — fold another source's view of the same slice (first wins on scalars, lists union by identity); `EventModelDescriptor.Merge(name, descriptors)` folds slices by name across sources; `EventModelDescriptor.Aggregates` is the model-level home for `AggregateDescriptor` (which stays, with `AppliedEvents`).

`HandlerRelationshipDescriptor` / `PublisherKind` / `PublisherOrigin` **fold in** via `HandlerRelationshipDescriptor.ToSliceDescriptor()` (kind → pattern + trigger kind, origin → trigger origin, target aggregate → aggregate types). The types stay, un-obsoleted, because the CritterWatch source generator still emits them — new sources should produce slices directly.

## The fluent API is an overlay (D2 / D5)

`EventModelDefinition` / `EventModelBuilder` / `EventModelSliceBuilder` now **name, group, annotate and link** only: `Slice(name)`, `InDomain(...)` (builder- and slice-level), `TriggeredBy(label)`, `LinksToSpecification("{Feature}/{Scenario}")`. The role-declaring methods (`Command<T>()`, `HandledBy<T>()`, `Emits<T>()`, `Projects<T>()`, `Reads<T>()`, typed trigger) moved behind **one explicitly documented escape hatch**, `slice.ForFlowNotOwnedHere(roles => roles.Command<T>()...)`, for flows this host's code does not own (partner systems). That is the only public-surface change that is not purely additive — the builder had zero consumers outside this repo's tests (CritterWatch has its own duplicate, which #1120 retires; Wolverine/Marten/Polecat/Fisher/Bobcat reference none of it).

## The discovery bridge (§3)

`IEventModelDefinitionSource` had zero implementations anywhere. Now:
- `EventModelDefinitionSource.For<T>() / For(type) / For(instance) / For(name, lambda)` — instantiates (from DI, else `ActivatorUtilities`), runs `Configure`, snapshots an `EventModelDescriptor`; `Subject` = `event-model://{name}`
- `services.AddEventModel<T>() / AddEventModel(type | instance | name, lambda) / AddEventModelsFromAssembly(asm) / AddEventModelSource(...)`
- `EventModelDiscovery.DiscoverAsync(services)` enumerates every registered source; `AssembleAsync` folds the full picture — one descriptor per model name, derived sources first so the overlay cannot overwrite a derived role

## #689 — a pending specification is a hotspot

`HotspotDescriptor.PendingSpecification(specIdentity)` (origin `PendingSpecification`, carries the identity) alongside the reserved `Prose` form; renders in the hotspot colour on the slice the spec binds to. The overlay surface for prose hotspots is deliberately **not** here (#690, later).

## Tests

60 in `EventTests/EventModeling`: overlay + escape hatch, descriptor defaults/compat, elements/lanes/ids/edges per pattern, merge rules, STJ round-trip under **both** CritterWatch's settings (camelCase + `JsonStringEnumConverter`) and the defaults, pre-#687 payload compat, the HRD fold, hotspots, DI discovery/assembly. `./build.sh compile` and `./build.sh test-events` green locally on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
