### PR TITLE
wolverine#4167: a Block never runs its action on the publisher's thread

### DIFF
--- a/src/CoreTests/Blocks/BlockIdleWakeupTests.cs
+++ b/src/CoreTests/Blocks/BlockIdleWakeupTests.cs
@@ -138,13 +138,18 @@ public class BlockIdleWakeupTests
     /// <summary>
     /// Post() enqueues; it must never absorb the action's latency. This measured 751ms for a 750ms
     /// action while continuations were synchronous.
+    ///
+    /// Deliberately asserts on ELAPSED TIME only, never on thread identity. Once the publisher awaits,
+    /// its thread goes back to the pool and the action can legitimately be scheduled onto that same
+    /// managed thread -- which is exactly what a 2-core CI runner did on net9.0. Thread identity is
+    /// only meaningful while the publisher is still occupying the thread, which is what
+    /// a_burst_posted_after_idle_never_executes_on_the_publisher measures instead.
     /// </summary>
     [Fact]
     public async Task post_does_not_absorb_the_latency_of_a_slow_action()
     {
         var firstDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var slowDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var handlerThread = 0;
 
         await using var block = new Block<string>(5, Block<string>.Unbounded, (item, _) =>
         {
@@ -154,7 +159,6 @@ public class BlockIdleWakeupTests
                 return Task.CompletedTask;
             }
 
-            Volatile.Write(ref handlerThread, Environment.CurrentManagedThreadId);
             Thread.Sleep(750);
             slowDone.TrySetResult();
             return Task.CompletedTask;
@@ -164,7 +168,6 @@ public class BlockIdleWakeupTests
         await firstDone.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        var publisher = Environment.CurrentManagedThreadId;
         var stopwatch = Stopwatch.StartNew();
         block.Post("slow");
         stopwatch.Stop();
@@ -172,6 +175,5 @@ public class BlockIdleWakeupTests
         stopwatch.ElapsedMilliseconds.ShouldBeLessThan(250);
 
         await slowDone.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-        Volatile.Read(ref handlerThread).ShouldNotBe(publisher);
     }
 }

