### PR TITLE
gh-701: RetryBlock.ShouldRetry — classify a failure as terminal instead of swallowing it

### DIFF
--- a/src/CoreTests/Blocks/RetryBlockShouldRetryTests.cs
+++ b/src/CoreTests/Blocks/RetryBlockShouldRetryTests.cs
@@ -1,0 +1,254 @@
+using JasperFx.Blocks;
+using JasperFx.Core;
+using Shouldly;
+
+namespace CoreTests.Blocks;
+
+/// <summary>
+/// <see cref="RetryBlock{T}.ShouldRetry"/> and <see cref="RetryBlock{T}.OnTerminalFailure"/> —
+/// classifying a failure as terminal instead of swallowing it inside the callback to stop the loop
+/// (jasperfx#701).
+/// </summary>
+/// <remarks>
+/// Every test here is driven by a deterministic signal — a <see cref="TaskCompletionSource"/> the
+/// handler completes, or the completion of <c>PostAsync</c> itself — rather than by polling for a log
+/// line. The pauses are zeroed so nothing waits on the retry schedule.
+/// </remarks>
+public class RetryBlockShouldRetryTests
+{
+    private readonly SpyLogger theLogger = new();
+
+    private static readonly TimeSpan[] NoPauses = [0.Milliseconds()];
+
+    private CancellationToken Cancellation => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task a_terminal_failure_ends_the_attempt_sequence_immediately()
+    {
+        var attempts = 0;
+        var abandoned = new TaskCompletionSource<Exception>();
+        var failure = new InvalidOperationException("PRECONDITION_FAILED - unknown delivery tag");
+
+        using var block = new RetryBlock<string>((_, _) =>
+        {
+            Interlocked.Increment(ref attempts);
+            throw failure;
+        }, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            MaximumAttempts = 5,
+            ShouldRetry = _ => false,
+            OnTerminalFailure = (_, e) =>
+            {
+                abandoned.SetResult(e);
+                return Task.CompletedTask;
+            }
+        };
+
+        block.Post("settle-me");
+
+        var caught = await abandoned.Task.WaitAsync(10.Seconds(), Cancellation);
+
+        caught.ShouldBeSameAs(failure);
+
+        // The point of the feature: one attempt, not MaximumAttempts of them. The RabbitMQ needle in
+        // wolverine#4012 burned three pointless retries for exactly this case.
+        attempts.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task the_terminal_callback_receives_the_message_and_the_exception()
+    {
+        var failure = new InvalidOperationException("no such receipt handle");
+        string? abandonedMessage = null;
+        Exception? abandonedException = null;
+
+        using var block = new RetryBlock<string>((_, _) => throw failure, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            ShouldRetry = _ => false,
+            OnTerminalFailure = (message, e) =>
+            {
+                abandonedMessage = message;
+                abandonedException = e;
+                return Task.CompletedTask;
+            }
+        };
+
+        await block.PostAsync("settle-me");
+
+        abandonedMessage.ShouldBe("settle-me");
+        abandonedException.ShouldBeSameAs(failure);
+    }
+
+    [Fact]
+    public async Task post_async_does_not_re_enqueue_a_terminal_failure()
+    {
+        var attempts = 0;
+        var terminalFailures = 0;
+
+        using var block = new RetryBlock<string>((_, _) =>
+        {
+            Interlocked.Increment(ref attempts);
+            throw new InvalidOperationException("terminal");
+        }, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            MaximumAttempts = 5,
+            ShouldRetry = _ => false,
+            OnTerminalFailure = (_, _) =>
+            {
+                Interlocked.Increment(ref terminalFailures);
+                return Task.CompletedTask;
+            }
+        };
+
+        // PostAsync tries inline first and re-posts to the block on failure. A terminal classification
+        // has to stop it there, so by the time this await returns the message is done for good.
+        await block.PostAsync("settle-me");
+
+        attempts.ShouldBe(1);
+        terminalFailures.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_failure_classified_as_transient_still_retries()
+    {
+        var attempts = 0;
+        var succeeded = new TaskCompletionSource();
+
+        using var block = new RetryBlock<string>((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) < 3)
+            {
+                throw new InvalidOperationException("transient");
+            }
+
+            succeeded.SetResult();
+            return Task.CompletedTask;
+        }, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            MaximumAttempts = 5,
+            ShouldRetry = _ => true
+        };
+
+        block.Post("settle-me");
+
+        await succeeded.Task.WaitAsync(10.Seconds(), Cancellation);
+
+        attempts.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task exhausting_the_attempts_is_not_a_terminal_failure()
+    {
+        var attempts = 0;
+        var terminalFailures = 0;
+        var exhausted = new TaskCompletionSource();
+
+        using var block = new RetryBlock<string>((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 3)
+            {
+                exhausted.SetResult();
+            }
+
+            throw new InvalidOperationException("always fails");
+        }, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            MaximumAttempts = 3,
+            ShouldRetry = _ => true,
+            OnTerminalFailure = (_, _) =>
+            {
+                Interlocked.Increment(ref terminalFailures);
+                return Task.CompletedTask;
+            }
+        };
+
+        block.Post("settle-me");
+
+        await exhausted.Task.WaitAsync(10.Seconds(), Cancellation);
+
+        // Running out of attempts and being classified terminal are different outcomes. The block has
+        // always logged the first one on its own; only the second reaches the callback.
+        terminalFailures.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task a_should_retry_predicate_that_throws_is_treated_as_transient()
+    {
+        var attempts = 0;
+        var succeeded = new TaskCompletionSource();
+
+        using var block = new RetryBlock<string>((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) < 2)
+            {
+                throw new InvalidOperationException("transient");
+            }
+
+            succeeded.SetResult();
+            return Task.CompletedTask;
+        }, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            MaximumAttempts = 5,
+            ShouldRetry = _ => throw new DivideByZeroException("a broken classifier")
+        };
+
+        block.Post("settle-me");
+
+        await succeeded.Task.WaitAsync(10.Seconds(), Cancellation);
+
+        // A classifier that blew up tells us nothing about the original failure, so the block falls
+        // back to retrying rather than silently dropping the message.
+        attempts.ShouldBe(2);
+        theLogger.Exceptions.ShouldContain(x => x is DivideByZeroException);
+    }
+
+    [Fact]
+    public async Task a_throwing_terminal_callback_is_logged_and_swallowed()
+    {
+        using var block = new RetryBlock<string>((_, _) => throw new InvalidOperationException("terminal"),
+            theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            ShouldRetry = _ => false,
+            OnTerminalFailure = (_, _) => throw new DivideByZeroException("a broken hook")
+        };
+
+        // A faulty hook must not escape into the caller, and must not take down the block's loop.
+        await block.PostAsync("settle-me");
+
+        theLogger.Exceptions.ShouldContain(x => x is DivideByZeroException);
+    }
+
+    [Fact]
+    public async Task no_predicate_leaves_the_pre_existing_behavior_alone()
+    {
+        var attempts = 0;
+        var exhausted = new TaskCompletionSource();
+
+        using var block = new RetryBlock<string>((_, _) =>
+        {
+            if (Interlocked.Increment(ref attempts) == 3)
+            {
+                exhausted.SetResult();
+            }
+
+            throw new InvalidOperationException("always fails");
+        }, theLogger, CancellationToken.None)
+        {
+            Pauses = NoPauses,
+            MaximumAttempts = 3
+        };
+
+        block.Post("settle-me");
+
+        await exhausted.Task.WaitAsync(10.Seconds(), Cancellation);
+
+        attempts.ShouldBe(3);
+    }
+}

