### PR TITLE
gh-704: a source disagreement is a hotspot, not a swallowed merge

### DIFF
--- a/docs/event-modeling/descriptors.md
+++ b/docs/event-modeling/descriptors.md
@@ -156,7 +156,9 @@ Registration order used to be the mechanism — `WolverineEventModelSource` was 
 Concretely:
 
 - **Scalars** go to the highest rung that claims them; a tie keeps the first value.
-- **Lists** go to the highest rung that claims them **outright** — a higher rung *replaces* rather than unions, because unioning derived `{A, C}` with observed `{A, B}` invents a slice emitting three events that nobody claimed. Lists claimed at the **same** rung union in order and deduplicate by identity: types by full name, external systems by direction + name, specifications by identity, hotspots by origin + text.
+- **Lists** go to the highest rung that claims them **outright** — a higher rung *replaces* rather than unions, because unioning derived `{A, C}` with observed `{A, B}` invents a slice emitting three events that nobody claimed. Lists claimed at the **same** rung union in order and deduplicate by identity: types by full name, external systems by direction + name, specifications by identity.
+- **Hotspots** always union, whatever the rungs. They are annotations rather than claims about the system, and arbitrating them would discard findings.
+- **Any dropped claim** becomes a [`SourceDisagreement` hotspot](/event-modeling/hotspots#a-source-disagreement-is-a-hotspot) naming the role, both claims and the rung each came from — so a losing claim is recorded rather than silently discarded.
 - **Slices** fold by name; slice order is first appearance.
 - **Aggregates** union by type full name.
 

--- a/docs/event-modeling/hotspots.md
+++ b/docs/event-modeling/hotspots.md
@@ -95,6 +95,30 @@ A slice hotspot renders as an element in that slice's wireframe lane. A model ho
 
 A slice that is *nothing but* a hotspot still renders one element — which is exactly what you want for a slice you have thought about but not built.
 
+## A source disagreement is a hotspot
+
+The third origin is the only one you never write. When two sources describe the same slice and make **different** claims about the same role, the merge keeps one and records the other as a `SourceDisagreement` hotspot:
+
+> ⚠ `EmittedEvents: Observed claims OrderPlaced, AuditRecorded; Derived claims OrderPlaced`
+
+*The code says this slice emits `OrderPlaced`; production says it appends `OrderPlaced` **and** `AuditRecorded`.* That is arguably the most valuable thing a four-source model can tell you, and a first-wins merge destroyed exactly that signal — the losing claim vanished with no trace.
+
+Alongside `Text`, a disagreement carries the structured form for a reader that wants to act on it:
+
+```cs
+hotspot.Role;          // EventModelRole.EmittedEvents
+hotspot.WinningClaim;  // (Observed, "OrderPlaced, AuditRecorded") — what the merge kept
+hotspot.LosingClaim;   // (Derived,  "OrderPlaced")                — what it dropped
+```
+
+A pair rather than a list because merges are pairwise: three sources disagreeing about one role leave two findings, each naming the two claims that actually met.
+
+**Nothing is recorded when nothing is lost.** Two sources on the same rung whose lists union have not disagreed about anything; neither have two sources making the *same* claim from different rungs — the code saying `OrderPlaced` and production agreeing is the happy case, and it is silent. A role only one source claims is not a disagreement either, because the other never spoke. What does get recorded is any claim the merge actually dropped, including the one first-wins has always discarded when two same-rung sources name different handlers.
+
+::: tip Hotspots are never arbitrated
+Every other role goes to the highest rung that claims it. `Hotspots` always unions, because hotspots are annotations rather than claims about the system — letting a higher-rung source's list replace a lower one would throw away the findings this exists to record.
+:::
+
 ## Prefer the pending spec
 
 ::: tip
@@ -140,4 +164,4 @@ foreach (var hotspot in helpdesk.Hotspots)
 <sup><a href='https://github.com/JasperFx/jasperfx/blob/master/src/DocSamples/EventModeling/EventModelUsageSamples.cs#L43-L67' title='Snippet source file'>snippet source</a> | <a href='#snippet-sample_assembling_the_event_model' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-`HotspotOrigin` tells them apart, and `SpecificationIdentity` is populated only for the pending-spec form. Hotspots from different sources are unioned and deduplicated on origin plus text — so prose and a pending spec that happen to share a string stay two distinct hotspots, because they mean two different things.
+`HotspotOrigin` tells them apart; `SpecificationIdentity` is populated only for the pending-spec form, and `Role` / `WinningClaim` / `LosingClaim` only for a source disagreement. Hotspots from different sources are unioned and deduplicated on origin plus text — so prose and a pending spec that happen to share a string stay two distinct hotspots, because they mean two different things.

--- a/src/EventTests/EventModeling/EventModelProvenanceTests.cs
+++ b/src/EventTests/EventModeling/EventModelProvenanceTests.cs
@@ -250,6 +250,11 @@ public class EventModelProvenanceTests
             .ShouldBe([T<OrderPlaced>().FullName, T<OrderShipped>().FullName]);
         merged.HandlerType!.FullName.ShouldBe(T<OrderHandler>().FullName);
         merged.Provenance.ShouldBeNull();
+
+        // The merged *values* are what they always were. jasperfx#704 additionally records the two
+        // claims first-wins dropped here -- the competing command types and domains -- as hotspots,
+        // which is the one thing about an unstamped merge that does change.
+        merged.Hotspots.Count(x => x.Origin == HotspotOrigin.SourceDisagreement).ShouldBe(2);
     }
 
     #endregion

