### PR TITLE
Don't pause a tenant agent forever over a high-water seed below its own position

### DIFF
--- a/src/EventTests/Daemon/HighWater/PolledTenantSetTests.cs
+++ b/src/EventTests/Daemon/HighWater/PolledTenantSetTests.cs
@@ -1,0 +1,69 @@
+using JasperFx.Events.Daemon.HighWater;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// The polled set is reconciled wholesale from the agents registered on a node, so anything that is
+// merely *starting* has to be held in it explicitly. These pin the two halves of that.
+public class PolledTenantSetTests
+{
+    [Fact]
+    public void set_tenants_keeps_a_pinned_tenant()
+    {
+        var set = new PolledTenantSet();
+
+        // t1's agent start is in flight, so it is not in the assignment snapshot below yet
+        set.Pin("t1");
+        set.SetTenants(["t2"]);
+
+        set.IsPolled("t1").ShouldBeTrue();
+        set.IsPolled("t2").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void pins_are_reference_counted_per_tenant()
+    {
+        var set = new PolledTenantSet();
+
+        // Two shards of the same tenant starting at once
+        set.Pin("t1");
+        set.Pin("t1");
+
+        set.Unpin("t1");
+        set.SetTenants([]);
+
+        // The second start is still running, so the tenant must still be polled for it
+        set.IsPolled("t1").ShouldBeTrue();
+
+        set.Unpin("t1");
+        set.SetTenants([]);
+
+        set.IsPolled("t1").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void unpinning_does_not_itself_remove_the_tenant()
+    {
+        var set = new PolledTenantSet();
+
+        set.Pin("t1");
+        set.Unpin("t1");
+
+        // Whether it belongs in the set is the next reconciliation's call, not the pin's — a start that
+        // succeeded has an agent by now, and dropping it here would stop polling a live tenant.
+        set.IsPolled("t1").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void unpinning_a_tenant_that_was_never_pinned_is_a_no_op()
+    {
+        var set = new PolledTenantSet();
+
+        set.Unpin("t1");
+
+        set.Activate("t2");
+        set.SetTenants(["t2"]);
+
+        set.Snapshot().ShouldBe(["t2"]);
+    }
+}

--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -135,6 +135,34 @@ public class PerTenantStartAgentAsyncTests
         agent.LastCommitted.ShouldBe(2010205);
     }
 
+    [Fact]
+    public async Task a_tenant_stops_being_polled_once_its_last_agent_stops()
+    {
+        // The release half of the in-flight start pin: a tenant held in the polled set for the duration
+        // of its start has to be let go again, or the coordinator keeps polling — and persisting
+        // high-water rows for — a tenant this node runs nothing for.
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 42);
+        detector.SetTenantMark("t2", 42);
+
+        await using var harness = new DaemonHarness(detector,
+            settings => settings.SlowPollingTime = 50.Milliseconds(),
+            shardFor(new ShardName("Trip")));
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+        await harness.Daemon.StartAgentAsync("Trip:All:t2", CancellationToken.None);
+
+        await harness.Daemon.StopAgentAsync("Trip:All:t1");
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (detector.LastPoll.Contains("t1") && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(25, TestContext.Current.CancellationToken);
+        }
+
+        detector.LastPoll.ShouldBe(["t2"]);
+    }
+
     // The Start command is applied on the agent's own command loop, so both the seeding and any failure
     // land just after StartAgentAsync returns. Wait for whichever arrives first rather than sleeping.
     private static async Task<SubscriptionAgent> startedAgentAsync(DaemonHarness harness)
@@ -603,6 +631,18 @@ public class PerTenantStartAgentAsyncTests
             lock (_tenantPolls)
             {
                 return _tenantPolls.SelectMany(x => x).Distinct().ToList();
+            }
+        }
+
+        // The tenant ids the most recent vectorized poll was asked about
+        public string[] LastPoll
+        {
+            get
+            {
+                lock (_tenantPolls)
+                {
+                    return _tenantPolls.Count == 0 ? [] : _tenantPolls[^1];
+                }
             }
         }
 