--- a/src/JasperFx/Blocks/RetryBlock.cs
+++ b/src/JasperFx/Blocks/RetryBlock.cs
@@ -50,6 +50,46 @@ public class RetryBlock<T> : IRetryBlock<T>, IDisposable
     public int MaximumAttempts { get; set; } = 3;
     public TimeSpan[] Pauses { get; set; } = [50.Milliseconds(), 100.Milliseconds(), 250.Milliseconds()];
 
+    /// <summary>
+    /// Optional classification of a failure as transient (retry) or terminal (stop now). Consulted
+    /// before every retry, including the first. Returning <c>false</c> ends the attempt sequence for
+    /// that message immediately, no matter how many attempts are left.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exists so a caller does not have to swallow an exception inside its own handler purely to stop
+    /// the retry loop. Swallowing works, but it makes the give-up path indistinguishable from success
+    /// at the block's boundary: the block never learns anything happened, so it cannot log it
+    /// differently or hand it to <see cref="OnTerminalFailure"/>. See jasperfx#701.
+    /// </para>
+    /// <para>
+    /// Null by default, which means "every failure is worth retrying" — the behavior of every
+    /// existing block.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// new RetryBlock&lt;Envelope&gt;(settleAsync, logger, token)
+    /// {
+    ///     ShouldRetry = e => !AzureServiceBusSettlement.IsTerminal(e)
+    /// };
+    /// </code>
+    /// </example>
+    public Func<Exception, bool>? ShouldRetry { get; set; }
+
+    /// <summary>
+    /// Optional notification that <see cref="ShouldRetry"/> classified a failure as terminal and the
+    /// message was abandoned. Awaited inline; exceptions thrown by the callback are logged and
+    /// swallowed so a faulty hook cannot take down the block's processing loop.
+    /// </summary>
+    /// <remarks>
+    /// This is the capability the swallow-in-the-callback pattern cannot provide: the block's owner
+    /// gets to meter, dead-letter or otherwise account for a give-up that is not a success. Not
+    /// invoked when a message is discarded for exhausting <see cref="MaximumAttempts"/> — that is a
+    /// different outcome, and one the block has always logged on its own.
+    /// </remarks>
+    public Func<T, Exception, Task>? OnTerminalFailure { get; set; }
+
     public void Dispose()
     {
         _block.Complete();
@@ -73,8 +113,52 @@ public class RetryBlock<T> : IRetryBlock<T>, IDisposable
         }
         catch (Exception e)
         {
+            if (isTerminal(e))
+            {
+                await abandonAsync(message, e, 1).ConfigureAwait(false);
+                return;
+            }
+
             _logger.LogError(e, "Error while trying to retry {Item}", message);
             Post(message);
+        }
+    }
+
+    private bool isTerminal(Exception e)
+    {
+        var shouldRetry = ShouldRetry;
+        if (shouldRetry == null) return false;
+
+        try
+        {
+            return !shouldRetry(e);
+        }
+        catch (Exception classificationFailure)
+        {
+            // A predicate that throws tells us nothing about the original failure, so fall back to
+            // the pre-jasperfx#701 behavior of retrying rather than silently dropping the message.
+            _logger.LogError(classificationFailure,
+                "ShouldRetry threw while classifying a failure; treating the failure as transient");
+            return false;
+        }
+    }
+
+    private async Task abandonAsync(T message, Exception e, int attempts)
+    {
+        _logger.LogError(e,
+            "Terminal failure for {Message} after {Attempts} attempt(s); no further attempts will be made",
+            message, attempts);
+
+        var onTerminalFailure = OnTerminalFailure;
+        if (onTerminalFailure == null) return;
+
+        try
+        {
+            await onTerminalFailure(message, e).ConfigureAwait(false);
+        }
+        catch (Exception callbackFailure)
+        {
+            _logger.LogError(callbackFailure, "Error in the OnTerminalFailure callback for {Message}", message);
         }
     }
 