--- a/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
+++ b/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
@@ -42,6 +42,10 @@ public class EventModelWireRoundTripTests
             {
                 HotspotDescriptor.PendingSpecification("Place Order/Rejects empty cart"),
                 HotspotDescriptor.Prose("Refund policy unclear when partially shipped"),
+                // jasperfx#704: the third origin, with its structured pair of competing claims
+                HotspotDescriptor.SourceDisagreement(EventModelRole.EmittedEvents,
+                    new EventModelClaim(EventModelProvenance.Observed, "OrderPlaced, AuditRecorded"),
+                    new EventModelClaim(EventModelProvenance.Derived, "OrderPlaced")),
             },
             Specifications = new[]
             {

--- a/src/EventTests/EventModeling/SourceDisagreementHotspotTests.cs
+++ b/src/EventTests/EventModeling/SourceDisagreementHotspotTests.cs
@@ -1,0 +1,234 @@
+using JasperFx.Descriptors;
+using JasperFx.Events.EventModeling;
+using Shouldly;
+
+namespace EventTests.EventModeling;
+
+/// <summary>
+/// jasperfx#704: a source disagreement is a hotspot, not a swallowed merge.
+/// </summary>
+public class SourceDisagreementHotspotTests
+{
+    private static TypeDescriptor T<TType>() => TypeDescriptor.For(typeof(TType));
+
+    private static EventModelSliceDescriptor Slice(EventModelProvenance provenance) =>
+        EventModelSliceDescriptor.Named("PlaceOrder") with { Provenance = provenance };
+
+    private static IReadOnlyList<HotspotDescriptor> DisagreementsIn(EventModelSliceDescriptor slice) =>
+        slice.Hotspots.Where(x => x.Origin == HotspotOrigin.SourceDisagreement).ToList();
+
+    #region the acceptance criterion
+
+    [Fact]
+    public void production_wins_and_the_losing_claim_becomes_a_hotspot()
+    {
+        // The issue's acceptance scenario, verbatim: a derived slice claiming events {A} merged with
+        // an observed slice claiming {A, B}.
+        var derived = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] };
+        var observed = Slice(EventModelProvenance.Observed) with
+        {
+            EmittedEvents = [T<OrderPlaced>(), T<AuditRecorded>()],
+        };
+
+        var merged = derived.Merge(observed);
+
+        // Production wins the roles...
+        merged.EmittedEvents.Select(x => x.Name).ShouldBe(["OrderPlaced", "AuditRecorded"]);
+
+        // ...and the claim that lost is recorded rather than dropped.
+        var hotspot = DisagreementsIn(merged).ShouldHaveSingleItem();
+
+        hotspot.Role.ShouldBe(EventModelRole.EmittedEvents);
+        hotspot.WinningClaim.ShouldBe(new EventModelClaim(EventModelProvenance.Observed, "OrderPlaced, AuditRecorded"));
+        hotspot.LosingClaim.ShouldBe(new EventModelClaim(EventModelProvenance.Derived, "OrderPlaced"));
+
+        // Enough for a reader to see which source to trust and which to fix, without unpacking the
+        // structured form.
+        hotspot.Text.ShouldBe(
+            "EmittedEvents: Observed claims OrderPlaced, AuditRecorded; Derived claims OrderPlaced");
+    }
+
+    [Fact]
+    public void a_disagreement_renders_in_the_canonical_hotspot_colour()
+    {
+        var merged = (Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] })
+            .Merge(Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<AuditRecorded>()] });
+
+        var element = merged.Elements.Single(x => x.Kind == EventModelElementKind.Hotspot);
+
+        // New semantics on shipped machinery: HotspotDescriptor already renders in both viewers, so
+        // there is nothing new to draw.
+        element.Lane.ShouldBe(EventModelLane.Wireframe);
+        EventModelPalette.ColorFor(element.Kind).ShouldBe("#E91E63");
+        element.Label.ShouldContain("EmittedEvents");
+    }
+
+    #endregion
+
+    #region what counts as a disagreement
+
+    [Fact]
+    public void a_scalar_dropped_by_first_wins_is_a_disagreement_even_at_the_same_rung()
+    {
+        // Two sources on the same rung claiming different handlers: the ladder cannot separate them,
+        // so first-wins drops one -- which is exactly the silent loss this issue is about.
+        var first = Slice(EventModelProvenance.Derived) with { HandlerType = T<OrderHandler>() };
+        var second = Slice(EventModelProvenance.Derived) with { HandlerType = T<LegacyOrderHandler>() };
+
+        var merged = first.Merge(second);
+
+        merged.HandlerType!.Name.ShouldBe("OrderHandler");
+
+        var hotspot = DisagreementsIn(merged).ShouldHaveSingleItem();
+        hotspot.Role.ShouldBe(EventModelRole.HandlerType);
+        hotspot.WinningClaim!.Value.ShouldBe("OrderHandler");
+        hotspot.LosingClaim!.Value.ShouldBe("LegacyOrderHandler");
+    }
+
+    [Fact]
+    public void lists_at_the_same_rung_union_and_record_nothing()
+    {
+        // Nothing was lost -- the union kept both claims -- so there is nothing to disagree about.
+        var first = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] };
+        var second = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<AuditRecorded>()] };
+
+        var merged = first.Merge(second);
+
+        merged.EmittedEvents.Count.ShouldBe(2);
+        DisagreementsIn(merged).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void identical_claims_at_different_rungs_record_nothing()
+    {
+        // The code says it emits OrderPlaced and production agrees. That is the happy case, and it is
+        // silent -- CritterWatch's "confirmed" expressed as the absence of a finding.
+        var derived = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] };
+        var observed = Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<OrderPlaced>()] };
+
+        DisagreementsIn(derived.Merge(observed)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void list_order_alone_is_not_a_disagreement()
+    {
+        var derived = Slice(EventModelProvenance.Derived) with
+        {
+            EmittedEvents = [T<OrderPlaced>(), T<AuditRecorded>()],
+        };
+        var observed = Slice(EventModelProvenance.Observed) with
+        {
+            EmittedEvents = [T<AuditRecorded>(), T<OrderPlaced>()],
+        };
+
+        DisagreementsIn(derived.Merge(observed)).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_role_only_one_source_claims_is_not_a_disagreement()
+    {
+        // Production has no opinion about the domain, so it is not disagreeing with the overlay --
+        // it simply never spoke. This is the per-claimed-role rule doing its job.
+        var declared = Slice(EventModelProvenance.Declared) with { Domain = "Ordering" };
+        var observed = Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<OrderPlaced>()] };
+
+        var merged = declared.Merge(observed);
+
+        merged.Domain.ShouldBe("Ordering");
+        DisagreementsIn(merged).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void a_model_with_no_disagreements_is_unchanged()
+    {
+        // Deliberately additive: complementary sources produce exactly what they always did.
+        var declared = Slice(EventModelProvenance.Declared) with { Domain = "Ordering", TriggerLabel = "Place Order" };
+        var derived = Slice(EventModelProvenance.Derived) with
+        {
+            CommandType = T<PlaceOrder>(), EmittedEvents = [T<OrderPlaced>()],
+        };
+
+        declared.Merge(derived).Hotspots.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region several sources
+
+    [Fact]
+    public void every_pair_that_disagrees_is_recorded()
+    {
+        // Merges are pairwise, so three sources disagreeing about one role leave two findings, each
+        // naming the two claims that actually met.
+        var declared = Slice(EventModelProvenance.Declared) with { EmittedEvents = [T<OrderPlaced>()] };
+        var derived = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderShipped>()] };
+        var observed = Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<AuditRecorded>()] };
+
+        var merged = declared.Merge(derived).Merge(observed);
+
+        merged.EmittedEvents.ShouldHaveSingleItem().Name.ShouldBe("AuditRecorded");
+
+        DisagreementsIn(merged).Select(x => x.Text).ShouldBe([
+            "EmittedEvents: Derived claims OrderShipped; Declared claims OrderPlaced",
+            "EmittedEvents: Observed claims AuditRecorded; Derived claims OrderShipped",
+        ]);
+    }
+
+    [Fact]
+    public void an_earlier_finding_survives_a_later_merge_against_a_higher_rung()
+    {
+        // Hotspots are annotations, not claims, so they union rather than being arbitrated. Letting a
+        // higher-rung source's hotspot list replace a lower one would discard exactly the findings
+        // this feature exists to record.
+        var withFinding = (Slice(EventModelProvenance.Declared) with { EmittedEvents = [T<OrderPlaced>()] })
+            .Merge(Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderShipped>()] });
+
+        DisagreementsIn(withFinding).ShouldHaveSingleItem();
+
+        var merged = withFinding.Merge(Slice(EventModelProvenance.Observed) with
+        {
+            Hotspots = [HotspotDescriptor.Prose("Does the CRM own the SLA clock?")],
+        });
+
+        DisagreementsIn(merged).ShouldHaveSingleItem();
+        merged.Hotspots.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void the_same_disagreement_is_not_recorded_twice()
+    {
+        var derived = Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] };
+        var observed = Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<AuditRecorded>()] };
+
+        // The same observation arriving twice -- two CritterWatch nodes reporting the same slice --
+        // is one finding, not two.
+        var merged = derived.Merge(observed).Merge(observed);
+
+        DisagreementsIn(merged).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public void disagreements_survive_assembly_of_a_whole_model()
+    {
+        var derived = new EventModelDescriptor("Orders", [
+            Slice(EventModelProvenance.Derived) with { EmittedEvents = [T<OrderPlaced>()] }
+        ]);
+
+        var observed = new EventModelDescriptor("Orders", [
+            Slice(EventModelProvenance.Observed) with { EmittedEvents = [T<OrderPlaced>(), T<AuditRecorded>()] }
+        ]);
+
+        var model = EventModelDescriptor.Merge("Orders", [derived, observed]);
+
+        DisagreementsIn(model.Slices.ShouldHaveSingleItem()).ShouldHaveSingleItem();
+    }
+
+    #endregion
+
+    public class PlaceOrder { }
+    public class OrderHandler { }
+    public class LegacyOrderHandler { }
+    public class OrderPlaced { }
+    public class OrderShipped { }
+    public class AuditRecorded { }
+}