--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -79,6 +79,78 @@ public class PerTenantStartAgentAsyncTests
     }
 
     [Fact]
+    public async Task tenant_agent_with_no_polled_ceiling_seeds_from_its_own_committed_position()
+    {
+        // Field failure, 2026-08-26, on a 2,100-tenant sharded Marten deployment under Wolverine-managed
+        // distribution: during a rollout's agent-start storm the vectorized poll had not produced a
+        // reading for this tenant yet, so tryStartAgentAsync seeded the agent through the `?? 0L`
+        // fallback while the shard's own progression row stood at 973,739. Apply's Start branch then
+        // threw "The last committed number (973739) cannot be higher than the high water mark (0)",
+        // which pauses the shard -- and nothing restarts a Paused agent under a node-distributed daemon,
+        // so that tenant's projection stayed dead for hours with perfectly intact data on both sides
+        // (973,739 events, max seq_id 973739, and the tenant's own persisted high-water row at 973739,
+        // written 207ms after the failing Start).
+        var detector = new StubPartitionedDetector(); // deliberately no mark for t1 -> CeilingFor is null
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+        harness.Database.ProjectionProgressFor(Arg.Any<ShardName>(), Arg.Any<CancellationToken>())
+            .Returns(973739L);
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        var agent = await startedAgentAsync(harness);
+
+        agent.Failure.ShouldBeNull();
+        agent.Status.ShouldBe(AgentStatus.Running);
+
+        // Seeded at the position it is resuming from, never below it. Nothing is replayed or skipped:
+        // loading starts above LastCommitted, so an agent whose mark equals its position simply waits
+        // for the coordinator to route the tenant's real mark.
+        agent.HighWaterMark.ShouldBe(973739);
+        agent.LastCommitted.ShouldBe(973739);
+    }
+
+    [Fact]
+    public async Task tenant_agent_with_a_polled_ceiling_behind_its_progression_still_starts()
+    {
+        // Same failure, second flavour, 13 minutes earlier on another shard of the same deployment: the
+        // tenant's ceiling WAS polled (2,008,443) but sat 1,762 events below the shard's committed
+        // progression (2,010,205), because a tenant's high-water holds at a sequence gap that an earlier
+        // process had already been walked past. A committed position above a *seeded snapshot* of the
+        // mark is not evidence of corruption and must not be fatal.
+        var detector = new StubPartitionedDetector();
+        detector.SetTenantMark("t1", 2008443);
+
+        await using var harness = new DaemonHarness(detector, shardFor(new ShardName("Trip")));
+        harness.Database.ProjectionProgressFor(Arg.Any<ShardName>(), Arg.Any<CancellationToken>())
+            .Returns(2010205L);
+
+        await harness.Daemon.StartAgentAsync("Trip:All:t1", CancellationToken.None);
+
+        var agent = await startedAgentAsync(harness);
+
+        agent.Failure.ShouldBeNull();
+        agent.Status.ShouldBe(AgentStatus.Running);
+        agent.HighWaterMark.ShouldBe(2010205);
+        agent.LastCommitted.ShouldBe(2010205);
+    }
+
+    // The Start command is applied on the agent's own command loop, so both the seeding and any failure
+    // land just after StartAgentAsync returns. Wait for whichever arrives first rather than sleeping.
+    private static async Task<SubscriptionAgent> startedAgentAsync(DaemonHarness harness)
+    {
+        var agent = harness.Daemon.CurrentAgents().ShouldHaveSingleItem().ShouldBeOfType<SubscriptionAgent>();
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(10);
+        while (agent.Failure == null && agent.HighWaterMark == 0 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(25, TestContext.Current.CancellationToken);
+        }
+
+        return agent;
+    }
+
+    [Fact]
     public async Task throws_for_a_tenant_identity_when_the_store_has_no_tenant_partitioning()
     {
         // Without per-tenant high-water tracking a tenant agent would seed from the store-global mark

--- a/src/JasperFx.Events/Daemon/HighWater/PolledTenantSet.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/PolledTenantSet.cs
@@ -12,6 +12,10 @@ public sealed class PolledTenantSet
     private readonly object _lock = new();
     private readonly HashSet<string> _tenants = new();
 
+    // Tenants held in the set for the duration of an in-flight agent start, reference counted because
+    // several shards of the same tenant can be starting at once. See Pin.
+    private readonly Dictionary<string, int> _pins = new();
+
     /// <summary>
     /// Add a tenant to the polled set. Returns true if it was newly added.
     /// </summary>
@@ -35,8 +39,48 @@ public sealed class PolledTenantSet
     }
 
     /// <summary>