@@ -105,6 +189,12 @@ public class RetryBlock<T> : IRetryBlock<T>, IDisposable
         }
         catch (Exception e)
         {
+            if (!_cancellationToken.IsCancellationRequested && isTerminal(e))
+            {
+                await abandonAsync(item.Message, e, item.Attempts).ConfigureAwait(false);
+                return;
+            }
+
             _logger.LogError(e, "Error while trying to retry {Item}", item.Message);
 
             if (_cancellationToken.IsCancellationRequested) return;


### PR DESCRIPTION
Closes #701.

## The problem

`RetryBlock<T>` retries until it succeeds or exhausts `MaximumAttempts`, with no way to be told *"this failure can never succeed, stop now."* Every caller that needs terminal-failure classification implements it as a `catch` inside its own callback, swallowing the exception because swallowing is what stops the loop. Wolverine does this three times — `RabbitMqChannelCallback`, `AzureServiceBusSettlement`, `SqsSettlement` — same shape, different needles.

It works, but the callback has to swallow an exception it did *not* handle, purely as a signal to the retry machinery. That makes the give-up path indistinguishable from success at the block's boundary: the block never learns anything happened, so it cannot log it differently, meter it, or hand it to anyone.

## What this adds

Two properties on `RetryBlock<T>`, both `null` by default:

```csharp
public Func<Exception, bool>? ShouldRetry { get; set; }
public Func<T, Exception, Task>? OnTerminalFailure { get; set; }
```

`ShouldRetry` is consulted before every retry, including the first. Returning `false` ends the attempt sequence for that message immediately, no matter how many attempts are left. Callers then read as classification rather than control flow:

```csharp
new RetryBlock<Envelope>(settleAsync, logger, token)
{
    ShouldRetry = e => !AzureServiceBusSettlement.IsTerminal(e)
};
```

`OnTerminalFailure` is the half you flagged in the issue as *"arguably the main reason to do this at all"* — the capability the swallow-in-the-callback pattern cannot provide. It is awaited inline so a caller can dead-letter as well as meter.

## Decisions worth a look

- **`OnTerminalFailure` is `Func<T, Exception, Task>`, not `Action<T, Exception>`.** A sync `Action` covers the counter case, but not the "move this envelope somewhere" case, and the block is already async throughout.
- **Exhausting `MaximumAttempts` is *not* a terminal failure** and does not reach the callback. Two different outcomes; the block has always logged the first one on its own. `exhausting_the_attempts_is_not_a_terminal_failure` pins this.
- **A `ShouldRetry` predicate that throws is treated as transient.** A classifier that blew up tells us nothing about the original failure, so falling back to today's retry behaviour beats silently dropping the message. Logged at Error either way.
- **A throwing `OnTerminalFailure` is logged and swallowed**, so a faulty hook cannot take down the block's processing loop or escape into a `PostAsync` caller.
- **Both the `PostAsync` inline path and the block's `executeAsync` path consult the predicate.** `PostAsync` tries once inline and re-posts on failure; a terminal classification has to stop it there rather than letting the message onto the queue.
- **`RetryBlockSync<T>` is deliberately untouched.** It rethrows rather than swallowing, so its caller already sees the exception and can classify it there — the discoverability problem this issue is about does not exist on that type. Happy to add the symmetric fail-fast (stop burning the remaining pauses on a terminal failure) if you'd rather have it here than in a follow-up.

## Verification

New `RetryBlockShouldRetryTests` — 8 tests covering terminal-stops-immediately, callback payload, the `PostAsync` path, transient-still-retries, exhaustion-is-not-terminal, both throwing-hook cases, and null-predicate parity with today's behaviour. Every one is driven by a `TaskCompletionSource` the handler completes rather than by polling for a log line, so none of them are timing-sensitive.

Full `CoreTests` suite green locally: 592 passed, 1 skipped.

## Downstream

Purely additive; nothing in this repo or downstream changes behaviour until a caller sets a predicate. Wolverine's three implementations stay as they are until it takes a JasperFx version containing this; the migration is mechanical and per-transport (wolverine#4012 item 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)