### PR TITLE
gh-703: the Event Model descriptor carries provenance, and production wins over declarations

### DIFF
--- a/docs/event-modeling/descriptors.md
+++ b/docs/event-modeling/descriptors.md
@@ -135,12 +135,40 @@ foreach (var hotspot in helpdesk.Hotspots)
 <sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L43-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assembling_the_event_model' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-Sources are enumerated in **registration order**, and `Merge` lets earlier sources win on scalars — so register derived sources before overlays. Concretely:
+### Provenance decides the merge
 
-- **Scalars** keep the first non-null value.
-- **Lists** are unioned in order and deduplicated by identity: types by full name, external systems by direction + name, specifications by identity, hotspots by origin + text.
+Four producers feed one descriptor — Gherkin specs, the C# overlay and code-first specs, Wolverine's chains, and runtime observation from CritterWatch — so something has to arbitrate when two of them describe the same slice. That something is a three-rung ladder of authority, `EventModelProvenance`:
+
+| Rung | Who | Beats |
+| --- | --- | --- |
+| `Declared` | A Gherkin spec, a code-first spec, the `EventModelDefinition` overlay | — |
+| `Derived` | Wolverine's handler / HTTP / gRPC chains, the source generator | `Declared` |
+| `Observed` | CritterWatch watching a running system | `Derived`, `Declared` |
+
+Production beats what the code implies, and the code beats what somebody wrote down. A source declares its rung once, on `IEventModelDefinitionSource.Provenance`; `EventModelDiscovery.DiscoverAsync` stamps it onto every slice the source returns.
+
+::: warning This inverts the pre-2.56 ordering
+Registration order used to be the mechanism — `WolverineEventModelSource` was registered at index 0 specifically so derived roles would beat overlays. It is now only a **tie-breaker between sources on the same rung**. `Provenance` defaults to `Declared` on every source, so an application whose sources have not been stamped yet gets exactly the merge it got before.
+:::
+
+**Precedence is per claimed role, not wholesale.** A role is claimed when the slice carries a value for it — a non-null scalar or a non-empty list — and a source that does not claim a role never overrides one that does, whatever rung it sits on. This is why slice names, domains, trigger labels and specification links keep coming from declarations and keep winning by default: production has no opinion about what a slice is called. The ladder only decides *factual* roles — which events are emitted, which aggregates are touched, which read models are produced.
+
+Concretely:
+
+- **Scalars** go to the highest rung that claims them; a tie keeps the first value.
+- **Lists** go to the highest rung that claims them **outright** — a higher rung *replaces* rather than unions, because unioning derived `{A, C}` with observed `{A, B}` invents a slice emitting three events that nobody claimed. Lists claimed at the **same** rung union in order and deduplicate by identity: types by full name, external systems by direction + name, specifications by identity, hotspots by origin + text.
 - **Slices** fold by name; slice order is first appearance.
 - **Aggregates** union by type full name.
+
+Ask a merged slice where any role came from with `ProvenanceFor`:
+
+```cs
+slice.ProvenanceFor(EventModelRole.EmittedEvents);  // Observed — production claimed these
+slice.ProvenanceFor(EventModelRole.Domain);         // Declared — only the overlay claims a domain
+slice.ProvenanceFor(EventModelRole.HandlerType);    // null — nothing claims it
+```
+
+Every rendered `EventModelElement` carries the same answer on its own `Provenance`, so a viewer can shade "production has seen this happen" differently from "somebody wrote it down" without re-deriving anything.
 
 Merging two slices with different names throws — slices merge by name, and a mismatch means a bug in whoever assembled the list.
 

--- a/docs/event-modeling/index.md
+++ b/docs/event-modeling/index.md
@@ -12,7 +12,9 @@ The command type, the handler, the aggregates, the events emitted, the messages 
 
 What you write by hand is an **overlay**: the display name of a slice, the bounded context it belongs to, the human label on its trigger ("Agent clicks Close"), a link to a specification that lives outside the compilation, and a hotspot for a question nobody has answered yet.
 
