### PR TITLE
gh-690: prose hotspots declared in the overlay

### DIFF
--- a/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
+++ b/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
@@ -76,6 +76,7 @@ public class EventModelWireRoundTripTests
     })
     {
         Aggregates = new[] { new AggregateDescriptor(T<Order>(), AggregateKind.WriteAggregate, new[] { T<OrderPlaced>() }) },
+        Hotspots = new[] { HotspotDescriptor.Prose("Do we own the SLA clock, or does the CRM?") },
     };
 
     [Theory]
@@ -90,6 +91,7 @@ public class EventModelWireRoundTripTests
         // record equality covers every positional + init slot; Elements/Edges are computed, so
         // comparing them proves the typed roles came back whole
         back.Name.ShouldBe(model.Name);
+        back.Hotspots.ShouldBe(model.Hotspots);
         // AggregateDescriptor / SpecificationDescriptor carry lists, and record equality compares
         // lists by reference — so compare those member-wise
         back.Aggregates.Count.ShouldBe(model.Aggregates.Count);
@@ -160,6 +162,12 @@ public class EventModelWireRoundTripTests
 
         // the model-level aggregate element
         doc.RootElement.GetProperty("aggregates")[0].GetProperty("kind").GetString().ShouldBe("writeAggregate");
+
+        // ...and the model-level prose hotspot (jasperfx#690)
+        var modelHotspot = doc.RootElement.GetProperty("hotspots")[0];
+        modelHotspot.GetProperty("origin").GetString().ShouldBe("prose");
+        modelHotspot.GetProperty("text").GetString().ShouldBe("Do we own the SLA clock, or does the CRM?");
+        modelHotspot.GetProperty("specificationIdentity").ValueKind.ShouldBe(JsonValueKind.Null);
     }
 
     [Theory]
@@ -188,6 +196,7 @@ public class EventModelWireRoundTripTests
 
         var back = JsonSerializer.Deserialize<EventModelDescriptor>(stripped, options)!;
         back.Aggregates.ShouldBeEmpty();
+        back.Hotspots.ShouldBeEmpty();
         var slice = back.Slices.Single();
         slice.CommandType!.FullName.ShouldBe("x.PlaceOrder");
         slice.Pattern.ShouldBeNull();

--- a/src/EventTests/EventModeling/HotspotDescriptorTests.cs
+++ b/src/EventTests/EventModeling/HotspotDescriptorTests.cs
@@ -17,7 +17,7 @@ public class HotspotDescriptorTests
     }
 
     [Fact]
-    public void prose_is_the_reserved_form_with_no_spec_identity()
+    public void prose_carries_the_note_itself_and_no_spec_identity()
     {
         var hotspot = HotspotDescriptor.Prose("Refund policy unclear");
 
@@ -39,6 +39,23 @@ public class HotspotDescriptorTests
         element.Id.ShouldBe("PlaceOrder/Hotspot/Place Order/Rejects empty cart");
         element.Lane.ShouldBe(EventModelLane.Wireframe);
         element.Type.ShouldBeNull();
+        EventModelPalette.ColorFor(element.Kind).ShouldBe("#E91E63");
+    }
+
+    // jasperfx#690: a prose hotspot renders exactly like a pending-spec one — same kind, same
+    // lane, same colour. Only the text and the missing spec identity tell them apart.
+    [Fact]
+    public void a_prose_hotspot_renders_the_same_way_a_pending_spec_one_does()
+    {
+        var slice = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            Hotspots = new[] { HotspotDescriptor.Prose("Refund policy unclear when partially shipped") },
+        };
+
+        var element = slice.Elements.Single(e => e.Kind == EventModelElementKind.Hotspot);
+        element.Id.ShouldBe("PlaceOrder/Hotspot/Refund policy unclear when partially shipped");
+        element.Label.ShouldBe("Refund policy unclear when partially shipped");
+        element.Lane.ShouldBe(EventModelLane.Wireframe);
         EventModelPalette.ColorFor(element.Kind).ShouldBe("#E91E63");
     }
 }

--- a/src/EventTests/EventModeling/OverlayHotspotTests.cs
+++ b/src/EventTests/EventModeling/OverlayHotspotTests.cs
@@ -1,0 +1,162 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+// jasperfx#690: prose hotspots declared through the overlay. The overlay still declares no
+// roles — a hotspot is an annotation, the one thing about an unfinished model that no source
+// can derive, because nobody has written the code or the spec that would give it away yet.
+public class OverlayHotspotTests
+{
+    [Fact]
+    public void a_slice_hotspot_lands_on_that_slice_as_prose()
+    {
+        var builder = new EventModelBuilder();
+        builder.Slice("CloseIncident")
+            .Hotspot("Can an incident be closed while a customer response is outstanding?");
+
+        var hotspot = builder.BuildSlices().Single().Hotspots.Single();
+        hotspot.Origin.ShouldBe(HotspotOrigin.Prose);
+        hotspot.Text.ShouldBe("Can an incident be closed while a customer response is outstanding?");
+        hotspot.SpecificationIdentity.ShouldBeNull();
+    }
+
+    [Fact]
+    public void slice_hotspots_keep_declaration_order_and_chain_with_the_rest_of_the_overlay()
+    {
+        var builder = new EventModelBuilder();
+        builder.Slice("CloseIncident")
+            .InDomain("Helpdesk")
+            .TriggeredBy("Agent clicks Close")
+            .Hotspot("first")
+            .LinksToSpecification("Close Incident/Closes a resolved incident")
+            .Hotspot("second");
+
+        var slice = builder.BuildSlices().Single();
+        slice.Domain.ShouldBe("Helpdesk");
+        slice.TriggerLabel.ShouldBe("Agent clicks Close");
+        slice.Specifications.Single().Identity.ShouldBe("Close Incident/Closes a resolved incident");
+        slice.Hotspots.Select(x => x.Text).ShouldBe(new[] { "first", "second" });
+    }
+
+    [Fact]
+    public void a_model_hotspot_lands_on_the_model_and_not_on_any_slice()
+    {
+        var builder = new EventModelBuilder { Name = "Helpdesk" };
+        builder.Hotspot("Who owns the SLA clock once an incident is escalated?");
+        builder.Slice("CloseIncident");
+
+        var model = builder.Build("fallback");
+        model.Hotspots.Single().Text.ShouldBe("Who owns the SLA clock once an incident is escalated?");
+        model.Hotspots.Single().Origin.ShouldBe(HotspotOrigin.Prose);
+        model.Slices.Single().Hotspots.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void model_hotspots_keep_declaration_order()
+    {
+        var builder = new EventModelBuilder();
+        builder.Hotspot("first").Hotspot("second");
+
+        builder.Build("m").Hotspots.Select(x => x.Text).ShouldBe(new[] { "first", "second" });
+    }
+
+    [Fact]
+    public void a_model_with_no_hotspots_declared_has_none()
+    {
+        var builder = new EventModelBuilder();
+        builder.Slice("CloseIncident");
+
+        var model = builder.Build("m");
+        model.Hotspots.ShouldBeEmpty();
+        model.Slices.Single().Hotspots.ShouldBeEmpty();
+    }
+
+    // The overlay is merged ONTO the derived slice, so an overlay hotspot has to survive the
+    // fold next to whatever the binding source already stamped there.
+    [Fact]
+    public void an_overlay_hotspot_survives_the_merge_next_to_a_derived_pending_spec_hotspot()
+    {
+        var derived = EventModelSliceDescriptor.Named("CloseIncident") with
+        {
+            CommandType = TypeDescriptor.For(typeof(CloseIncident)),
+            Hotspots = new[] { HotspotDescriptor.PendingSpecification("Close Incident/Rejects an open incident") },
+        };
+
+        var builder = new EventModelBuilder();
+        builder.Slice("CloseIncident").Hotspot("Do we notify the customer on close?");
+        var overlay = builder.BuildSlices().Single();
+
+        var merged = derived.Merge(overlay);
+
+        merged.CommandType.ShouldBe(TypeDescriptor.For(typeof(CloseIncident)));
+        merged.Hotspots.Select(x => (x.Origin, x.Text)).ShouldBe(new[]
+        {
+            (HotspotOrigin.PendingSpecification, "Close Incident/Rejects an open incident"),
+            (HotspotOrigin.Prose, "Do we notify the customer on close?"),
+        });
+    }
+
+    [Fact]
+    public void the_same_prose_hotspot_from_two_sources_is_folded_into_one()
+    {
+        var slice = EventModelSliceDescriptor.Named("CloseIncident") with
+        {
+            Hotspots = new[] { HotspotDescriptor.Prose("Do we notify the customer on close?") },
+        };
+
+        slice.Merge(slice with { }).Hotspots.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void prose_and_a_pending_spec_with_the_same_text_are_not_folded_together()
+    {
+        var slice = EventModelSliceDescriptor.Named("CloseIncident") with
+        {
+            Hotspots = new[] { HotspotDescriptor.Prose("Close Incident/Rejects an open incident") },
+        };
+
+        var other = EventModelSliceDescriptor.Named("CloseIncident") with
+        {
+            Hotspots = new[] { HotspotDescriptor.PendingSpecification("Close Incident/Rejects an open incident") },
+        };
+
+        slice.Merge(other).Hotspots.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void model_level_hotspots_are_unioned_across_sources_and_deduplicated()
+    {
+        var derived = new EventModelDescriptor("Helpdesk", Array.Empty<EventModelSliceDescriptor>())
+        {
+            Hotspots = new[] { HotspotDescriptor.Prose("shared") },
+        };
+
+        var builder = new EventModelBuilder { Name = "Helpdesk" };
+        builder.Hotspot("shared").Hotspot("overlay only");
+
+        var merged = EventModelDescriptor.Merge("Helpdesk", new[] { derived, builder.Build("Helpdesk") });
+
+        merged.Hotspots.Select(x => x.Text).ShouldBe(new[] { "shared", "overlay only" });
+    }
+
+    // The whole point of declaring a hotspot: an unfinished model still renders, and the
+    // unfinished part is visible on the canvas rather than in someone's head.
+    [Fact]
+    public void a_slice_that_is_nothing_but_a_hotspot_still_renders_one_element()
+    {
+        var builder = new EventModelBuilder();
+        builder.Slice("EscalateIncident")
+            .Hotspot("No idea yet what escalation does to the SLA clock");
+
+        var slice = builder.BuildSlices().Single();
+        var element = slice.Elements.Single();
+        element.Kind.ShouldBe(EventModelElementKind.Hotspot);
+        element.Lane.ShouldBe(EventModelLane.Wireframe);
+        element.Label.ShouldBe("No idea yet what escalation does to the SLA clock");
+        slice.Edges.ShouldBeEmpty();
+    }
+
+    public class CloseIncident { }
+}

--- a/src/JasperFx.Events/EventModeling/EventModelBuilder.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelBuilder.cs
@@ -3,12 +3,13 @@ namespace JasperFx.Events.EventModeling;
 /// <summary>
 /// Fluent root used by an <see cref="EventModelDefinition"/> (or an inline
 /// <c>services.AddEventModel(name, configure)</c> lambda) to lay the overlay on an
-/// Event Model: name slices, group them by domain, label triggers and link
-/// specifications. Each call to <see cref="Slice"/> opens one slice.
+/// Event Model: name slices, group them by domain, label triggers, link
+/// specifications and flag open questions. Each call to <see cref="Slice"/> opens one slice.
 /// </summary>
 public class EventModelBuilder
 {
     private readonly List<EventModelSliceBuilder> _slices = new();
+    private readonly List<HotspotDescriptor> _hotspots = new();
     private string? _defaultDomain;
 
     /// <summary>
@@ -26,6 +27,24 @@ public class EventModelBuilder
     public EventModelBuilder InDomain(string domain)
     {
         _defaultDomain = domain;
+        return this;
+    }
+
+    /// <summary>
+    /// Mark an open question about the model as a whole in plain prose — the question that is not
+    /// about any one slice ("do we even own the SLA clock?"). For a question about a single slice,
+    /// use <see cref="EventModelSliceBuilder.Hotspot"/> instead so it renders on that slice.
+    /// </summary>
+    /// <remarks>
+    /// The same caveat as the per-slice form: prefer a pending specification (jasperfx#689) once
+    /// the question is sharp enough to name a scenario, because that hotspot retires itself when
+    /// the spec passes. Prose stays until someone deletes the line.
+    /// </remarks>
+    /// <param name="text">The open question, in the words you would say out loud.</param>
+    /// <returns>This builder for chaining.</returns>
+    public EventModelBuilder Hotspot(string text)
+    {
+        _hotspots.Add(HotspotDescriptor.Prose(text));
         return this;
     }
 
@@ -51,9 +70,10 @@ public class EventModelBuilder
         => _slices.Select(x => x.Build()).ToList();
 
     /// <summary>
-    /// Snapshot the whole overlay as an <see cref="EventModelDescriptor"/>.
+    /// Snapshot the whole overlay as an <see cref="EventModelDescriptor"/>, model-level hotspots
+    /// included.
     /// </summary>
     /// <param name="fallbackName">Name used when <see cref="Name"/> is unset.</param>
     public EventModelDescriptor Build(string fallbackName)
-        => new(Name ?? fallbackName, BuildSlices());
+        => new(Name ?? fallbackName, BuildSlices()) { Hotspots = _hotspots.ToList() };
 }

--- a/src/JasperFx.Events/EventModeling/EventModelDefinition.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelDefinition.cs
@@ -2,9 +2,9 @@ namespace JasperFx.Events.EventModeling;
 
 /// <summary>
 /// Base class application authors derive from to lay an <em>overlay</em> on the
-/// Event Model — names for slices, domain grouping, trigger labels and links to
-/// specifications. Override <see cref="Configure"/> to populate the supplied
-/// <see cref="EventModelBuilder"/>.
+/// Event Model — names for slices, domain grouping, trigger labels, links to
+/// specifications and prose hotspots for the questions still open. Override
+/// <see cref="Configure"/> to populate the supplied <see cref="EventModelBuilder"/>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -34,7 +34,7 @@ public abstract class EventModelDefinition
 
     /// <summary>
     /// Populate <paramref name="builder"/> with the overlay — slice names, domains, trigger
-    /// labels, specification links. Called once by the discovery layer.
+    /// labels, specification links, hotspots. Called once by the discovery layer.
     /// </summary>
     /// <param name="builder">Builder that accumulates the overlay.</param>
     public abstract void Configure(EventModelBuilder builder);

--- a/src/JasperFx.Events/EventModeling/EventModelSliceBuilder.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelSliceBuilder.cs
@@ -3,7 +3,7 @@ using JasperFx.Descriptors;
 namespace JasperFx.Events.EventModeling;
 
 /// <summary>
-/// Per-slice overlay builder. The methods here <em>name, group, annotate and link</em> —
+/// Per-slice overlay builder. The methods here <em>name, group, annotate, link and flag</em> —
 /// they never declare a role. Roles are derived by the sources that can see them and the
 /// overlay is merged onto the derived slice by name (jasperfx#687 reshape).
 /// </summary>
@@ -13,6 +13,7 @@ public class EventModelSliceBuilder
     private string? _domain;
     private string? _triggerLabel;
     private readonly List<SpecificationDescriptor> _specifications = new();
+    private readonly List<HotspotDescriptor> _hotspots = new();
     private ExternallyOwnedRoles? _externallyOwned;
 
     /// <summary>
@@ -66,6 +67,26 @@ public class EventModelSliceBuilder
     }
 
     /// <summary>
+    /// Mark an open question on this slice in plain prose — the modelling conversation's
+    /// "we haven't decided this yet", carried into the model so it renders as a hotspot in the
+    /// slice's wireframe lane instead of dying in a whiteboard photo.
+    /// </summary>
+    /// <remarks>
+    /// Reach for this only when there is nothing to write a specification against yet. The
+    /// primary hotspot mechanism is <em>a pending specification is a hotspot</em> (jasperfx#689):
+    /// once the question is sharp enough to name a scenario, write the pending spec and let the
+    /// binding source stamp the hotspot, so the hotspot disappears on its own the day the spec
+    /// passes. Prose has no such lifecycle — nothing retires it but you.
+    /// </remarks>
+    /// <param name="text">The open question, in the words you would say out loud.</param>
+    /// <returns>This builder for chaining.</returns>
+    public EventModelSliceBuilder Hotspot(string text)
+    {
+        _hotspots.Add(HotspotDescriptor.Prose(text));
+        return this;
+    }
+
+    /// <summary>
     /// <b>Escape hatch.</b> Declare roles for a flow whose code this host does <em>not</em> own —
     /// a partner system's command and the events it emits, a legacy service with no Wolverine
     /// chain to derive from. For anything this host's own code implements, do not use this:
@@ -87,6 +108,7 @@ public class EventModelSliceBuilder
             TriggerLabel = _triggerLabel,
             Domain = _domain,
             Specifications = _specifications.ToList(),
+            Hotspots = _hotspots.ToList(),
         };
 
         return _externallyOwned is null ? overlay : overlay.Merge(_externallyOwned.ToSlice(_sliceName));

--- a/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
@@ -83,7 +83,11 @@ public sealed record EventModelSliceDescriptor(
     /// <summary>External systems on either end of this slice (translation edges).</summary>
     public IReadOnlyList<ExternalSystemDescriptor> ExternalSystems { get; init; } = Array.Empty<ExternalSystemDescriptor>();
 
-    /// <summary>Hotspots attached to this slice — primarily pending specifications (jasperfx#689).</summary>
+    /// <summary>
+    /// Hotspots attached to this slice — primarily pending specifications (jasperfx#689), plus any
+    /// prose the overlay declared with <c>Hotspot("…")</c> (jasperfx#690). Each one renders as a
+    /// <see cref="EventModelElementKind.Hotspot"/> element in the wireframe lane.
+    /// </summary>
     public IReadOnlyList<HotspotDescriptor> Hotspots { get; init; } = Array.Empty<HotspotDescriptor>();
 
     /// <summary>
@@ -289,8 +293,9 @@ public sealed record EventModelSliceDescriptor(
 /// </summary>
 /// <remarks>
 /// The positional constructor is the original 2.x shape and is kept source- and
-/// binary-compatible; <see cref="Aggregates"/> is an additive <c>init</c> property.
-/// Use <see cref="Merge"/> to assemble the full picture from several sources.
+/// binary-compatible; <see cref="Aggregates"/> and <see cref="Hotspots"/> are additive
+/// <c>init</c> properties. Use <see cref="Merge"/> to assemble the full picture from several
+/// sources.
 /// </remarks>
 /// <param name="Name">Display name of the model.</param>
 /// <param name="Slices">Slices that make up the model, in declaration order.</param>
@@ -306,10 +311,20 @@ public sealed record EventModelDescriptor(
     public IReadOnlyList<AggregateDescriptor> Aggregates { get; init; } = Array.Empty<AggregateDescriptor>();
 
     /// <summary>
+    /// Hotspots that belong to the model rather than to any one slice — the open question that
+    /// spans the whole flow, declared through the overlay with <c>Hotspot("…")</c> on the
+    /// <c>EventModelBuilder</c> (jasperfx#690). Hotspots about a single slice live on
+    /// <see cref="EventModelSliceDescriptor.Hotspots"/> instead, where they render in that slice's
+    /// wireframe lane.
+    /// </summary>
+    public IReadOnlyList<HotspotDescriptor> Hotspots { get; init; } = Array.Empty<HotspotDescriptor>();
+
+    /// <summary>
     /// Assemble one model from several sources' descriptors. Slices with the same name are
     /// folded with <see cref="EventModelSliceDescriptor.Merge"/> in the order the descriptors
     /// are given (earlier wins on scalars — put derived sources before the overlay); aggregates
-    /// are unioned by type. Slice order is first appearance.
+    /// are unioned by type and model-level hotspots by origin + text. Slice order is first
+    /// appearance.
     /// </summary>
     /// <param name="name">Name of the assembled model.</param>
     /// <param name="descriptors">Descriptors to fold, derived sources first.</param>
@@ -319,6 +334,8 @@ public sealed record EventModelDescriptor(
         var indexByName = new Dictionary<string, int>(StringComparer.Ordinal);
         var aggregates = new List<AggregateDescriptor>();
         var aggregateNames = new HashSet<string>(StringComparer.Ordinal);
+        var hotspots = new List<HotspotDescriptor>();
+        var hotspotKeys = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var descriptor in descriptors)
         {
@@ -339,8 +356,13 @@ public sealed record EventModelDescriptor(
             {
                 if (aggregateNames.Add(aggregate.Type.FullName)) aggregates.Add(aggregate);
             }
+
+            foreach (var hotspot in descriptor.Hotspots)
+            {
+                if (hotspotKeys.Add($"{hotspot.Origin}:{hotspot.Text}")) hotspots.Add(hotspot);
+            }
         }
 
-        return new EventModelDescriptor(name, slices) { Aggregates = aggregates };
+        return new EventModelDescriptor(name, slices) { Aggregates = aggregates, Hotspots = hotspots };
     }
 }

--- a/src/JasperFx/Descriptors/EventModeling/HotspotDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/HotspotDescriptor.cs
@@ -13,16 +13,18 @@ public enum HotspotOrigin
     PendingSpecification,
 
     /// <summary>
-    /// Free-text prose declared through the overlay. Reserved form — the overlay surface for it
-    /// is a later stage (jasperfx#690); sources may still emit it.
+    /// Free-text prose declared through the overlay with <c>Hotspot("…")</c> on a slice or on the
+    /// model (jasperfx#690) — the open question that has no specification behind it yet. Sources
+    /// may emit it too.
     /// </summary>
     Prose,
 }
 
 /// <summary>
-/// A hotspot attached to a slice — an open question, a conflict, or (primarily) a
-/// specification that is still pending. Renders in the canonical hotspot colour
-/// on the slice it is attached to (jasperfx#687 decision 6, jasperfx#689).
+/// A hotspot — an open question, a conflict, or (primarily) a specification that is still
+/// pending. Attached to a slice, where it renders in the canonical hotspot colour in the
+/// wireframe lane, or to the whole model when the question is not about one slice
+/// (jasperfx#687 decision 6, jasperfx#689, jasperfx#690).
 /// </summary>
 /// <param name="Origin">Whether this hotspot is a pending specification or prose.</param>
 /// <param name="Text">
@@ -42,7 +44,7 @@ public sealed record HotspotDescriptor(
     public static HotspotDescriptor PendingSpecification(string specificationIdentity)
         => new(HotspotOrigin.PendingSpecification, specificationIdentity, specificationIdentity);
 
-    /// <summary>A prose hotspot. Reserved form — see <see cref="HotspotOrigin.Prose"/>.</summary>
+    /// <summary>A free-text prose hotspot — see <see cref="HotspotOrigin.Prose"/> (jasperfx#690).</summary>
     public static HotspotDescriptor Prose(string text)
         => new(HotspotOrigin.Prose, text);
 }


### PR DESCRIPTION
Closes #690.

`HotspotOrigin.Prose` has existed since #687 as a reserved form — a hotspot a source could emit but nobody could author. #689 made *a pending specification is a hotspot* the primary mechanism and deliberately deferred this one. This adds the authoring surface.

## What's here

`Hotspot("…")` on both overlay builders:

```csharp
public class HelpdeskModel : EventModelDefinition
{
    public override void Configure(EventModelBuilder builder)
    {
        // about the model as a whole
        builder.Hotspot("Who owns the SLA clock once an incident is escalated?");

        builder.Slice("CloseIncident")
            .TriggeredBy("Agent clicks Close")
            // about this one slice
            .Hotspot("Can an incident be closed while a customer response is outstanding?");
    }
}
```

- `EventModelSliceBuilder.Hotspot(text)` adds a `HotspotDescriptor.Prose` to that slice. It renders as a `Hotspot` element in the wireframe lane in the canonical magenta, exactly like a pending-spec hotspot — a slice that is *nothing but* a hotspot still renders one element, which is the point.
- `EventModelBuilder.Hotspot(text)` attaches to the model instead, through a new additive `EventModelDescriptor.Hotspots` init property, for questions that aren't about any one slice.

Both merge the way everything else in the model does: unioned across sources, deduplicated on origin + text, order preserved. Prose and a pending spec that happen to share text stay two hotspots, since the origin is part of the key.

## Guidance in the XML docs

Prose is the escape valve, not the default. The docs on both methods say so: once a question is sharp enough to name a scenario, write the pending spec instead — that hotspot retires itself the day the spec passes, and prose has no lifecycle at all.

## Compatibility

Purely additive. `EventModelDescriptor`'s positional constructor is unchanged, `Hotspots` defaults to empty, and the existing round-trip test that replays a pre-#687 payload now also asserts it comes back empty.

## Tests

New `OverlayHotspotTests` covers the slice and model surfaces, declaration order, chaining with the rest of the overlay, the merge onto a derived slice, dedup, the origin-is-part-of-the-key case, and the hotspot-only slice rendering. `HotspotDescriptorTests` gains prose rendering; the wire round-trip tests now carry a model-level prose hotspot in both serializer shapes.

EventTests 864/864 and CoreTests 578/578 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)