### PR TITLE
gh-709/gh-710: prime the high water once, and pin tenants across every priming poll

### DIFF
--- a/src/EventTests/Daemon/HighWater/HighWaterPrimingRaceTests.cs
+++ b/src/EventTests/Daemon/HighWater/HighWaterPrimingRaceTests.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics.Metrics;
+using JasperFx.Core;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Daemon.HighWater;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace EventTests.Daemon.HighWater;
+
+// jasperfx#709: HighWaterAgent.IsRunning used to be set on the FIRST line of StartAsync, before the
+// Detect() it is meant to gate. The daemon's `if (!_highWater.IsRunning) await
+// StartHighWaterDetectionAsync()` therefore let a concurrent starter skip the priming and read
+// Tracker.HighWaterMark while it was still 0 — seeding an agent below its own committed position.
+// Field-reachable under Wolverine-managed distribution, which starts agents 25-way parallel by default.
+public class HighWaterPrimingRaceTests
+{
+    private static HighWaterAgent buildAgent(IHighWaterDetector detector, ShardStateTracker tracker,
+        CancellationToken token)
+    {
+        var settings = new DaemonSettings { Wakeup = new NeverWakeup() };
+        return new HighWaterAgent(new Meter("jasperfx.tests.highwater.priming"), detector, tracker,
+            NullLogger.Instance, settings, token);
+    }
+
+    [Fact]
+    public async Task is_running_stays_false_until_the_first_detection_completes()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new GatedDetector();
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+
+        var agent = buildAgent(detector, tracker, cts.Token);
+
+        var starting = agent.StartAsync();
+        (await detector.EnteredDetectAsync()).ShouldBeTrue();
+
+        // The whole bug in one assertion: a concurrent caller checking this flag mid-detection must not
+        // be told the agent is running, because the tracker's mark is still 0 at this point.
+        agent.IsRunning.ShouldBeFalse();
+        tracker.HighWaterMark.ShouldBe(0);
+
+        detector.Release(1000);
+        await starting;
+
+        agent.IsRunning.ShouldBeTrue();
+        tracker.HighWaterMark.ShouldBe(1000);
+
+        await cts.CancelAsync();
+        await agent.StopAsync();
+    }
+
+    [Fact]
+    public async Task a_failed_detection_leaves_the_agent_not_running()
+    {
+        using var cts = new CancellationTokenSource();
+        var detector = new GatedDetector();
+        var tracker = new ShardStateTracker(NullLogger.Instance);
+
+        var agent = buildAgent(detector, tracker, cts.Token);
+
+        var starting = agent.StartAsync();
+        (await detector.EnteredDetectAsync()).ShouldBeTrue();
+        detector.Fail(new InvalidOperationException("the database is down"));
+
+        await Should.ThrowAsync<InvalidOperationException>(async () => await starting);
+
+        // Previously IsRunning stayed true after a failed Detect, so every later start skipped the
+        // priming forever and seeded from a mark that had never been read.
+        agent.IsRunning.ShouldBeFalse();
+    }
+
+    private sealed class GatedDetector : IHighWaterDetector
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<long> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _detectCount;
+
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        // Skips HighWaterAgent's recurring poll loop, so DetectCount only ever reflects the priming.
+        public bool SupportsTenantPartitioning => true;
+
+        public int DetectCount => Volatile.Read(ref _detectCount);
+
+        public Task<bool> EnteredDetectAsync() => _entered.Task.WaitAsync(10.Seconds()).ContinueWith(_ => true);
+
+        public void Release(long mark) => _release.TrySetResult(mark);
+
+        public void Fail(Exception e) => _release.TrySetException(e);
+
+        public async Task<HighWaterStatistics> Detect(CancellationToken token)
+        {
+            Interlocked.Increment(ref _detectCount);
+            _entered.TrySetResult();
+
+            var mark = await _release.Task.ConfigureAwait(false);
+
+            return new HighWaterStatistics { CurrentMark = mark, LastMark = mark, HighestSequence = mark };
+        }
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+
+        public Task<HighWaterVector> DetectForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => Task.FromResult(new HighWaterVector([]));
+
+        public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => DetectForTenantsAsync(tenantIds, token);
+    }
+
+    private sealed class NeverWakeup : IDaemonWakeup
+    {
+        public Task WaitAsync(TimeSpan timeout, CancellationToken token) => Task.Delay(Timeout.Infinite, token);
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/EventTests/Daemon/HighWater/PolledTenantSetTests.cs
+++ b/src/EventTests/Daemon/HighWater/PolledTenantSetTests.cs
@@ -59,11 +59,49 @@ public class PolledTenantSetTests
     {
         var set = new PolledTenantSet();
 
+        // jasperfx#710: the pin count must not go negative, or a later Pin/Unpin pair would leave the
+        // tenant pinned forever.
+        set.Pin("t1");
+        set.Unpin("t1");
+        set.Unpin("t1");
         set.Unpin("t1");
 
-        set.Activate("t2");
-        set.SetTenants(["t2"]);
+        set.Pin("t1");
+        set.Unpin("t1");
+        set.SetTenants([]);
 
-        set.Snapshot().ShouldBe(["t2"]);
+        set.IsPolled("t1").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void deactivate_does_not_remove_a_pinned_tenant()
+    {
+        var set = new PolledTenantSet();
+
+        set.Activate("t1");
+        set.Pin("t1");
+
+        // jasperfx#710: Pin used to guard only against SetTenants, so the obvious-looking Deactivate
+        // silently defeated it and put back the field failure jasperfx#702 fixed.
+        set.Deactivate("t1").ShouldBeFalse();
+        set.IsPolled("t1").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void deactivate_works_again_once_the_last_pin_is_released()
+    {
+        var set = new PolledTenantSet();
+
+        set.Activate("t1");
+        set.Pin("t1");
+        set.Pin("t1");
+
+        set.Unpin("t1");
+        set.Deactivate("t1").ShouldBeFalse();
+        set.IsPolled("t1").ShouldBeTrue();
+
+        set.Unpin("t1");
+        set.Deactivate("t1").ShouldBeTrue();
+        set.IsPolled("t1").ShouldBeFalse();
     }
 }

--- a/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
+++ b/src/EventTests/Daemon/PerTenantStartAgentAsyncTests.cs
@@ -136,6 +136,50 @@ public class PerTenantStartAgentAsyncTests
     }
 
     [Fact]
+    public async Task a_start_arriving_mid_priming_waits_for_the_mark_instead_of_seeding_from_zero()
+    {
+        // jasperfx#709. HighWaterAgent.IsRunning used to flip on the FIRST line of StartAsync, before the
+        // Detect() it is meant to gate, so a second concurrent StartAgentAsync saw "running", skipped the
+        // priming, and read Tracker.HighWaterMark while it was still 0.
+        //
+        // Asserted through a SubscribeFromPresent shard rather than through the seeded HighWaterMark,
+        // and that choice is load-bearing. For a plain catch-up shard a wrong seed SELF-HEALS: the
+        // daemon's IObserver<ShardState>.OnNext forwards the store-global mark to every registered agent
+        // as soon as priming publishes it, so the agent is corrected moments later and the seed leaves no
+        // trace. FromPresent is where the damage sticks -- it resolves "present" to whatever mark it is
+        // handed and REWINDS the progression row to it, a database write that no later mark undoes.
+        var detector = new GatedGlobalDetector();
+
+        var blocker = shardFor(new ShardName("Trip"));
+        var fromPresent = shardFor(new ShardName("Sub"), new AsyncOptions().SubscribeFromPresent());
+
+        await using var harness = new DaemonHarness(detector, blocker, fromPresent);
+
+        // First start enters Detect and blocks there, holding the priming window open.
+        var first = harness.Daemon.StartAgentAsync("Trip:All", CancellationToken.None);
+        (await detector.EnteredDetectAsync()).ShouldBeTrue();
+
+        // Second start arrives mid-priming -- the exact window the bug lived in.
+        var second = harness.Daemon.StartAgentAsync("Sub:All", CancellationToken.None);
+
+        detector.Release(1000);
+        await first;
+        await second;
+
+        // Primed once for both starters. 25-way parallel agent starts must not mean 25 concurrent
+        // max(seq_id) scans either.
+        detector.DetectCount.ShouldBe(1);
+
+        // "Present" is the primed mark...
+        await harness.Store.Received(1).RewindSubscriptionProgressAsync(
+            Arg.Any<IEventDatabase>(), "Sub:All", Arg.Any<CancellationToken>(), 1000L);
+
+        // ...and never sequence 0, which would replay the whole history.
+        await harness.Store.DidNotReceive().RewindSubscriptionProgressAsync(
+            Arg.Any<IEventDatabase>(), "Sub:All", Arg.Any<CancellationToken>(), 0L);
+    }
+
+    [Fact]
     public async Task a_tenant_stops_being_polled_once_its_last_agent_stops()
     {
         // The release half of the in-flight start pin: a tenant held in the polled set for the duration
@@ -682,6 +726,51 @@ public class PerTenantStartAgentAsyncTests
 
             return Task.FromResult(new HighWaterVector(statistics));
         }
+
+        public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => DetectForTenantsAsync(tenantIds, token);
+    }
+
+    // jasperfx#709: a detector whose store-global Detect() blocks until released, so a test can hold a
+    // start inside the priming window and send a second one in behind it. SupportsTenantPartitioning is
+    // true only to keep HighWaterAgent's recurring poll loop from running — DetectCount then counts
+    // primings and nothing else.
+    private sealed class GatedGlobalDetector : IHighWaterDetector
+    {
+        private readonly TaskCompletionSource _entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<long> _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _detectCount;
+
+        public Uri DatabaseUri { get; } = new("fake://db1");
+
+        public bool SupportsTenantPartitioning => true;
+
+        public int DetectCount => Volatile.Read(ref _detectCount);
+
+        public async Task<bool> EnteredDetectAsync()
+        {
+            var winner = await Task.WhenAny(_entered.Task, Task.Delay(10.Seconds()));
+            return winner == _entered.Task;
+        }
+
+        public void Release(long mark) => _release.TrySetResult(mark);
+
+        public async Task<HighWaterStatistics> Detect(CancellationToken token)
+        {
+            Interlocked.Increment(ref _detectCount);
+            _entered.TrySetResult();
+
+            var mark = await _release.Task.ConfigureAwait(false);
+
+            return new HighWaterStatistics { CurrentMark = mark, LastMark = mark, HighestSequence = mark };
+        }
+
+        public Task<HighWaterStatistics> DetectInSafeZone(CancellationToken token) => Detect(token);
+
+        public Task<HighWaterVector> DetectForTenantsAsync(IReadOnlyCollection<string> tenantIds,
+            CancellationToken token)
+            => Task.FromResult(new HighWaterVector([]));
 
         public Task<HighWaterVector> DetectInSafeZoneForTenantsAsync(IReadOnlyCollection<string> tenantIds,
             CancellationToken token)

--- a/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/HighWaterAgent.cs
@@ -74,8 +74,6 @@ public class HighWaterAgent: IDisposable
 
     public async Task StartAsync()
     {
-        IsRunning = true;
-
         _current = await _detector.Detect(_token).ConfigureAwait(false);
 
         // jasperfx#539: seed the liveness heartbeat so IsStale is meaningful from the first cycle and the
@@ -90,6 +88,16 @@ public class HighWaterAgent: IDisposable
                 LastHeartbeat = DateTimeOffset.UtcNow,
                 AgentStatus = RunningStatus
             });
