### PR TITLE
Document the Event Model, with IncidentService as the sample

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,6 +18,7 @@ export default withMermaid(
 
       nav: [
         { text: 'Guide', link: '/guide/' },
+        { text: 'Event Modeling', link: '/event-modeling/' },
         { text: 'Code Generation', link: '/codegen/' },
         { text: 'Command Line', link: '/cli/' },
         { text: 'Configuration', link: '/configuration/critter-stack-defaults' },
@@ -40,6 +41,16 @@ export default withMermaid(
             { text: 'Introduction', link: '/guide/' },
             { text: 'Installation', link: '/guide/installation' },
             { text: 'Quick Start', link: '/guide/quickstart' }
+          ]
+        },
+        {
+          text: 'Event Modeling',
+          collapsed: false,
+          items: [
+            { text: 'Overview', link: '/event-modeling/' },
+            { text: 'The Overlay', link: '/event-modeling/overlay' },
+            { text: 'Hotspots', link: '/event-modeling/hotspots' },
+            { text: 'Descriptors & the Wire', link: '/event-modeling/descriptors' }
           ]
         },
         {

--- a/docs/event-modeling/descriptors.md
+++ b/docs/event-modeling/descriptors.md
@@ -1,0 +1,165 @@
+# Descriptors and the Wire
+
+Every source of an Event Model — Wolverine's chains, the Bobcat generator, a source generator, your overlay — writes into the same two records, and every viewer reads from them. This page is the shape.
+
+## `EventModelSliceDescriptor`
+
+One slice. The positional constructor is the original 2.x shape and is kept source- and binary-compatible; everything added since is an `init` property with a safe default, so older payloads and precompiled callers keep working.
+
+| Slot | Filled by | Holds |
+|------|-----------|-------|
+| `Name` | Both | Display name; also the merge key across sources |
+| `Pattern` | Derived | `Command`, `View`, `Automation` or `Translation` |
+| `TriggerKind` | Derived | `Http`, `Grpc`, `MessageHandler`, `JobScheduler`, `Human`, `External` |
+| `TriggerOrigin` | Derived | HTTP verb + route, gRPC service + method, or a label |
+| `TriggerType` | Derived | CLR type of the trigger, e.g. an inbound request DTO |
+| `TriggerLabel` | **Overlay** | "Agent clicks Close" |
+| `CommandType` | Derived | The inbound message type |
+| `HandlerType` | Derived | The handler or endpoint type — distinct from the aggregates |
+| `AggregateTypes` | Derived | Projected write models the handler decides against |
+| `EmittedEvents` | Derived | Events the slice writes, in declaration order |
+| `PublishedMessages` | Derived | Non-event messages — cascaded commands, integration messages |
+| `ProjectionTypes` | Derived | Projections consuming the slice's events |
+| `ReadModelTypes` | Derived | Read models the slice reads or produces |
+| `ExternalSystems` | Derived | Systems on either end of a translation |
+| `Specifications` | Derived (mostly) | Bound specs by `{Feature}/{Scenario}` plus resolved types |
+| `Hotspots` | Both | Pending specs (derived) and prose (overlay) |
+| `Domain` | **Overlay** | Bounded context |
+
+This is what a derived source produces for `CloseIncident`:
+
+<!-- snippet: sample_a_derived_slice -->
+<a id='snippet-sample_a_derived_slice'></a>
+```cs
+// This is what a source builds — Wolverine reading its own HTTP chain for
+// CloseIncidentEndpoint. You never hand-write this; it is here so you can see
+// exactly which slots the overlay is *not* allowed to fill.
+var derived = new EventModelSliceDescriptor(
+    "CloseIncident",
+    TriggerLabel: null,
+    TriggerType: null,
+    CommandType: TypeDescriptor.For(typeof(CloseIncident)),
+    HandlerType: TypeDescriptor.For(typeof(CloseIncidentEndpoint)),
+    EmittedEvents: [TypeDescriptor.For(typeof(IncidentClosed))],
+    ProjectionTypes: [],
+    ReadModelTypes: [TypeDescriptor.For(typeof(Incident))])
+{
+    Pattern = SlicePattern.Command,
+    TriggerKind = TriggerKind.Http,
+    TriggerOrigin = new PublisherOrigin
+    {
+        HttpMethod = "POST",
+        HttpRoute = "/api/incidents/close/{id}",
+        Label = "POST /api/incidents/close/{id}"
+    },
+    AggregateTypes = [TypeDescriptor.For(typeof(Incident))],
+    PublishedMessages = [TypeDescriptor.For(typeof(ArchiveIncident))]
+};
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L72-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_a_derived_slice' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+## `EventModelDescriptor`
+
+The whole model: its `Slices`, the `Aggregates` those slices reference by type (each with its kind and applied events), and model-level `Hotspots`.
+
+## The rendering contract
+
+`Elements` and `Edges` are **computed from the typed roles on every read**. They are not stored and cannot disagree with the roles underneath them; a deserializer simply ignores whatever arrived and recomputes.
+
+Each element carries a deterministic id — `{slice}/{kind}/{type full name or label}` — a kind, a lane, a label, and the CLR type identity when it has one. Edges reference elements by that id.
+
+<!-- snippet: sample_reading_the_rendering_contract -->
+<a id='snippet-sample_reading_the_rendering_contract'></a>
+```cs
+// Elements and Edges are computed from the typed roles on every read, so a viewer
+// draws straight from the descriptor with no second transform
+foreach (var element in slice.Elements)
+{
+    Console.WriteLine($"{element.Lane,-12} {element.Kind,-15} {element.Label} " +
+                      $"({EventModelPalette.ColorFor(element.Kind)})");
+}
+
+foreach (var edge in slice.Edges)
+{
+    Console.WriteLine($"{edge.FromId} -> {edge.ToId}");
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L123-L138' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_reading_the_rendering_contract' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`EventModelPalette.ColorFor` is the shared reference so two viewers of one descriptor agree on what a colour means:
+
+| Kind | Lane | Colour |
+|------|------|--------|
+| `Trigger` | Wireframe | `#FFFFFF` white |
+| `ExternalSystem` | Wireframe | `#F8BBD0` pink |
+| `Hotspot` | Wireframe | `#E91E63` magenta |
+| `Command` | Command | `#5B9BD5` blue |
+| `Handler` | Command | `#5B9BD5` blue, outlined |
+| `Aggregate` | Command | `#FFF2A8` pale yellow |
+| `Event` | EventStream | `#F5A623` orange |
+| `Message` | EventStream | `#5B9BD5` blue, dashed |
+| `Projection` | ReadModel | `#7ED321` green, outlined |
+| `ReadModel` | ReadModel | `#7ED321` green |
+
+## Discovery and assembly
+
+`EventModelDiscovery` walks every registered `IEventModelDefinitionSource`, asks each for its descriptor (skipping any that return null), and folds the results into one descriptor per model name:
+
+<!-- snippet: sample_assembling_the_event_model -->
+<a id='snippet-sample_assembling_the_event_model'></a>
+```cs
+// Ask every registered source — Wolverine's chains, the Bobcat generator, your
+// overlays — for its view, then fold them into one descriptor per model name
+var models = await EventModelDiscovery.AssembleAsync(services);
+
+var helpdesk = models.Single(x => x.Name == "Helpdesk");
+
+foreach (var slice in helpdesk.Slices)
+{
+    Console.WriteLine($"{slice.Domain}/{slice.Name}: {slice.Pattern}");
+
+    foreach (var hotspot in slice.Hotspots)
+    {
+        Console.WriteLine($"  ⚠ {hotspot.Origin}: {hotspot.Text}");
+    }
+}
+
+// Questions that belong to the model rather than to one slice
+foreach (var hotspot in helpdesk.Hotspots)
+{
+    Console.WriteLine($"⚠ {hotspot.Text}");
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L43-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assembling_the_event_model' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Sources are enumerated in **registration order**, and `Merge` lets earlier sources win on scalars — so register derived sources before overlays. Concretely:
+
+- **Scalars** keep the first non-null value.
+- **Lists** are unioned in order and deduplicated by identity: types by full name, external systems by direction + name, specifications by identity, hotspots by origin + text.
+- **Slices** fold by name; slice order is first appearance.
+- **Aggregates** union by type full name.
+
+Merging two slices with different names throws — slices merge by name, and a mismatch means a bug in whoever assembled the list.
+
+## Serialization
+
+The descriptors are plain records and serialize with `System.Text.Json` as-is. CritterWatch's wire shape is camelCase with camelCase string enums:
+
+<!-- snippet: sample_serializing_an_event_model -->
+<a id='snippet-sample_serializing_an_event_model'></a>
+```cs
+var options = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+};
+
+var json = JsonSerializer.Serialize(model, options);
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L143-L153' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_serializing_an_event_model' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Because `Elements` and `Edges` are computed properties, they go **out** on the wire — a viewer gets the rendering contract without a second transform — and are ignored coming back in.

--- a/docs/event-modeling/hotspots.md
+++ b/docs/event-modeling/hotspots.md
@@ -1,0 +1,143 @@
+# Hotspots
+
+A **hotspot** is the model admitting it does not know something yet. On a whiteboard it is the pink sticky note with a question mark on it; on a JasperFx Event Model it is a `HotspotDescriptor`, rendered in the wireframe lane in the canonical hotspot magenta (`#E91E63`).
+
+Hotspots come from two places, and the difference between them matters more than it looks.
+
+## A pending specification is a hotspot
+
+This is the primary mechanism, and the one you should reach for first.
+
+When a slice has a specification bound to it that cannot pass yet — no bound steps, or steps that fail — the binding source stamps a hotspot on that slice automatically. Nobody writes it, and nobody has to remember to delete it: the day the spec passes, the hotspot is gone.
+
+In IncidentService, the sample has no `ResolveIncident` slice yet. Rather than write a note about it:
+
+<!-- snippet: sample_incident_service_pending_spec_hotspot -->
+<a id='snippet-sample_incident_service_pending_spec_hotspot'></a>
+```cs
+public class ResolutionSlices : EventModelDefinition
+{
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.Slice("ResolveIncident")
+            // The question is sharp enough to name a scenario, so name it. The spec is
+            // pending, and a pending spec is a hotspot — one that retires itself the day
+            // the spec passes, which a prose note never does.
+            .TriggeredBy("Agent clicks Resolve")
+            .LinksToSpecification("Resolve Incident/An agent resolves a pending incident");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceEventModel.cs#L62-L79' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_pending_spec_hotspot' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The scenario named there does not exist yet either. That is the point — the model shows an unbuilt slice with an open question on it, and the question closes itself when someone writes the code that makes the scenario pass.
+
+## Prose hotspots
+
+Sometimes there is nothing to write a specification *against* yet. The question is real, but it is not yet sharp enough to name a scenario — you do not know the rule, so you cannot write the test.
+
+`Hotspot("…")` puts that question on the canvas:
+
+<!-- snippet: sample_incident_service_hotspots -->
+<a id='snippet-sample_incident_service_hotspots'></a>
+```cs
+public class IncidentServiceHotspots : EventModelDefinition
+{
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        // Not about any one slice — nobody has decided this yet
+        builder.Hotspot("Do we own the SLA clock, or does the CRM?");
+
+        builder.Slice("CloseIncident")
+            // Both of these rules are sitting commented out in CloseIncidentEndpoint.
+            // Written down here, they show up on the canvas instead of in a code comment
+            // nobody outside the team will ever read.
+            .Hotspot("Can an incident be closed before the customer acknowledges the resolution?")
+            .Hotspot("What happens to an outstanding response to the customer when we close?");
+
+        builder.Slice("ArchiveIncident")
+            .Hotspot("Three days is a guess. Ask legal what retention actually requires.");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceEventModel.cs#L37-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_hotspots' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Those first two are not invented. Open `CloseIncidentEndpoint` in the Wolverine sample and you will find both rules sitting in a commented-out block:
+
+```csharp
+/* More logic for later
+if (current.Status is not IncidentStatus.ResolutionAcknowledgedByCustomer)
+    throw new InvalidOperationException("Only incident with acknowledged resolution can be closed");
+
+if (current.HasOutstandingResponseToCustomer)
+    throw new InvalidOperationException("Cannot close incident that has outstanding responses to customer");
+*/
+```
+
+That is a hotspot in its natural habitat: a real, undecided rule, parked in a comment where only somebody already reading that file will ever see it. Declared in the overlay, the same two questions appear on the canvas in front of whoever is looking at the model — including the people who would actually know the answer.
+
+## Slice-level or model-level
+
+`Hotspot` exists on both builders and they mean different things:
+
+| Call | Attaches to | Use when |
+|------|-------------|----------|
+| `builder.Slice("X").Hotspot("…")` | That slice | The question is about one thing the system does |
+| `builder.Hotspot("…")` | The whole model | The question spans the flow, or is not about any one slice |
+
+A slice hotspot renders as an element in that slice's wireframe lane. A model hotspot lands on `EventModelDescriptor.Hotspots` and is rendered by the viewer wherever it shows model-level notes.
+
+A slice that is *nothing but* a hotspot still renders one element — which is exactly what you want for a slice you have thought about but not built.
+
+## Prefer the pending spec
+
+::: tip
+Prose is the escape valve, not the default.
+:::
+
+The two forms have very different lifecycles:
+
+- A **pending-specification** hotspot is evidence. It appears because a real spec is failing or unbound, and it disappears the moment that stops being true. It cannot lie to you.
+- A **prose** hotspot is a note. Nothing retires it but you. Six months on, a stale prose hotspot describing a question the team settled long ago is worse than no hotspot at all, because it teaches people to ignore the magenta ones.
+
+So the moment a question becomes sharp enough to name a scenario, promote it: write the pending spec, `LinksToSpecification` it, and delete the prose line. `"Can an incident be closed before the customer acknowledges the resolution?"` becomes `"Close Incident/Rejects an incident with no acknowledged resolution"`, and from then on the model tracks it for you.
+
+## Reading them back
+
+Both kinds arrive on the assembled descriptor, tagged with their origin:
+
+<!-- snippet: sample_assembling_the_event_model -->
+<a id='snippet-sample_assembling_the_event_model'></a>
+```cs
+// Ask every registered source — Wolverine's chains, the Bobcat generator, your
+// overlays — for its view, then fold them into one descriptor per model name
+var models = await EventModelDiscovery.AssembleAsync(services);
+
+var helpdesk = models.Single(x => x.Name == "Helpdesk");
+
+foreach (var slice in helpdesk.Slices)
+{
+    Console.WriteLine($"{slice.Domain}/{slice.Name}: {slice.Pattern}");
+
+    foreach (var hotspot in slice.Hotspots)
+    {
+        Console.WriteLine($"  ⚠ {hotspot.Origin}: {hotspot.Text}");
+    }
+}
+
+// Questions that belong to the model rather than to one slice
+foreach (var hotspot in helpdesk.Hotspots)
+{
+    Console.WriteLine($"⚠ {hotspot.Text}");
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L43-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assembling_the_event_model' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`HotspotOrigin` tells them apart, and `SpecificationIdentity` is populated only for the pending-spec form. Hotspots from different sources are unioned and deduplicated on origin plus text — so prose and a pending spec that happen to share a string stay two distinct hotspots, because they mean two different things.

--- a/docs/event-modeling/index.md
+++ b/docs/event-modeling/index.md
@@ -1,0 +1,155 @@
+# Event Modeling Overview
+
+[Event Modeling](https://eventmodeling.org) is a way to design a system by laying its behaviour out on a timeline: what a user does, what command that becomes, what events it writes, and what read models fall out the other side. It is normally a whiteboard exercise. The whiteboard is then photographed, dropped in a wiki, and starts drifting away from the code the same afternoon.
+
+JasperFx.Events carries the model as a **semantic model in the codebase** instead. Most of it is derived from code you have already written, so it cannot drift; the small remainder that code genuinely cannot express, you declare.
+
+## The one rule
+
+> **Roles are derived. Names, groupings, labels, links and open questions are declared.**
+
+The command type, the handler, the aggregates, the events emitted, the messages published, the projections, the read models, the trigger kind, the slice pattern — all of that is *stamped by the source that can already see it*: Wolverine from its HTTP, handler and gRPC chains; the Bobcat generator from Gherkin specifications; a source generator from your projection types.
+
+What you write by hand is an **overlay**: the display name of a slice, the bounded context it belongs to, the human label on its trigger ("Agent clicks Close"), a link to a specification that lives outside the compilation, and a hotspot for a question nobody has answered yet.
+
+The overlay is merged *onto* the derived model, derived first, so a hand-written line can never overwrite what the code actually does. If the code and your overlay disagree about a role, the code wins — silently and always.
+
+## The sample: IncidentService
+
+Every example in this section models the [IncidentService sample](https://github.com/JasperFx/wolverine/tree/main/src/Samples/IncidentService/IncidentService) from the Wolverine repository — a small helpdesk where a customer logs an incident, an agent categorises it, and eventually somebody closes it.
+
+Its events, aggregate and commands:
+
+<!-- snippet: sample_incident_service_events -->
+<a id='snippet-sample_incident_service_events'></a>
+```cs
+public record IncidentLogged(Guid CustomerId, Contact Contact, string Description, Guid LoggedBy);
+
+public record IncidentCategorised(Guid IncidentId, IncidentCategory Category, Guid CategorisedBy);
+
+public record IncidentClosed(Guid ClosedBy);
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceDomain.cs#L12-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_events' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+<!-- snippet: sample_incident_service_aggregate -->
+<a id='snippet-sample_incident_service_aggregate'></a>
+```cs
+public class Incident
+{
+    public Guid Id { get; set; }
+    public int Version { get; set; }
+    public IncidentStatus Status { get; set; } = IncidentStatus.Pending;
+    public IncidentCategory? Category { get; set; }
+    public bool HasOutstandingResponseToCustomer { get; set; }
+
+    public void Apply(IncidentLogged _) { }
+    public void Apply(IncidentCategorised e) => Category = e.Category;
+    public void Apply(IncidentClosed _) => Status = IncidentStatus.Closed;
+
+    public bool ShouldDelete(Archived @event) => true;
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceDomain.cs#L22-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_aggregate' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+<!-- snippet: sample_incident_service_commands -->
+<a id='snippet-sample_incident_service_commands'></a>
+```cs
+public record LogIncident(Guid CustomerId, Contact Contact, string Description, Guid LoggedBy);
+
+public record CategoriseIncident(IncidentCategory Category, Guid CategorisedBy, int Version);
+
+public record CloseIncident(Guid ClosedBy, int Version);
+
+public record ArchiveIncident(Guid IncidentId);
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceDomain.cs#L41-L51' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_commands' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+In the real sample each command has a Wolverine HTTP endpoint next to it — `[WolverinePost("/api/incidents/close/{id}")]` on `CloseIncidentEndpoint`, `[Aggregate]` on the `Incident` parameter. Those attributes are exactly what a derived source reads, which is why none of it is repeated in the overlay.
+
+## Slices and lanes
+
+A **slice** is one vertical stripe of the timeline: one thing the system does, end to end. `CloseIncident` is a slice. So is `GetIncident`, and so is the archival that happens three days later.
+
+Each slice renders across four lanes, top to bottom:
+
+| Lane | Holds | Example in IncidentService |
+|------|-------|----------------------------|
+| **Wireframe** | Triggers, external systems, hotspots | "Agent clicks Close" |
+| **Command** | The command, the handler, the aggregates | `CloseIncident` → `CloseIncidentEndpoint` → `Incident` |
+| **EventStream** | Emitted events and published messages | `IncidentClosed`, `ArchiveIncident` |
+| **ReadModel** | Projections and read models | `Incident` |
+
+```mermaid
+graph LR
+    subgraph Wireframe
+        T["Agent clicks Close"]
+        H["⚠ Close before acknowledgement?"]
+    end
+    subgraph Command
+        C["CloseIncident"] --> HD["CloseIncidentEndpoint"]
+        HD --> A["Incident"]
+    end
+    subgraph EventStream
+        E["IncidentClosed"]
+        M["ArchiveIncident"]
+    end
+    subgraph ReadModel
+        R["Incident"]
+    end
+
+    T --> C
+    HD --> E
+    HD --> M
+    E --> R
+```
+
+Every slice is also one of four **patterns** — `Command`, `View`, `Automation` or `Translation` — which the source derives from the shape of the code, not from anything you declare.
+
+## What you actually write
+
+The whole overlay for IncidentService is this:
+
+<!-- snippet: sample_incident_service_overlay -->
+<a id='snippet-sample_incident_service_overlay'></a>
+```cs
+public class IncidentServiceModel : EventModelDefinition
+{
+    // Every source that contributes to "Helpdesk" is folded into one model under this name
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.InDomain("Incidents");
+
+        builder.Slice("LogIncident")
+            .TriggeredBy("Customer submits the incident form")
+            .LinksToSpecification("Log Incident/Logs an incident from the web form");
+
+        builder.Slice("CategoriseIncident")
+            .TriggeredBy("Agent picks a category");
+
+        builder.Slice("CloseIncident")
+            .TriggeredBy("Agent clicks Close");
+
+        builder.Slice("ArchiveIncident")
+            .InDomain("Retention")
+            .TriggeredBy("Three days after close");
+
+        builder.Slice("GetIncident")
+            .TriggeredBy("Agent opens the incident detail screen");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceEventModel.cs#L5-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_overlay' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Five slice names, four trigger labels, one domain, one specification link. Nothing about `CloseIncident` the command, `CloseIncidentEndpoint` the handler, or `IncidentClosed` the event — Wolverine already knows all three, and repeating them here would only give them somewhere to drift to.
+
+## Where to go next
+
+- **[The Overlay](/event-modeling/overlay)** — the authoring API in full, plus registration and the escape hatch for flows you do not own.
+- **[Hotspots](/event-modeling/hotspots)** — recording what the model has *not* decided yet.
+- **[Descriptors](/event-modeling/descriptors)** — the wire shape, the rendering contract, and how sources are assembled into one model.

--- a/docs/event-modeling/overlay.md
+++ b/docs/event-modeling/overlay.md
@@ -1,0 +1,208 @@
+# The Overlay
+
+The overlay is the hand-written half of an Event Model. It **names, groups, annotates, links and flags** — and it declares no roles at all. Everything role-shaped (the command, the handler, the aggregates, the events, the projections, the read models, the trigger *kind*, the slice pattern) belongs to the sources that read your code.
+
+## `EventModelDefinition`
+
+Derive from `EventModelDefinition` and override `Configure`:
+
+<!-- snippet: sample_incident_service_overlay -->
+<a id='snippet-sample_incident_service_overlay'></a>
+```cs
+public class IncidentServiceModel : EventModelDefinition
+{
+    // Every source that contributes to "Helpdesk" is folded into one model under this name
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.InDomain("Incidents");
+
+        builder.Slice("LogIncident")
+            .TriggeredBy("Customer submits the incident form")
+            .LinksToSpecification("Log Incident/Logs an incident from the web form");
+
+        builder.Slice("CategoriseIncident")
+            .TriggeredBy("Agent picks a category");
+
+        builder.Slice("CloseIncident")
+            .TriggeredBy("Agent clicks Close");
+
+        builder.Slice("ArchiveIncident")
+            .InDomain("Retention")
+            .TriggeredBy("Three days after close");
+
+        builder.Slice("GetIncident")
+            .TriggeredBy("Agent opens the incident detail screen");
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceEventModel.cs#L5-L35' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_overlay' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+`Name` is the model this overlay contributes to. Several definitions can return the same name and they are all folded into one model — which is how IncidentService keeps its slice names in one class and its open questions in another. Leave `Name` alone and it defaults to the class name.
+
+## Slice names are the merge key
+
+`builder.Slice("CloseIncident")` does not *create* a slice. It opens an overlay for a slice, keyed by name, that is later merged onto whatever a derived source stamped under that same name. By convention the name is the command's short name, because that is what Wolverine names its own slice.
+
+Get the name wrong and nothing breaks loudly — you simply get two slices on the canvas, one derived and one bare. That is usually how you notice.
+
+## The builder methods
+
+### `InDomain(string)`
+
+Groups slices into a bounded context so a large model can collapse into sub-diagrams. On `EventModelBuilder` it is a running default that applies to every slice opened *after* the call; on a slice it overrides that default:
+
+```csharp
+builder.InDomain("Incidents");
+
+builder.Slice("LogIncident");                       // Incidents
+builder.Slice("CategoriseIncident");                // Incidents
+builder.Slice("ArchiveIncident").InDomain("Retention");  // Retention
+```
+
+### `TriggeredBy(string)`
+
+A human-readable label for what starts the slice — "Agent clicks Close", "Customer submits the incident form". This is the one thing about a trigger that code genuinely cannot express. The trigger's *kind* (`Http`, `Grpc`, `MessageHandler`, `JobScheduler`, `Human`, `External`) and its CLR type are derived; only the sentence is yours.
+
+### `LinksToSpecification(string)`
+
+Binds a specification to the slice by its `{Feature}/{Scenario}` identity.
+
+Use this **only** for a specification the binding source cannot see for itself — a manual test plan, a partner's acceptance suite, something outside the compilation. Specs the Bobcat generator or a code-first runner can see are bound by them, with their step types resolved, and re-typing them here would just be a second copy waiting to go stale.
+
+### `Hotspot(string)`
+
+Records an open question. See **[Hotspots](/event-modeling/hotspots)**.
+
+## Registration
+
+Every overlay is surfaced as an `IEventModelDefinitionSource` singleton:
+
+<!-- snippet: sample_registering_an_event_model -->
+<a id='snippet-sample_registering_an_event_model'></a>
+```cs
+// One definition at a time
+services.AddEventModel<IncidentServiceModel>();
+services.AddEventModel<IncidentServiceHotspots>();
+
+// ...or every EventModelDefinition in an assembly
+services.AddEventModelsFromAssembly(typeof(IncidentServiceModel).Assembly);
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L13-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_an_event_model' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: warning AOT
+`AddEventModelsFromAssembly` walks `Assembly.ExportedTypes` and is marked `[RequiresUnreferencedCode]`. Applications publishing native AOT should register each definition explicitly with `AddEventModel<T>()`.
+:::
+
+For something small, skip the class entirely:
+
+<!-- snippet: sample_registering_an_inline_event_model -->
+<a id='snippet-sample_registering_an_inline_event_model'></a>
+```cs
+services.AddEventModel("Helpdesk", model =>
+{
+    model.InDomain("Incidents");
+
+    model.Slice("CloseIncident")
+        .TriggeredBy("Agent clicks Close")
+        .Hotspot("Can an incident be closed before the customer acknowledges the resolution?");
+});
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L27-L38' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_registering_an_inline_event_model' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Definitions registered by type are resolved from the container at discovery time, or constructed through `ActivatorUtilities` if they are not registered — so a definition can take constructor dependencies (a feature-flag service, configuration) and still be discovered.
+
+## The escape hatch
+
+Sometimes a flow belongs on the model but its code is not yours: a partner system's command, a legacy service with no Wolverine chain to read. `ForFlowNotOwnedHere` is the explicitly-documented way to declare roles for exactly those flows.
+
+IncidentService pushing closures out to a CRM it does not own:
+
+<!-- snippet: sample_incident_service_external_flow -->
+<a id='snippet-sample_incident_service_external_flow'></a>
+```cs
+public class CrmNotification : EventModelDefinition
+{
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.Slice("NotifyCrmOfClosure")
+            .InDomain("Integrations")
+            .TriggeredBy("Incident closed")
+            .ForFlowNotOwnedHere(roles => roles
+                .Pattern(SlicePattern.Translation)
+                .TriggeredBy(TriggerKind.MessageHandler)
+                .UsesAggregate<Incident>()
+                .ExternalSystem("Salesforce", ExternalSystemDirection.Outbound, "rabbitmq://queue/crm-updates"));
+    }
+}
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/IncidentServiceEventModel.cs#L81-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_incident_service_external_flow' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+::: danger Don't reach for this
+For anything your host's own code implements, do not use `ForFlowNotOwnedHere`. A declaration here is a second, hand-maintained copy of what the code already says, and it will drift — that is the entire problem the derived-roles design exists to solve. The escape hatch is for code that is not in your compilation at all.
+:::
+
+## Why the split is enforced by merge order
+
+Sources are merged derived-first, and merging keeps the *first* non-null value for every scalar. So if Wolverine stamped `CommandType = CloseIncident` and your overlay somehow also set one, Wolverine's wins:
+
+<!-- snippet: sample_a_derived_slice -->
+<a id='snippet-sample_a_derived_slice'></a>
+```cs
+// This is what a source builds — Wolverine reading its own HTTP chain for
+// CloseIncidentEndpoint. You never hand-write this; it is here so you can see
+// exactly which slots the overlay is *not* allowed to fill.
+var derived = new EventModelSliceDescriptor(
+    "CloseIncident",
+    TriggerLabel: null,
+    TriggerType: null,
+    CommandType: TypeDescriptor.For(typeof(CloseIncident)),
+    HandlerType: TypeDescriptor.For(typeof(CloseIncidentEndpoint)),
+    EmittedEvents: [TypeDescriptor.For(typeof(IncidentClosed))],
+    ProjectionTypes: [],
+    ReadModelTypes: [TypeDescriptor.For(typeof(Incident))])
+{
+    Pattern = SlicePattern.Command,
+    TriggerKind = TriggerKind.Http,
+    TriggerOrigin = new PublisherOrigin
+    {
+        HttpMethod = "POST",
+        HttpRoute = "/api/incidents/close/{id}",
+        Label = "POST /api/incidents/close/{id}"
+    },
+    AggregateTypes = [TypeDescriptor.For(typeof(Incident))],
+    PublishedMessages = [TypeDescriptor.For(typeof(ArchiveIncident))]
+};
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L72-L99' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_a_derived_slice' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+<!-- snippet: sample_merging_the_overlay_onto_a_derived_slice -->
+<a id='snippet-sample_merging_the_overlay_onto_a_derived_slice'></a>
+```cs
+var builder = new EventModelBuilder();
+builder.Slice("CloseIncident")
+    .InDomain("Incidents")
+    .TriggeredBy("Agent clicks Close")
+    .Hotspot("Can an incident be closed before the customer acknowledges the resolution?");
+
+var overlay = builder.BuildSlices().Single();
+
+// Derived first: scalars keep the first non-null value, so a derived role always wins
+var merged = derived.Merge(overlay);
+
+Console.WriteLine(merged.CommandType!.Name);   // CloseIncident — from the chain
+Console.WriteLine(merged.TriggerLabel);        // Agent clicks Close — from the overlay
+Console.WriteLine(merged.Hotspots.Count);      // 1 — from the overlay
+```
+<sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L101-L118' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_merging_the_overlay_onto_a_derived_slice' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Lists are unioned rather than replaced, deduplicated by identity, order preserved — so an overlay hotspot lands next to a derived one instead of displacing it.

--- a/jasperfx.slnx
+++ b/jasperfx.slnx
@@ -17,6 +17,7 @@
   <Folder Name="/src/">
     <Project Path="src/CodegenTests.FSharp/CodegenTests.FSharp.csproj" />
     <Project Path="src/CodegenTests.FSharpFixture/CodegenTests.FSharpFixture.fsproj" />
+    <Project Path="src/DocSamples/DocSamples.csproj" />
     <Project Path="src/FSharpCodegenTarget/FSharpCodegenTarget.csproj" />
     <Project Path="src/FSharpTypes/FSharpTypes.fsproj" />
     <Project Path="src/JasperFx.Aspire.Tests/JasperFx.Aspire.Tests.csproj" />

--- a/src/DocSamples/DocSamples.csproj
+++ b/src/DocSamples/DocSamples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -9,11 +9,16 @@
       No test packages here on purpose. This project holds compile-checked documentation samples
       (mdsnippets sources), contains zero [Fact]/[Theory] methods, and is not in jasperfx.slnx or
       any Nuke target. It carried xunit + the VSTest runner + Microsoft.NET.Test.Sdk purely as
-      inherited boilerplate; xunit.v3 would additionally have forced OutputType=Exe on a
-      Microsoft.NET.Sdk.Web project for no benefit.
+      inherited boilerplate.
+
+      Microsoft.NET.Sdk, not Microsoft.NET.Sdk.Web: the Web SDK defaults OutputType to Exe and
+      these samples are a library with no Program.Main, so the project did not actually compile —
+      which quietly cost us the compile-checking that is its whole reason to exist. No sample here
+      uses an ASP.NET type, so the plain SDK is all it ever needed.
     -->
     <ItemGroup>
         <ProjectReference Include="..\JasperFx\JasperFx.csproj" />
+        <ProjectReference Include="..\JasperFx.Events\JasperFx.Events.csproj" />
         <ProjectReference Include="..\JasperFx.RuntimeCompiler\JasperFx.RuntimeCompiler.csproj" />
     </ItemGroup>
 

--- a/src/DocSamples/DocSamples.csproj
+++ b/src/DocSamples/DocSamples.csproj
@@ -6,15 +6,19 @@
     </PropertyGroup>
 
     <!--
-      No test packages here on purpose. This project holds compile-checked documentation samples
-      (mdsnippets sources), contains zero [Fact]/[Theory] methods, and is not in jasperfx.slnx or
-      any Nuke target. It carried xunit + the VSTest runner + Microsoft.NET.Test.Sdk purely as
-      inherited boilerplate.
+      Every snippet in docs/ comes from this project, so the docs are only as trustworthy as this
+      project's last successful build. It is in jasperfx.slnx on purpose: the Nuke Compile target
+      builds the whole solution, which is what keeps a sample from going stale against an API
+      change without anyone noticing. Don't remove it from the solution without replacing that
+      check with another one.
 
       Microsoft.NET.Sdk, not Microsoft.NET.Sdk.Web: the Web SDK defaults OutputType to Exe and
-      these samples are a library with no Program.Main, so the project did not actually compile —
-      which quietly cost us the compile-checking that is its whole reason to exist. No sample here
-      uses an ASP.NET type, so the plain SDK is all it ever needed.
+      these samples are a library with no Program.Main, so for a while the project did not compile
+      at all — which quietly cost us exactly the checking described above. No sample here uses an
+      ASP.NET type, so the plain SDK is all it ever needed.
+
+      No test packages here on purpose: zero [Fact]/[Theory] methods. It carried xunit + the VSTest
+      runner + Microsoft.NET.Test.Sdk purely as inherited boilerplate.
     -->
     <ItemGroup>
         <ProjectReference Include="..\JasperFx\JasperFx.csproj" />

--- a/src/DocSamples/EventModeling/EventModelUsageSamples.cs
+++ b/src/DocSamples/EventModeling/EventModelUsageSamples.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DocSamples.EventModeling;
+
+public class EventModelUsageSamples
+{
+    public void register_the_overlay(IServiceCollection services)
+    {
+        #region sample_registering_an_event_model
+
+        // One definition at a time
+        services.AddEventModel<IncidentServiceModel>();
+        services.AddEventModel<IncidentServiceHotspots>();
+
+        // ...or every EventModelDefinition in an assembly
+        services.AddEventModelsFromAssembly(typeof(IncidentServiceModel).Assembly);
+
+        #endregion
+    }
+
+    public void register_an_inline_overlay(IServiceCollection services)
+    {
+        #region sample_registering_an_inline_event_model
+
+        services.AddEventModel("Helpdesk", model =>
+        {
+            model.InDomain("Incidents");
+
+            model.Slice("CloseIncident")
+                .TriggeredBy("Agent clicks Close")
+                .Hotspot("Can an incident be closed before the customer acknowledges the resolution?");
+        });
+
+        #endregion
+    }
+
+    public async Task assemble_the_model(IServiceProvider services)
+    {
+        #region sample_assembling_the_event_model
+
+        // Ask every registered source — Wolverine's chains, the Bobcat generator, your
+        // overlays — for its view, then fold them into one descriptor per model name
+        var models = await EventModelDiscovery.AssembleAsync(services);
+
+        var helpdesk = models.Single(x => x.Name == "Helpdesk");
+
+        foreach (var slice in helpdesk.Slices)
+        {
+            Console.WriteLine($"{slice.Domain}/{slice.Name}: {slice.Pattern}");
+
+            foreach (var hotspot in slice.Hotspots)
+            {
+                Console.WriteLine($"  ⚠ {hotspot.Origin}: {hotspot.Text}");
+            }
+        }
+
+        // Questions that belong to the model rather than to one slice
+        foreach (var hotspot in helpdesk.Hotspots)
+        {
+            Console.WriteLine($"⚠ {hotspot.Text}");
+        }
+
+        #endregion
+    }
+
+    public void what_a_derived_source_stamps()
+    {
+        #region sample_a_derived_slice
+
+        // This is what a source builds — Wolverine reading its own HTTP chain for
+        // CloseIncidentEndpoint. You never hand-write this; it is here so you can see
+        // exactly which slots the overlay is *not* allowed to fill.
+        var derived = new EventModelSliceDescriptor(
+            "CloseIncident",
+            TriggerLabel: null,
+            TriggerType: null,
+            CommandType: TypeDescriptor.For(typeof(CloseIncident)),
+            HandlerType: TypeDescriptor.For(typeof(CloseIncidentEndpoint)),
+            EmittedEvents: [TypeDescriptor.For(typeof(IncidentClosed))],
+            ProjectionTypes: [],
+            ReadModelTypes: [TypeDescriptor.For(typeof(Incident))])
+        {
+            Pattern = SlicePattern.Command,
+            TriggerKind = TriggerKind.Http,
+            TriggerOrigin = new PublisherOrigin
+            {
+                HttpMethod = "POST",
+                HttpRoute = "/api/incidents/close/{id}",
+                Label = "POST /api/incidents/close/{id}"
+            },
+            AggregateTypes = [TypeDescriptor.For(typeof(Incident))],
+            PublishedMessages = [TypeDescriptor.For(typeof(ArchiveIncident))]
+        };
+
+        #endregion
+
+        #region sample_merging_the_overlay_onto_a_derived_slice
+
+        var builder = new EventModelBuilder();
+        builder.Slice("CloseIncident")
+            .InDomain("Incidents")
+            .TriggeredBy("Agent clicks Close")
+            .Hotspot("Can an incident be closed before the customer acknowledges the resolution?");
+
+        var overlay = builder.BuildSlices().Single();
+
+        // Derived first: scalars keep the first non-null value, so a derived role always wins
+        var merged = derived.Merge(overlay);
+
+        Console.WriteLine(merged.CommandType!.Name);   // CloseIncident — from the chain
+        Console.WriteLine(merged.TriggerLabel);        // Agent clicks Close — from the overlay
+        Console.WriteLine(merged.Hotspots.Count);      // 1 — from the overlay
+
+        #endregion
+    }
+
+    public void read_the_rendering_contract(EventModelSliceDescriptor slice)
+    {
+        #region sample_reading_the_rendering_contract
+
+        // Elements and Edges are computed from the typed roles on every read, so a viewer
+        // draws straight from the descriptor with no second transform
+        foreach (var element in slice.Elements)
+        {
+            Console.WriteLine($"{element.Lane,-12} {element.Kind,-15} {element.Label} " +
+                              $"({EventModelPalette.ColorFor(element.Kind)})");
+        }
+
+        foreach (var edge in slice.Edges)
+        {
+            Console.WriteLine($"{edge.FromId} -> {edge.ToId}");
+        }
+
+        #endregion
+    }
+
+    public void serialize_for_a_viewer(EventModelDescriptor model)
+    {
+        #region sample_serializing_an_event_model
+
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+        };
+
+        var json = JsonSerializer.Serialize(model, options);
+
+        #endregion
+
+        Console.WriteLine(json);
+    }
+}

--- a/src/DocSamples/EventModeling/IncidentServiceDomain.cs
+++ b/src/DocSamples/EventModeling/IncidentServiceDomain.cs
@@ -1,0 +1,93 @@
+using JasperFx.Events;
+
+namespace DocSamples.EventModeling;
+
+// The IncidentService sample domain from Wolverine:
+// https://github.com/JasperFx/wolverine/tree/main/src/Samples/IncidentService/IncidentService
+//
+// Trimmed to what the Event Modeling docs need, and with the Wolverine / Marten attributes
+// left off so this project keeps compiling without those references. The shapes — the events,
+// the aggregate, the commands, the endpoint types — are the sample's own.
+
+#region sample_incident_service_events
+
+public record IncidentLogged(Guid CustomerId, Contact Contact, string Description, Guid LoggedBy);
+
+public record IncidentCategorised(Guid IncidentId, IncidentCategory Category, Guid CategorisedBy);
+
+public record IncidentClosed(Guid ClosedBy);
+
+#endregion
+
+#region sample_incident_service_aggregate
+
+public class Incident
+{
+    public Guid Id { get; set; }
+    public int Version { get; set; }
+    public IncidentStatus Status { get; set; } = IncidentStatus.Pending;
+    public IncidentCategory? Category { get; set; }
+    public bool HasOutstandingResponseToCustomer { get; set; }
+
+    public void Apply(IncidentLogged _) { }
+    public void Apply(IncidentCategorised e) => Category = e.Category;
+    public void Apply(IncidentClosed _) => Status = IncidentStatus.Closed;
+
+    public bool ShouldDelete(Archived @event) => true;
+}
+
+#endregion
+
+#region sample_incident_service_commands
+
+public record LogIncident(Guid CustomerId, Contact Contact, string Description, Guid LoggedBy);
+
+public record CategoriseIncident(IncidentCategory Category, Guid CategorisedBy, int Version);
+
+public record CloseIncident(Guid ClosedBy, int Version);
+
+public record ArchiveIncident(Guid IncidentId);
+
+#endregion
+
+// The Wolverine HTTP endpoints and message handler. Stand-ins here: in the real sample these
+// carry [WolverinePost] / [Aggregate] and it is those attributes a derived source reads.
+public static class LogIncidentEndpoint;
+
+public static class CategoriseIncidentEndpoint;
+
+public static class CloseIncidentEndpoint;
+
+public static class GetIncidentEndpoint;
+
+public static class ArchiveIncidentHandler;
+
+public record IncidentDetails(Guid Id, IncidentStatus Status, IncidentCategory? Category);
+
+public record CustomerIncidentsSummary(Guid CustomerId, int Pending, int Closed);
+
+public record Contact(ContactChannel ContactChannel, string? EmailAddress = null);
+
+public enum ContactChannel
+{
+    Email,
+    Phone,
+    InPerson,
+    GeneratedBySystem
+}
+
+public enum IncidentStatus
+{
+    Pending = 1,
+    Resolved = 8,
+    ResolutionAcknowledgedByCustomer = 16,
+    Closed = 32
+}
+
+public enum IncidentCategory
+{
+    Software,
+    Hardware,
+    Network,
+    Database
+}

--- a/src/DocSamples/EventModeling/IncidentServiceEventModel.cs
+++ b/src/DocSamples/EventModeling/IncidentServiceEventModel.cs
@@ -1,0 +1,100 @@
+using JasperFx.Events.EventModeling;
+
+namespace DocSamples.EventModeling;
+
+#region sample_incident_service_overlay
+
+public class IncidentServiceModel : EventModelDefinition
+{
+    // Every source that contributes to "Helpdesk" is folded into one model under this name
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.InDomain("Incidents");
+
+        builder.Slice("LogIncident")
+            .TriggeredBy("Customer submits the incident form")
+            .LinksToSpecification("Log Incident/Logs an incident from the web form");
+
+        builder.Slice("CategoriseIncident")
+            .TriggeredBy("Agent picks a category");
+
+        builder.Slice("CloseIncident")
+            .TriggeredBy("Agent clicks Close");
+
+        builder.Slice("ArchiveIncident")
+            .InDomain("Retention")
+            .TriggeredBy("Three days after close");
+
+        builder.Slice("GetIncident")
+            .TriggeredBy("Agent opens the incident detail screen");
+    }
+}
+
+#endregion
+
+#region sample_incident_service_hotspots
+
+public class IncidentServiceHotspots : EventModelDefinition
+{
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        // Not about any one slice — nobody has decided this yet
+        builder.Hotspot("Do we own the SLA clock, or does the CRM?");
+
+        builder.Slice("CloseIncident")
+            // Both of these rules are sitting commented out in CloseIncidentEndpoint.
+            // Written down here, they show up on the canvas instead of in a code comment
+            // nobody outside the team will ever read.
+            .Hotspot("Can an incident be closed before the customer acknowledges the resolution?")
+            .Hotspot("What happens to an outstanding response to the customer when we close?");
+
+        builder.Slice("ArchiveIncident")
+            .Hotspot("Three days is a guess. Ask legal what retention actually requires.");
+    }
+}
+
+#endregion
+
+#region sample_incident_service_pending_spec_hotspot
+
+public class ResolutionSlices : EventModelDefinition
+{
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.Slice("ResolveIncident")
+            // The question is sharp enough to name a scenario, so name it. The spec is
+            // pending, and a pending spec is a hotspot — one that retires itself the day
+            // the spec passes, which a prose note never does.
+            .TriggeredBy("Agent clicks Resolve")
+            .LinksToSpecification("Resolve Incident/An agent resolves a pending incident");
+    }
+}
+
+#endregion
+
+#region sample_incident_service_external_flow
+
+public class CrmNotification : EventModelDefinition
+{
+    public override string Name => "Helpdesk";
+
+    public override void Configure(EventModelBuilder builder)
+    {
+        builder.Slice("NotifyCrmOfClosure")
+            .InDomain("Integrations")
+            .TriggeredBy("Incident closed")
+            .ForFlowNotOwnedHere(roles => roles
+                .Pattern(SlicePattern.Translation)
+                .TriggeredBy(TriggerKind.MessageHandler)
+                .UsesAggregate<Incident>()
+                .ExternalSystem("Salesforce", ExternalSystemDirection.Outbound, "rabbitmq://queue/crm-updates"));
+    }
+}
+
+#endregion