+    /// Hold a tenant in the polled set until <see cref="Unpin" />, so a wholesale
+    /// <see cref="SetTenants" /> cannot drop it. The daemon pins a tenant for the duration of an agent
+    /// start: the assignment snapshot a concurrent start or stop reconciles against is built from the
+    /// agents already REGISTERED on the node, which by definition does not include one whose start is
+    /// still in flight. Dropped mid-start, that tenant is missing from the very poll the start is
+    /// waiting on, and the agent is then seeded with no ceiling at all. Reference counted, because
+    /// several shards of one tenant can be starting at the same time.
+    /// </summary>
+    public void Pin(string tenantId)
+    {
+        lock (_lock)
+        {
+            _pins[tenantId] = _pins.TryGetValue(tenantId, out var count) ? count + 1 : 1;
+            _tenants.Add(tenantId);
+        }
+    }
+
+    /// <summary>
+    /// Release a <see cref="Pin" />. The tenant stays in the polled set — whether it belongs there is
+    /// decided by the next <see cref="SetTenants" />, which is exactly the reconciliation the daemon
+    /// runs when a start succeeds or fails.
+    /// </summary>
+    public void Unpin(string tenantId)
+    {
+        lock (_lock)
+        {
+            if (!_pins.TryGetValue(tenantId, out var count)) return;
+
+            if (count <= 1)
+            {
+                _pins.Remove(tenantId);
+            }
+            else
+            {
+                _pins[tenantId] = count - 1;
+            }
+        }
+    }
+
+    /// <summary>
     /// Replace the polled set wholesale — convenient when the daemon receives a fresh assignment snapshot
-    /// from Wolverine rather than incremental activate/deactivate deltas.
+    /// from Wolverine rather than incremental activate/deactivate deltas. Pinned tenants survive.
     /// </summary>
     public void SetTenants(IEnumerable<string> tenantIds)
     {
@@ -46,6 +90,11 @@ public sealed class PolledTenantSet
             foreach (var tenantId in tenantIds)
             {
                 _tenants.Add(tenantId);
+            }
+
+            foreach (var pinned in _pins.Keys)
+            {
+                _tenants.Add(pinned);
             }
         }
     }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -686,11 +686,29 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
             // would run DetermineStartingPositionAsync against high-water 0, which for a
             // SubscribeFromPresent subscription resolves "present" to sequence 0 and rewinds its
             // progression row, replaying the tenant's entire history.
-            _tenantHighWater.PolledTenants.Activate(requested.TenantId);
-            await pollTenantHighWaterAsync().ConfigureAwait(false);
+            //
+            // Pin rather than Activate: syncTenantPolling() rebuilds the polled set from the agents
+            // REGISTERED on this node, and this agent is not registered until its start completes. Any
+            // concurrent start or stop that reconciles in the meantime would drop this tenant again, and
+            // the poll below would then silently skip it — leaving the agent to be seeded with no
+            // ceiling at all (an unrecoverable pause for a catch-up shard, a full-history replay for a
+            // FromPresent one). Field-observed under Wolverine-managed distribution with 25-way start
+            // parallelism and thousands of agents per node.
+            _tenantHighWater.PolledTenants.Pin(requested.TenantId);
 