+
+        // jasperfx#709: the flag means "detection has COMPLETED", not "detection has been requested".
+        // It used to be set on the first line of this method, before the Detect() it is meant to gate --
+        // so the daemon's `if (!_highWater.IsRunning) await StartHighWaterDetectionAsync()` let a
+        // concurrent starter skip priming and then read Tracker.HighWaterMark while it was still 0,
+        // seeding an agent below its own committed position. Set after the mark is published, so a
+        // caller that observes IsRunning can trust the tracker. It also means a Detect() that throws
+        // leaves the agent NOT running, so the next start retries the priming instead of inheriting a
+        // permanently false "running".
+        IsRunning = true;
 
         // #4913: under per-tenant event partitioning the store-global high-water mark is not used to
         // advance any projection — tenant agents advance from the per-tenant vectorized poll driven by

--- a/src/JasperFx.Events/Daemon/HighWater/PolledTenantSet.cs
+++ b/src/JasperFx.Events/Daemon/HighWater/PolledTenantSet.cs
@@ -28,12 +28,20 @@ public sealed class PolledTenantSet
     }
 
     /// <summary>
-    /// Remove a tenant from the polled set. Returns true if it was present.
+    /// Remove a tenant from the polled set. Returns true if it was present and removed.
     /// </summary>
