### PR TITLE
gh-688: ProjectionScenario exposes its plan and observes each step

### DIFF
--- a/src/EventTests/TestSupport/projection_scenario_observation_tests.cs
+++ b/src/EventTests/TestSupport/projection_scenario_observation_tests.cs
@@ -1,0 +1,181 @@
+using JasperFx.Events.TestSupport;
+using Shouldly;
+using Xunit;
+using static EventTests.TestSupport.projection_scenario_tests;
+
+namespace EventTests.TestSupport;
+
+// jasperfx#688: the scripted step model is observable — the plan before execution, and one
+// StepStarted / StepSucceeded|StepFailed pair per step as it runs, numbered the way the
+// exception report numbers them.
+public class projection_scenario_observation_tests
+{
+    private readonly FakeProjectionScenario theScenario = new();
+    private readonly RecordingObserver theObserver = new();
+
+    public projection_scenario_observation_tests()
+    {
+        theScenario.Observer = theObserver;
+    }
+
+    [Fact]
+    public void planned_steps_are_readable_before_execution_with_kind_number_and_description()
+    {
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.AssertAgainstProjectedData("custom check", (_, _) => Task.CompletedTask);
+
+        var plan = theScenario.PlannedSteps;
+
+        plan.Count.ShouldBe(3);
+        plan.Select(x => x.Number).ShouldBe(new[] { 1, 2, 3 });
+        plan.Select(x => x.Kind).ShouldBe(new[]
+        {
+            ProjectionScenarioStepKind.Action,
+            ProjectionScenarioStepKind.Assertion,
+            ProjectionScenarioStepKind.Assertion,
+        });
+        plan[0].Description.ShouldStartWith("Append(");
+        plan[1].Description.ShouldContain("FakeDocument");
+        plan[1].Description.ShouldContain("should exist");
+        plan[2].Description.ShouldBe("custom check");
+
+        theObserver.Events.ShouldBeEmpty(); // nothing has run
+    }
+
+    [Fact]
+    public async Task planned_steps_is_empty_for_an_empty_scenario_and_survives_execution()
+    {
+        theScenario.PlannedSteps.ShouldBeEmpty();
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        var before = theScenario.PlannedSteps;
+
+        await theScenario.ExecuteAsync();
+
+        theScenario.PlannedSteps.ShouldBe(before);
+    }
+
+    [Fact]
+    public async Task each_step_raises_started_then_succeeded_in_plan_order_with_plan_numbering()
+    {
+        theScenario.Documents[1] = new FakeDocument();
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+
+        var plan = theScenario.PlannedSteps;
+
+        await theScenario.ExecuteAsync();
+
+        theObserver.Events.ShouldBe(new[]
+        {
+            ("started", plan[0]),
+            ("succeeded", plan[0]),
+            ("started", plan[1]),
+            ("succeeded", plan[1]),
+            ("started", plan[2]),
+            ("succeeded", plan[2]),
+        });
+    }
+
+    [Fact]
+    public async Task a_failed_assertion_is_reported_and_the_run_continues()
+    {
+        // Documents[1] is missing, so step 2 fails; Documents[2] exists, so step 3 passes
+        theScenario.Documents[2] = new FakeDocument();
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.DocumentShouldExist<FakeDocument>(2);
+
+        var plan = theScenario.PlannedSteps;
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(() => theScenario.ExecuteAsync());
+
+        theObserver.Events.ShouldBe(new[]
+        {
+            ("started", plan[0]),
+            ("succeeded", plan[0]),
+            ("started", plan[1]),
+            ("failed", plan[1]),
+            ("started", plan[2]),
+            ("succeeded", plan[2]),
+        });
+        theObserver.Failures.Single().step.Number.ShouldBe(2);
+        theObserver.Failures.Single().exception.ShouldBeOfType<ProjectionScenarioAssertionException>();
+
+        // the same number the exception report prints
+        ex.Message.ShouldContain($"FAILED:   2. {plan[1].Description}");
+    }
+
+    [Fact]
+    public async Task a_failed_action_is_reported_and_every_later_step_is_skipped_with_its_plan_number()
+    {
+        theScenario.Documents[1] = new FakeDocument();
+
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        theScenario.AppendEvents("boom", _ => throw new InvalidOperationException("boom"));
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+
+        var plan = theScenario.PlannedSteps;
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(() => theScenario.ExecuteAsync());
+
+        theObserver.Events.ShouldBe(new[]
+        {
+            ("started", plan[0]),
+            ("succeeded", plan[0]),
+            ("started", plan[1]),
+            ("failed", plan[1]),
+            ("skipped", plan[2]),
+            ("skipped", plan[3]),
+        });
+        theObserver.Failures.Single().exception.ShouldBeOfType<InvalidOperationException>();
+        ex.Message.ShouldContain("FAILED:   2. boom");
+        ex.Message.ShouldContain("Skipped the remaining 2 step(s)");
+    }
+
+    [Fact]
+    public async Task no_observer_is_fine()
+    {
+        theScenario.Observer = null;
+        theScenario.Append(Guid.NewGuid(), new AEvent());
+        await theScenario.ExecuteAsync();
+    }
+
+    [Fact]
+    public async Task no_observer_and_a_failed_action_still_drains_the_skipped_steps()
+    {
+        // Regression: the skip loop must dequeue outside the null-conditional observer call,
+        // or with no observer the queue never drains and ExecuteAsync never returns.
+        theScenario.Observer = null;
+        theScenario.AppendEvents("boom", _ => throw new InvalidOperationException("boom"));
+        theScenario.DocumentShouldExist<FakeDocument>(1);
+        theScenario.DocumentShouldExist<FakeDocument>(2);
+
+        var ex = await Should.ThrowAsync<ProjectionScenarioException>(
+            () => theScenario.ExecuteAsync().WaitAsync(TimeSpan.FromSeconds(10)));
+
+        ex.Message.ShouldContain("Skipped the remaining 2 step(s)");
+    }
+
+    private sealed class RecordingObserver : IProjectionScenarioObserver
+    {
+        public List<(string, ProjectionScenarioStepDescription)> Events { get; } = new();
+        public List<(ProjectionScenarioStepDescription step, Exception exception)> Failures { get; } = new();
+
+        public void StepStarted(ProjectionScenarioStepDescription step) => Events.Add(("started", step));
+        public void StepSucceeded(ProjectionScenarioStepDescription step) => Events.Add(("succeeded", step));
+
+        public void StepFailed(ProjectionScenarioStepDescription step, Exception exception)
+        {
+            Events.Add(("failed", step));
+            Failures.Add((step, exception));
+        }
+
+        public void StepSkipped(ProjectionScenarioStepDescription step) => Events.Add(("skipped", step));
+    }
+}