-The overlay is merged *onto* the derived model, derived first, so a hand-written line can never overwrite what the code actually does. If the code and your overlay disagree about a role, the code wins — silently and always.
+The overlay sits on the bottom rung of a three-rung ladder of authority — **declared** below **derived from code** below **observed in production** — so a hand-written line can never overwrite what the code actually does, and neither can overwrite what a running system was seen doing. If the code and your overlay disagree about a role, the code wins. See [provenance](/event-modeling/descriptors#provenance-decides-the-merge) for how the ladder is applied, role by role.
+
+Note that this only applies to roles the other rungs *claim*. Nothing but a declaration ever claims a slice's name, its domain, its trigger label or its specification links, so those are yours and stay yours.
 
 ## The sample: IncidentService
 

--- a/src/EventTests/EventModeling/EventModelProvenanceTests.cs
+++ b/src/EventTests/EventModeling/EventModelProvenanceTests.cs
@@ -1,0 +1,401 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+/// <summary>
+/// jasperfx#703: the descriptor carries provenance, and production wins over declarations.
+/// </summary>
+public class EventModelProvenanceTests
+{
+    private static TypeDescriptor T<TType>() => TypeDescriptor.For(typeof(TType));
+
+    private static EventModelSliceDescriptor Slice(EventModelProvenance? provenance = null) =>
+        EventModelSliceDescriptor.Named("PlaceOrder") with { Provenance = provenance };
+
+    #region the ladder
+
+    [Fact]
+    public void a_declared_role_is_overridden_by_a_derived_one()
+    {
+        var declared = Slice(EventModelProvenance.Declared) with { EmittedEvents = [T<OrderPlaced>()] };
+        var derived = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderShipped>()] };
+
+        declared.Merge(derived).EmittedEvents.ShouldHaveSingleItem().FullName.ShouldBe(T<OrderShipped>().FullName);
+    }
+
+    [Fact]
+    public void a_derived_role_is_overridden_by_an_observed_one()
+    {
+        var derived = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] };
+        var observed = Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<OrderShipped>()] };
+
+        derived.Merge(observed).EmittedEvents.ShouldHaveSingleItem().FullName.ShouldBe(T<OrderShipped>().FullName);
+    }
+
+    [Fact]
+    public void the_ladder_decides_regardless_of_the_order_the_sources_are_merged_in()
+    {
+        var declared = Slice(EventModelProvenance.Declared) with { CommandType = T<PlaceOrder>() };
+        var observed = Slice(EventModelProvenance.Observed) with { CommandType = T<ShipOrder>() };
+
+        // This is the inversion: before jasperfx#703, whichever side was merged first won outright,
+        // which is why WolverineEventModelSource had to be registered at index 0.
+        declared.Merge(observed).CommandType!.FullName.ShouldBe(T<ShipOrder>().FullName);
+        observed.Merge(declared).CommandType!.FullName.ShouldBe(T<ShipOrder>().FullName);
+    }
+
+    #endregion
+
+    #region per claimed role, not wholesale
+
+    [Fact]
+    public void a_source_that_does_not_claim_a_role_never_overrides_one_that_does()
+    {
+        var declared = Slice(EventModelProvenance.Declared) with
+        {
+            Domain = "Orders",
+            Specifications = [new SpecificationDescriptor("Place Order/Place an order")],
+            TriggerLabel = "User clicks Place Order",
+        };
+
+        // Production sees events happen. It has no opinion whatsoever about what the slice is called,
+        // which bounded context it belongs to, or which spec covers it.
+        var observed = Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<OrderPlaced>()] };
+
+        var merged = declared.Merge(observed);
+
+        merged.Domain.ShouldBe("Orders");
+        merged.Specifications.ShouldHaveSingleItem().Identity.ShouldBe("Place Order/Place an order");
+        merged.TriggerLabel.ShouldBe("User clicks Place Order");
+        merged.EmittedEvents.ShouldHaveSingleItem().FullName.ShouldBe(T<OrderPlaced>().FullName);
+    }
+
+    [Fact]
+    public void a_name_declared_by_an_overlay_survives_every_rung()
+    {
+        // The acceptance criterion of jasperfx#703, end to end: three sources, a declared role beaten
+        // by a derived one, a derived role beaten by an observed one, and the declaration-only roles
+        // untouched by either.
+        var overlay = new EventModelDescriptor("Orders", [
+            EventModelSliceDescriptor.Named("PlaceOrder") with
+            {
+                Provenance = EventModelProvenance.Declared,
+                Domain = "Ordering",
+                TriggerLabel = "User clicks Place Order",
+                AggregateTypes = [T<Cart>()],
+            }
+        ]);
+
+        var derived = new EventModelDescriptor("Orders", [
+            EventModelSliceDescriptor.Named("PlaceOrder") with
+            {
+                Provenance = EventModelProvenance.Derived,
+                CommandType = T<PlaceOrder>(),
+                AggregateTypes = [T<Order>()],
+                EmittedEvents = [T<OrderPlaced>()],
+            }
+        ]);
+
+        var observed = new EventModelDescriptor("Orders", [
+            EventModelSliceDescriptor.Named("PlaceOrder") with
+            {
+                Provenance = EventModelProvenance.Observed,
+                EmittedEvents = [T<OrderPlaced>(), T<AuditRecorded>()],
+            }
+        ]);
+
+        var merged = EventModelDescriptor.Merge("Orders", [overlay, derived, observed]);
+        var slice = merged.Slices.ShouldHaveSingleItem();
+
+        // Production wins the events.
+        slice.EmittedEvents.Select(x => x.FullName)
+            .ShouldBe([T<OrderPlaced>().FullName, T<AuditRecorded>().FullName]);
+
+        // The code wins the aggregate over the overlay's guess.
+        slice.AggregateTypes.ShouldHaveSingleItem().FullName.ShouldBe(T<Order>().FullName);
+
+        // The declaration keeps everything nothing else claims.
+        slice.Domain.ShouldBe("Ordering");
+        slice.TriggerLabel.ShouldBe("User clicks Place Order");
+    }
+
+    #endregion
+
+    #region per-role attribution
+
+    [Fact]
+    public void a_merged_slice_reports_which_rung_claimed_each_role()
+    {
+        var overlay = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            Provenance = EventModelProvenance.Declared, Domain = "Ordering",
+        };
+
+        var derived = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            Provenance = EventModelProvenance.Derived, CommandType = T<PlaceOrder>(),
+        };
+
+        var observed = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            Provenance = EventModelProvenance.Observed, EmittedEvents = [T<OrderPlaced>()],
+        };
+
+        var merged = overlay.Merge(derived).Merge(observed);
+
+        merged.ProvenanceFor(EventModelRole.Domain).ShouldBe(EventModelProvenance.Declared);
+        merged.ProvenanceFor(EventModelRole.CommandType).ShouldBe(EventModelProvenance.Derived);
+        merged.ProvenanceFor(EventModelRole.EmittedEvents).ShouldBe(EventModelProvenance.Observed);
+
+        // Nothing claimed the handler, so nobody is attributed with it.
+        merged.ProvenanceFor(EventModelRole.HandlerType).ShouldBeNull();
+    }
+
+    [Fact]
+    public void an_unmerged_slice_attributes_every_role_it_claims_to_its_own_rung()
+    {
+        var slice = Slice(EventModelProvenance.Derived) with
+        {
+            CommandType = T<PlaceOrder>(), EmittedEvents = [T<OrderPlaced>()],
+        };
+
+        slice.ProvenanceFor(EventModelRole.CommandType).ShouldBe(EventModelProvenance.Derived);
+        slice.ProvenanceFor(EventModelRole.EmittedEvents).ShouldBe(EventModelProvenance.Derived);
+        slice.ProvenanceFor(EventModelRole.Domain).ShouldBeNull();
+    }
+
+    [Fact]
+    public void an_unattributed_slice_reads_as_declared()
+    {
+        var slice = Slice() with { CommandType = T<PlaceOrder>() };
+
+        slice.Provenance.ShouldBeNull();
+        slice.ProvenanceFor(EventModelRole.CommandType).ShouldBe(EventModelProvenance.Declared);
+    }
+
+    [Fact]
+    public void a_merged_slice_summarises_as_the_highest_rung_that_contributed()
+    {
+        var merged = Slice(EventModelProvenance.Declared).Merge(Slice(EventModelProvenance.Observed));
+
+        merged.Provenance.ShouldBe(EventModelProvenance.Observed);
+    }
+
+    #endregion
+
+    #region list semantics
+
+    [Fact]
+    public void a_higher_rung_replaces_a_list_rather_than_unioning_with_it()
+    {
+        var derived = Slice(EventModelProvenance.Derived) with
+        {
+            EmittedEvents = [T<OrderPlaced>(), T<OrderShipped>()],
+        };
+
+        var observed = Slice(EventModelProvenance.Observed) with
+        {
+            EmittedEvents = [T<OrderPlaced>(), T<AuditRecorded>()],
+        };
+
+        // Unioning would invent a slice emitting three events that nobody ever claimed. Production
+        // wins outright; what became of OrderShipped is a finding, and jasperfx#704 records it.
+        derived.Merge(observed).EmittedEvents.Select(x => x.FullName)
+            .ShouldBe([T<OrderPlaced>().FullName, T<AuditRecorded>().FullName]);
+    }
+
+    [Fact]
+    public void two_sources_on_the_same_rung_still_union_their_lists()
+    {
+        var first = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] };
+        var second = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderShipped>()] };
+
+        first.Merge(second).EmittedEvents.Select(x => x.FullName)
+            .ShouldBe([T<OrderPlaced>().FullName, T<OrderShipped>().FullName]);
+    }
+
+    #endregion
+
+    #region compatibility
+
+    [Fact]
+    public void unattributed_sources_merge_exactly_as_they_did_before()
+    {
+        // Neither side is stamped, so both sit on Declared, every role ties, and every tie resolves
+        // on the order the sources were given -- which is what Merge did for every role before
+        // jasperfx#703. This is the hinge the whole change rests on.
+        var first = Slice() with
+        {
+            CommandType = T<PlaceOrder>(),
+            EmittedEvents = [T<OrderPlaced>()],
+            Domain = "Ordering",
+        };
+
+        var second = Slice() with
+        {
+            CommandType = T<ShipOrder>(),
+            EmittedEvents = [T<OrderShipped>()],
+            Domain = "Fulfilment",
+            HandlerType = T<OrderHandler>(),
+        };
+
+        var merged = first.Merge(second);
+
+        merged.CommandType!.FullName.ShouldBe(T<PlaceOrder>().FullName);
+        merged.Domain.ShouldBe("Ordering");
+        merged.EmittedEvents.Select(x => x.FullName)
+            .ShouldBe([T<OrderPlaced>().FullName, T<OrderShipped>().FullName]);
+        merged.HandlerType!.FullName.ShouldBe(T<OrderHandler>().FullName);
+        merged.Provenance.ShouldBeNull();
+    }
+
+    #endregion
+
+    #region rendering
+
+    [Fact]
+    public void elements_carry_the_provenance_of_the_role_they_render()
+    {
+        var slice = EventModelSliceDescriptor.Named("PlaceOrder") with
+        {
+            Provenance = EventModelProvenance.Declared, TriggerLabel = "User clicks Place Order",
+        };
+
+        var merged = slice
+            .Merge(EventModelSliceDescriptor.Named("PlaceOrder") with
+            {
+                Provenance = EventModelProvenance.Derived, CommandType = T<PlaceOrder>(),
+            })
+            .Merge(EventModelSliceDescriptor.Named("PlaceOrder") with
+            {
+                Provenance = EventModelProvenance.Observed, EmittedEvents = [T<OrderPlaced>()],
+            });
+
+        EventModelProvenance? provenanceOf(EventModelElementKind kind)
+            => merged.Elements.Single(x => x.Kind == kind).Provenance;
+
+        provenanceOf(EventModelElementKind.Trigger).ShouldBe(EventModelProvenance.Declared);
+        provenanceOf(EventModelElementKind.Command).ShouldBe(EventModelProvenance.Derived);
+        provenanceOf(EventModelElementKind.Event).ShouldBe(EventModelProvenance.Observed);
+    }
+
+    [Fact]
+    public void elements_of_an_unattributed_slice_read_as_the_declared_floor()
+    {
+        var slice = Slice() with { CommandType = T<PlaceOrder>() };
+
+        // One rule, not two: an unattributed source is treated as a declaration by the merge, so its
+        // elements say so too rather than reporting a null the merge does not honour.
+        slice.Elements.Single(x => x.Kind == EventModelElementKind.Command).Provenance
+            .ShouldBe(EventModelProvenance.Declared);
+    }
+
+    #endregion
+
+    #region discovery
+
+    [Fact]
+    public async Task discovery_stamps_each_source_with_its_own_rung()
+    {
+        var services = new ServiceCollection()
+            .AddEventModelSource(new StubSource("declared", EventModelProvenance.Declared,
+                s => s with { Domain = "Ordering" }))
+            .AddEventModelSource(new StubSource("observed", EventModelProvenance.Observed,
+                s => s with { EmittedEvents = [T<OrderPlaced>()] }))
+            .BuildServiceProvider();
+
+        var descriptors = await EventModelDiscovery.DiscoverAsync(services);
+
+        descriptors[0].Slices[0].Provenance.ShouldBe(EventModelProvenance.Declared);
+        descriptors[1].Slices[0].Provenance.ShouldBe(EventModelProvenance.Observed);
+    }
+
+    [Fact]
+    public async Task a_source_that_stamps_its_own_slices_is_left_alone()
+    {
+        // WithProvenance only fills in unattributed slices, so a source that can attribute per slice
+        // -- a generator emitting some slices from Gherkin and some from code -- is not flattened.
+        var services = new ServiceCollection()
+            .AddEventModelSource(new StubSource("mixed", EventModelProvenance.Declared,
+                s => s with { Provenance = EventModelProvenance.Observed }))
+            .BuildServiceProvider();
+
+        var descriptors = await EventModelDiscovery.DiscoverAsync(services);
+
+        descriptors[0].Slices[0].Provenance.ShouldBe(EventModelProvenance.Observed);
+    }
+
+    [Fact]
+    public async Task assembly_lets_a_later_registered_observed_source_beat_an_earlier_derived_one()
+    {
+        // Registration order used to be the whole mechanism. Here the derived source is registered
+        // first and still loses the events, because the ladder decides now.
+        var services = new ServiceCollection()
+            .AddEventModelSource(new StubSource("derived", EventModelProvenance.Derived,
+                s => s with { EmittedEvents = [T<OrderPlaced>()], CommandType = T<PlaceOrder>() }))
+            .AddEventModelSource(new StubSource("observed", EventModelProvenance.Observed,
+                s => s with { EmittedEvents = [T<AuditRecorded>()] }))
+            .BuildServiceProvider();
+
+        var models = await EventModelDiscovery.AssembleAsync(services);
+        var slice = models.ShouldHaveSingleItem().Slices.ShouldHaveSingleItem();
+
+        slice.EmittedEvents.ShouldHaveSingleItem().FullName.ShouldBe(T<AuditRecorded>().FullName);
+
+        // ...and the derived command survives, because production never claimed one.
+        slice.CommandType!.FullName.ShouldBe(T<PlaceOrder>().FullName);
+    }
+
+    [Fact]
+    public void the_default_rung_for_a_source_is_declared()
+    {
+        // A default interface member, so every existing IEventModelDefinitionSource keeps compiling
+        // -- UnstampedSource declares nothing -- and lands on the rung an overlay or a spec belongs on.
+        IEventModelDefinitionSource unstamped = new UnstampedSource();
+
+        unstamped.Provenance.ShouldBe(EventModelProvenance.Declared);
+    }
+
+    #endregion
+
+    private sealed class StubSource : IEventModelDefinitionSource
+    {
+        private readonly Func<EventModelSliceDescriptor, EventModelSliceDescriptor> _configure;
+
+        public StubSource(string name, EventModelProvenance provenance,
+            Func<EventModelSliceDescriptor, EventModelSliceDescriptor> configure)
+        {
+            Subject = new Uri($"event-model://{name}");
+            Provenance = provenance;
+            _configure = configure;
+        }
+
+        public Uri Subject { get; }
+
+        public EventModelProvenance Provenance { get; }
+
+        public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+            => Task.FromResult<EventModelDescriptor?>(
+                new EventModelDescriptor("Orders", [_configure(EventModelSliceDescriptor.Named("PlaceOrder"))]));
+    }
+
+    private sealed class UnstampedSource : IEventModelDefinitionSource
+    {
+        public Uri Subject => new("event-model://unstamped");
+
+        public Task<EventModelDescriptor?> TryCreateAsync(IServiceProvider services, CancellationToken token)
+            => Task.FromResult<EventModelDescriptor?>(null);
+    }
+
+    public class PlaceOrder { }
+    public class ShipOrder { }
+    public class OrderHandler { }
+    public class Order { }
+    public class Cart { }
+    public class OrderPlaced { }
+    public class OrderShipped { }
+    public class AuditRecorded { }
+}

--- a/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
+++ b/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
@@ -71,6 +71,20 @@ public class EventModelWireRoundTripTests
             ExternalSystems = new[] { new ExternalSystemDescriptor("Legacy", ExternalSystemDirection.Inbound) },
             EmittedEvents = new[] { T<OrderPlaced>() },
         },
+        // jasperfx#703: a slice assembled from all three rungs, so the summary Provenance and the
+        // per-role ClaimedBy map are on the wire under test too, not just the single-source shape.
+        (EventModelSliceDescriptor.Named("MergedFromThreeSources") with
+            {
+                Provenance = EventModelProvenance.Declared, Domain = "Orders",
+            })
+            .Merge(EventModelSliceDescriptor.Named("MergedFromThreeSources") with
+            {
+                Provenance = EventModelProvenance.Derived, CommandType = T<PlaceOrder>(),
+            })
+            .Merge(EventModelSliceDescriptor.Named("MergedFromThreeSources") with
+            {
+                Provenance = EventModelProvenance.Observed, EmittedEvents = new[] { T<OrderPlaced>() },
+            }),
         EventModelSliceDescriptor.Named("GrpcPlace") with { TriggerKind = TriggerKind.Grpc, Pattern = SlicePattern.Command },
         EventModelSliceDescriptor.Named("BusPlace") with { TriggerKind = TriggerKind.MessageHandler, Pattern = SlicePattern.Command },
     })