--- a/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
@@ -209,6 +209,21 @@ public sealed record EventModelSliceDescriptor(
     /// records it rather than letting it vanish. Same-rung lists still union in order, deduplicated
     /// by identity, exactly as before.
     /// </para>
+    /// <para>
+    /// <b>A dropped claim becomes a hotspot</b> (jasperfx#704). Whenever both sides claim a role and
+    /// the merged answer does not contain the other side's claim, a
+    /// <see cref="HotspotOrigin.SourceDisagreement"/> hotspot is appended naming the role, both
+    /// claims and the rung each came from. That covers a higher rung replacing a list <em>and</em>
+    /// two same-rung sources disagreeing on a scalar, where first-wins has always silently dropped
+    /// the loser. Nothing is recorded when nothing is lost — same-rung lists union, so a model with
+    /// no disagreements is identical to one produced before jasperfx#704.
+    /// </para>
+    /// <para>
+    /// <b><see cref="Hotspots"/> itself is unioned, never arbitrated.</b> Hotspots are annotations,
+    /// not factual claims about the system, and letting a higher-rung source's hotspot list replace a
+    /// lower one would discard exactly the findings this feature exists to record — including the
+    /// disagreements a previous merge already found.
+    /// </para>
     /// </remarks>
     public EventModelSliceDescriptor Merge(EventModelSliceDescriptor other)
     {
@@ -220,6 +235,7 @@ public sealed record EventModelSliceDescriptor(
         }
 
         var claimedBy = new Dictionary<EventModelRole, EventModelProvenance>();
+        var disagreements = new List<HotspotDescriptor>();
 
         // True when other's claim on this role outranks ours -- or when we make no claim at all.
         // False on a tie, which is what preserves the pre-jasperfx#703 first-wins behaviour.
@@ -228,64 +244,131 @@ public sealed record EventModelSliceDescriptor(
             var mine = ProvenanceFor(role);
             var theirs = other.ProvenanceFor(role);
 
-            var winner = (mine, theirs) switch
+            var takeTheirs = theirs is not null && (mine is null || theirs > mine);
+
+            if ((takeTheirs ? theirs : mine) is { } rung) claimedBy[role] = rung;
+
+            return takeTheirs;
+        }
+
+        // Both sides claimed the role and the merge kept only one of them. Record what was lost.
+        void disagree(EventModelRole role, bool tookTheirs, string mineValue, string theirsValue)
+        {
+            var mineClaim = new EventModelClaim(ProvenanceFor(role)!.Value, mineValue);
+            var theirsClaim = new EventModelClaim(other.ProvenanceFor(role)!.Value, theirsValue);
+
+            disagreements.Add(tookTheirs
+                ? HotspotDescriptor.SourceDisagreement(role, theirsClaim, mineClaim)
+                : HotspotDescriptor.SourceDisagreement(role, mineClaim, theirsClaim));
+        }
+
+        T? mergeScalar<T>(EventModelRole role, T? mine, T? theirs, Func<T, string> display) where T : class
+        {
+            var tookTheirs = takeOther(role);
+
+            if (Claims(role) && other.Claims(role))
             {
-                (null, null) => (EventModelProvenance?)null,
-                (null, not null) => theirs,
-                (not null, null) => mine,
-                _ => theirs > mine ? theirs : mine,
-            };
+                var mineValue = display(mine!);
+                var theirsValue = display(theirs!);
+                if (!string.Equals(mineValue, theirsValue, StringComparison.Ordinal))
+                {
+                    disagree(role, tookTheirs, mineValue, theirsValue);
+                }
+            }
 
-            if (winner is { } rung) claimedBy[role] = rung;
+            return tookTheirs ? theirs : mine;
+        }
 
-            return theirs is not null && (mine is null || theirs > mine);
+        T? mergeValue<T>(EventModelRole role, T? mine, T? theirs) where T : struct
+        {
+            var tookTheirs = takeOther(role);
+
+            if (Claims(role) && other.Claims(role) && !Equals(mine!.Value, theirs!.Value))
+            {
+                disagree(role, tookTheirs, mine.Value.ToString()!, theirs.Value.ToString()!);
+            }
+
+            return tookTheirs ? theirs : mine;
         }
 
         IReadOnlyList<T> mergeList<T>(EventModelRole role, IReadOnlyList<T> mine, IReadOnlyList<T> theirs,
-            Func<T, string> key)
+            Func<T, string> key, Func<T, string> display)
         {
             var myRung = ProvenanceFor(role);
             var theirRung = other.ProvenanceFor(role);
 
-            takeOther(role);
+            var tookTheirs = takeOther(role);
 
             if (theirRung is null) return mine;
             if (myRung is null) return theirs;
-            if (theirRung > myRung) return theirs;
-            if (myRung > theirRung) return mine;
 
-            return union(mine, theirs, key);
+            // Same rung: the union keeps both claims, so nothing was lost and nothing disagreed.
+            if (myRung == theirRung) return union(mine, theirs, key);
+
+            if (!sameSet(mine, theirs, key))
+            {
+                disagree(role, tookTheirs, render(mine, display), render(theirs, display));
+            }
+
+            return tookTheirs ? theirs : mine;
         }
 
         IReadOnlyList<TypeDescriptor> mergeTypes(EventModelRole role, IReadOnlyList<TypeDescriptor> mine,
             IReadOnlyList<TypeDescriptor> theirs)
