### PR TITLE
Bump the GitHub Actions pins off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/docs-prs.yml
+++ b/.github/workflows/docs-prs.yml
@@ -19,7 +19,7 @@ jobs:
     name: "linting, spell check and build"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         name: Check out the code
 
       - name: Lint Code Base
@@ -27,7 +27,7 @@ jobs:
         with:
           args: "--disable MD009 -- docs/**/*.md"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         name: Install Node.js
         with:
           node-version: ${{ env.node_version }}
@@ -39,12 +39,12 @@ jobs:
         name: run cSpell
 
       - name: Install .NET 9.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
 
       - name: Install .NET 10.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,12 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install .NET 10.0.x
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 
@@ -33,7 +33,7 @@ jobs:
         run: dotnet tool install -g MarkdownSnippets.Tool
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.node_version }}
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         run: npm run docs-build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,15 +38,15 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install .NET 9.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
 
       - name: Install .NET 10.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/on-manual-do-nuget-publish.yml
+++ b/.github/workflows/on-manual-do-nuget-publish.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install .NET 9.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 9.0.x
 
       - name: Install .NET 10.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 


### PR DESCRIPTION
The 2.55.0 docs deploy surfaced this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`, `cloudflare/wrangler-action@v3`

`actions/setup-dotnet@v4` is the same story — it escaped that particular warning only because `docs.yml` was already on v5, so no v4 step ran in that job. `dotnet.yml` and `on-manual-do-nuget-publish.yml` still pin v4 and would warn on their next run.

## The bumps

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/setup-dotnet` | v4 / v5 | **v6** |
| `cloudflare/wrangler-action` | v3 | **v4** |

Every one of these declares `using: node24` natively rather than being force-migrated. The markdownlint step in `docs-prs.yml` is a Docker action and needs nothing.

## Breaking changes, checked rather than assumed

These skip several majors, so I read the release notes instead of trusting semver:

- **`setup-node` v6** limited automatic caching to npm. `docs.yml` asks for `cache: npm` explicitly and `docs-prs.yml` asks for no cache at all, so neither is affected.
- **`wrangler-action` v4** still accepts all four inputs `docs.yml` passes: `apiToken`, `accountId`, `packageManager`, `command`.
- **`checkout`** and **`setup-dotnet`** had no breaking changes across this range.

## What this PR's CI does and does not prove

Only `dotnet.yml` runs on this PR, so a green build validates `checkout@v7` and `setup-dotnet@v6` — and nothing else.

`setup-node@v7` and `wrangler-action@v4` appear only in `docs.yml` (`workflow_dispatch` only) and `docs-prs.yml`, so **neither bump is exercised here**. The checks above are static. `docs.yml` should be dispatched once after merge; that run is the only thing that actually exercises both.

### Separately: `docs-prs.yml` is dead

I assumed `docs-prs.yml` would cover `setup-node@v7` on this PR. It does not — it triggers on `master`, and this repo's default branch is `main`:

```yaml
on:
  push:
    branches:
      - master
  pull_request:
    branches:
      - master
```

So the markdownlint, cSpell and docs-build gate has not run on any PR for as long as the branch has been `main` — including the docs PR (#696) that added a whole new documentation section. Out of scope for a pin bump, but it should be fixed; happy to do it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