@@ -129,6 +143,12 @@ public class EventModelWireRoundTripTests
                 actual.Specifications[j].ResolvedTypes.ShouldBe(expected.Specifications[j].ResolvedTypes);
             }
             actual.Domain.ShouldBe(expected.Domain);
+            actual.Provenance.ShouldBe(expected.Provenance);
+            actual.ClaimedBy.Count.ShouldBe(expected.ClaimedBy.Count);
+            foreach (var claim in expected.ClaimedBy)
+            {
+                actual.ClaimedBy[claim.Key].ShouldBe(claim.Value);
+            }
 
             actual.Elements.ShouldBe(expected.Elements);
             actual.Edges.ShouldBe(expected.Edges);

--- a/src/JasperFx.Events/EventModeling/EventModelDefinition.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelDefinition.cs
@@ -12,9 +12,11 @@ namespace JasperFx.Events.EventModeling;
 /// command, handler, aggregates, emitted events, published messages, projections, read models,
 /// trigger kind, slice pattern — are <em>derived</em> by the sources that can see them:
 /// Wolverine from its handler / HTTP / gRPC chains, the Bobcat generator from Gherkin with
-/// shipped grammars. The overlay never declares them; it is folded onto the derived model by
-/// <see cref="EventModelDescriptor.Merge"/> with the derived sources first, so it cannot
-/// overwrite a derived role. The one exception is
+/// shipped grammars. The overlay never declares them; it is folded into the model by
+/// <see cref="EventModelDescriptor.Merge"/>, which sits it on the
+/// <see cref="EventModelProvenance.Declared"/> rung — the bottom of the ladder — so it cannot
+/// overwrite a role derived from code or observed in production, whatever order the sources were
+/// registered in (jasperfx#703). The one exception is
 /// <see cref="EventModelSliceBuilder.ForFlowNotOwnedHere"/> — an explicit escape hatch for flows
 /// whose code this host does not own.
 /// </para>

