### PR TITLE
gh-697: never adopt a runtime-compiled assembly as the application

### DIFF
--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Loader;
 using ExtensionStandIn;
 using JasperFx;
 using JasperFx.CodeGeneration;
@@ -435,6 +438,91 @@ public class JasperFxOptionsTests
     public void does_not_mistake_applications_or_suites_for_framework_assemblies(string assemblyName)
     {
         JasperFxOptions.IsCritterStackAssembly(assemblyName).ShouldBeFalse();
+    }
+
+    // GH-697 (ported from JasperFx/wolverine#4024): the walk used to know about System*/Microsoft*/test
+    // runners/Critter Stack and nothing else, so it would adopt a RUNTIME-COMPILED assembly -- the ones
+    // JasperFx.RuntimeCompiler emits with a Path.GetRandomFileName() name and loads from a stream. In
+    // Wolverine's instrumented run, 41 of 44 false-positive divergence warnings were exactly this.
+
+    [Fact]
+    public void a_dynamic_assembly_can_never_be_the_application()
+    {
+        var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("gh697.dynamic"), AssemblyBuilderAccess.Run);
+
+        dynamicAssembly.IsDynamic.ShouldBeTrue();
+        JasperFxOptions.CannotBeApplicationAssembly(dynamicAssembly).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void a_runtime_compiled_assembly_can_never_be_the_application()
+    {
+        // A real stream-loaded assembly, which is how AssemblyGenerator loads what Roslyn produces.
+        // Loading from a stream is precisely what leaves Location empty.
+        var context = new AssemblyLoadContext("gh697", isCollectible: true);
+        try
+        {
+            using var stream = File.OpenRead(typeof(Widgets1.Decision).Assembly.Location);
+            var loaded = context.LoadFromStream(stream);
+
+            loaded.IsDynamic.ShouldBeFalse();
+            loaded.Location.ShouldBeEmpty();
+            JasperFxOptions.CannotBeApplicationAssembly(loaded).ShouldBeTrue();
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    [Fact]
+    public void an_ordinary_assembly_on_disk_is_still_a_candidate()
+    {
+        JasperFxOptions.CannotBeApplicationAssembly(GetType().Assembly).ShouldBeFalse();
+        JasperFxOptions.CannotBeApplicationAssembly(typeof(Widgets1.Decision).Assembly).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_single_file_publish_makes_the_empty_location_signal_meaningless()
+    {
+        // Published as a single file, EVERY bundled assembly reports an empty Location -- including the
+        // real application assembly. Disqualifying on Location there would reject the very thing the walk
+        // is looking for, so the signal has to be switched off. Passed explicitly because a test process
+        // is never single-file.
+        var context = new AssemblyLoadContext("gh697-singlefile", isCollectible: true);
+        try
+        {
+            using var stream = File.OpenRead(typeof(Widgets1.Decision).Assembly.Location);
+            var bundled = context.LoadFromStream(stream);
+
+            JasperFxOptions.CannotBeApplicationAssembly(bundled, locationDistinguishesAssemblies: true).ShouldBeTrue();
+            JasperFxOptions.CannotBeApplicationAssembly(bundled, locationDistinguishesAssemblies: false).ShouldBeFalse();
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    [Fact]
+    public void a_dynamic_assembly_is_disqualified_even_in_a_single_file_publish()
+    {
+        // IsDynamic is not a Location heuristic, so bundling changes nothing about it.
+        var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("gh697.dynamic.bundled"), AssemblyBuilderAccess.Run);
+
+        JasperFxOptions.CannotBeApplicationAssembly(dynamicAssembly, locationDistinguishesAssemblies: false)
+            .ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_walk_never_returns_a_disqualified_assembly()
+    {
+        var assembly = RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
+
+        assembly.ShouldNotBeNull();
+        JasperFxOptions.CannotBeApplicationAssembly(assembly).ShouldBeFalse();
     }
 
     [Fact]

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -228,6 +228,11 @@ public class JasperFxOptions : SystemPartBase
                 continue;
             }
 
+            if (CannotBeApplicationAssembly(assembly))
+            {
+                continue;
+            }
+
             if (assembly.HasAttribute<IgnoreAssemblyAttribute>())
             {
                 continue;
@@ -251,6 +256,46 @@ public class JasperFxOptions : SystemPartBase
 
         return Assembly.GetEntryAssembly();
     }
+
+    // GH-697 (ported from JasperFx/wolverine#4024, which closed JasperFx/wolverine#3778): some assemblies
+    // can never BE the application, and until now the walk would happily adopt one. The runtime-compiled
+    // assemblies are the common case: AssemblyGenerator names them with Path.GetRandomFileName() and loads
+    // them from a stream, so they carry a random 8.3-style name ("ofqrxydn.tlz") and no Location -- and a
+    // walk that runs during code generation finds one sitting immediately outside the JasperFx frames. The
+    // filter above knew about System*/Microsoft*/test runners/Critter Stack and nothing else, so the first
+    // frame "outside the framework" was frequently code the framework had generated moments earlier.
+    //
+    // Wolverine instrumented a fully green 2495-test suite: the divergence warning fired 44 times, 41 of
+    // them blamed on these generated assemblies, and every one of the 44 was a false positive. Adopting one
+    // is worse than a noisy warning, because the same walk picks the assembly used for type discovery --
+    // so discovery scans a generated assembly holding none of the application's types and fails silently,
+    // with the only symptom appearing somewhere downstream.
+    //
+    // JasperFx's own assembly needs no special case here, unlike Wolverine's: IsCritterStackAssembly
+    // already excludes "JasperFx" by name, so there is no reason to mark the assembly [IgnoreAssembly] --
+    // and doing so would change what every OTHER consumer of that attribute (type scanning above all) sees.
+    internal static bool CannotBeApplicationAssembly(Assembly assembly)
+        => CannotBeApplicationAssembly(assembly, LocationDistinguishesAssemblies);
+
+    // Split for testability: the single-file case cannot be reproduced in a test process.
+    internal static bool CannotBeApplicationAssembly(Assembly assembly, bool locationDistinguishesAssemblies)
+    {
+        if (assembly.IsDynamic)
+        {
+            return true;
+        }
+
+        return locationDistinguishesAssemblies && string.IsNullOrEmpty(assembly.Location);
+    }
+
+    // An empty Location means "compiled at runtime" ONLY in a normally-deployed process. Publish as a
+    // single file and every bundled assembly reports an empty Location -- including the real application
+    // assembly -- so the signal carries no information and using it would reject the very thing we are
+    // looking for. The entry assembly is the cheap tell: if even IT has no Location, we are bundled.
+    // The walk then matches nothing and falls through to Assembly.GetEntryAssembly(), which is the right
+    // answer for a single-file app anyway.
+    internal static readonly bool LocationDistinguishesAssemblies =
+        !string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location);
 
     // GH-600: under an async test fixture the frames between JasperFx and the test class belong to the
     // test *runner*, not the test assembly, so the walk above would otherwise adopt something like


### PR DESCRIPTION
Closes #697. Ports the one fix from JasperFx/wolverine#4024 that JasperFx actually needed.

The issue asked me to check three things rather than assume them. Only the second turned out to be a real defect here; the other two are already correct, and I've said why below rather than leaving that implicit — this issue is the stated blocker for consolidating Wolverine onto the shared `JasperFxOptions.ApplicationAssemblyReuseWarning`, so what's *not* broken matters as much as what is.

## The defect: the walk could adopt generated code

`DetermineCallingAssembly` skipped `System*` / `Microsoft*` / test runners / Critter Stack assemblies, and nothing else. But `AssemblyGenerator` names its output with `Path.GetRandomFileName()` and loads it from a stream ([AssemblyGenerator.cs:177](src/JasperFx.RuntimeCompiler/AssemblyGenerator.cs#L177), [:203](src/JasperFx.RuntimeCompiler/AssemblyGenerator.cs#L203)) — so runtime-compiled assemblies carry a random 8.3-style name and an empty `Location`, and a walk running during code generation finds one sitting immediately outside the JasperFx frames.

Wolverine's instrumented run of a fully green 2495-test suite: 44 divergence warnings, 41 blamed on generated assemblies, **all 44 false positives**.

The warning is the mild symptom. The same walk picks the assembly used for type discovery, so adopting a generated assembly means scanning one that holds none of the application's types — a silent discovery failure whose only symptom shows up somewhere downstream.

The fix skips `IsDynamic` and empty-`Location` assemblies.

## One wrinkle the port needed: single-file publish

Published as a single file, **every** bundled assembly reports an empty `Location` — including the real application assembly. Using the signal there would reject exactly what the walk is looking for.

So the `Location` half is gated on whether the entry assembly itself has a `Location`. If it doesn't, the process is bundled, the signal carries no information, and it's switched off; the walk then matches nothing and falls through to `Assembly.GetEntryAssembly()`, which is the right answer for a single-file app anyway. `IsDynamic` is not a `Location` heuristic and stays on regardless.

## The two that don't apply

- **Entry-point capture** — `AddJasperFx` already resolves the registration assembly eagerly at [JasperFxServiceCollectionExtensions.cs:61](src/JasperFx/JasperFxServiceCollectionExtensions.cs#L61), before deferring into `optionsBuilder.Configure`, and the deferred lambda only assigns the resolved local. Every JasperFx-internal caller (`CritterStackDefaults`, the `EnvironmentCheckExtensions` family) reaches it synchronously on `IServiceCollection`, so there is no `IHostBuilder`-style deferral to lose the frame.
- **Checking the remembered-pin branch** — `establishApplicationAssembly` already calls `checkForDivergentApplicationAssembly` from the branch that adopts `RememberedApplicationAssembly` ([JasperFxOptions.cs:171](src/JasperFx/JasperFxOptions.cs#L171)). Still true, as the issue expected.

## And no `[IgnoreAssembly]` on JasperFx

The issue floated marking `JasperFx.dll` the way core Wolverine uses `[WolverineIgnore]`. Not needed and not desirable: `IsCritterStackAssembly` already excludes `"JasperFx"` by name, and adding the attribute would change what every *other* consumer of it sees — type scanning above all.

## Tests

Six new tests in `JasperFxOptionsTests`, using real assemblies rather than mocks: a genuine `AssemblyBuilder` dynamic assembly, and a genuine stream-loaded assembly (the same mechanism `AssemblyGenerator` uses, which is what leaves `Location` empty). Both single-file states are covered by passing the flag explicitly, since a test process is never single-file.

CoreTests 584/585 (1 pre-existing skip), CodegenTests 419/419, CommandLineTests 295/295 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)