-            => mergeList(role, mine, theirs, x => x.FullName);
+            => mergeList(role, mine, theirs, x => x.FullName, x => x.Name);
 
-        var merged = new EventModelSliceDescriptor(
-            Name,
-            takeOther(EventModelRole.TriggerLabel) ? other.TriggerLabel : TriggerLabel,
-            takeOther(EventModelRole.TriggerType) ? other.TriggerType : TriggerType,
-            takeOther(EventModelRole.CommandType) ? other.CommandType : CommandType,
-            takeOther(EventModelRole.HandlerType) ? other.HandlerType : HandlerType,
-            mergeTypes(EventModelRole.EmittedEvents, EmittedEvents, other.EmittedEvents),
-            mergeTypes(EventModelRole.ProjectionTypes, ProjectionTypes, other.ProjectionTypes),
-            mergeTypes(EventModelRole.ReadModelTypes, ReadModelTypes, other.ReadModelTypes))
+        var triggerLabel = mergeScalar(EventModelRole.TriggerLabel, TriggerLabel, other.TriggerLabel, x => x);
+        var triggerType = mergeScalar(EventModelRole.TriggerType, TriggerType, other.TriggerType, x => x.Name);
+        var commandType = mergeScalar(EventModelRole.CommandType, CommandType, other.CommandType, x => x.Name);
+        var handlerType = mergeScalar(EventModelRole.HandlerType, HandlerType, other.HandlerType, x => x.Name);
+        var emittedEvents = mergeTypes(EventModelRole.EmittedEvents, EmittedEvents, other.EmittedEvents);
+        var projectionTypes = mergeTypes(EventModelRole.ProjectionTypes, ProjectionTypes, other.ProjectionTypes);
+        var readModelTypes = mergeTypes(EventModelRole.ReadModelTypes, ReadModelTypes, other.ReadModelTypes);
+        var pattern = mergeValue(EventModelRole.Pattern, Pattern, other.Pattern);
+        var triggerKind = mergeValue(EventModelRole.TriggerKind, TriggerKind, other.TriggerKind);
+        var triggerOrigin = mergeScalar(EventModelRole.TriggerOrigin, TriggerOrigin, other.TriggerOrigin,
+            x => x.Label ?? x.ToString());
+        var aggregateTypes = mergeTypes(EventModelRole.AggregateTypes, AggregateTypes, other.AggregateTypes);
+        var publishedMessages = mergeTypes(EventModelRole.PublishedMessages, PublishedMessages, other.PublishedMessages);
+        var externalSystems = mergeList(EventModelRole.ExternalSystems, ExternalSystems, other.ExternalSystems,
+            x => $"{x.Direction}:{x.Name}", x => x.Name);
+        var specifications = mergeList(EventModelRole.Specifications, Specifications, other.Specifications,
+            x => x.Identity, x => x.Identity);
+        var domain = mergeScalar(EventModelRole.Domain, Domain, other.Domain, x => x);
+
+        // Hotspots are annotations rather than claims about the system, so they always union: a
+        // higher rung replacing the list would throw away the findings recorded here.
+        takeOther(EventModelRole.Hotspots);
+        var hotspots = union(union(Hotspots, other.Hotspots, hotspotKey), disagreements, hotspotKey);
+
+        return new EventModelSliceDescriptor(Name, triggerLabel, triggerType, commandType, handlerType,
+            emittedEvents, projectionTypes, readModelTypes)
         {
-            Pattern = takeOther(EventModelRole.Pattern) ? other.Pattern : Pattern,
-            TriggerKind = takeOther(EventModelRole.TriggerKind) ? other.TriggerKind : TriggerKind,
-            TriggerOrigin = takeOther(EventModelRole.TriggerOrigin) ? other.TriggerOrigin : TriggerOrigin,
-            AggregateTypes = mergeTypes(EventModelRole.AggregateTypes, AggregateTypes, other.AggregateTypes),
-            PublishedMessages = mergeTypes(EventModelRole.PublishedMessages, PublishedMessages, other.PublishedMessages),
-            ExternalSystems = mergeList(EventModelRole.ExternalSystems, ExternalSystems, other.ExternalSystems,
-                x => $"{x.Direction}:{x.Name}"),
-            Hotspots = mergeList(EventModelRole.Hotspots, Hotspots, other.Hotspots, x => $"{x.Origin}:{x.Text}"),
-            Specifications = mergeList(EventModelRole.Specifications, Specifications, other.Specifications,
-                x => x.Identity),
-            Domain = takeOther(EventModelRole.Domain) ? other.Domain : Domain,
+            Pattern = pattern,
+            TriggerKind = triggerKind,
+            TriggerOrigin = triggerOrigin,
+            AggregateTypes = aggregateTypes,
+            PublishedMessages = publishedMessages,
+            ExternalSystems = externalSystems,
+            Hotspots = hotspots,
+            Specifications = specifications,
+            Domain = domain,
             Provenance = higher(Provenance, other.Provenance),
+            ClaimedBy = claimedBy,
         };