--- a/src/JasperFx.Events/EventModeling/EventModelServiceCollectionExtensions.cs
+++ b/src/JasperFx.Events/EventModeling/EventModelServiceCollectionExtensions.cs
@@ -86,9 +86,10 @@ public static class EventModelServiceCollectionExtensions
 public static class EventModelDiscovery
 {
     /// <summary>
-    /// Ask every registered source for its descriptor. Sources that return null are skipped.
-    /// Returned in registration order — derived sources should be registered before overlays so
-    /// <see cref="Assemble"/> lets derived roles win.
+    /// Ask every registered source for its descriptor, stamping each one with the source's
+    /// <see cref="IEventModelDefinitionSource.Provenance"/> (jasperfx#703). Sources that return null
+    /// are skipped. Returned in registration order, which <see cref="Assemble"/> now uses only to
+    /// break ties between sources on the same rung.
     /// </summary>
     public static async Task<IReadOnlyList<EventModelDescriptor>> DiscoverAsync(IServiceProvider services, CancellationToken token = default)
     {
@@ -96,15 +97,15 @@ public static class EventModelDiscovery
         foreach (var source in services.GetServices<IEventModelDefinitionSource>())
         {
             var descriptor = await source.TryCreateAsync(services, token).ConfigureAwait(false);
-            if (descriptor is not null) descriptors.Add(descriptor);
+            if (descriptor is not null) descriptors.Add(descriptor.WithProvenance(source.Provenance));
         }
 
         return descriptors;
     }
 
     /// <summary>
-    /// Fold the discovered descriptors into one model per name — overlays onto derived sources,
-    /// slices by name — and return them in first-appearance order.
+    /// Fold the discovered descriptors into one model per name — slices by name, each role decided by
+    /// the <see cref="EventModelProvenance"/> ladder — and return them in first-appearance order.
     /// </summary>
     public static IReadOnlyList<EventModelDescriptor> Assemble(IEnumerable<EventModelDescriptor> descriptors)
     {

--- a/src/JasperFx.Events/EventModeling/IEventModelDefinitionSource.cs
+++ b/src/JasperFx.Events/EventModeling/IEventModelDefinitionSource.cs
@@ -17,6 +17,27 @@ public interface IEventModelDefinitionSource
     Uri Subject { get; }
 
     /// <summary>
+    /// Which rung of the provenance ladder this source's claims sit on (jasperfx#703).
+    /// <see cref="EventModelProvenance.Declared"/> by default, because that is what an overlay or a
+    /// spec is; a source that reads roles out of code overrides it with
+    /// <see cref="EventModelProvenance.Derived"/>, and one that watches a running system with
+    /// <see cref="EventModelProvenance.Observed"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="EventModelDiscovery.DiscoverAsync"/> stamps this onto every slice the source
+    /// returns that is not already attributed, so a source only has to answer this once rather than
+    /// tag each slice.
+    /// </para>
+    /// <para>
+    /// ⚠️ This replaces registration order as the way derived roles beat declared ones. Defaulting to
+    /// <see cref="EventModelProvenance.Declared"/> means every existing source ties, and a tie still
+    /// resolves on order — so nothing changes until a source says otherwise.
+    /// </para>
+    /// </remarks>
+    EventModelProvenance Provenance => EventModelProvenance.Declared;
+
+    /// <summary>
     /// Build an <see cref="EventModelDescriptor"/> for this source.
     /// Returns <see langword="null"/> when the source cannot produce a
     /// descriptor — e.g. the underlying definition type failed to

--- a/src/JasperFx/Descriptors/EventModeling/EventModelElement.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelElement.cs
@@ -95,6 +95,40 @@ public sealed record EventModelElement(
     public static EventModelElement ForLabel(string sliceName, EventModelElementKind kind, string label)
         => new(IdFor(sliceName, kind, label), kind, LaneFor(kind), label, null);
 
+    /// <summary>
+    /// Which rung of the provenance ladder claimed the role this element renders (jasperfx#703) —
+    /// stamped from the owning slice's <see cref="EventModelSliceDescriptor.ProvenanceFor"/>, so a
+    /// viewer can shade "production has seen this happen" differently from "somebody wrote it down"
+    /// without re-deriving anything.
+    /// </summary>
+    /// <remarks>
+    /// The <em>effective</em> rung, so it follows the same one rule the merge does: an unattributed
+    /// source is treated as a declaration, and its elements read
+    /// <see cref="EventModelProvenance.Declared"/> rather than null. Null means only that nothing
+    /// claims the role at all, which for a rendered element happens only on the kinds that have no
+    /// role of their own.
+    /// </remarks>
+    public EventModelProvenance? Provenance { get; init; }
+
+    /// <summary>The role an element of <paramref name="kind"/> renders, for provenance lookup.</summary>
+    /// <remarks>
+    /// A trigger is the one kind with three possible sources — <c>TriggerType</c>, <c>TriggerLabel</c>
+    /// and <c>TriggerOrigin</c> — so the slice resolves that one itself rather than going through here.
+    /// </remarks>
+    public static EventModelRole? RoleFor(EventModelElementKind kind) => kind switch
+    {
+        EventModelElementKind.Command => EventModelRole.CommandType,
+        EventModelElementKind.Handler => EventModelRole.HandlerType,
+        EventModelElementKind.Aggregate => EventModelRole.AggregateTypes,
+        EventModelElementKind.Event => EventModelRole.EmittedEvents,
+        EventModelElementKind.Message => EventModelRole.PublishedMessages,
+        EventModelElementKind.Projection => EventModelRole.ProjectionTypes,
+        EventModelElementKind.ReadModel => EventModelRole.ReadModelTypes,
+        EventModelElementKind.ExternalSystem => EventModelRole.ExternalSystems,
+        EventModelElementKind.Hotspot => EventModelRole.Hotspots,
+        _ => null,
+    };
+
     /// <summary>The canonical lane for an element kind.</summary>
     public static EventModelLane LaneFor(EventModelElementKind kind) => kind switch
     {

--- a/src/JasperFx/Descriptors/EventModeling/EventModelProvenance.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelProvenance.cs
@@ -1,0 +1,119 @@
+namespace JasperFx.Events.EventModeling;
+
+/// <summary>
+/// How much authority a source's claim about an Event Model carries — the three-rung ladder that
+/// decides precedence when several sources describe the same slice (jasperfx#703).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Higher rung wins.</b> Four producers now feed one <see cref="EventModelDescriptor"/>: Gherkin
+/// specs, the C# overlay / code-first specs, Wolverine's chains, and runtime observation from
+/// CritterWatch. Something has to arbitrate, and "whoever registered first" is neither readable nor
+/// defensible. Production beats what the code implies, and the code beats what somebody wrote down.
+/// </para>
+/// <para>
+/// ⚠️ <b>This inverts the ordering that shipped before jasperfx#703</b>, where
+/// <c>WolverineEventModelSource</c> was registered at index 0 specifically so derived roles would
+/// beat overlays. Registration order is no longer the mechanism; the ladder is. Order now only
+/// breaks ties between sources on the same rung.
+/// </para>
+/// <para>
+/// ⚠️ <b>Precedence is per claimed role, not wholesale</b> — see
+/// <see cref="EventModelSliceDescriptor.ProvenanceFor"/>. A source that does not claim a role never
+/// overrides one that does, so slice names, domains and specification links keep coming from
+/// declarations and keep winning by default: nothing else claims them.
+/// </para>
+/// <para>
+/// <b>Relationship to CritterWatch's <c>LifecycleProvenance</c>.</b> The two vocabularies overlap but
+/// are not the same axis, and conflating them is a trap. CritterWatch's <c>Inferred | Observed |
+/// Confirmed</c> is a <em>reconciliation</em> of one edge across static and runtime discovery:
+/// <c>Confirmed</c> means "both sources agree", not "seen in production". This enum is a ladder of
+/// authority instead. <see cref="Declared"/> and <see cref="Derived"/> both map onto CritterWatch's
+/// <c>Inferred</c>, <see cref="Observed"/> onto its <c>Observed</c>, and its <c>Confirmed</c> has no
+/// rung here — agreement between rungs is expressed by the <em>absence</em> of a disagreement
+/// hotspot (jasperfx#704) rather than by a fourth value.
+/// </para>
+/// </remarks>
+public enum EventModelProvenance
+{
+    /// <summary>
+    /// Somebody wrote it down — a Gherkin spec, a code-first specification, or the C# overlay's
+    /// <c>EventModelDefinition</c>. The lowest rung, and the only source of slice names, domains and
+    /// specification links.
+    /// </summary>
+    Declared = 0,
+
+    /// <summary>
+    /// Read out of the code — Wolverine's handler / HTTP / gRPC chains, the source generator's view
+    /// of a projection. Beats a declaration, because the code is what actually ships.
+    /// </summary>
+    Derived = 1,
+
+    /// <summary>
+    /// Seen happening in a running system — CritterWatch's runtime observation of appends and
+    /// causations. The top rung: production is the only source that can see a path static analysis
+    /// missed, and it cannot be argued with.
+    /// </summary>
+    Observed = 2,
+}
+
+/// <summary>
+/// The roles of an <see cref="EventModelSliceDescriptor"/> that provenance is tracked against — one
+/// entry per mergeable member, so precedence can be decided per claimed role rather than wholesale
+/// (jasperfx#703).
+/// </summary>
+/// <remarks>
+/// A role is <em>claimed</em> when the slice carries a value for it: a non-null scalar, or a non-empty
+/// list. That definition is deliberately structural rather than something a source has to opt into,
+/// so every existing source gets correct per-role attribution without changing a line.
+/// </remarks>
+public enum EventModelRole
+{
+    /// <summary><see cref="EventModelSliceDescriptor.TriggerLabel"/>.</summary>
+    TriggerLabel,
+
+    /// <summary><see cref="EventModelSliceDescriptor.TriggerType"/>.</summary>
+    TriggerType,
+
+    /// <summary><see cref="EventModelSliceDescriptor.TriggerKind"/>.</summary>
+    TriggerKind,
+
+    /// <summary><see cref="EventModelSliceDescriptor.TriggerOrigin"/>.</summary>
+    TriggerOrigin,
+
+    /// <summary><see cref="EventModelSliceDescriptor.Pattern"/>.</summary>
+    Pattern,
+
+    /// <summary><see cref="EventModelSliceDescriptor.CommandType"/>.</summary>
+    CommandType,
+
+    /// <summary><see cref="EventModelSliceDescriptor.HandlerType"/>.</summary>
+    HandlerType,
+
+    /// <summary><see cref="EventModelSliceDescriptor.AggregateTypes"/>.</summary>
+    AggregateTypes,
+
+    /// <summary><see cref="EventModelSliceDescriptor.EmittedEvents"/>.</summary>
+    EmittedEvents,
+
+    /// <summary><see cref="EventModelSliceDescriptor.PublishedMessages"/>.</summary>
+    PublishedMessages,
+
+    /// <summary><see cref="EventModelSliceDescriptor.ProjectionTypes"/>.</summary>
+    ProjectionTypes,
+
+    /// <summary><see cref="EventModelSliceDescriptor.ReadModelTypes"/>.</summary>
+    ReadModelTypes,
+
+    /// <summary><see cref="EventModelSliceDescriptor.ExternalSystems"/>.</summary>
+    ExternalSystems,
+
+    /// <summary><see cref="EventModelSliceDescriptor.Hotspots"/>.</summary>
+    Hotspots,
+
+    /// <summary><see cref="EventModelSliceDescriptor.Specifications"/>.</summary>
+    Specifications,
+
+    /// <summary><see cref="EventModelSliceDescriptor.Domain"/>.</summary>
+    Domain,
+}

--- a/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
@@ -103,6 +103,77 @@ public sealed record EventModelSliceDescriptor(
     public string? Domain { get; init; }
 
     /// <summary>
+    /// Which rung of the provenance ladder the source that produced this slice sits on
+    /// (jasperfx#703). Null means unattributed, which <see cref="ProvenanceFor"/> reads as
+    /// <see cref="EventModelProvenance.Declared"/> — so a model whose sources have not been stamped
+    /// yet merges exactly as it did before, on registration order.
+    /// </summary>
+    /// <remarks>
+    /// On a slice assembled by <see cref="Merge"/> this is the highest rung that contributed
+    /// anything. It is a summary for viewers that do not care which role came from where;
+    /// <see cref="ClaimedBy"/> is the per-role truth.
+    /// </remarks>
+    public EventModelProvenance? Provenance { get; init; }
+
+    /// <summary>
+    /// Per-role attribution: which rung claimed each role of this slice. Stamped by
+    /// <see cref="Merge"/>, which is the only place the answer can differ role by role.
+    /// </summary>
+    /// <remarks>
+    /// Empty on a slice straight from one source — there is nothing to disambiguate, so
+    /// <see cref="ProvenanceFor"/> derives the answer from <see cref="Provenance"/> and whether the
+    /// role is claimed at all. Prefer <see cref="ProvenanceFor"/> over reading this directly.
+    /// </remarks>
+    public IReadOnlyDictionary<EventModelRole, EventModelProvenance> ClaimedBy { get; init; }
+        = new Dictionary<EventModelRole, EventModelProvenance>();
+
+    /// <summary>
+    /// The rung that claimed <paramref name="role"/> on this slice, or null when nothing claims it.
+    /// </summary>
+    /// <remarks>
+    /// This is the acceptance criterion of jasperfx#703 in one method: after a merge of three
+    /// sources, ask any role which source's claim survived.
+    /// </remarks>
+    public EventModelProvenance? ProvenanceFor(EventModelRole role)
+    {
+        if (ClaimedBy.TryGetValue(role, out var claimed)) return claimed;
+
+        return Claims(role) ? Provenance ?? EventModelProvenance.Declared : null;
+    }
+
+    /// <summary>
+    /// Does this slice carry a value for <paramref name="role"/>? A non-null scalar or a non-empty
+    /// list. Structural on purpose: no source has to opt into being attributed.
+    /// </summary>
+    public bool Claims(EventModelRole role) => role switch
+    {
+        EventModelRole.TriggerLabel => TriggerLabel is not null,
+        EventModelRole.TriggerType => TriggerType is not null,
+        EventModelRole.TriggerKind => TriggerKind is not null,
+        EventModelRole.TriggerOrigin => TriggerOrigin is not null,
+        EventModelRole.Pattern => Pattern is not null,
+        EventModelRole.CommandType => CommandType is not null,
+        EventModelRole.HandlerType => HandlerType is not null,
+        EventModelRole.AggregateTypes => AggregateTypes.Count > 0,
+        EventModelRole.EmittedEvents => EmittedEvents.Count > 0,
+        EventModelRole.PublishedMessages => PublishedMessages.Count > 0,
+        EventModelRole.ProjectionTypes => ProjectionTypes.Count > 0,
+        EventModelRole.ReadModelTypes => ReadModelTypes.Count > 0,
+        EventModelRole.ExternalSystems => ExternalSystems.Count > 0,
+        EventModelRole.Hotspots => Hotspots.Count > 0,
+        EventModelRole.Specifications => Specifications.Count > 0,
+        EventModelRole.Domain => Domain is not null,
+        _ => false,
+    };
+
+    /// <summary>
+    /// Stamp this slice with the rung of the source that produced it, if it is not already
+    /// attributed. A source that stamps its own slices individually is left alone.
+    /// </summary>
+    public EventModelSliceDescriptor WithProvenance(EventModelProvenance provenance)
+        => Provenance is null ? this with { Provenance = provenance } : this;
+
+    /// <summary>
     /// The rendering contract — every element of the slice with a stable id, a kind (→ colour)
     /// and a lane. Computed from the typed roles on each read.
     /// </summary>
@@ -115,11 +186,30 @@ public sealed record EventModelSliceDescriptor(
     public IReadOnlyList<EventModelEdge> Edges => buildGraph().edges;
 
     /// <summary>
-    /// Fold another source's view of the <em>same</em> slice into this one. Scalars keep the
-    /// first non-null value (this instance wins); lists are unioned in order, deduplicated by
-    /// identity. The overlay is typically merged <em>onto</em> the derived slice so derived roles
-    /// are never overwritten by a name-only declaration.
+    /// Fold another source's view of the <em>same</em> slice into this one, role by role, with the
+    /// higher rung of <see cref="EventModelProvenance"/> winning (jasperfx#703).
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Per claimed role, not wholesale.</b> A source that does not claim a role never overrides
+    /// one that does, whatever rung it sits on. That is why slice names, domains and specification
+    /// links keep coming from declarations: nothing else claims them, so nothing else can take them.
+    /// </para>
+    /// <para>
+    /// <b>Ties fall back to first-wins</b>, which is what this method did for every role before
+    /// jasperfx#703 — so two unattributed sources merge exactly as they always have, on the order
+    /// they were given. That is the compatibility hinge: a model whose sources have not been stamped
+    /// yet is byte-identical to what it produced before.
+    /// </para>
+    /// <para>
+    /// <b>A higher rung replaces a list, it does not union with it.</b> Unioning is what made the old
+    /// merge lossy in the other direction: derived <c>{A, C}</c> unioned with observed <c>{A, B}</c>
+    /// silently invents a slice that emits three events and nobody ever claimed. Production winning
+    /// means the answer is <c>{A, B}</c>; what happened to <c>C</c> is a finding, and jasperfx#704
+    /// records it rather than letting it vanish. Same-rung lists still union in order, deduplicated
+    /// by identity, exactly as before.
+    /// </para>
+    /// </remarks>
     public EventModelSliceDescriptor Merge(EventModelSliceDescriptor other)
     {
         if (!string.Equals(Name, other.Name, StringComparison.Ordinal))
@@ -129,30 +219,84 @@ public sealed record EventModelSliceDescriptor(
                 nameof(other));
         }
 
-        return new EventModelSliceDescriptor(
-            Name,
-            TriggerLabel ?? other.TriggerLabel,
-            TriggerType ?? other.TriggerType,
-            CommandType ?? other.CommandType,
-            HandlerType ?? other.HandlerType,
-            unionTypes(EmittedEvents, other.EmittedEvents),
-            unionTypes(ProjectionTypes, other.ProjectionTypes),
-            unionTypes(ReadModelTypes, other.ReadModelTypes))
+        var claimedBy = new Dictionary<EventModelRole, EventModelProvenance>();
+
+        // True when other's claim on this role outranks ours -- or when we make no claim at all.
+        // False on a tie, which is what preserves the pre-jasperfx#703 first-wins behaviour.
+        bool takeOther(EventModelRole role)
         {
-            Pattern = Pattern ?? other.Pattern,
-            TriggerKind = TriggerKind ?? other.TriggerKind,
-            TriggerOrigin = TriggerOrigin ?? other.TriggerOrigin,
-            AggregateTypes = unionTypes(AggregateTypes, other.AggregateTypes),
-            PublishedMessages = unionTypes(PublishedMessages, other.PublishedMessages),
-            ExternalSystems = union(ExternalSystems, other.ExternalSystems, x => $"{x.Direction}:{x.Name}"),
-            Hotspots = union(Hotspots, other.Hotspots, x => $"{x.Origin}:{x.Text}"),
-            Specifications = union(Specifications, other.Specifications, x => x.Identity),
-            Domain = Domain ?? other.Domain,
+            var mine = ProvenanceFor(role);
+            var theirs = other.ProvenanceFor(role);
+
+            var winner = (mine, theirs) switch
+            {
+                (null, null) => (EventModelProvenance?)null,
+                (null, not null) => theirs,
+                (not null, null) => mine,
+                _ => theirs > mine ? theirs : mine,
+            };
+
+            if (winner is { } rung) claimedBy[role] = rung;
+
+            return theirs is not null && (mine is null || theirs > mine);
+        }
+
+        IReadOnlyList<T> mergeList<T>(EventModelRole role, IReadOnlyList<T> mine, IReadOnlyList<T> theirs,
+            Func<T, string> key)
+        {
+            var myRung = ProvenanceFor(role);
+            var theirRung = other.ProvenanceFor(role);
+
+            takeOther(role);
+
+            if (theirRung is null) return mine;
+            if (myRung is null) return theirs;
+            if (theirRung > myRung) return theirs;
+            if (myRung > theirRung) return mine;
+
+            return union(mine, theirs, key);
+        }
+
+        IReadOnlyList<TypeDescriptor> mergeTypes(EventModelRole role, IReadOnlyList<TypeDescriptor> mine,
+            IReadOnlyList<TypeDescriptor> theirs)
+            => mergeList(role, mine, theirs, x => x.FullName);
+
+        var merged = new EventModelSliceDescriptor(
+            Name,
+            takeOther(EventModelRole.TriggerLabel) ? other.TriggerLabel : TriggerLabel,
+            takeOther(EventModelRole.TriggerType) ? other.TriggerType : TriggerType,
+            takeOther(EventModelRole.CommandType) ? other.CommandType : CommandType,
+            takeOther(EventModelRole.HandlerType) ? other.HandlerType : HandlerType,
+            mergeTypes(EventModelRole.EmittedEvents, EmittedEvents, other.EmittedEvents),
+            mergeTypes(EventModelRole.ProjectionTypes, ProjectionTypes, other.ProjectionTypes),
+            mergeTypes(EventModelRole.ReadModelTypes, ReadModelTypes, other.ReadModelTypes))
+        {
+            Pattern = takeOther(EventModelRole.Pattern) ? other.Pattern : Pattern,
+            TriggerKind = takeOther(EventModelRole.TriggerKind) ? other.TriggerKind : TriggerKind,
+            TriggerOrigin = takeOther(EventModelRole.TriggerOrigin) ? other.TriggerOrigin : TriggerOrigin,
+            AggregateTypes = mergeTypes(EventModelRole.AggregateTypes, AggregateTypes, other.AggregateTypes),
+            PublishedMessages = mergeTypes(EventModelRole.PublishedMessages, PublishedMessages, other.PublishedMessages),
+            ExternalSystems = mergeList(EventModelRole.ExternalSystems, ExternalSystems, other.ExternalSystems,
+                x => $"{x.Direction}:{x.Name}"),
+            Hotspots = mergeList(EventModelRole.Hotspots, Hotspots, other.Hotspots, x => $"{x.Origin}:{x.Text}"),
+            Specifications = mergeList(EventModelRole.Specifications, Specifications, other.Specifications,
+                x => x.Identity),
+            Domain = takeOther(EventModelRole.Domain) ? other.Domain : Domain,
+            Provenance = higher(Provenance, other.Provenance),
         };
+
+        return merged with { ClaimedBy = claimedBy };
     }
 
-    private static IReadOnlyList<TypeDescriptor> unionTypes(IReadOnlyList<TypeDescriptor> first, IReadOnlyList<TypeDescriptor> second)
-        => union(first, second, x => x.FullName);
+    /// <summary>The higher of two rungs, or whichever is set, or null when neither is.</summary>
+    private static EventModelProvenance? higher(EventModelProvenance? first, EventModelProvenance? second)
+        => (first, second) switch
+        {
+            (null, null) => null,
+            (null, not null) => second,
+            (not null, null) => first,
+            _ => second > first ? second : first,
+        };
 
     private static IReadOnlyList<T> union<T>(IReadOnlyList<T> first, IReadOnlyList<T> second, Func<T, string> key)
     {
@@ -174,10 +318,20 @@ public sealed record EventModelSliceDescriptor(
         var elements = new List<EventModelElement>();
         var edges = new List<EventModelEdge>();
 
-        EventModelElement add(EventModelElement element)
+        EventModelElement add(EventModelElement element, EventModelRole? role = null)
         {
-            elements.Add(element);
-            return element;
+            // The rendering contract carries the ladder too (jasperfx#703), so a viewer can shade an
+            // observed role differently from a declared one without re-deriving anything. Trigger
+            // elements pass their role in explicitly -- they are the one kind with three possible
+            // sources.
+            role ??= EventModelElement.RoleFor(element.Kind);
+
+            var stamped = role is { } claimed && ProvenanceFor(claimed) is { } rung
+                ? element with { Provenance = rung }
+                : element;
+
+            elements.Add(stamped);
+            return stamped;
         }
 
         void link(EventModelElement? from, EventModelElement? to)
@@ -190,15 +344,18 @@ public sealed record EventModelSliceDescriptor(
         EventModelElement? trigger = null;
         if (TriggerType is not null)
         {
-            trigger = add(EventModelElement.ForType(Name, EventModelElementKind.Trigger, TriggerType));
+            trigger = add(EventModelElement.ForType(Name, EventModelElementKind.Trigger, TriggerType),
+                EventModelRole.TriggerType);
         }
         else if (TriggerLabel is not null)
         {
-            trigger = add(EventModelElement.ForLabel(Name, EventModelElementKind.Trigger, TriggerLabel));
+            trigger = add(EventModelElement.ForLabel(Name, EventModelElementKind.Trigger, TriggerLabel),
+                EventModelRole.TriggerLabel);
         }
         else if (TriggerOrigin?.Label is not null)
         {
-            trigger = add(EventModelElement.ForLabel(Name, EventModelElementKind.Trigger, TriggerOrigin.Label));
+            trigger = add(EventModelElement.ForLabel(Name, EventModelElementKind.Trigger, TriggerOrigin.Label),
+                EventModelRole.TriggerOrigin);
         }
 
         var inboundSystems = ExternalSystems
@@ -320,14 +477,30 @@ public sealed record EventModelDescriptor(
     public IReadOnlyList<HotspotDescriptor> Hotspots { get; init; } = Array.Empty<HotspotDescriptor>();
 
     /// <summary>
-    /// Assemble one model from several sources' descriptors. Slices with the same name are
-    /// folded with <see cref="EventModelSliceDescriptor.Merge"/> in the order the descriptors
-    /// are given (earlier wins on scalars — put derived sources before the overlay); aggregates
-    /// are unioned by type and model-level hotspots by origin + text. Slice order is first
-    /// appearance.
+    /// Stamp every unattributed slice with <paramref name="provenance"/> — the rung of the source
+    /// that produced this descriptor (jasperfx#703). Slices a source attributed itself are left alone.
     /// </summary>
+    public EventModelDescriptor WithProvenance(EventModelProvenance provenance)
+        => this with { Slices = Slices.Select(x => x.WithProvenance(provenance)).ToList() };
+
+    /// <summary>
+    /// Assemble one model from several sources' descriptors. Slices with the same name are folded
+    /// with <see cref="EventModelSliceDescriptor.Merge"/>, which decides each role by the
+    /// <see cref="EventModelProvenance"/> ladder — observed beats derived beats declared — and falls
+    /// back to the order the descriptors are given only to break a tie between sources on the same
+    /// rung. Aggregates are unioned by type and model-level hotspots by origin + text. Slice order is
+    /// first appearance.
+    /// </summary>
+    /// <remarks>
+    /// ⚠️ Before jasperfx#703 this was first-wins for every role, and callers registered derived
+    /// sources ahead of overlays to make derived roles beat declared ones. Registration order is no
+    /// longer the mechanism: stamp the sources instead, through
+    /// <see cref="IEventModelDefinitionSource.Provenance"/> or
+    /// <see cref="EventModelSliceDescriptor.WithProvenance"/>. Unstamped sources all sit on
+    /// <see cref="EventModelProvenance.Declared"/>, tie, and merge exactly as they did before.
+    /// </remarks>
     /// <param name="name">Name of the assembled model.</param>
-    /// <param name="descriptors">Descriptors to fold, derived sources first.</param>
+    /// <param name="descriptors">Descriptors to fold. Order breaks ties within a rung.</param>
     public static EventModelDescriptor Merge(string name, IEnumerable<EventModelDescriptor> descriptors)
     {
         var slices = new List<EventModelSliceDescriptor>();


### PR DESCRIPTION
Closes #703. Design of record: `.claude/notes/DESIGN-2026-08-26-inner-loop-provenance-and-embedded.md` in the CritterWatch repo (JasperFx/stoat#9), decisions D8/D9.

⚠️ **This is a behaviour change with a downstream consumer.** See *Migration* at the bottom.

## What this adds

A three-rung ladder of authority, plus per-role attribution so "where did *emits `OrderPlaced`* come from?" has an answer:

```
Declared  <  Derived (from code)  <  Observed (in production)
```

| Surface | What it is |
| --- | --- |
| `EventModelProvenance` | The ladder |
| `EventModelRole` | One entry per mergeable member of a slice — the key of the attribution map |
| `EventModelSliceDescriptor.Provenance` | The rung of the source that produced this slice; on a merged slice, the highest that contributed |
| `EventModelSliceDescriptor.ProvenanceFor(role)` | **The acceptance criterion in one method** — which rung claimed each role |
| `EventModelSliceDescriptor.ClaimedBy` | The per-role map itself, stamped by `Merge` |
| `EventModelElement.Provenance` | The same answer on the rendering contract, so viewers shade without re-deriving |
| `IEventModelDefinitionSource.Provenance` | A source answers once; `DiscoverAsync` stamps every slice it returns |

`Provenance` on the source is a **default interface member** returning `Declared`, so every existing implementation keeps compiling untouched.

## On the vocabulary — I did not reuse CritterWatch's spelling, deliberately

The issue proposes adopting CW's `inferred | observed | confirmed` "rather than inventing one". Having read `LifecycleProvenance` in CritterWatch, I think that would import a name whose meaning is different one repo over. CW's enum is a **reconciliation** of a single edge across static and runtime discovery — `Confirmed` means *"both sources agree"*, not *"seen in production"* — and it has no rung at all for "declared by an overlay" versus "derived from code", which is precisely the distinction #703 needs.

So this ships `Declared | Derived | Observed`, and the XML docs state the mapping explicitly: `Declared` and `Derived` both collapse onto CW's `Inferred`, `Observed` onto its `Observed`, and CW's `Confirmed` has no rung here — agreement between rungs is expressed by the **absence** of a disagreement hotspot (#704) rather than by a fourth value. Easy to rename if you'd rather match CW literally, but the semantics would need reconciling either way.

## The two rules that matter

**1. Precedence is per claimed role, not wholesale.** A role is *claimed* when the slice carries a value for it — a non-null scalar or a non-empty list. That definition is structural on purpose: no source has to opt into being attributed, so every existing source gets correct per-role attribution without changing a line. A source that does not claim a role never overrides one that does, whatever rung it sits on. Slice names, domains, trigger labels and specification links therefore keep coming from declarations and keep winning by default, because nothing else claims them.

**2. A higher rung replaces a list, it does not union with it.** This is the one place I went beyond the letter of the issue, and I think it is forced. Unioning derived `{A, C}` with observed `{A, B}` yields a slice emitting three events that nobody ever claimed — lossy in the opposite direction from first-wins. Production winning means the answer is `{A, B}`; what became of `C` is a *finding*, and #704 records it rather than letting it vanish. Lists claimed at the same rung still union in order and deduplicate by identity, exactly as before.

## One design question I resolved against my first instinct

`EventModelElement.Provenance` reads `Declared` on an unattributed slice rather than `null`. My first pass had it null — "no opinion, render as you always have" — but that puts two different rules in the codebase: `ProvenanceFor` has to return the `Declared` floor for unattributed roles (it is what makes ties, and therefore backwards compatibility, work), and having the element disagree with it means a viewer and the merge would answer the same question differently. One rule wins. Flag it if you'd rather have the null and take the second rule.

## Migration

**Registration order stops being the mechanism.** `WolverineEventModelSource` is registered at index 0 today specifically so derived roles beat overlays; order is now only a **tie-breaker between sources on the same rung**.

Nothing breaks on the way there, because `IEventModelDefinitionSource.Provenance` defaults to `Declared`: every existing source ties, every tie resolves on order, and an unstamped application merges byte-identically to today. `unattributed_sources_merge_exactly_as_they_did_before` pins that, and the 864 pre-existing `EventTests` pass untouched.

The follow-ups, once this ships:
- **wolverine** — `WolverineEventModelSource` overrides `Provenance => Derived`. One line, and index 0 stops being load-bearing.
- **bobcat** — the Gherkin generator's source stays `Declared` (the default), so nothing to do.
- **CritterWatch** — runtime observation feeds in as `Observed`, which is the whole point of the exercise.

Worth a release-note line for the ordering inversion, per the issue's acceptance criteria.

## Verification

- New `EventModelProvenanceTests` — 18 tests over the ladder, per-role precedence, list replace-vs-union, the compatibility hinge, element stamping, and discovery-time stamping. Includes the issue's acceptance scenario end to end: three sources, a declared role beaten by a derived one, a derived role beaten by an observed one, and the overlay's name and domain surviving all of it.
- `EventModelWireRoundTripTests` extended with a slice merged from all three rungs, so `Provenance` and the enum-keyed `ClaimedBy` map round-trip under both CritterWatch's camelCase + string-enum options and the STJ defaults.
- Docs updated: `docs/event-modeling/descriptors.md` gains a *Provenance decides the merge* section with the ladder table and the inversion warning; `index.md`'s "derived first" claim is corrected.
- Full solution builds; `CoreTests` 584, `CommandLineTests` 295, `CodegenTests` 419, `EventTests` 882 — all green.

#704 builds on this and follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)