### PR DESCRIPTION
Stacked on #695 — review that one first. Now targets `main`, so the diff below still carries #695's commit; it collapses to just the docs once #695 merges.

The Event Modeling semantic model shipped across #687, #689 and #690 with nothing but XML docs behind it. This adds a docs section, modelling Wolverine's [IncidentService sample](https://github.com/JasperFx/wolverine/tree/main/src/Samples/IncidentService/IncidentService) end to end.

## Pages

| Page | Covers |
|------|--------|
| [Overview](docs/event-modeling/index.md) | What the model is, the derived-vs-declared rule, slices and the four lanes, the IncidentService domain |
| [The Overlay](docs/event-modeling/overlay.md) | `EventModelDefinition`, every builder method, registration, the `ForFlowNotOwnedHere` escape hatch, and why merge order enforces the split |
| [Hotspots](docs/event-modeling/hotspots.md) | Pending specs as the primary mechanism, prose as the escape valve, slice vs model level, and how to promote one to the other |
| [Descriptors & the Wire](docs/event-modeling/descriptors.md) | Slot-by-slot table of who fills what, the computed rendering contract, the palette, discovery and merge semantics, serialization |

The through-line is the one rule the design turns on: **roles are derived, prose is declared**. Each page comes back to it — the overlay page shows it enforced by merge order, the descriptors page has a column marking every slot derived or overlay.

