### PR TITLE
jasperfx#716: HardStopAsync must set the agent's own Status, not just publish it

### DIFF
--- a/src/EventTests/Daemon/HardStopLeavesStatusRunningTests.cs
+++ b/src/EventTests/Daemon/HardStopLeavesStatusRunningTests.cs
@@ -1,0 +1,75 @@
+using JasperFx;
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Daemon;
+
+// jasperfx#716: SubscriptionAgent has three stop paths, and only two of them set the agent's own
+// Status. StopAndDrainAsync sets Stopped in its finally; ReportCriticalFailureAsync sets Stopped or
+// Paused. HardStopAsync publishes AgentStatus="Stopped" to the tracker -- so the persisted extended
+// progression row reads Stopped -- and then leaves the object's Status at its initialized Running.
+//
+// That asymmetry is invisible until something POLLS the agent object rather than the tracker, which is
+// exactly what Wolverine's EventSubscriptionAgent does: wolverine GH-3519 made the wrapper's Status
+// delegate to the inner agent precisely so NodeAgentController could see a dead shard and restart it.
+// A hard-stopped agent reports Running forever, so the wrapper reports Running, AllRunningAgentUris()
+// lists it, CheckHealthAsync passes, and nothing ever recovers the shard.
+//
+// HardStopAsync is what stopRunningAgents / stopRunningAgentsForTenant call at the top of EVERY rebuild,
+// and what tryStartAgentAsync calls to tear down a faulted start.
+//
+// The rebuild path masks it -- rebuildAgent's stopIfRunningAsync reaches the same registered object
+// moments later and StopAndDrains it, which does set Stopped -- so the exposure is a caller with
+// nothing behind it, the faulted-start teardown being the clearest. That masking is also why this is a
+// latent defect rather than the cause of any reported symptom; do not attach one to it without
+// building the repro.
+public class HardStopLeavesStatusRunningTests
+{
+    [Fact]
+    public async Task hard_stop_sets_the_agent_status_to_stopped()
+    {
+        await using var harness = new Harness();
+
+        harness.Agent.Status.ShouldBe(AgentStatus.Running);
+
+        await harness.Agent.HardStopAsync();
+
+        harness.Agent.Status.ShouldBe(AgentStatus.Stopped);
+    }
+
+    [Fact]
+    public async Task stop_and_drain_sets_the_agent_status_to_stopped()
+    {
+        // The control: the graceful path already does this, and is why the gap above reads as an
+        // oversight rather than a deliberate difference.
+        await using var harness = new Harness();
+
+        await harness.Agent.StopAndDrainAsync(CancellationToken.None);
+
+        harness.Agent.Status.ShouldBe(AgentStatus.Stopped);
+    }
+
+    private sealed class Harness : IAsyncDisposable
+    {
+        public Harness()
+        {
+            Tracker = new ShardStateTracker(new NulloLogger());
+            Agent = new SubscriptionAgent(new ShardName("Trip"), new AsyncOptions(), TimeProvider.System,
+                Substitute.For<IEventLoader>(), Substitute.For<ISubscriptionExecution>(), Tracker,
+                Substitute.For<ISubscriptionMetrics>(), NullLogger.Instance);
+        }
+
+        public ShardStateTracker Tracker { get; }
+        public SubscriptionAgent Agent { get; }
+
+        public ValueTask DisposeAsync()
+        {
+            Tracker.As<IDisposable>().Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
+++ b/src/JasperFx.Events/Daemon/SubscriptionAgent.cs
@@ -260,6 +260,21 @@ public partial class SubscriptionAgent : ISubscriptionAgent, IAsyncDisposable
     {
         await _execution.HardStopAsync().ConfigureAwait(false);
         await DisposeAsync().ConfigureAwait(false);
+
+        // jasperfx#716: set the agent's OWN status too, exactly as StopAndDrainAsync's finally does.
+        // Publishing AgentStatus="Stopped" on the tracker only reaches the observers and the persisted
+        // extended-progression row; an external supervisor that POLLS this object read Running on an
+        // agent this method has just disposed. Wolverine's EventSubscriptionAgent is exactly such a
+        // supervisor -- GH-3519 made its wrapper Status delegate here so NodeAgentController could see a
+        // dead shard -- and its own guards are spelled `Status != AgentStatus.Stopped`.
+        //
+        // The rebuild path happens to mask it: rebuildProjection hard-stops the continuous agent and
+        // then rebuildAgent's stopIfRunningAsync reaches the SAME registered object and StopAndDrains
+        // it, which does set Stopped. The exposure is a caller with nothing behind it -- most obviously
+        // tryStartAgentAsync's teardown of a faulted start, whose own comment cites GH-3519 as the thing
+        // it is protecting.
+        Status = AgentStatus.Stopped;
+
         await _tracker.PublishAsync(stamp(new ShardState(Name, LastCommitted)
         {
             Action = ShardAction.Stopped,


### PR DESCRIPTION
Closes #716.

`SubscriptionAgent` has three stop paths and only two of them set the object's own `Status`:

| path | publishes `AgentStatus="Stopped"` to the tracker | sets the object's own `Status` |
|---|---|---|
| `StopAndDrainAsync` | ✅ | ✅ `Stopped`, in its `finally` |
| `ReportCriticalFailureAsync` | ✅ | ✅ `Stopped` / `Paused` |
| **`HardStopAsync`** | ✅ | ❌ **stays at the initialized `Running`** |

`DisposeAsync` does not touch it either, so the value is `Running` for the lifetime of an agent
`HardStopAsync` has just disposed.

That is invisible to anything reading the **tracker** — observers and the persisted
extended-progression row are correct — and wrong for anything **polling the agent**. Wolverine's
`EventSubscriptionAgent` is the latter by design: GH-3519 made its wrapper `Status` delegate to the
inner agent so `NodeAgentController` could see a dead shard, and both that wedge recovery and
`AllRunningAgentUris()` are spelled `Status != AgentStatus.Stopped`.

Two consumers inside this repo get more truthful at the same time:

- **`tryStartAgentAsync`'s idempotence guard** (`_agents.TryFind(...) && running.Status == AgentStatus.Running`)
  stops *refusing to restart* over a hard-stopped registration. `stopRunningAgents` does not remove the
  agent from `_agents`, so the stale entry is reachable.
- **`describeStartFailure`** stops reporting the self-contradictory *"An agent is registered for this
  shard in status 'Running' rather than running"*.

## ⚠️ Latent, and deliberately not attached to a reported symptom

The rebuild path masks it. `rebuildProjection` hard-stops the continuous agent, and then
`rebuildAgent`'s `stopIfRunningAsync` reaches the **same** registered object and `StopAndDrainAsync`es
it — which does set `Stopped`. So the zombie is cleaned up by the next step of the same method.

I originally filed #716 as the cause of
[CritterWatch#1176](https://github.com/JasperFx/CritterWatch/issues/1176). **It is not**, and I would
rather that be in the history than quietly dropped: packing this change and running that reproduction
end to end produced behaviour *identical* to the published package — shard frozen for 161 s either way.
The real cause was [wolverine#4193](https://github.com/JasperFx/wolverine/issues/4193) (a
locally-stopped agent that keeps its assignment row is recovered by neither of two paths that defer to
each other), fixed in JasperFx/wolverine#4194.

So the exposure that remains is a caller with nothing behind it — most obviously
`tryStartAgentAsync`'s teardown of a faulted start, whose own comment cites GH-3519 as the thing it is
protecting. Worth taking on its own merits; not urgent.

## The test

Pins both paths together, with the `StopAndDrainAsync` half as the control so the asymmetry reads as an
oversight rather than a deliberate difference. Proven non-vacuous:

```
before:  Failed: 1, Passed: 907   ShouldAssertException : harness.Agent.Status
                                    should be AgentStatus.Stopped but was AgentStatus.Running
after:   EventTests 908/908  ·  EventStoreTests 136/136     (net9.0 and net10.0)
```

`ReportCriticalFailureAsync` calls `_execution.HardStopAsync()` — the execution's, not the agent's — and
sets `Paused` itself, so this cannot clobber a pause reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm
