### PR TITLE
gh-721: honor ForceSingleTenancy in TenantedEventSlicer.SliceAsync(EventRange)

### DIFF
--- a/src/EventStoreTests/Grouping/TenantedEventSlicerTests.cs
+++ b/src/EventStoreTests/Grouping/TenantedEventSlicerTests.cs
@@ -1,6 +1,7 @@
 using JasperFx;
 using JasperFx.Events;
 using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
 using Shouldly;
 
 namespace EventStoreTests.Grouping;
@@ -109,6 +110,59 @@ public class TenantedEventSlicerTests
         var group = groups.OfType<SliceGroup<SimpleAggregate, Guid>>().Single();
         group.TenantId.ShouldBe(StorageConstants.DefaultTenantId);
         group.Slices[stream1].Events().ShouldBe([e1, e2]);
+    }
+
+    [Fact]
+    public async Task force_single_tenancy_ignores_tenant_grouping_on_the_event_range_overload()
+    {
+        var inner = new ByStream<SimpleAggregate, Guid>();
+        var slicer = new TenantedEventSlicer<SimpleAggregate, Guid>(inner)
+        {
+            ForceSingleTenancy = true
+        };
+
+        var stream1 = Guid.NewGuid();
+        var e1 = MakeEvent(new AEvent(), "tenant-a", stream1, 1);
+        var e2 = MakeEvent(new BEvent(), "tenant-b", stream1, 2);
+
+        var range = new EventRange(new ShardName("temp"), 10) { Events = [e1, e2] };
+
+        var groups = await slicer.SliceAsync(range);
+
+        // All events should be in a single group with default tenant
+        groups.Count.ShouldBe(1);
+        var group = groups.OfType<SliceGroup<SimpleAggregate, Guid>>().Single();
+        group.TenantId.ShouldBe(StorageConstants.DefaultTenantId);
+        group.Slices[stream1].Events().ShouldBe([e1, e2]);
+    }
+
+    [Fact]
+    public async Task event_range_overload_groups_by_tenant_when_not_forcing_single_tenancy()
+    {
+        var inner = new ByStream<SimpleAggregate, Guid>();
+        var slicer = new TenantedEventSlicer<SimpleAggregate, Guid>(inner);
+
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        var e1 = MakeEvent(new AEvent(), "tenant-a", stream1, 1);
+        var e2 = MakeEvent(new BEvent(), "tenant-b", stream2, 2);
+        var e3 = MakeEvent(new AEvent(), "tenant-a", stream1, 3);
+        var e4 = MakeEvent(new CEvent(), "tenant-b", stream2, 4);
+
+        var range = new EventRange(new ShardName("temp"), 10) { Events = [e1, e2, e3, e4] };
+
+        var groups = await slicer.SliceAsync(range);
+
+        groups.Count.ShouldBe(2);
+
+        var tenantA = groups.OfType<SliceGroup<SimpleAggregate, Guid>>()
+            .Single(g => g.TenantId == "tenant-a");
+        tenantA.Slices[stream1].Events().ShouldBe([e1, e3]);
+
+        var tenantB = groups.OfType<SliceGroup<SimpleAggregate, Guid>>()
+            .Single(g => g.TenantId == "tenant-b");
+        tenantB.Slices[stream2].Events().ShouldBe([e2, e4]);
     }
 
     [Fact]

--- a/src/JasperFx.Events/Grouping/TenantedEventSlicer.cs
+++ b/src/JasperFx.Events/Grouping/TenantedEventSlicer.cs
@@ -34,7 +34,9 @@ public class TenantedEventSlicer<TDoc, TId> : IEventSlicer where TId : notnull
     public async ValueTask<IReadOnlyList<object>> SliceAsync(EventRange range)
     {
         var groups = new List<object>();
-        var byTenant = range.Events.GroupBy(x => x.TenantId)
+        var byTenant = ForceSingleTenancy
+            ? [new TenantGroup(StorageConstants.DefaultTenantId, range.Events)]
+            : range.Events.GroupBy(x => x.TenantId)
             .Select(g => new TenantGroup(g.Key, g)).ToList();
         foreach (var tenantGroup in byTenant)
         {
@@ -42,7 +44,7 @@ public class TenantedEventSlicer<TDoc, TId> : IEventSlicer where TId : notnull
             {
                 Upstream = range.Upstream
             };
-            
+
             await _inner.SliceAsync(tenantGroup.Events, group);
             
             groups.Add(group);


### PR DESCRIPTION
Closes #721

## The bug

`TenantedEventSlicer<TDoc, TId>` honored `ForceSingleTenancy` in one of its two overloads and not the other:

- `SliceAsync(IReadOnlyList<IEvent>)` — honored it, putting every event into one `TenantGroup(StorageConstants.DefaultTenantId, events)`.
- `SliceAsync(EventRange)` — unconditionally did `range.Events.GroupBy(x => x.TenantId)`.

The existing test `force_single_tenancy_ignores_tenant_grouping` only covered the first.

## The daemon call path

The async projection daemon reaches **only** the `EventRange` overload:

- `JasperFxAggregationProjectionBase.BuildExecution` wires `SliceBehavior.Preprocess`, which slices in `GroupedProjectionExecution.groupEventRangeAsync` via `range.SliceAsync(_runner.Slicer)`.
- The `SliceBehavior.JustInTime` alternative in `AggregationRunner` does the same.
- Inline and live aggregation go through `SliceAsync(events)` — the overload that already honored the flag.

## Why it matters

`ForceSingleTenancy` is the JasperFx.Events half of the fix for wolverine#2053, transferred to marten#4085. Marten's half is `SingleStreamProjection.BuildSlicer` setting the flag from `EventGraph.TenancyStyle`, carrying the comment *"This will address https://github.com/JasperFx/wolverine/issues/2053"*.

But marten#4085 is an async-daemon-only bug — the report states that live aggregation works correctly and only async projections during rebuild/catchup are affected. So the flag was set on exactly the path that ignored it, and honored on exactly the path that never needed it: the fix never took effect where the bug lives.

## The change

`SliceAsync(EventRange)` now respects `ForceSingleTenancy` consistently with the list overload. The `Upstream = range.Upstream` propagation on each `SliceGroup` is preserved.

## Tests

Two tests added to `src/EventStoreTests/Grouping/TenantedEventSlicerTests.cs`:

- `force_single_tenancy_ignores_tenant_grouping_on_the_event_range_overload` — mirrors the existing list-overload test; fails before this change (`groups.Count` is 2, expected 1) and passes after.
- `event_range_overload_groups_by_tenant_when_not_forcing_single_tenancy` — pins the non-forced `EventRange` path so the fix does not regress normal tenant grouping.

`dotnet test src/EventStoreTests/EventStoreTests.csproj -f net9.0` — 138 passed, 0 failed.

## Notes / out of scope

- Deliberately **not** hoisting `ForceSingleTenancy` determination into `JasperFxSingleStreamProjectionBase` — that is a separate design question (related to #649) touching downstream repos.
- `TenantedEventSlicer<TDoc, TId, TQuerySession>` (the multi-stream variant) still has no `ForceSingleTenancy` property at all, so both of its overloads are consistent with each other; it is left alone here. Multi-stream has its own `TenancyGrouping` enum covering similar ground.
- As noted in #721, marten#4085 has not been reproduced end-to-end against Postgres as part of this change; that is worth confirming separately before deciding whether that issue gets reopened or merely cross-referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)