+    /// <remarks>
+    /// jasperfx#710: a pinned tenant is never removed, and this returns false for it. Without that,
+    /// the obvious-looking call here would silently defeat <see cref="Pin" /> and reintroduce the
+    /// field failure jasperfx#702 fixed — an agent whose start is still in flight losing its tenant
+    /// from the very poll it is waiting on.
+    /// </remarks>
     public bool Deactivate(string tenantId)
     {
         lock (_lock)
         {
+            if (_pins.ContainsKey(tenantId)) return false;
+
             return _tenants.Remove(tenantId);
         }
     }

--- a/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
+++ b/src/JasperFx.Events/Daemon/JasperFxAsyncDaemon.cs
@@ -624,10 +624,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
     public async Task StartAgentAsync(string shardName, CancellationToken token)
     {
-        if (!_highWater.IsRunning)
-        {
-            await StartHighWaterDetectionAsync().ConfigureAwait(false);
-        }
+        // jasperfx#709: single-flight, so 25-way parallel agent starts prime the mark once and all of
+        // them WAIT for it, instead of one priming while the other 24 skip ahead and seed from 0.
+        await ensureHighWaterDetectionAsync().ConfigureAwait(false);
 
         // TODO -- DO NOT LIKE THIS. Would rather have an overload that takes ShardName now
         if (!shardName.Contains(":"))
@@ -874,10 +873,9 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
 
     public async Task StartAllAsync()
     {
-        if (!_highWater.IsRunning)
-        {
-            await StartHighWaterDetectionAsync().ConfigureAwait(false);
-        }
+        // jasperfx#709: see ensureHighWaterDetectionAsync — StartAllAsync and StartAgentAsync can race
+        // each other just as easily as two StartAgentAsync calls can.
+        await ensureHighWaterDetectionAsync().ConfigureAwait(false);
 
         var shards = new List<AsyncShard<TOperations, TQuerySession>>();
 
@@ -1028,6 +1026,75 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         }
 
         await _highWater.StartAsync().ConfigureAwait(false);
+    }
+
+    private readonly object _highWaterStartLock = new();
+    private Task? _inFlightHighWaterStart;
+
+    /// <summary>
+    /// jasperfx#709: prime the store-global high water exactly once, and make every concurrent caller
+    /// wait for the SAME priming rather than skip it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The old shape was a bare <c>if (!_highWater.IsRunning) await StartHighWaterDetectionAsync();</c>,
+    /// and <see cref="HighWaterAgent.StartAsync" /> sets <c>IsRunning = true</c> BEFORE it awaits the
+    /// detection that flag is meant to gate. So a second concurrent starter saw "running", skipped the
+    /// priming, and read <c>Tracker.HighWaterMark</c> while it was still 0 — seeding an agent below its
+    /// own committed position. jasperfx#702 made that non-fatal (the Start command clamps rather than
+    /// pausing the shard), but the seed was still wrong, and for a SubscribeFromPresent subscription a
+    /// seed of 0 rewinds the progression row over the whole history, which the clamp cannot help with.
+    /// </para>
+    /// <para>
+    /// Deliberately a rendezvous on the in-flight task rather than a cached "already primed" flag: the
+    /// daemon stops <see cref="_highWater" /> when its last agent stops, so a later start has to be able
+    /// to prime it again. The task is cleared on completion for exactly that reason, and a failed
+    /// priming faults every waiter — proceeding to seed agents from a mark that was never detected is
+    /// the bug, not the recovery.
+    /// </para>
+    /// </remarks>
+    private Task ensureHighWaterDetectionAsync()
+    {
+        TaskCompletionSource completion;
+
+        lock (_highWaterStartLock)
+        {
+            if (_inFlightHighWaterStart is { } inFlight)
+            {
+                return inFlight;
+            }
+
+            if (_highWater.IsRunning)
+            {
+                return Task.CompletedTask;
+            }
+
+            completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _inFlightHighWaterStart = completion.Task;
+        }
+
+        return primeHighWaterAsync(completion);
+    }
+
+    private async Task primeHighWaterAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await StartHighWaterDetectionAsync().ConfigureAwait(false);
+            completion.TrySetResult();
+        }
+        catch (Exception e)
+        {
+            completion.TrySetException(e);
+            throw;
+        }
+        finally
+        {
+            lock (_highWaterStartLock)
+            {
+                _inFlightHighWaterStart = null;
+            }
+        }
     }
 
     private ConcurrentBag<ShardState>? _shardStateTracker;
@@ -1703,9 +1770,21 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
         long ceiling;
         if (_tenantHighWater != null)
         {
-            _tenantHighWater.PolledTenants.Activate(tenantId);
-            await pollTenantHighWaterAsync().ConfigureAwait(false);
-            ceiling = _tenantHighWater.CeilingFor(tenantId) ?? Tracker.HighWaterMark;
+            // jasperfx#710: Pin, not Activate — a concurrent syncTenantPolling() would otherwise drop
+            // this tenant before the poll below and leave CeilingFor null, falling back to the
+            // store-global mark. Under per-tenant partitioning that mark is max(seq_id) fanned across
+            // every tenant partition, so the rebuild would run to a ceiling far above this tenant's own
+            // height and look stuck rather than finishing.
+            _tenantHighWater.PolledTenants.Pin(tenantId);
+            try
+            {
+                await pollTenantHighWaterAsync().ConfigureAwait(false);
+                ceiling = _tenantHighWater.CeilingFor(tenantId) ?? Tracker.HighWaterMark;
+            }
+            finally
+            {
+                _tenantHighWater.PolledTenants.Unpin(tenantId);
+            }
         }
         else
         {
@@ -1983,30 +2062,60 @@ public partial class JasperFxAsyncDaemon<TOperations, TQuerySession, TProjection
                 continue;
             }
 
