### PR TITLE
gh-700: EventStoreExplorerCompliance requires the usage descriptor to describe registered projections

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using JasperFx.Events.Projections;
 using Shouldly;
 using Xunit;
 
@@ -13,6 +15,28 @@ public record VoyageBegun(string Ship);
 public record PortVisited(string Port);
 
 #endregion
+
+/// <summary>
+/// An aggregate registered as an <see cref="ProjectionLifecycle.Inline"/> snapshot, so the suite has
+/// a projection registration to look for in <c>EventStoreUsage.Subscriptions</c>.
+/// </summary>
+/// <remarks>
+/// Inline rather than async on purpose: an implementation that described the daemon's shards instead
+/// of the registrations would look correct and still answer nothing for an inline-only store, which
+/// is exactly the shape of the store that went several releases describing none of its projections
+/// (JasperFx/fisher#120). <c>SubscriptionDescriptor</c> already handles Inline — its metrics block is
+/// gated on <see cref="ProjectionLifecycle.Async"/> — so requiring it costs nothing.
+/// </remarks>
+public partial class VoyageSnapshot
+{
+    public Guid Id { get; set; }
+    public string Ship { get; set; } = string.Empty;
+    public List<string> Ports { get; set; } = new();
+
+    public static VoyageSnapshot Create(VoyageBegun e) => new() { Ship = e.Ship };
+
+    public void Apply(PortVisited e) => Ports.Add(e.Port);
+}
 
 /// <summary>
 /// The event store explorer surface on <see cref="IEventStore"/> — <c>GetRecentStreamsAsync</c>,
@@ -40,6 +64,7 @@ public abstract class EventStoreExplorerCompliance<TFixture, TOperations, TQuery
         config.SchemaName = "compliance_explorer";
         config.AddEventType<VoyageBegun>();
         config.AddEventType<PortVisited>();
+        config.Snapshot<VoyageSnapshot>(SnapshotLifecycle.Inline);
     };
 
     protected override Action<ComplianceStoreConfig> Configuration => _configuration;
@@ -170,5 +195,29 @@ public abstract class EventStoreExplorerCompliance<TFixture, TOperations, TQuery
         var names = usage.Events.Select(x => x.EventTypeName).ToList();
         names.ShouldContain(EventTypeNameFor<VoyageBegun>());
         names.ShouldContain(EventTypeNameFor<PortVisited>());
+    }
+
+    [Fact]
+    public async Task usage_describes_the_registered_projections()
+    {
+        var usage = await EventStore.TryCreateUsage(Cancellation);
+
+        // Same escape as above: a store that cannot describe itself is a legitimate answer. What is
+        // being caught here is a store that DOES return a usage and silently under-fills it.
+        if (usage == null)
+        {
+            return;
+        }
+
+        // Every member of EventStoreUsage is a list or a nullable that starts empty, so an unfilled
+        // slot is indistinguishable from a genuinely empty one — no exception, no warning, and no
+        // field saying which of the two it is. Consumers then render a confident wrong answer:
+        // "projections list" prints "No projections in this store" for a store with twenty of them,
+        // "projections rebuild" matches none of them, and CritterWatch sees a store with no
+        // projections. That is JasperFx/fisher#120, where the fix was one missing Describe() call.
+        usage.Subscriptions.ShouldNotBeEmpty(
+            "The store returned a usage descriptor but left Subscriptions empty, even though a projection was registered. Two shipped commands read this slot directly.");
+
+        usage.Subscriptions.Select(x => x.Name).ShouldContain(nameof(VoyageSnapshot));
     }
 }


### PR DESCRIPTION
Closes #700.

## The gap

`EventStoreExplorerCompliance` had one test over `IEventStore.TryCreateUsage`, and it asserted on `usage.Events` and nothing else. A store could populate that one list and leave every other slot on `EventStoreUsage` empty while passing the suite — which is what JasperFx/fisher#120 did for several releases.

Every member of `EventStoreUsage` is a list or a nullable that starts empty, so an unfilled slot is indistinguishable from a genuinely empty one. No exception, no warning, no field saying which of the two it is. The consumer renders a confident wrong answer:

```
$ dotnet run -- projections list

Projections and Subscriptions
└── sqlite://localhost/App_Data%2Fapp.db
    └── No projections in this store.
```

The store had twenty registered projections. `projections rebuild` matched none of them for the same reason, and CritterWatch saw a store with no projections. The fix on Fisher's side was one line — and that is the argument *for* a shared test: nothing about the omission was dialect-specific, so no store-level decision anywhere would have prompted somebody to look.

## What this adds

A sibling test, `usage_describes_the_registered_projections`, plus a `VoyageSnapshot` aggregate registered as an **Inline** snapshot so there is something for it to find.

```csharp
usage.Subscriptions.ShouldNotBeEmpty("…");
usage.Subscriptions.Select(x => x.Name).ShouldContain(nameof(VoyageSnapshot));
```

Both assertions are there on purpose: the first names the actual failure in language a store author can act on, and the second catches a store that fills the slot with something other than its registrations.

## Decisions worth a look

- **Scope is `Subscriptions` only.** Per your call on the issue. `RegisteredEventTypes` alongside `Events` (polecat#411 — the same failure one member over), `ProjectionErrors` / `ProjectionRebuildErrors` and `EventMetadata` are the same class of gap, but requiring them is a bigger question about how much of the descriptor is contract versus best-effort, and requiring `RegisteredEventTypes` today would likely go red on Polecat before polecat#411 ships. Easy follow-up once that call is made.
- **Inline, not Async.** The reported store's twenty projections were all `ProjectionLifecycle.Inline`, and an implementation that described the daemon's shards rather than the registrations would look correct and still answer nothing for it. `SubscriptionDescriptor` already handles Inline — its metrics block is gated on `Async` — so requiring it costs nothing.
- **The `if (usage == null) return;` escape stays.** A store that cannot describe itself is a legitimate answer; the failure being targeted is a store that *does* return a usage and silently under-fills it.
- **Not gated on `SupportsExplorerSurface`,** matching the existing `usage_describes_the_registered_event_types` — `TryCreateUsage` is a separate seam from the `GetRecentStreamsAsync` / `GetStreamMetadataAsync` explorer surface, and it has its own null escape.
- **`VoyageSnapshot` is `partial`**, following `ParcelSnapshot` in the snapshot-lifecycle suite: this package ships as source, and `JasperFx.Events.SourceGenerator` emits the dispatcher per consuming assembly.

## Downstream impact

This is a **new requirement on every store that runs the suite**, so it will go red anywhere `TryCreateUsage` returns a usage without calling `Projections.Describe`. That is the intent — Marten and Polecat both call it and should stay green, Fisher is fixed as of fisher#120 — but it is worth landing deliberately rather than as a surprise on the next pin bump. The suite also now registers an inline snapshot in the `compliance_explorer` schema, so consuming stores will provision document storage for `VoyageSnapshot` there.

## Verification

`JasperFx.Events.ComplianceTests` and `EventStoreTests` both build clean. The suite itself has no runner in this repo — it is exercised from Marten, Polecat and Fisher — so the cross-store run happens on their pin bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)