-            var tenantShard = baseShard with { Name = baseShard.Name.ForTenant(requested.TenantId) };
-            var tenantStarted = await startContinuousShardAsync(tenantShard).ConfigureAwait(false);
+            bool tenantStarted;
+            try
+            {
+                await pollTenantHighWaterAsync().ConfigureAwait(false);
+
+                var tenantShard = baseShard with { Name = baseShard.Name.ForTenant(requested.TenantId) };
+                tenantStarted = await startContinuousShardAsync(tenantShard).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tenantHighWater.PolledTenants.Unpin(requested.TenantId);
+            }
+
             if (!tenantStarted)
             {
                 // Reconcile the polled-tenant set so a failed start doesn't leave the coordinator

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -570,13 +570,26 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
                 break;
 
             case CommandType.Start:
-                if (command.LastCommitted > command.HighWaterMark)
+                // A Start seed below the position this agent is resuming from used to throw here, which
+                // funnels into ReportCriticalFailureAsync and PAUSES the shard -- and under a
+                // node-distributed daemon nothing ever restarts a paused agent, so one bad seed took a
+                // tenant's projection out until the next deployment. The premise no longer holds either:
+                // the seed is a SNAPSHOT of the mark taken at start (per tenant since marten#4717, so it
+                // can be missing entirely, or holding below a sequence gap this shard was already walked
+                // past), not a store-wide invariant. Clamp to the committed position and say so. Nothing
+                // is replayed or skipped: loading only ever starts above LastCommitted, so an agent whose
+                // mark equals its position simply idles until the real mark is routed to it.
+                var startingHighWater = command.HighWaterMark;
+                if (command.LastCommitted > startingHighWater)
                 {
-                    throw new InvalidOperationException(
-                        $"The last committed number ({command.LastCommitted}) cannot be higher than the high water mark ({command.HighWaterMark})");
+                    _logger.LogWarning(
+                        "Projection/subscription {Identity} was started with a high water seed of {Seed}, below its own committed position of {LastCommitted}. Starting at the committed position and waiting for the next high water reading",
+                        ProjectionShardIdentity, startingHighWater, command.LastCommitted);
+
+                    startingHighWater = command.LastCommitted;
                 }
 
-                HighWaterMark = command.HighWaterMark;
+                HighWaterMark = startingHighWater;
                 LastCommitted = LastEnqueued = command.LastCommitted;
                 _bufferedCeiling = LastCommitted; // jasperfx#525
 


### PR DESCRIPTION
**The problem.** A tenant-scoped agent that is seeded with a high-water mark below its own committed position dies, permanently. `SubscriptionAgent.Apply`'s `Start` branch throws, which funnels into `ReportCriticalFailureAsync` → `AgentStatus.Paused` → and under a node-distributed daemon nothing ever restarts a paused agent (Wolverine's `NodeAgentController.StartAgentAsync` returns early for anything that is not `Stopped`, and `EventSubscriptionAgent.CheckHealthAsync` returns `Unhealthy` before it ever reaches its stall detector / auto-restart). One momentarily missing ceiling therefore takes a tenant's projection out until the next deployment.

**The proposal.** Two small changes, one per cause:

1. `SubscriptionAgent.Apply` **clamps** such a seed to the committed position and logs a warning, instead of throwing. Nothing is replayed or skipped — loading only ever starts above `LastCommitted`, and the mark can only be raised afterwards (`Apply` ignores a lower `MarkHighWater`), so an agent whose seed equals its position simply idles until the coordinator routes it the real mark.
2. `PolledTenantSet` gains a reference-counted `Pin`/`Unpin` that a wholesale `SetTenants` cannot drop, and `StartAgentAsync`'s per-tenant branch pins the tenant across its priming poll **and** its start.

### Why the guard's premise no longer holds

Since marten#4717 the value handed to `Command.Started` for a tenant agent is not the store-wide high water but `_tenantHighWater.CeilingFor(tenantId) ?? 0L` — a per-tenant *snapshot taken at start*. That snapshot can be:

- **missing** (`?? 0L`), because `syncTenantPolling()` rebuilds the polled set from the agents *registered* on the node — which by definition excludes an agent whose start is still in flight. Any concurrent start or stop that reconciles between `Activate(tenant)` and the poll's `PolledTenants.Snapshot()` drops the tenant, and `VectorizedHighWaterMonitor` then silently skips it (`TryGetStatistics` miss → no `_current` entry → `CeilingFor` null);
- **stale**, because a tenant's mark deliberately holds below a sequence gap until `StaleSequenceThreshold` lets the detector skip it, while the projection may already have been walked past that gap by an earlier process.

A committed position above such a snapshot is not evidence of corruption, so it should not be fatal.

For a `SubscribeFromPresent` shard the missing-ceiling case is worse than a pause: `FromPresent` resolves "present" to the mark it is handed, so a seed of 0 makes `ShouldUpdateProgressFirst` rewind the progression row to 0 and replay the tenant's entire history — the regression `primes_the_tenant_ceiling_before_determining_the_starting_position` pins for the sequential path, reintroduced by the race. Hence fixing the race as well as the fallout.

### Field evidence

Production, 2026-08-26, one deployment: 2,173 tenants over 512 shard databases, Wolverine-managed distribution, 3 nodes × ~7,450 agents, `MaxAgentStartParallelism` 25. JasperFx 2.55.0 / Marten 9.29.0 / Wolverine 6.29.2.

| | shard A | shard B |
|---|---|---|
| agent | `claim_lines/all/v21/<tenant>` | `patientstableid/all/<tenant>` |
| failure | `last committed (973739) … high water mark (0)` | `last committed (2010205) … high water mark (2008443)` |
| events for that tenant | 973,739, `max(seq_id)` 973739, 0 archived | 2,010,205, `max(seq_id)` 2010205, 0 archived |
| tenant's persisted `HighWaterMark:<tenant>` row | **973739**, written 207 ms *after* the failing `Start` | 2010205, written 3 min after |

So the data was intact on both sides in both cases; the only thing wrong was the number the agent was seeded with. A: the priming poll produced no reading for that tenant, yet a poll 207 ms later did — the polled-set window. B: the ceiling was 1,762 events behind a progression row that was itself correct.

Two occurrences over ~22,000 agent starts in 24 h, both inside a rollout's start storm. Both agents stayed `Paused` and were still reporting `Unhealthy` every minute hours later; a fleet-wide sweep of `mt_event_progression` found exactly one `Paused` shard out of 22,346 assignments — this one. Neither Wolverine's node-local auto-restart nor its GH-3888 release-to-a-peer can reach a paused agent, and CritterWatch's `restart` cannot either (it only lifts a `Paused` *restriction*, and this shard has none — the daemon paused it).

### Tests

- `tenant_agent_with_no_polled_ceiling_seeds_from_its_own_committed_position` and `tenant_agent_with_a_polled_ceiling_behind_its_progression_still_starts` — the two field cases, red before the change with the exact production message.
- `PolledTenantSetTests` — pinning survives a wholesale `SetTenants`, pins are reference counted (several shards of one tenant start at once), and `Unpin` does not itself remove the tenant.
- `a_tenant_stops_being_polled_once_its_last_agent_stops` — the release half, so a forgotten `Unpin` cannot leave the coordinator polling and persisting rows for a tenant this node runs nothing for.

Full `EventTests` (871), `EventStoreTests` (136) and `CoreTests` (585) pass.

### Alternatives considered

- **Fail the start instead of clamping.** A failed start *is* retried (the leader re-places it) while a paused agent is not, so that would also avoid the permanent stall. It throws away a start for a condition that is harmless, though, and it does not help the `FromPresent` rewind. Happy to switch if you prefer the louder shape.
- **Leave the throw and only fix the race.** The stale-ceiling case (shard B above) is reachable without any race at all, so the guard would keep killing shards.
- The `?? 0L` fallback is deliberately left in place: with the clamp it is no longer fatal, and there is no better value available at that moment.