--- a/src/CoreTests/Blocks/BlockIdleWakeupTests.cs
+++ b/src/CoreTests/Blocks/BlockIdleWakeupTests.cs
@@ -1,0 +1,177 @@
+using System.Diagnostics;
+using JasperFx.Blocks;
+using Shouldly;
+
+namespace CoreTests.Blocks;
+
+// wolverine#4167. A Block's channel must not allow synchronous continuations: with them on, a reader
+// parked in WaitToReadAsync gets resumed by TryWrite on the PUBLISHER's thread, so Post() executes the
+// action inline instead of enqueuing it. These tests all failed before that flag was turned off, and
+// three of the four failed on net9.0 as well -- only the bounded case was net10-specific.
+public class BlockIdleWakeupTests
+{
+    [Fact]
+    public async Task post_after_idle_does_not_process_inline_on_the_publisher()
+    {
+        var processed = 0;
+        var firstDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var block = new Block<string>(5, Block<string>.Unbounded, (item, _) =>
+        {
+            Interlocked.Increment(ref processed);
+            if (item == "first")
+            {
+                firstDone.TrySetResult();
+            }
+
+            if (item == "second")
+            {
+                secondDone.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        });
+
+        block.Post("first");
+        await firstDone.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Let processAsync park in WaitToReadAsync. This is the idle worker.
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        block.Post("second");
+
+        Volatile.Read(ref processed).ShouldBe(1);
+
+        await secondDone.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Volatile.Read(ref processed).ShouldBe(2);
+        block.Count.ShouldBe(0u);
+    }
+
+    [Fact]
+    public async Task burst_posted_after_idle_is_fully_drained()
+    {
+        const int wave = 20;
+        var processed = 0;
+        var idle = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var block = new Block<int>(5, Block<int>.Unbounded, (item, _) =>
+        {
+            var n = Interlocked.Increment(ref processed);
+            if (n == 1)
+            {
+                idle.TrySetResult();
+            }
+
+            if (n == 1 + wave)
+            {
+                done.TrySetResult();
+            }
+
+            return Task.CompletedTask;
+        });
+
+        block.Post(0);
+        await idle.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        for (var i = 1; i <= wave; i++)
+        {
+            block.Post(i);
+        }
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Volatile.Read(ref processed).ShouldBe(1 + wave);
+        block.Count.ShouldBe(0u);
+    }
+
+    /// <summary>
+    /// The regression that actually bit: a whole burst executing on the publisher. Both capacities are
+    /// covered because they used to differ -- an unbounded channel ran continuations inline on every
+    /// runtime, a bounded one only from net10 onward.
+    /// </summary>
+    [Theory]
+    [InlineData(Block<int>.Unbounded)]
+    [InlineData(Block<int>.DefaultBoundedCapacity)]
+    public async Task a_burst_posted_after_idle_never_executes_on_the_publisher(int capacity)
+    {
+        const int wave = 20;
+        var processed = 0;
+        var inline = 0;
+        var idle = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var publisherThread = 0;
+
+        await using var block = new Block<int>(5, capacity, (item, _) =>
+        {
+            if (Environment.CurrentManagedThreadId == Volatile.Read(ref publisherThread))
+            {
+                Interlocked.Increment(ref inline);
+            }
+
+            var n = Interlocked.Increment(ref processed);
+            if (n == 1) idle.TrySetResult();
+            if (n == 1 + wave) done.TrySetResult();
+
+            return Task.CompletedTask;
+        });
+
+        block.Post(0);
+        await idle.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        Volatile.Write(ref publisherThread, Environment.CurrentManagedThreadId);
+
+        for (var i = 1; i <= wave; i++)
+        {
+            block.Post(i);
+        }
+
+        Volatile.Read(ref inline).ShouldBe(0);
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        Volatile.Read(ref processed).ShouldBe(1 + wave);
+        block.Count.ShouldBe(0u);
+    }
+
+    /// <summary>
+    /// Post() enqueues; it must never absorb the action's latency. This measured 751ms for a 750ms
+    /// action while continuations were synchronous.
+    /// </summary>
+    [Fact]
+    public async Task post_does_not_absorb_the_latency_of_a_slow_action()
+    {
+        var firstDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var slowDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerThread = 0;
+
+        await using var block = new Block<string>(5, Block<string>.Unbounded, (item, _) =>
+        {
+            if (item == "first")
+            {
+                firstDone.TrySetResult();
+                return Task.CompletedTask;
+            }
+
+            Volatile.Write(ref handlerThread, Environment.CurrentManagedThreadId);
+            Thread.Sleep(750);
+            slowDone.TrySetResult();
+            return Task.CompletedTask;
+        });
+
+        block.Post("first");
+        await firstDone.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        var publisher = Environment.CurrentManagedThreadId;
+        var stopwatch = Stopwatch.StartNew();
+        block.Post("slow");
+        stopwatch.Stop();
+
+        stopwatch.ElapsedMilliseconds.ShouldBeLessThan(250);
+
+        await slowDone.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        Volatile.Read(ref handlerThread).ShouldNotBe(publisher);
+    }
+}

--- a/src/JasperFx/Blocks/Block.cs
+++ b/src/JasperFx/Blocks/Block.cs
@@ -61,18 +61,31 @@ public class Block<T> : BlockBase<T>
         // A bounded channel using BoundedChannelFullMode.Wait gives us back pressure: writers wait for
         // capacity rather than silently dropping items (GH-3287). Post() honors this by blocking-waiting
         // for room when TryWrite fails. Unbounded channels never block or drop, but grow with memory.
+        // AllowSynchronousContinuations MUST stay false (wolverine#4167). With it on, a reader parked in
+        // WaitToReadAsync is resumed by TryWrite *on the publisher's thread*, so Post() runs the action
+        // inline instead of enqueuing it. Measured on a 5-worker unbounded block: after the workers went
+        // idle, 20 posted items all executed inline and serialized on the caller, and a Post() carrying a
+        // 750ms synchronous action took 751ms to return. A parallel block silently collapses into a
+        // synchronous call on whatever thread published -- which also stalls that thread's real work
+        // (e.g. a broker listener loop) for the duration of the action.
+        //
+        // This is NOT purely a .NET 10 regression. UnboundedChannel has always run these continuations
+        // inline; only BoundedChannel used to force them async, by ORing cancellationToken.CanBeCanceled
+        // into the waiter (a workaround for dotnet/runtime#33858 that dotnet/runtime#116021 removed in
+        // .NET 10 once the cancellation path no longer completed waiters under the channel lock). So
+        // unbounded blocks were always affected and bounded blocks regressed on net10.
         _channel = boundedCapacity == Unbounded
             ? Channel.CreateUnbounded<T>(new UnboundedChannelOptions
             {
                 SingleReader = parallelCount == 1,
                 SingleWriter = false,
-                AllowSynchronousContinuations = true
+                AllowSynchronousContinuations = false
             })
             : Channel.CreateBounded<T>(new BoundedChannelOptions(boundedCapacity)
             {
                 SingleReader = parallelCount == 1,
                 SingleWriter = false,
-                AllowSynchronousContinuations = true,
+                AllowSynchronousContinuations = false,
                 FullMode = BoundedChannelFullMode.Wait
             });
 


### PR DESCRIPTION
Fixes the root cause reported in JasperFx/wolverine#4167.

`Block` built its channel with `AllowSynchronousContinuations = true`, so a reader parked in `WaitToReadAsync` was resumed by `TryWrite` **on the publishing thread**. `Post()` then executed the action inline instead of enqueuing it.

Measured on a 5-worker unbounded block after the workers went idle:

```
after posting 20: processed=21  inline-on-publisher=20  Count=0
Post() of a 750ms synchronous action took 751ms to return
publisher thread=4  handler thread=4
```

All 20 items ran inline, serialized on the caller. A parallel block silently collapses into a synchronous call on whoever published, and that thread's own work — a broker listener loop, an HTTP request — stalls for the duration.

## Not purely a .NET 10 regression

The issue attributes this to dotnet/runtime#116021. That is half right. The `| cancellationToken.CanBeCanceled` OR it removed lived in `BoundedChannel.cs`; `UnboundedChannel` never had it:

| channel | net9.0 | net10.0 |
|---|---|---|
| **Unbounded** | inline 20/20 | inline 20/20 |
| **Bounded** | inline **0**/20 | inline 20/20 |

So unbounded blocks were always affected, and bounded blocks regressed on net10 — which is why the new bounded theory case fails only on net10. Wolverine's buffered local queue (the reported configuration) is unbounded, so it was never new; what net10 newly broke is broker-backed `BufferedReceiver` and `DurableReceiver`.

## What this does not include

The issue's second proposal — `while (TryRead)` instead of a single `TryRead` — is **not** here. That half did not reproduce: `Count` returned to 0 and every posted item drained, on both runtimes and both capacities. `WaitToReadAsync` returns synchronously while items remain, so the single `TryRead` strands nothing. It may be worth taking on allocation/latency merits, separately.

## Verification

| | net9.0 | net10.0 |
|---|---|---|
| new tests, without the fix | 3/5 fail | 4/5 fail |
| new tests, with the fix | 5/5 pass | 5/5 pass |
| full `CoreTests` | 597 pass, 1 skip | 597 pass, 1 skip |

## ⚠️ Do not release ahead of the Wolverine fix

Turning inline continuations off removes the accidental serialization that was hiding a genuine race in `Wolverine.Runtime.Batching.BatchingOptions.BuildHandler`. Once this lands, Wolverine builds **two** `BatchingProcessor` instances under concurrent first-touch — batches fragment and the losing instance leaks a `Timer` plus worker tasks. A Wolverine-side fix ships alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)