### PR TITLE
gh-718: cover an identity-less [BoundaryAggregate] in the DCB compliance suite

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -166,6 +166,28 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
 | Subscriptions | `SubscriptionCompliance` |
 
+### Identity-less boundary aggregates (jasperfx#718)
+
+`DcbTagQueryAndConsistencyCompliance` carries one aggregate — `CourseLoad` — with no `Id` and no
+`[AggregateIdentity]`, marked `[BoundaryAggregate]`. It is there because every other DCB aggregate in
+the suite happens to have an identity, so a store could require one for a *boundary* aggregate and
+still pass the whole suite. Both SQL stores did: Fisher threw from its own identity resolution
+(fisher#135), Polecat from `DocumentMapping`'s constructor (polecat#521), despite the marker being
+the documented cross-stack answer.
+
+Its two facts fold **with matching events present**, and that is load-bearing rather than incidental.
+`FetchForWritingByTags` only resolves the aggregator when the query finds events, so a boundary over
+an empty result — the ordinary "this must not exist yet" assertion — succeeds on a store that cannot
+fold the type at all.
+
+The type is declared in the shared source rather than as a per-consumer partial, which works because
+the package ships as source: the attribute lands on the aggregate in the consumer's own compilation,
+which is both the compilation the generator emits `[GeneratedEvolver]` into and the assembly the
+runtime scans as `typeof(TDoc).Assembly`. It is deliberately never registered — no snapshot, no live
+aggregation — since a DCB aggregate is discovered lazily on first use, and registering it eagerly
+would move the failure to store construction, where it would take every other fact in the suite down
+with it.
+
 ### The document contract (jasperfx#647)
 
 A second, independent family covers the small *document* slice that `JasperFx.Events` now abstracts

--- a/src/JasperFx.Events.ComplianceTests/Suites/DcbTagQueryAndConsistencyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DcbTagQueryAndConsistencyCompliance.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using JasperFx.Events.Aggregation;
 using JasperFx.Events.Tags;
 using Shouldly;
 using Xunit;
@@ -61,6 +62,45 @@ public partial class StudentCourseEnrollment
     public void Apply(StudentDropped e)
     {
         IsDropped = true;
+    }
+}
+
+#endregion
+
+#region sample_compliance_dcb_boundary_aggregate
+
+/// <summary>
+/// A pure DCB boundary aggregate: conventional Apply methods, but no Id property and no
+/// [AggregateIdentity], because it is defined by a tag query spanning streams rather than by
+/// being keyed to one stream. <see cref="BoundaryAggregateAttribute"/> is what opts it into
+/// source-generated evolver emission; without it the generator cannot infer a TId and emits
+/// nothing.
+/// </summary>
+/// <remarks>
+/// Deliberately not registered in the suite's configuration -- neither snapshotted nor declared
+/// as a live aggregation. A store discovers a DCB aggregate lazily on first use, so the whole
+/// resolution path this type covers is the one that runs inside
+/// <c>AggregateByTagsAsync</c>/<c>FetchForWritingByTags</c>. See jasperfx#718.
+/// </remarks>
+[BoundaryAggregate]
+public class CourseLoad
+{
+    public int Enrollments { get; set; }
+    public int Assignments { get; set; }
+
+    public void Apply(StudentEnrolled e)
+    {
+        Enrollments++;
+    }
+
+    public void Apply(AssignmentSubmitted e)
+    {
+        Assignments++;
+    }
+
+    public void Apply(StudentDropped e)
+    {
+        Enrollments--;
     }
 }
 
@@ -299,6 +339,74 @@ public abstract class DcbTagQueryAndConsistencyCompliance<TFixture, TOperations,
         var aggregate = await EventsFor(session).AggregateByTagsAsync<StudentCourseEnrollment>(query, Cancellation);
         aggregate.ShouldBeNull();
     }