+    }
 
-        return merged with { ClaimedBy = claimedBy };
+    private static string hotspotKey(HotspotDescriptor hotspot) => $"{hotspot.Origin}:{hotspot.Text}";
+
+    private static string render<T>(IReadOnlyList<T> items, Func<T, string> display)
+        => string.Join(", ", items.Select(display));
+
+    private static bool sameSet<T>(IReadOnlyList<T> first, IReadOnlyList<T> second, Func<T, string> key)
+    {
+        if (first.Count != second.Count) return false;
+
+        var keys = new HashSet<string>(first.Select(key), StringComparer.Ordinal);
+        return second.All(x => keys.Contains(key(x)));
     }
 
     /// <summary>The higher of two rungs, or whichever is set, or null when neither is.</summary>

--- a/src/JasperFx/Descriptors/EventModeling/HotspotDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/HotspotDescriptor.cs
@@ -18,7 +18,38 @@ public enum HotspotOrigin
     /// may emit it too.
     /// </summary>
     Prose,
+
+    /// <summary>
+    /// Two sources describing the same slice made different claims about the same role, and
+    /// <see cref="EventModelSliceDescriptor.Merge"/> had to drop one of them (jasperfx#704).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <em>The code says this slice emits <c>OrderPlaced</c>; production says it appends
+    /// <c>OrderPlaced</c> <b>and</b> <c>AuditRecorded</c></em> is arguably the most valuable thing a
+    /// four-source model can tell you, and a first-wins merge destroyed exactly that signal — the
+    /// losing claim vanished with no trace. This origin records it instead.
+    /// </para>
+    /// <para>
+    /// Emitted by <see cref="EventModelSliceDescriptor.Merge"/> rather than by any source, and only
+    /// when a claim is actually lost. Two sources on the same rung whose lists simply union have not
+    /// disagreed about anything, so nothing is recorded — a model with no disagreements is identical
+    /// to one produced before jasperfx#704.
+    /// </para>
+    /// </remarks>
+    SourceDisagreement,
 }
+
+/// <summary>
+/// One source's claim about one role, as it stood before a merge resolved the disagreement
+/// (jasperfx#704).
+/// </summary>
+/// <param name="Provenance">The rung the claim came from — enough to see which source to trust.</param>
+/// <param name="Value">
+///     Display rendering of what was claimed: short type names for the typed roles, the value itself
+///     for the scalar ones.
+/// </param>
+public sealed record EventModelClaim(EventModelProvenance Provenance, string Value);
 
 /// <summary>
 /// A hotspot — an open question, a conflict, or (primarily) a specification that is still
@@ -40,6 +71,35 @@ public sealed record HotspotDescriptor(
     string Text,
     string? SpecificationIdentity = null)
 {
+    /// <summary>
+    /// The role two sources disagreed about, when <see cref="Origin"/> is
+    /// <see cref="HotspotOrigin.SourceDisagreement"/>; otherwise null (jasperfx#704).
+    /// </summary>
+    public EventModelRole? Role { get; init; }
+
+    /// <summary>
+    /// The claim the merge kept, when <see cref="Origin"/> is
+    /// <see cref="HotspotOrigin.SourceDisagreement"/>; otherwise null (jasperfx#704).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Text"/> already renders the same information for a viewer that only knows how to
+    /// draw a hotspot. This and <see cref="LosingClaim"/> are the structured form, for a reader that
+    /// wants to act on it — decide which source to trust and which to fix.
+    /// </remarks>
+    public EventModelClaim? WinningClaim { get; init; }
+
+    /// <summary>
+    /// The claim the merge dropped, when <see cref="Origin"/> is
+    /// <see cref="HotspotOrigin.SourceDisagreement"/>; otherwise null (jasperfx#704).
+    /// </summary>
+    /// <remarks>
+    /// A pair rather than a list because merges are pairwise: three sources disagreeing about one
+    /// role produce two of these, each naming the two claims that actually met. Keeping it to two
+    /// scalars also keeps <see cref="HotspotDescriptor"/>'s record equality value-based, which the
+    /// merge's own de-duplication relies on.
+    /// </remarks>
+    public EventModelClaim? LosingClaim { get; init; }
+
     /// <summary>A hotspot for a specification that is pending (jasperfx#689).</summary>
     public static HotspotDescriptor PendingSpecification(string specificationIdentity)
         => new(HotspotOrigin.PendingSpecification, specificationIdentity, specificationIdentity);
@@ -47,4 +107,18 @@ public sealed record HotspotDescriptor(
     /// <summary>A free-text prose hotspot — see <see cref="HotspotOrigin.Prose"/> (jasperfx#690).</summary>
     public static HotspotDescriptor Prose(string text)
         => new(HotspotOrigin.Prose, text);
+
+    /// <summary>
+    /// A hotspot for two sources making different claims about <paramref name="role"/>
+    /// (jasperfx#704). <paramref name="winner"/> is the claim the merge kept.
+    /// </summary>
+    public static HotspotDescriptor SourceDisagreement(EventModelRole role, EventModelClaim winner,
+        EventModelClaim loser)
+        => new(HotspotOrigin.SourceDisagreement,
+            $"{role}: {winner.Provenance} claims {winner.Value}; {loser.Provenance} claims {loser.Value}")
+        {
+            Role = role,
+            WinningClaim = winner,
+            LosingClaim = loser,
+        };
 }


### PR DESCRIPTION
Closes #704. Design of record: `.claude/notes/DESIGN-2026-08-26-inner-loop-provenance-and-embedded.md` in the CritterWatch repo (JasperFx/stoat#9), decision D10.

> **Stacked on #703.** Per your call, this branches off `main` and carries #703's commit in its own diff. **Review [the second commit](https://github.com/JasperFx/jasperfx/pull/707) only** — I'll rebase this onto `main` once #703 lands.

## What this adds

`HotspotOrigin.SourceDisagreement`. When two sources describe the same slice and make different claims about the same role, `Merge` keeps one and **records** the other instead of dropping it:

> ⚠ `EmittedEvents: Observed claims OrderPlaced, AuditRecorded; Derived claims OrderPlaced`

`HotspotDescriptor` already exists and already renders in both viewers — the Bobcat console and CritterWatch — so this is new semantics on shipped machinery, not new rendering. It lands in the wireframe lane in the canonical hotspot magenta, pinned by a test.

Alongside `Text`, the structured form for a reader who wants to act on it:

```cs
hotspot.Role;          // EventModelRole.EmittedEvents
hotspot.WinningClaim;  // (Observed, "OrderPlaced, AuditRecorded") — what the merge kept
hotspot.LosingClaim;   // (Derived,  "OrderPlaced")                — what it dropped
```

## Decisions worth a look

**A pair, not a list.** My first pass had `IReadOnlyList<EventModelClaim> Claims`, and it broke `HotspotDescriptor`'s record equality — which the merge's own de-duplication and the wire round-trip test both rely on, since records compare lists by reference. A pair is also the honest shape: merges are pairwise, so three sources disagreeing about one role leave two findings, each naming the two claims that actually met. `every_pair_that_disagrees_is_recorded` pins that.

**Same-rung scalar conflicts count as disagreements.** The issue frames this around cross-rung conflict, but the rule I landed on is *"both sides claimed it and the merged answer does not contain the other side's claim"*, which also catches two same-rung sources naming different handlers. That is the original silent loss — first-wins has always discarded one — and there is no principled reason it deserves less visibility than a cross-rung one. It does mean an **unstamped** application that already had a conflicting scalar now gains a hotspot where it previously had none; I think that is the feature working, but it is the one behavioural surprise in here and easy to scope back to cross-rung-only if you'd rather.

**Nothing is recorded when nothing is lost.** Same-rung lists union, so they haven't disagreed. Identical claims across rungs agree — the code saying `OrderPlaced` and production agreeing is the happy case, and it is silent. That is CritterWatch's `Confirmed` expressed as the absence of a finding, which is why #703 didn't need a fourth rung for it. A role only one source claims was never contested. List *order* alone is not a disagreement.

**`Hotspots` is now unioned rather than arbitrated.** This is a deliberate exception to #703's ladder and it took a bug to notice: if a higher-rung source's hotspot list *replaced* a lower one, a three-way merge would silently throw away the disagreement a previous merge had just recorded. Hotspots are annotations, not claims about the system. `an_earlier_finding_survives_a_later_merge_against_a_higher_rung` guards it.

**`Merge` is restructured** to compute every merged role into a local before constructing the descriptor. The disagreements have to be fully collected before `Hotspots` is set, and depending on object-initializer evaluation order for that is the kind of thing that breaks the next time somebody reorders a property.

## Verification

- New `SourceDisagreementHotspotTests` — 12 tests. Includes the issue's acceptance scenario verbatim: a derived slice claiming `{A}` merged with an observed slice claiming `{A, B}` produces the observed roles **plus** a disagreement hotspot naming both claims, rendering in the canonical hotspot colour.
- `EventModelWireRoundTripTests` extended with a `SourceDisagreement` hotspot carrying its claim pair, under both CritterWatch's camelCase + string-enum options and the STJ defaults.
- Docs: `hotspots.md` gains *A source disagreement is a hotspot*; `descriptors.md`'s merge rules updated for the union-hotspots exception and the dropped-claim rule.
- Full solution builds; `CoreTests` 584, `CommandLineTests` 295, `CodegenTests` 419, `EventTests` 894 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)