### PR TITLE
Add VariableSource.Existing, a variable lookup that never manufactures

### DIFF
--- a/docs/codegen/variables.md
+++ b/docs/codegen/variables.md
@@ -88,6 +88,23 @@ During code arrangement, the engine resolves variables in this order:
 
 If a variable cannot be resolved through any of these sources, the code generation will throw an exception describing the missing dependency.
 
+::: warning A variable source is a factory, not a lookup
+Step 4 *builds* what the earlier steps could not find. That makes `IMethodVariables.TryFindVariable(type, VariableSource.All)`
+-- and `VariableSource.NotServices` -- a poor way to ask "does this method already have one of these?", because the answer
+is manufactured on the spot, and taking a dependency on it pulls the newly built frame into the method.
+
+Use `VariableSource.Existing` for that question instead. It answers only from steps 1-3 and returns `null` rather than
+consulting any `IVariableSource`:
+
+```csharp
+var session = chain.TryFindVariable(typeof(IDocumentSession), VariableSource.Existing);
+if (session != null)
+{
+    // ...the method really does have one, so it is safe to use
+}
+```
+:::
+
 ## InjectedField
 
 `InjectedField` is a specialized `Variable` that represents a constructor parameter and corresponding private field on the generated type:

--- a/src/CodegenTests/MethodFrameArrangerTests.cs
+++ b/src/CodegenTests/MethodFrameArrangerTests.cs
@@ -25,6 +25,48 @@ public class MethodFrameArrangerTests
         code.ShouldContain("OpenSession(messageContext, tenantId)");
     }
 
+    // wolverine#4198. VariableSource.All / NotServices are FACTORIES -- they build what they cannot
+    // find. A caller that only wants to know whether the method already has one of these needs an
+    // answer that is not manufactured on the spot.
+    [Fact]
+    public void existing_does_not_manufacture_a_variable_from_a_source()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("GeneratedHandler", typeof(IHttpHandlerShape));
+        var method = type.MethodFor(nameof(IHttpHandlerShape.Handle));
+        method.Sources.Add(new MessageContextVariableSource());
+
+        var probe = new ProbeForExistingFrame(typeof(TestMessageContext));
+        method.Frames.Add(probe);
+
+        var code = assembly.GenerateCode();
+
+        // Nothing in this method wanted a message context, so asking for one does not conjure it up
+        probe.Found.ShouldBeNull();
+        code.ShouldNotContain("new CodegenTests.TestMessageContext()");
+    }
+
+    [Fact]
+    public void existing_finds_a_variable_the_method_already_has()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("GeneratedHandler", typeof(IHttpHandlerShape));
+        var method = type.MethodFor(nameof(IHttpHandlerShape.Handle));
+        method.Sources.Add(new MessageContextVariableSource());
+
+        // This frame genuinely wants the context, so by the time the probe asks, the method has one
+        method.Frames.Add(new UsesMessageBusFrame());
+
+        var probe = new ProbeForExistingFrame(typeof(TestMessageContext));
+        method.Frames.Add(probe);
+
+        var code = assembly.GenerateCode();
+
+        probe.Found.ShouldNotBeNull();
+        probe.Found.Usage.ShouldBe("messageContext");
+        CountOccurrences(code, "var messageContext = new CodegenTests.TestMessageContext()").ShouldBe(1);
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         return haystack.Split(needle).Length - 1;
@@ -155,6 +197,37 @@ public class OpenOutboxedSessionFrame : SyncFrame
     public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
     {
         writer.WriteLine($"{_factory.Usage}.OpenSession({_context.Usage}, {_tenantId.Usage});");
+        Next?.GenerateCode(method, writer);
+    }
+}
+
+/// <summary>
+///     Asks the arranger whether the method ALREADY has a variable of the given type, and records the
+///     answer. See wolverine#4198.
+/// </summary>
+public class ProbeForExistingFrame : SyncFrame
+{
+    private readonly Type _type;
+
+    public ProbeForExistingFrame(Type type)
+    {
+        _type = type;
+    }
+
+    public Variable? Found { get; private set; }
+
+    public override IEnumerable<Variable> FindVariables(IMethodVariables chain)
+    {
+        Found = chain.TryFindVariable(_type, VariableSource.Existing);
+        if (Found != null)
+        {
+            yield return Found;
+        }
+    }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        writer.WriteLine($"// probe found: {Found?.Usage ?? "nothing"}");
         Next?.GenerateCode(method, writer);
     }
 }

