### PR TITLE
Prime the scope that actually gets created, and honor open generic registrations (wolverine#4171, wolverine#4159)

### DIFF
--- a/src/CodegenTests/Services/open_generic_registrations.cs
+++ b/src/CodegenTests/Services/open_generic_registrations.cs
@@ -1,0 +1,165 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Services;
+using JasperFx.RuntimeCompiler;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Shouldly;
+
+namespace CodegenTests.Services;
+
+// wolverine#4159. Codegen inline-constructed Lazy<T> and produced handlers that silently consumed
+// nothing: `new Lazy<IFoo>()` compiles, but its factory is Activator.CreateInstance<IFoo>(), so the
+// first .Value throws MissingMemberException for any T that is not publicly default-constructible --
+// which is every DI-registered service. The host started healthy, listeners attached, health checks
+// passed, and the handlers did nothing.
+//
+// The cause was in findFamily: the open-generic close-over was gated on IsNotConcrete(), and Lazy<T>
+// is a concrete class. So a host's `TryAddScoped(typeof(Lazy<>), typeof(LazyResolver<>))` adapter was
+// never consulted and the self-binding-any-public-concrete-type fallback won instead.
+//
+// Two adapters appear below, and the difference matters. LazyResolver<T> takes an IServiceProvider,
+// which is what the reporter registered and what the convention looks like in the wild -- but it
+// drags the whole method onto service location on its own, so it cannot tell us whether a rule
+// changed anything. EagerLazyResolver<T> is inline-constructible, so the generated code visibly
+// differs between "built inline from the registration" and "located from the container".
+public class open_generic_registrations
+{
+    private readonly ITestOutputHelper _output;
+    private readonly ServiceCollection theServices = new();
+    private readonly GenerationRules theRules = new();
+
+    public open_generic_registrations(ITestOutputHelper output)
+    {
+        _output = output;
+        theServices.AddScoped<IWidget, AWidget>();
+    }
+
+    private (string Code, ServiceContainer Graph) generate()
+    {
+        var graph = new ServiceContainer(theServices, theServices.BuildServiceProvider());
+
+        var assembly = new GeneratedAssembly(theRules);
+        var type = assembly.AddType("LazyHarness", typeof(ServiceHarness<WidgetResult>));
+        var buildMethod = type.MethodFor("Build");
+
+        var call = new MethodCall(typeof(LazyWidgetHandler), nameof(LazyWidgetHandler.Handle));
+        buildMethod.Frames.Add(call);
+        buildMethod.Frames.Code("return {0};", call.ReturnVariable!);
+
+        var source = new ServiceCollectionServerVariableSource(graph);
+        source.StartNewType();
+        source.StartNewMethod();
+
+        var code = assembly.GenerateCode(source);
+        _output.WriteLine(code);
+        return (code, graph);
+    }
+
+    // The bug itself. `new System.Lazy<IWidget>()` is what shipped, and it is never a usable instance.
+    [Fact]
+    public void an_open_generic_registration_is_used_instead_of_self_binding()
+    {
+        theServices.TryAddScoped(typeof(Lazy<>), typeof(EagerLazyResolver<>));
+
+        var (code, _) = generate();
+
+        code.ShouldNotContain("new System.Lazy<");
+        code.ShouldContain("new CodegenTests.Services.EagerLazyResolver<CodegenTests.Services.IWidget>");
+    }
+
+    // Same thing with the adapter shape the reporter actually registered. It needs an IServiceProvider,
+    // so the method lands on service location -- either way the container's registration is what
+    // produces the instance, and `new System.Lazy<>` is gone.
+    [Fact]
+    public void the_service_provider_flavoured_adapter_is_also_honored()
+    {
+        theServices.TryAddScoped(typeof(Lazy<>), typeof(LazyResolver<>));
+
+        var (code, _) = generate();
+
+        code.ShouldNotContain("new System.Lazy<");
+        code.ShouldContain("GetRequiredService<System.Lazy<CodegenTests.Services.IWidget>>");
+    }
+
+    // The whole point: the instance the generated code hands the handler has to actually work.
+    // Before the fix this threw MissingMemberException on the first .Value.
+    [Theory]
+    [InlineData(typeof(EagerLazyResolver<>))]
+    [InlineData(typeof(LazyResolver<>))]
+    public void the_resolved_lazy_can_be_dereferenced(Type adapter)
+    {
+        theServices.TryAddScoped(typeof(Lazy<>), adapter);
+
+        var (code, graph) = generate();
+
+        var compiler = new AssemblyGenerator();
+        compiler.ReferenceAssembly(GetType().Assembly);
+        var builtAssembly = compiler.Generate(code);
+        var builtType = builtAssembly.ExportedTypes.Single();
+
+        var result = ((ServiceHarness<WidgetResult>)graph.BuildFromType(builtType)).Build();
+
+        result.Widget.ShouldBeOfType<AWidget>();
+    }
+
+    // No registration at all: self-binding a concrete generic is still the right answer, so nothing
+    // else regresses. A Lazy<T> with no adapter registered remains the caller's problem.
+    [Fact]
+    public void a_concrete_generic_with_no_registration_still_self_binds()
+    {
+        var (code, _) = generate();
+
+        code.ShouldContain("new System.Lazy<");
+    }
+
+    // The reporter's finding 3: the Type overload accepted an open generic and matched nothing, so the
+    // call was a silent no-op. Against the inline-constructible adapter the difference is visible --
+    // without the rule this method builds the resolver inline (asserted above), with it the Lazy comes
+    // from the container.
+    [Fact]
+    public void always_use_service_location_accepts_an_open_generic()
+    {
+        theServices.TryAddScoped(typeof(Lazy<>), typeof(EagerLazyResolver<>));
+        theRules.AlwaysUseServiceLocationFor(typeof(Lazy<>));
+
+        var (code, _) = generate();
+
+        code.ShouldContain("GetRequiredService<System.Lazy<CodegenTests.Services.IWidget>>");
+        code.ShouldNotContain("new CodegenTests.Services.EagerLazyResolver<");
+    }
+
+    // ...and an open generic matches only its own closed forms, not every generic.
+    [Fact]
+    public void an_unrelated_closed_generic_is_left_alone()
+    {
+        theServices.TryAddScoped(typeof(Lazy<>), typeof(EagerLazyResolver<>));
+        theRules.AlwaysUseServiceLocationFor(typeof(Lazy<IThingamajig>));
+
+        var (code, _) = generate();
+
+        code.ShouldNotContain("GetRequiredService<System.Lazy<CodegenTests.Services.IWidget>>");
+        code.ShouldContain("new CodegenTests.Services.EagerLazyResolver<CodegenTests.Services.IWidget>");
+    }
+}
+
+public interface IThingamajig;
+
+/// <summary>The conventional adapter, and the one wolverine#4159 was reported against.</summary>
+public class LazyResolver<T>(IServiceProvider services)
+    : Lazy<T>(() => services.GetRequiredService<T>()) where T : notnull;
+
+/// <summary>
+/// Takes the service itself rather than the container, so codegen can build it inline. That makes the
+/// generated code differ visibly between inline construction and service location.
+/// </summary>
+public class EagerLazyResolver<T>(T value) : Lazy<T>(() => value) where T : notnull;
+
+public class LazyWidgetHandler
+{
+    public static WidgetResult Handle(Lazy<IWidget> widget)
+    {
+        return new WidgetResult(widget.Value);
+    }
+}

--- a/src/CodegenTests/Services/scope_postprocessor_sources.cs
+++ b/src/CodegenTests/Services/scope_postprocessor_sources.cs
@@ -1,0 +1,175 @@
+using JasperFx;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using JasperFx.CodeGeneration.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace CodegenTests.Services;
+
+// wolverine#4171. A host that wants to seed the service-location child scope with instances the
+// generated method already owns used to do it from a frame in the method: find the scoped
+// IServiceProvider during arrangement, cast its Creator to IScopedContainerCreation, and register
+// postprocessors on it.
+//
+// That only ever worked when something in the method asked for an IServiceProvider *by name*. Frames
+// resolve their variables in MethodFrameArranger's first pass, but the scope for an opaque
+// scoped/transient registration is not created until ServiceCollectionServerVariableSource
+// .ReplaceVariables runs *after* that pass -- so the activator frame found nothing, attached nothing,
+// and said nothing. Wolverine shipped that way from GH-3001 until wolverine#4171: a handler whose only
+// reason to service-locate was an opaque lambda got an unprimed scope, and every test covering the
+// feature happened to put an IServiceProvider on the handler signature.
+//
+// ScopePostProcessorSources moves the attachment to the one place that knows a scope was created.
+public class scope_postprocessor_sources
+{
+    private readonly ITestOutputHelper _output;
+    private readonly ServiceCollection theServices = new();
+    private readonly List<Func<SyncFrame>> thePostProcessors = new();
+
+    public scope_postprocessor_sources(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private string generate<T>(string methodName)
+    {
+        var graph = new ServiceContainer(theServices, theServices.BuildServiceProvider());
+
+        var assembly = new GeneratedAssembly(new GenerationRules());
+        var type = assembly.AddType("ScopePrimingHarness", typeof(ServiceHarness<WidgetResult>));
+        var buildMethod = type.MethodFor("Build");
+
+        var call = new MethodCall(typeof(T), methodName);
+        buildMethod.Frames.Add(call);
+        buildMethod.Frames.Code("return {0};", call.ReturnVariable!);
+
+        var source = new ServiceCollectionServerVariableSource(graph);
+        source.ScopePostProcessorSources.AddRange(thePostProcessors);
+        source.StartNewType();
+        source.StartNewMethod();
+
+        var code = assembly.GenerateCode(source);
+        _output.WriteLine(code);
+        return code;
+    }
+
+    // The case that was silently broken: nothing asks for an IServiceProvider, but the opaque scoped
+    // lambda still drags the method onto service location and a scope IS created.
+    [Fact]
+    public void postprocessors_run_when_only_an_opaque_registration_forces_the_scope()
+    {
+        theServices.AddScoped<IWidget, AWidget>();
+        theServices.AddScoped<IScopedLambda>(_ => new ScopedLambda());
+        thePostProcessors.Add(() => new LinePostprocessor("// PRIMED"));
+
+        var code = generate<OpaqueOnlyHandler>(nameof(OpaqueOnlyHandler.Handle));
+
+        code.ShouldNotContain("IServiceProvider services");
+        code.IndexOf("serviceScope =", StringComparison.Ordinal)
+            .ShouldBeLessThan(code.IndexOf("// PRIMED", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void postprocessors_are_handed_the_scoped_provider()
+    {
+        theServices.AddScoped<IWidget, AWidget>();
+        theServices.AddScoped<IScopedLambda>(_ => new ScopedLambda());
+        thePostProcessors.Add(() => new ProviderConsumingPostprocessor());
+
+        var code = generate<OpaqueOnlyHandler>(nameof(OpaqueOnlyHandler.Handle));
+
+        code.ShouldContain("var scopedThing = serviceScope.ServiceProvider;");
+    }
+
+    // Control: a method that can build everything inline creates no scope, so nothing is attached and
+    // the generated code is exactly what it was before any postprocessor was registered.
+    [Fact]
+    public void nothing_is_emitted_when_no_scope_is_created()
+    {
+        theServices.AddScoped<IWidget, AWidget>();
+        thePostProcessors.Add(() => new LinePostprocessor("// PRIMED"));
+
+        var code = generate<InlineOnlyHandler>(nameof(InlineOnlyHandler.Handle));
+
+        code.ShouldNotContain("// PRIMED");
+        code.ShouldNotContain("serviceScope");
+    }
+
+    // Each generated method gets its own postprocessor instances, because those frames hold per-method
+    // variable state. Two methods off one source must not share a frame.
+    [Fact]
+    public void a_fresh_postprocessor_is_built_for_each_method()
+    {
+        var built = new List<SyncFrame>();
+        theServices.AddScoped<IWidget, AWidget>();
+        theServices.AddScoped<IScopedLambda>(_ => new ScopedLambda());
+
+        var graph = new ServiceContainer(theServices, theServices.BuildServiceProvider());
+        var source = new ServiceCollectionServerVariableSource(graph);
+        source.ScopePostProcessorSources.Add(() =>
+        {
+            var frame = new LinePostprocessor("// PRIMED");
+            built.Add(frame);
+            return frame;
+        });
+
+        // StartNewType folds into StartNewMethod, so this is two methods, not three.
+        source.StartNewMethod();
+        source.StartNewMethod();
+
+        built.Count.ShouldBe(2);
+        built[0].ShouldNotBeSameAs(built[1]);
+    }
+
+    // ReplaceServiceProvider means the host handed us a container it owns -- Wolverine.HTTP's
+    // httpContext.RequestServices. No scope is created there, so there is nothing to prime and we must
+    // not emit against someone else's container.
+    [Fact]
+    public void nothing_is_attached_to_an_externally_supplied_provider()
+    {
+        theServices.AddScoped<IWidget, AWidget>();
+        theServices.AddScoped<IScopedLambda>(_ => new ScopedLambda());
+
+        var graph = new ServiceContainer(theServices, theServices.BuildServiceProvider());
+
+        var assembly = new GeneratedAssembly(new GenerationRules());
+        var type = assembly.AddType("ExternalProviderHarness", typeof(ServiceHarness<WidgetResult>));
+        var buildMethod = type.MethodFor("Build");
+
+        var call = new MethodCall(typeof(OpaqueOnlyHandler), nameof(OpaqueOnlyHandler.Handle));
+        buildMethod.Frames.Add(call);
+        buildMethod.Frames.Code("return {0};", call.ReturnVariable!);
+
+        var source = new ServiceCollectionServerVariableSource(graph);
+        source.ScopePostProcessorSources.Add(() => new LinePostprocessor("// PRIMED"));
+        source.StartNewType();
+        source.StartNewMethod();
+        source.ReplaceServiceProvider(new Variable(typeof(IServiceProvider), "externalProvider"));
+
+        var code = assembly.GenerateCode(source);
+        _output.WriteLine(code);
+
+        code.ShouldContain("externalProvider");
+        code.ShouldNotContain("// PRIMED");
+        code.ShouldNotContain("CreateAsyncScope");
+    }
+}
+
+public class OpaqueOnlyHandler
+{
+    // No IServiceProvider anywhere -- the opaque IScopedLambda is the only thing forcing the scope.
+    public static WidgetResult Handle(IWidget widget, IScopedLambda opaque)
+    {
+        return new WidgetResult(widget);
+    }
+}
+
+public class InlineOnlyHandler
+{
+    public static WidgetResult Handle(IWidget widget)
+    {
+        return new WidgetResult(widget);
+    }
+}

--- a/src/JasperFx/CodeGeneration/Services/LazyServiceLocationFrame.cs
+++ b/src/JasperFx/CodeGeneration/Services/LazyServiceLocationFrame.cs
@@ -16,7 +16,15 @@ public class LazyServiceLocationVariableSource : IVariableSource
 
     public bool Matches(Type type)
     {
-        return type == _serviceType;
+        if (type == _serviceType) return true;
+
+        // An open generic service type matches every closed version of itself, so
+        // AlwaysUseServiceLocationFor(typeof(Lazy<>)) covers Lazy<IFoo>, Lazy<IBar> and the rest.
+        // The Type overload accepted an open generic without complaint and then matched nothing,
+        // which made it a silent no-op -- see wolverine#4159.
+        return _serviceType.IsGenericTypeDefinition
+               && type.IsConstructedGenericType
+               && type.GetGenericTypeDefinition() == _serviceType;
     }
 
     public Variable Create(Type type)

--- a/src/JasperFx/CodeGeneration/Services/ServiceCollectionServerVariableSource.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceCollectionServerVariableSource.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using JasperFx.CodeGeneration.Frames;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,13 +15,49 @@ because at least one dependency is directly using IServiceProvider or has an opa
     private bool _usesScopedContainerDirectly;
     private readonly List<StandInVariable> _standins = new();
     private readonly List<InjectedSingleton> _fields = new();
-    private Variable _scoped = new ScopedContainerCreation().Scoped;
+    private Variable _scoped;
     private List<ServiceLocationReport> _serviceLocations = [];
     private bool _replacedServiceProvider;
 
     public ServiceCollectionServerVariableSource(IServiceContainer services)
     {
         _services = (ServiceContainer?)services;
+        _scoped = newScopedProvider();
+    }
+
+    /// <summary>
+    ///     Frames to emit immediately after the service-location child scope is created, before anything
+    ///     is resolved out of it. One frame is built per generated method, so each may hold per-method
+    ///     state. Frames implementing <see cref="IUsesServiceProviderFrame" /> are handed the scoped
+    ///     provider variable; a frame that finds nothing to do is expected to emit nothing.
+    /// </summary>
+    /// <remarks>
+    ///     This is how a host seeds the child scope with instances the generated code already owns --
+    ///     Wolverine primes it with the handler's MessageContext and the outbox-enrolled persistence
+    ///     session, so a service-located IMessageContext or IDocumentSession is that same instance
+    ///     rather than a second, un-enrolled one.
+    ///
+    ///     Attaching here rather than from a frame in the generated method is deliberate. A frame can
+    ///     only look for the scoped provider during <c>MethodFrameArranger</c>'s first resolution pass,
+    ///     but the scope for an opaque scoped/transient registration is not created until
+    ///     <see cref="ReplaceVariables" /> runs after it -- so a frame-based activator silently found
+    ///     nothing and attached nothing for exactly the chains that most needed it. See wolverine#4171.
+    ///
+    ///     Nothing is attached when <see cref="ReplaceServiceProvider" /> has supplied an external
+    ///     provider (e.g. Wolverine.HTTP's <c>httpContext.RequestServices</c>): no scope is created
+    ///     there, and that container belongs to the host, not to the generated method.
+    /// </remarks>
+    public List<Func<SyncFrame>> ScopePostProcessorSources { get; } = new();
+
+    private Variable newScopedProvider()
+    {
+        var creation = new ScopedContainerCreation();
+        foreach (var source in ScopePostProcessorSources)
+        {
+            creation.AddPostProcessor(source());
+        }
+
+        return creation.Scoped;
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2067:DynamicallyAccessedMembers",
@@ -112,7 +149,7 @@ because at least one dependency is directly using IServiceProvider or has an opa
     public void ResetServiceProvider()
     {
         _replacedServiceProvider = false;
-        _scoped = new ScopedContainerCreation().Scoped;
+        _scoped = newScopedProvider();
     }
 
     public ServiceLocationReport[] ServiceLocations()
@@ -153,7 +190,9 @@ because at least one dependency is directly using IServiceProvider or has an opa
     {
         if (!_replacedServiceProvider)
         {
-            _scoped = new ScopedContainerCreation().Scoped;
+            // A fresh scope -- and therefore a fresh set of postprocessor frames -- per generated
+            // method, because those frames carry per-method variable state.
+            _scoped = newScopedProvider();
         }
 
         _usesScopedContainerDirectly = false;

--- a/src/JasperFx/ServiceContainer.cs
+++ b/src/JasperFx/ServiceContainer.cs
@@ -240,18 +240,29 @@ public class ServiceContainer : IServiceProviderIsService, IServiceContainer
             return family;
         }
 
-        if (serviceType.IsGenericType && serviceType.IsNotConcrete())
+        if (serviceType.IsGenericType)
         {
             var templateType = serviceType.GetGenericTypeDefinition();
             var templatedParameterTypes = serviceType.GetGenericArguments();
-        
+
+            // An open generic registration wins over the self-binding fallback below, and it has to win
+            // for CONCRETE closed types too -- this used to be gated on IsNotConcrete(), which quietly
+            // excluded every concrete generic. Lazy<T> is the one that hurt (wolverine#4159): a host
+            // registering the conventional `TryAddScoped(typeof(Lazy<>), typeof(LazyResolver<>))` adapter
+            // never had it consulted, because Lazy<T> is a concrete class, so codegen fell through to
+            // self-binding and emitted `new Lazy<ISomeService>()`. That compiles, and it is never usable:
+            // the parameterless constructor uses Activator.CreateInstance<T>(), so .Value throws
+            // MissingMemberException for any T without a public parameterless constructor -- which is
+            // every DI-registered service. It failed silently, at first use, on a host that had started
+            // healthy.
             if (_families.TryFind(templateType, out var generic))
             {
                 family = generic.Close(templatedParameterTypes);
                 _families = _families.AddOrUpdate(serviceType, family);
                 return family;
             }
-            else
+
+            if (serviceType.IsNotConcrete())
             {
                 // Memoize the "miss"
                 family = new ServiceFamily(serviceType, ArraySegment<ServiceDescriptor>.Empty);


### PR DESCRIPTION
Needed by [wolverine#4171](https://github.com/JasperFx/wolverine/issues/4171) and [wolverine#4159](https://github.com/JasperFx/wolverine/issues/4159). Three codegen defects, all of which fail silently on a host that started healthy.

## 1. Scope postprocessors attach where the scope is created

A host that wants to seed the service-location child scope with instances the generated method already owns had to do it from a frame in the method: find the scoped `IServiceProvider` during arrangement, cast its `Creator` to `IScopedContainerCreation`, register postprocessors.

That only ever worked when something in the method asked for an `IServiceProvider` **by name**. Frames resolve their variables in `MethodFrameArranger`'s first pass:

```csharp
foreach (var frame in frames) frame.ResolveVariables(this);   // step 1  -- the activator looks here
_services?.ReplaceVariables(this);                            // step 1a -- the scope is created here
```

So for a chain whose only reason to service-locate is an opaque scoped/transient registration, the activator's deliberately non-forcing `TryFindVariable` found nothing, attached nothing, and said nothing.

Wolverine has shipped that way since its GH-3001. A handler whose only service location came from an opaque lambda got an **unprimed** scope: a service-located `IMessageContext` was a second, un-enrolled context, and a service-located Marten `IDocumentSession` was a second, un-enrolled session. Every Wolverine test covering the feature happens to put an `IServiceProvider` on the handler signature — the one shape that did work — which is why nobody saw it.

`ScopePostProcessorSources` moves the attachment into the one place that knows a scope was created. A fresh frame is built per generated method, because those frames carry per-method variable state. Nothing is attached when `ReplaceServiceProvider` supplied an external container (Wolverine.HTTP's `httpContext.RequestServices`) — no scope is created there, and it belongs to the host.

## 2. An open generic registration beats self-binding a concrete closed type

`findFamily` gated its open-generic close-over on `IsNotConcrete()`, which quietly excluded **every concrete generic**. `Lazy<T>` is the one that hurt. A host registering the conventional adapter:

```csharp
services.TryAddScoped(typeof(Lazy<>), typeof(LazyResolver<>));
```

never had it consulted, because `Lazy<T>` is a concrete class — so codegen fell through to the self-binding-any-public-concrete-type fallback and emitted:

```csharp
var lazyOfSomeService = new System.Lazy<ISomeService>();
```

That compiles, and it can never work: the parameterless constructor uses `Activator.CreateInstance<T>()`, so `.Value` throws `MissingMemberException` for any `T` without a public parameterless constructor — which is every DI-registered service. The reporter's host booted, listeners attached, health checks passed, and twelve integration tests recorded zero message execution.

A concrete generic with **no** registration still self-binds, so nothing else moves.

## 3. `AlwaysUseServiceLocationFor` accepts an open generic

`LazyServiceLocationVariableSource.Matches` was `type == _serviceType`, so the `Type` overload took `typeof(Lazy<>)` without complaint and then matched nothing — a silent no-op whose generated output was byte-identical to not calling it. An open generic now matches its own closed forms, and only those.

## Tests

`CodegenTests/Services/open_generic_registrations.cs` and `CodegenTests/Services/scope_postprocessor_sources.cs`.

**6 of the 7 open-generic tests fail against main**, including the reporter's exact `MissingMemberException` reproduced end-to-end through a compiled harness, for both adapter shapes. The seventh is the control pinning unchanged self-binding.

A note on that test design: `LazyResolver<T>(IServiceProvider)` — the shape actually reported — cannot discriminate, because it forces service location on its own. An early draft's `ShouldContain("LazyResolver")` was matching a codegen *comment* rather than emitted code. `EagerLazyResolver<T>(T value)` is inline-constructible, so inline-vs-located is visible in the output, and both adapters are covered.

The postprocessor tests cannot be run against main — `ScopePostProcessorSources` is the new API. Their weight is carried on the Wolverine side, where the opaque-only handler goes from a different `IMessageContext` instance to the same one, and the HTTP equivalent goes from `context:different session:different` to `context:same session:same`.

## Verification

CodegenTests 431, CoreTests 597, CommandLineTests 295, CodegenTests.FSharp 1 — all green.

Packed as `2.58.0-local1` and consumed by Wolverine (hash-checked against the loaded assembly, since a `wolverine_slim.slnx` build compiles `../jasperfx` from source and would otherwise mislead): **CoreTests 2666, Wolverine.Http.Tests 996, `wolverine.slnx -c Release -f net9.0` clean.** The Wolverine adoption is committed and held until this ships — it deletes `ScopePrimingActivatorFrame` and cannot compile against 2.57.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