+            // jasperfx#710: Pin, not Activate. syncTenantPolling() rebuilds the polled set wholesale
+            // from the agents REGISTERED on this node, so any concurrent start or stop that reconciles
+            // between here and the poll below would drop these tenants — and a tenant missing from the
+            // poll gets no reading, so CeilingFor comes back null and its catch-up is skipped entirely,
+            // with no exception and no log line. Held across the poll AND the catch-up loop, since the
+            // loop keeps reading CeilingFor.
             foreach (var tenantId in tenants)
             {
-                _tenantHighWater!.PolledTenants.Activate(tenantId);
+                _tenantHighWater!.PolledTenants.Pin(tenantId);
             }
-            await pollTenantHighWaterAsync().ConfigureAwait(false);
 
-            foreach (var tenantId in tenants)
+            try
             {
-                if (cancellation.IsCancellationRequested) return;
+                await pollTenantHighWaterAsync().ConfigureAwait(false);
 
-                var ceiling = _tenantHighWater!.CeilingFor(tenantId) ?? 0L;
-                if (ceiling == 0L)
+                foreach (var tenantId in tenants)
                 {
-                    // Tenant exists but has no events for this projection yet.
-                    continue;
+                    if (cancellation.IsCancellationRequested) return;
+
+                    // jasperfx#710: null and 0 are different facts and used to be flattened together by
+                    // `?? 0L`. Null means this tenant has never been polled — which after the pin above
+                    // should not happen, so say so rather than skipping in silence. Zero means it was
+                    // polled and genuinely has no events yet, which is the benign case.
+                    var reading = _tenantHighWater!.CeilingFor(tenantId);
+                    if (reading == null)
+                    {
+                        Logger.LogWarning(
+                            "No high water reading for tenant {TenantId} while catching up {ShardName}, so its catch-up is skipped. The tenant was pinned for the priming poll, so this indicates the poll did not run or returned nothing for it",
+                            tenantId, asyncShard.Name.Identity);
+                        continue;
+                    }
+
+                    var ceiling = reading.Value;
+                    if (ceiling == 0L)
+                    {
+                        // Tenant exists but has no events for this projection yet.
+                        continue;
+                    }
+
+                    var tenantShard = asyncShard with { Name = asyncShard.Name.ForTenant(tenantId) };
+                    var state = progress.FirstOrDefault(x => x.ShardName == tenantShard.Name.Identity)
+                                ?? new ShardState(tenantShard.Name, 0);
+                    var agent = buildAgentForShard(tenantShard);
+
+                    await agent.CatchUpAsync(ceiling, state, cancellation).ConfigureAwait(false);
+                    throwIfRecordedExceptions(recorder, cancellation);
                 }
-
-                var tenantShard = asyncShard with { Name = asyncShard.Name.ForTenant(tenantId) };
-                var state = progress.FirstOrDefault(x => x.ShardName == tenantShard.Name.Identity)
-                            ?? new ShardState(tenantShard.Name, 0);
-                var agent = buildAgentForShard(tenantShard);
-
-                await agent.CatchUpAsync(ceiling, state, cancellation).ConfigureAwait(false);
-                throwIfRecordedExceptions(recorder, cancellation);
+            }
+            finally
+            {
+                foreach (var tenantId in tenants)
+                {
+                    _tenantHighWater!.PolledTenants.Unpin(tenantId);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #709. Closes #710.

Both were found reviewing #702, which made the first non-fatal without closing it. They share one root cause — something the daemon needs primed is read before the priming that fills it — so they land together.

## #709: `IsRunning` flipped before `Detect()` completed

`HighWaterAgent.StartAsync` set the flag on its **first line**, ahead of the detection it exists to gate, and the daemon's guard was a bare `if (!_highWater.IsRunning) await StartHighWaterDetectionAsync()` outside any lock. A second concurrent `StartAgentAsync` saw "running", skipped the priming, and read `Tracker.HighWaterMark` while it was still `0`.

Two layers, because there were two separate things wrong:

- **`IsRunning` now means "detection has COMPLETED"** — set after the mark is published, so a caller that observes it can trust the tracker. A `Detect()` that throws now also leaves the agent *not* running, where it previously left a permanently false "running" that made every later start skip priming forever.
- **`StartAgentAsync` and `StartAllAsync` go through `ensureHighWaterDetectionAsync`**, a single-flight rendezvous. Fixing only the flag would have swapped one bug for another: 25-way parallel starts would all see `IsRunning == false` and each launch their own `max(seq_id)` scan, which on the 512-partition deployment from #702 is not a small thing.

The rendezvous is on the **in-flight task**, not a cached "already primed" flag, because the daemon stops the high-water agent when its last agent stops (`StopAgentAsync`) and a later start has to be able to prime it again. A failed priming faults every waiter, which matches what the first caller has always experienced and beats proceeding to seed agents from a mark that was never read.

`StartHighWaterDetectionAsync` itself is untouched and stays public — tests call it directly, including twice in a row, so it keeps its unconditional semantics.

### The test that passed against the broken code, and what it taught me

My first regression test asserted on the second agent's seeded `HighWaterMark` — and it **passed without the fix**. Worth stating why, because it changes how the bug should be described:

For a plain catch-up shard a wrong seed **self-heals**. The daemon's `IObserver<ShardState>.OnNext` forwards the store-global mark to every registered agent the instant priming publishes it, so the mis-seeded agent is corrected moments later and the seed leaves no trace. (#702's clamp then hides the interim.)

Where the damage sticks is `SubscribeFromPresent`: it resolves "present" to whatever mark it is handed and **rewinds the progression row** to it — a database write no later mark undoes. So the test now drives a `FromPresent` shard into the priming window and asserts the rewind target, mirroring the existing `primes_the_tenant_ceiling_before_determining_the_starting_position`. Verified red against the unfixed code ("Actually received no matching calls" — it rewound to 0).

## #710: catch-up and rebuild still used `Activate` rather than #702's `Pin`

`syncTenantPolling()` rebuilds the polled set wholesale from the agents **registered** on the node, so an `Activate`d tenant whose work has not registered an agent yet is droppable by any concurrent start or stop. Dropped before the poll, the tenant gets no reading and `CeilingFor` returns null.

- **`catchUpPerTenantAsync`** pins its whole tenant batch across the priming poll *and* the catch-up loop, since the loop keeps reading `CeilingFor`.
- **Its `CeilingFor(tenantId) ?? 0L` flattened two different facts into one.** Null means "never polled" — which after the pin should not happen, so it now logs a warning rather than skipping that tenant's catch-up in total silence. Zero means "polled, genuinely no events yet" and keeps its existing benign `continue`. This was the quietest failure in the family and the main reason the issue was worth filing.
- **The per-tenant rebuild path** pins across its poll, so a dropped tenant no longer falls back to the store-global mark — which under per-tenant partitioning is `max(seq_id)` fanned across every partition, far above that tenant's own height.
- **`PolledTenantSet.Deactivate` no longer removes a pinned tenant.** It had no production callers, but it is public API on the class whose entire job is now "the set that survives reconciliation", and it silently defeated `Pin`.

## Coverage, stated honestly

New tests, all verified red against the unfixed code:

| Test | Pins |
| --- | --- |
| `is_running_stays_false_until_the_first_detection_completes` | the #709 root cause, at the agent level |
| `a_failed_detection_leaves_the_agent_not_running` | the false-"running"-forever tail |
| `a_start_arriving_mid_priming_waits_for_the_mark_instead_of_seeding_from_zero` | the daemon-level race, through the FromPresent rewind |
| `deactivate_does_not_remove_a_pinned_tenant` | the pin bypass |
| `deactivate_works_again_once_the_last_pin_is_released` | reference counting through `Deactivate` |
| `unpinning_a_tenant_that_was_never_pinned_is_a_no_op` | strengthened — the pin count cannot go negative |

**The two #710 call-site changes have no end-to-end race test.** `catchUpPerTenantAsync` has no existing harness (`CrossTenantRebuildTests` substitutes `ICrossTenantRebuildSource` directly and never drives the daemon path), and building one is disproportionate to a change that is mechanically identical to what #702 already shipped and tested in `StartAgentAsync`. They are covered by the `PolledTenantSet` tests plus inspection. Flagging it rather than implying coverage I did not write.

## Verification

Full local `./build.sh` — Restore, Compile, SmokeTestAot, SmokeTestCommands, TestAspire, TestSourceGenerators, TestEventStore, TestEvents, TestCommandLine, TestCodegenFSharp, TestCodegen, TestCore all **Succeeded** across net9.0 and net10.0, exit 0. `EventTests` 906, `EventStoreTests` 136, `CoreTests` 592 (+1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)