--- a/src/JasperFx/CodeGeneration/Model/MethodFrameArranger.cs
+++ b/src/JasperFx/CodeGeneration/Model/MethodFrameArranger.cs
@@ -233,6 +233,14 @@ internal class MethodFrameArranger : IMethodVariables
             return created;
         }
 
+        // Everything above this line is a lookup; everything below it is a factory. A caller asking
+        // VariableSource.Existing is asking whether this method ALREADY has one, and a manufactured
+        // answer would be a different answer. See wolverine#4198.
+        if (variableSource == VariableSource.Existing)
+        {
+            return null;
+        }
+
         var source = allVariableSources(variableSource).FirstOrDefault(x => x.Matches(type));
         return source?.Create(type);
     }

--- a/src/JasperFx/CodeGeneration/Model/VariableSource.cs
+++ b/src/JasperFx/CodeGeneration/Model/VariableSource.cs
@@ -1,7 +1,27 @@
-﻿namespace JasperFx.CodeGeneration.Model;
+namespace JasperFx.CodeGeneration.Model;
 
+/// <summary>
+///     Which variable sources <see cref="IMethodVariables.TryFindVariable" /> is allowed to consult
+///     when the method does not already have a variable of the requested type.
+/// </summary>
 public enum VariableSource
 {
+    /// <summary>
+    ///     Every source, including the IoC container.
+    /// </summary>
     All,
-    NotServices
+
+    /// <summary>
+    ///     Every source except the IoC container.
+    /// </summary>
+    NotServices,
+
+    /// <summary>
+    ///     No sources at all: answer only from what the method already has -- its arguments, its derived
+    ///     variables, and the variables its frames already create. A variable source is a factory, so
+    ///     <see cref="All" /> and <see cref="NotServices" /> both BUILD what they cannot find; use this
+    ///     when the question really is "does this method already have one of these?" and a manufactured
+    ///     answer would be wrong. See wolverine#4198.
+    /// </summary>
+    Existing
 }

--- a/src/JasperFx/CodeGeneration/Services/ServiceVariables.cs
+++ b/src/JasperFx/CodeGeneration/Services/ServiceVariables.cs
@@ -65,7 +65,15 @@ public class ServiceVariables : IEnumerable<Variable>, IMethodVariables
 
     Variable IMethodVariables.TryFindVariable(Type type, VariableSource source)
     {
-        if (type == typeof(IServiceProvider)) return _serviceProvider.Value;
+        if (type == typeof(IServiceProvider))
+        {
+            // _serviceProvider is lazy, and resolving it can spin up a brand new scope creation --
+            // which is exactly what VariableSource.Existing promises not to do.
+            if (source == VariableSource.Existing && !_serviceProvider.IsValueCreated) return null;
+
+            return _serviceProvider.Value;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Needed by [wolverine#4198](https://github.com/JasperFx/wolverine/issues/4198), which is a hard blocker for 6.31.0 upgraders.

### The problem

`IMethodVariables.TryFindVariable` resolves in two halves. The first is a lookup — method arguments, derived variables, and the variables the method's frames already create. The second is a factory: `allVariableSources(...).FirstOrDefault(x => x.Matches(type))?.Create(type)`.

Both existing `VariableSource` values run the factory half. So a caller asking *"does this method already have one of these?"* gets an answer that is manufactured on the spot, and taking a dependency on it pulls the newly built frame into the generated method.

Wolverine's GH-3001 scope priming asks exactly that question about a persistence session, and documents itself as self-guarding. It is not: every store integration registers an `IVariableSource` for its session type, so since Wolverine 6.30.3 every chain that service-locates *anything* — for any reason, with or without persistence — has been opening an outbox-enrolled Marten session that is handed to the priming holder and never read. Two reporters on wolverine#4198 counted 17 and 30 affected chains in one application each; under sharded multi-tenancy `OutboxedSessionFactory.OpenSession` throws outright, so a handler that touches no database fails on a database it does not use.

### The change

`VariableSource.Existing` stops before the factory half and returns `null` instead. It is a new enum member, so no interface changes and nothing existing shifts behavior:

```csharp
var session = chain.TryFindVariable(typeof(IDocumentSession), VariableSource.Existing);
if (session != null)
{
    // ...the method really does have one
}
```

`ServiceVariables` honors it too — its `IServiceProvider` variable is lazy, and materializing it can create a scope.

Two tests in `MethodFrameArrangerTests` cover both directions: `Existing` does not conjure a variable out of a registered source, and it still finds one the method genuinely has. The first fails on `main`.