## Why IncidentService earns its keep here

The hotspot page uses the sample's own code as the worked example. `CloseIncidentEndpoint` has two real business rules sitting in a commented-out block:

```csharp
/* More logic for later
if (current.Status is not IncidentStatus.ResolutionAcknowledgedByCustomer) ...
if (current.HasOutstandingResponseToCustomer) ...
*/
```

That is a hotspot in its natural habitat — a genuinely undecided rule, parked where only someone already reading that file will see it. The page shows the same two questions declared in the overlay, where they land on the canvas in front of the people who could actually answer them.

## DocSamples didn't compile

Every snippet is compile-checked out of `DocSamples`, which meant discovering that the project has not built at all: it is `Microsoft.NET.Sdk.Web`, that SDK defaults `OutputType` to `Exe`, and there is no `Program.Main` here — so it failed with CS5001 and quietly lost the compile-checking that is its stated reason to exist.

No sample in it uses an ASP.NET type, so it drops back to `Microsoft.NET.Sdk` and builds again. `JasperFx.Events` added as a reference for the new samples.

Fixing the SDK alone would only hold until the next API change broke a sample silently, so `DocSamples` also joins `jasperfx.slnx`. The Nuke `Compile` target builds the whole solution, so every snippet in `docs/` is now compiled on every CI run and a sample that drifts from the API fails the build.

## Verification

`npm run docs-build` is clean, including VitePress dead-link checking. All 17 snippets expand. `dotnet build jasperfx.slnx -c Release` → 0 errors, with `DocSamples.dll` in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