+
+    #region sample_compliance_dcb_identity_less_boundary_aggregate
+
+    [Fact]
+    public async Task can_aggregate_by_tags_into_identity_less_boundary_aggregate()
+    {
+        // CourseLoad has no Id and no [AggregateIdentity] -- a store that resolves a boundary
+        // aggregate through single-stream identity resolution fails here rather than treating
+        // [BoundaryAggregate] as an opt-out. The fold has to happen over events that actually
+        // matched: an empty boundary never reaches the aggregator at all, so it passes on a
+        // store that cannot fold the type. See jasperfx#718.
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        var enrolled = EventsFor(session).BuildEvent(new StudentEnrolled("Alice", "Math"));
+        enrolled.WithTag(studentId, courseId);
+
+        var submitted = EventsFor(session).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(studentId, courseId);
+
+        EventsFor(session).Append(streamId, enrolled, submitted);
+        await SaveChangesAsync(session);
+
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var aggregate = await EventsFor(session).AggregateByTagsAsync<CourseLoad>(query, Cancellation);
+
+        aggregate.ShouldNotBeNull();
+        aggregate.Enrollments.ShouldBe(1);
+        aggregate.Assignments.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task can_fetch_for_writing_by_tags_with_identity_less_boundary_aggregate()
+    {
+        // Same identity-less type through the write surface, again with matching events present so
+        // the aggregator is genuinely resolved before anything is appended.
+        var studentId = new StudentId(Guid.NewGuid());
+        var courseId = new CourseId(Guid.NewGuid());
+
+        await using var session1 = OpenSession();
+        await AppendTaggedEventAsync(session1, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), studentId,
+            courseId);
+
+        await using var session2 = OpenSession();
+        var query = new EventTagQuery().Or<StudentId>(studentId);
+        var boundary = await EventsFor(session2).FetchForWritingByTags<CourseLoad>(query, Cancellation);
+
+        boundary.Aggregate.ShouldNotBeNull();
+        boundary.Aggregate!.Enrollments.ShouldBe(1);
+        boundary.LastSeenSequence.ShouldBeGreaterThan(0);
+
+        var submitted = EventsFor(session2).BuildEvent(new AssignmentSubmitted("HW1", 95));
+        submitted.WithTag(studentId, courseId);
+        boundary.AppendOne(submitted);
+
+        await SaveChangesAsync(session2);
+
+        await using var session3 = OpenSession();
+        var after = await EventsFor(session3).AggregateByTagsAsync<CourseLoad>(query, Cancellation);
+        after.ShouldNotBeNull();
+        after.Enrollments.ShouldBe(1);
+        after.Assignments.ShouldBe(1);
+    }
+
+    #endregion
 
     [Fact]
     public async Task can_fetch_for_writing_by_tags_happy_path()


### PR DESCRIPTION
Closes #718.

## What

Adds `CourseLoad` to `DcbTagQueryAndConsistencyCompliance` — no `Id`, no `[AggregateIdentity]`, marked `[BoundaryAggregate]` — plus two facts over it:

- `can_aggregate_by_tags_into_identity_less_boundary_aggregate`
- `can_fetch_for_writing_by_tags_with_identity_less_boundary_aggregate`

## Why

Every DCB aggregate in the suite happened to carry an `Id`, so a store could require a single-stream identity for a *boundary* aggregate and pass every DCB test in the library. Both SQL stores did — Fisher threw from its own identity resolution ([fisher#135](https://github.com/JasperFx/fisher/issues/135), fixed), Polecat still throws from `DocumentMapping`'s constructor ([polecat#521](https://github.com/JasperFx/polecat/issues/521)) — despite `[BoundaryAggregate]` being the documented cross-stack answer.

## Three decisions worth reviewing

**Both facts fold with matching events present.** `FetchForWritingByTags` only resolves the aggregator when the query finds events, so a boundary over an empty result — the ordinary "this must not exist yet" assertion — succeeds on a store that cannot fold the type at all. Coverage that skipped this would pass on a broken store.

**Declared in the shared source, not as a per-consumer partial.** The package ships as source, so the attribute lands on the aggregate in the consumer's own compilation — both the compilation the generator emits `[GeneratedEvolver]` into and the assembly the runtime scans as `typeof(TDoc).Assembly`. No `ComplianceFlatTableProjection`-style seam is needed.

**Deliberately unregistered** — no `Snapshot`, no `LiveAggregation`. A DCB aggregate is discovered lazily on first use, so this keeps the failure inside the two new facts. Registering it eagerly would move a broken store's failure to store construction and take the suite's other 25 facts down with it.

## Verification

The suite is not executed in this repo (only the *document* suites are enrolled against the in-memory reference store), so the store half is verified on enrollment — Polecat is expected to fail these two until polecat#521 lands, which is the point.

The generator half was checked directly: a temporary generator test over the exact `CourseLoad` shape confirmed it emits `CourseLoad_StringEvolver`, `IGeneratedSyncEvolver<CourseLoad, string>` and the assembly-level `[GeneratedEvolver]`. `JasperFx.Events.SourceGenerator.Tests` ran 57/57 green with it; the temp test was then reverted.

Also adds a README section under the suite table recording why the type is there, why the fold needs events, and why it is unregistered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)