--- a/src/JasperFx.Events/TestSupport/ProjectionScenario.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenario.cs
@@ -25,6 +25,7 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
     where TOperations : TQuerySession, IStorageOperations
 {
     private readonly Queue<ScenarioStep<TOperations, TQuerySession>> _steps = new();
+    private readonly List<ScenarioStep<TOperations, TQuerySession>> _plan = new();
     private TOperations? _session;
     private bool _hasExecuted;
 
@@ -72,6 +73,37 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
 
         return Daemon.WaitForNonStaleData(Timeout).WaitAsync(ct);
     }
+
+    /// <summary>
+    ///     Every scripted step, in order, with the number the run will give it — readable
+    ///     <em>before</em> <see cref="ExecuteAsync" /> so a runner can render the plan up front, and
+    ///     unchanged by execution (jasperfx#688). Descriptions are read live, so a step's text is
+    ///     whatever it is at the moment you ask.
+    /// </summary>
+    public IReadOnlyList<ProjectionScenarioStepDescription> PlannedSteps
+    {
+        get
+        {
+            var planned = new List<ProjectionScenarioStepDescription>(_plan.Count);
+            for (var i = 0; i < _plan.Count; i++)
+            {
+                planned.Add(describe(i + 1, _plan[i]));
+            }
+
+            return planned;
+        }
+    }
+
+    /// <summary>
+    ///     Optional observer notified of every step's start and outcome as the scenario runs
+    ///     (jasperfx#688). Numbering matches <see cref="PlannedSteps" /> and the
+    ///     <see cref="ProjectionScenarioException" /> report. An observer that throws fails the
+    ///     scenario — it is part of the run, not a best-effort side channel.
+    /// </summary>
+    public IProjectionScenarioObserver? Observer { get; set; }
+
+    private static ProjectionScenarioStepDescription describe(int number, ScenarioStep<TOperations, TQuerySession> step)
+        => new(number, step.Kind, step.Description);
 
     /// <summary>
     ///     The scenario deletes all existing event data plus the storage for every
@@ -137,6 +169,7 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
     {
         var step = new ScenarioAction<TOperations, TQuerySession>(action);
         _steps.Enqueue(step);
+        _plan.Add(step);
 
         return step;
     }
@@ -145,6 +178,7 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
     {
         var step = new ScenarioAssertion<TOperations, TQuerySession>(check);
         _steps.Enqueue(step);
+        _plan.Add(step);
 
         return step;
     }
@@ -192,17 +226,22 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
             {
                 number++;
                 var step = _steps.Dequeue();
+                var observed = describe(number, step);
+
+                Observer?.StepStarted(observed);
 
                 try
                 {
                     await step.Execute(this, ct).ConfigureAwait(false);
                     descriptions.Add($"{number.ToString().PadLeft(3)}. {step.Description}");
+                    Observer?.StepSucceeded(observed);
                 }
                 catch (Exception e)
                 {
                     descriptions.Add($"FAILED: {number.ToString().PadLeft(3)}. {step.Description}");
                     descriptions.Add(e.ToString());
                     exceptions.Add(e);
+                    Observer?.StepFailed(observed, e);
 
                     // A failed action means every later step would run against a state nobody
                     // intended, so stop right here instead of piling up cascading noise. Failed
@@ -214,7 +253,14 @@ public abstract partial class ProjectionScenario<TOperations, TQuerySession>
                         {
                             descriptions.Add(
                                 $"Skipped the remaining {_steps.Count} step(s) after the failed action");
-                            _steps.Clear();
+                            while (_steps.Count != 0)
+                            {
+                                // Dequeue OUTSIDE the null-conditional: ?. short-circuits its
+                                // arguments, and a never-drained queue is an infinite loop.
+                                var skipped = _steps.Dequeue();
+                                number++;
+                                Observer?.StepSkipped(describe(number, skipped));
+                            }
                         }
 
                         break;

--- a/src/JasperFx.Events/TestSupport/ProjectionScenarioObserver.cs
+++ b/src/JasperFx.Events/TestSupport/ProjectionScenarioObserver.cs
@@ -1,0 +1,51 @@
+namespace JasperFx.Events.TestSupport;
+
+/// <summary>
+///     Whether a scripted <see cref="ProjectionScenario{TOperations,TQuerySession}" /> step is an
+///     action (an append / start-stream that mutates the store) or an assertion (a check against
+///     the projected data). A failed action stops the run; failed assertions accumulate.
+/// </summary>
+public enum ProjectionScenarioStepKind
+{
+    /// <summary>An event append or stream start. Consecutive actions batch into one commit.</summary>
+    Action,
+
+    /// <summary>A check against the projected data. Runs after the preceding actions are committed and the daemon has caught up.</summary>
+    Assertion,
+}
+
+/// <summary>
+///     The observable face of one scripted step (jasperfx#688). <see cref="Number" /> is the
+///     1-based position the step holds in the scenario — the same number the
+///     <see cref="ProjectionScenarioException" /> report prints — and <see cref="Description" /> is
+///     the same renderable text.
+/// </summary>
+/// <param name="Number">1-based position of the step in the scenario.</param>
+/// <param name="Kind">Action or assertion.</param>
+/// <param name="Description">The step's renderable description.</param>
+public sealed record ProjectionScenarioStepDescription(
+    int Number,
+    ProjectionScenarioStepKind Kind,
+    string Description);
+
+/// <summary>
+///     Observes a <see cref="ProjectionScenario{TOperations,TQuerySession}" /> run step by step
+///     (jasperfx#688), so a spec runner can render outcomes live instead of parsing the exception
+///     report. Every executed step raises exactly one <see cref="StepStarted" /> followed by exactly
+///     one of <see cref="StepSucceeded" /> / <see cref="StepFailed" />; steps the scenario never
+///     reaches because an earlier action failed raise <see cref="StepSkipped" /> instead.
+/// </summary>
+public interface IProjectionScenarioObserver
+{
+    /// <summary>The step is about to execute.</summary>
+    void StepStarted(ProjectionScenarioStepDescription step);
+
+    /// <summary>The step executed without throwing.</summary>
+    void StepSucceeded(ProjectionScenarioStepDescription step);
+
+    /// <summary>The step threw. For an action this also ends the run.</summary>
+    void StepFailed(ProjectionScenarioStepDescription step, Exception exception);
+
+    /// <summary>The step was never executed because an earlier action failed.</summary>
+    void StepSkipped(ProjectionScenarioStepDescription step);
+}

--- a/src/JasperFx.Events/TestSupport/ScenarioStep.cs
+++ b/src/JasperFx.Events/TestSupport/ScenarioStep.cs
@@ -5,6 +5,8 @@ internal abstract class ScenarioStep<TOperations, TQuerySession>
 {
     public string Description { get; set; } = string.Empty;
 
+    public abstract ProjectionScenarioStepKind Kind { get; }
+
     public abstract Task Execute(ProjectionScenario<TOperations, TQuerySession> scenario,
         CancellationToken ct = default);
 }
@@ -18,6 +20,8 @@ internal class ScenarioAction<TOperations, TQuerySession>: ScenarioStep<TOperati
     {
         _action = action;
     }
+
+    public override ProjectionScenarioStepKind Kind => ProjectionScenarioStepKind.Action;
 
     public override async Task Execute(ProjectionScenario<TOperations, TQuerySession> scenario,
         CancellationToken ct = default)
@@ -41,6 +45,8 @@ internal class ScenarioAssertion<TOperations, TQuerySession>: ScenarioStep<TOper
     {
         _check = check;
     }
+
+    public override ProjectionScenarioStepKind Kind => ProjectionScenarioStepKind.Assertion;
 
     public override Task Execute(ProjectionScenario<TOperations, TQuerySession> scenario,
         CancellationToken ct = default)


### PR DESCRIPTION
Closes #688.

`JasperFx.Events.TestSupport.ProjectionScenario<TOperations, TQuerySession>` already *is* a scripted step model; this makes it observable from outside, so Bobcat's code-first event-sourcing API (bobcat#105) can project it onto Bobcat's step model — render the plan up front, and each outcome live — instead of parsing the exception text.

- **`PlannedSteps`** — `IReadOnlyList<ProjectionScenarioStepDescription>` (`Number`, `Kind` = `Action | Assertion`, `Description`), readable **before** `ExecuteAsync` and unchanged by execution. The queue still drives the run; a parallel list holds the plan. Descriptions are read live because the fluent `Append(...)` / `DocumentShouldExist<T>(...)` methods set `Description` *after* enqueue.
- **`Observer`** — `IProjectionScenarioObserver` with `StepStarted / StepSucceeded / StepFailed(step, exception) / StepSkipped`, numbered exactly as the `ProjectionScenarioException` report numbers them (pinned: the test asserts the report contains `FAILED:   2. …` for the step the observer saw as `Number == 2`). `StepSkipped` fires for every step after a failed action. An observer that throws fails the scenario — it is part of the run, not best-effort.
- `ScenarioStep` gains a `Kind`; no other behaviour change. **Marten / Polecat / Fisher subclasses need no change** (checked: they override only the abstract store seam — `DeleteExistingDataAsync`, `HasAnyAsyncProjections`, `BuildDaemonAsync`, `OpenSession`, `SaveChangesAsync`, `EventsFor`, `LoadDocumentAsync`).

Caught while writing it: the skip loop has to dequeue **outside** the null-conditional observer call — `Observer?.StepSkipped(describe(n, _steps.Dequeue()))` short-circuits its *argument* when `Observer` is null, so the queue never drained and `ExecuteAsync` hung. Pinned by `no_observer_and_a_failed_action_still_drains_the_skipped_steps` (with a 10 s `WaitAsync`).

Tests: 7 new in `EventTests/TestSupport/projection_scenario_observation_tests.cs` (plan before execution, empty/after-execution, started→succeeded pairs in plan order, failed assertion continues, failed action skips the rest with plan numbers, no observer, no-observer + failed action). `./build.sh compile` and `./build.sh test-events` green locally on net9.0 and net10.0 (812/812).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
