### PR TITLE
gh-723 + gh-724 + gh-725: resolve ForceSingleTenancy in the shared base, and cover it and composites

### DIFF
--- a/src/EventStoreTests/Aggregation/SingleStreamProjectionTenancySeamTests.cs
+++ b/src/EventStoreTests/Aggregation/SingleStreamProjectionTenancySeamTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
+using Shouldly;
+
+namespace EventStoreTests.Aggregation;
+
+/// <summary>
+/// jasperfx#723: JasperFxSingleStreamProjectionBase resolves ForceSingleTenancy itself, from
+/// <see cref="IEventTenancySource" /> on the session, rather than leaving it to each store's subclass.
+/// </summary>
+/// <remarks>
+/// The point of the seam is that a store which has not opted in is left exactly where it was, so the
+/// negative case here carries as much weight as the positive one.
+/// </remarks>
+public class SingleStreamProjectionTenancySeamTests
+{
+    private static bool ForcesSingleTenancyFor(IProbeSession session)
+    {
+        var slicer = new ProbeProjection().BuildSlicer(session);
+        return slicer.ShouldBeOfType<TenantedEventSlicer<SimpleAggregate, Guid>>().ForceSingleTenancy;
+    }
+
+    [Fact]
+    public void forces_single_tenancy_when_the_session_reports_a_single_tenanted_event_store()
+    {
+        ForcesSingleTenancyFor(new SingleTenantedProbeSession()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void does_not_force_single_tenancy_when_the_event_store_is_conjoined()
+    {
+        ForcesSingleTenancyFor(new ConjoinedProbeSession()).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void a_session_that_has_not_adopted_the_seam_keeps_the_pre_723_behavior()
+    {
+        // Not implementing IEventTenancySource must be safe: this is every store on the release that
+        // introduces the seam, so anything other than false here would be a silent behavior change
+        // shipped to stores that did nothing.
+        ForcesSingleTenancyFor(new PlainProbeSession()).ShouldBeFalse();
+    }
+}
+
+public interface IProbeSession;
+
+public class PlainProbeSession : IProbeSession;
+
+public class SingleTenantedProbeSession : IProbeSession, IEventTenancySource
+{
+    public TenancyStyle EventTenancyStyle => TenancyStyle.Single;
+}
+
+public class ConjoinedProbeSession : IProbeSession, IEventTenancySource
+{
+    public TenancyStyle EventTenancyStyle => TenancyStyle.Conjoined;
+}
+
+public class ProbeOperations : IProbeSession, IStorageOperations
+{
+    public Task<IProjectionStorage<TDoc, TId>> FetchProjectionStorageAsync<TDoc, TId>(string tenantId,
+        CancellationToken cancellationToken) => throw new NotSupportedException();
+
+    public bool EnableSideEffectsOnInlineProjections => false;
+
+    public ValueTask<IMessageSink> GetOrStartMessageSink() => throw new NotSupportedException();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}
+
+public class ProbeProjection : JasperFxSingleStreamProjectionBase<SimpleAggregate, Guid, ProbeOperations, IProbeSession>;

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -233,6 +233,22 @@ public sealed class ComplianceStoreConfig
     }
 
     /// <summary>
+    /// Composite projections the suite asked the store to build, by name.
+    /// </summary>
+    public List<string> CompositeProjections { get; } = new();
+
+    /// <summary>
+    /// Build a composite projection with the given name and populate its stages.
+    /// </summary>
+    /// <inheritdoc cref="IComplianceStoreRegistrar.AddCompositeProjection" path="/remarks"/>
+    public ComplianceStoreConfig AddCompositeProjection(string name, Action<IComplianceCompositeBuilder> configure)
+    {
+        CompositeProjections.Add(name);
+        _registrations.Add(registrar => registrar.AddCompositeProjection(name, configure));
+        return this;
+    }
+
+    /// <summary>
     /// Register the shared compliance subscription with the store's async daemon.
     /// </summary>
     /// <inheritdoc cref="IComplianceStoreRegistrar.Subscribe" path="/remarks"/>

--- a/src/JasperFx.Events.ComplianceTests/IComplianceCompositeBuilder.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceCompositeBuilder.cs
@@ -1,0 +1,28 @@
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The store-neutral slice of a composite projection's configuration surface that
+/// <see cref="CompositeProjectionCompliance{TFixture,TOperations,TQuerySession}" /> needs — adding a
+/// snapshot member to a numbered stage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately tiny. A composite's real configuration surface is large and mostly product-typed
+/// (<c>Add(IProjection, Action&lt;AsyncOptions&gt;, int)</c> and friends reach each product's own
+/// projection and options types), but the one member the compliance suite needs is spelled the same
+/// everywhere: <c>Snapshot&lt;T&gt;(int stageNumber)</c>.
+/// </para>
+/// <para>
+/// It declares its own void-returning member rather than naming a shared return type, because the
+/// products disagree there and only there — Marten's <c>Snapshot&lt;T&gt;</c> returns a
+/// <c>DocumentMappingExpression&lt;T&gt;</c> for further configuration, while Polecat's and Fisher's
+/// return void. Nothing in a compliance fact uses that return value, so the seam drops it.
+/// </para>
+/// </remarks>
+public interface IComplianceCompositeBuilder
+{
+    /// <summary>
+    /// Add a self-aggregating snapshot type as a member of the composite, in the given 1-based stage.
+    /// </summary>
+    void Snapshot<TDoc>(int stageNumber) where TDoc : notnull;
+}

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -130,6 +130,41 @@ public interface IComplianceStoreRegistrar
     void AddProjection(ProjectionBase projection, ProjectionLifecycle lifecycle);
 
     /// <summary>
+    /// Build a composite projection with the given name and populate its stages.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Routed through the registrar rather than <see cref="AddProjection" /> because a composite
+    /// cannot be constructed by a suite. Every product subclasses the shared
+    /// <c>CompositeProjection&lt;TOperations,TQuerySession&gt;</c> and keeps the constructor internal —
+    /// it needs the store's options — so a composite only ever comes into being through that product's
+    /// own <c>Projections.CompositeProjectionFor(name, configure)</c>, whose <c>configure</c> parameter
+    /// is typed to the product's own subclass.
+    /// </para>
+    /// <para>
+    /// The implementation is a forward plus an adapter, because the *calls* are identical across the
+    /// products even though the types are not — all three expose <c>Snapshot&lt;T&gt;(int stageNumber)</c>
+    /// on their composite (Marten returns a mapping expression, Polecat and Fisher return void, which is
+    /// why <see cref="IComplianceCompositeBuilder" /> declares its own void-returning member rather than
+    /// trying to name a shared return type):
+    /// </para>
+    /// <code>
+    /// public void AddCompositeProjection(string name, Action&lt;IComplianceCompositeBuilder&gt; configure)
+    ///     => _options.Projections.CompositeProjectionFor(name, c => configure(new Builder(c)));
+    /// </code>
+    /// <para>
+    /// Carries a throwing default for the same reason as <see cref="UseBinarySerializer{TEvent}" />: a
+    /// store that has not implemented composites does not enroll in
+    /// <see cref="CompositeProjectionCompliance{TFixture,TOperations,TQuerySession}" />, never reaches
+    /// this member, and keeps compiling. See
+    /// <see href="https://github.com/JasperFx/jasperfx/issues/725" />.
+    /// </para>
+    /// </remarks>
+    void AddCompositeProjection(string name, Action<IComplianceCompositeBuilder> configure)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement AddCompositeProjection, so it cannot run the composite projection compliance suite.");
+
+    /// <summary>
     /// Register the shared compliance subscription with the store's async daemon.
     /// </summary>
     /// <remarks>

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -101,17 +101,50 @@ public class dcb_tag_query_and_consistency_compliance
 
 ### Opt-in capability suites
 
-Two suites cover capabilities that are opt-in rather than part of the baseline event contract, and
-their seam members on `IComplianceStoreRegistrar` carry throwing defaults: a store that has not
+Several suites cover capabilities that are opt-in rather than part of the baseline event contract,
+and their seam members on `IComplianceStoreRegistrar` carry throwing defaults: a store that has not
 implemented the capability does not enroll, never reaches the member, and keeps compiling.
 
-`AggregateWriteCacheCompliance` (jasperfx#674) is the newer of the two. `IAggregateWriteCache` is a
+`AggregateWriteCacheCompliance` (jasperfx#674) is the oldest of them. `IAggregateWriteCache` is a
 *baseline-only* cache — the stream version and every event after the cached version are still read on
 every fetch — so the suite's job is to prove that turning it on is unobservable except in latency,
 including when the cached baseline is wrong. Note the shape of the load-bearing assertion: every
 correctness fact about caching is vacuously true of a store that ignored the opt-in entirely, so the
 suite supplies its own `RecordingAggregateWriteCache` and asserts a nonzero hit count. Same reasoning
 as the gzipped serializer in `BinaryEventSerializationCompliance`.
+
+`CompositeProjectionCompliance` (jasperfx#725) is opt-in through
+`IComplianceStoreRegistrar.AddCompositeProjection`. It needs a seam because a composite cannot be
+constructed by a suite at all: every product subclasses the shared
+`CompositeProjection<TOperations,TQuerySession>` and keeps the constructor internal, since it needs the
+store's options, so a composite only comes into being through that product's own
+`Projections.CompositeProjectionFor(name, configure)` — whose `configure` parameter is typed to the
+product's own subclass. The implementation is a forward plus a small adapter, because the *calls* are
+identical across the products even where the types are not; all three expose
+`Snapshot<T>(int stageNumber)` on their composite, and `IComplianceCompositeBuilder` declares its own
+void-returning member only because Marten's returns a mapping expression while Polecat's and Fisher's
+return void:
+
+```csharp
+public void AddCompositeProjection(string name, Action<IComplianceCompositeBuilder> configure)
+    => _options.Projections.CompositeProjectionFor(name, c => configure(new Builder(c)));
+```
+
+Its load-bearing fact is the rebuild one, and the members are additive for that reason: a store that
+replayed the stream over surviving rows instead of tearing the member down reads back exactly doubled,
+which a last-write-wins aggregate would hide. Two of the three products already carry a *local* test
+named for that class of bug — `Bug_439_composite_member_teardown` and `composite_member_teardown` —
+which is what marks the behaviour as shared rather than product-owned.
+
+`SingleTenantedEventSlicingCompliance` (jasperfx#724) is opt-in for a different reason: it needs no
+registrar seam at all, but the precondition it constructs is unusual enough that a store should adopt
+it knowingly. On a single-tenanted store, events whose `tenant_id` values disagree must still fold into
+one aggregate — wolverine#2053 / marten#4085 — and only the *async daemon* ever got that wrong, so the
+suite drives the daemon rather than asserting on a live aggregate. Note its guard: it stamps
+disagreeing tenant ids through `IEvent.TenantId`, then reads the events back and **skips** if the store
+normalised them away, because an unmixed store satisfies the assertion for a reason that has nothing to
+do with the behaviour under test. Vacuous green is worse than a skip, since only one of the two is
+visible.
 
 ## Capability gates
 
@@ -165,6 +198,8 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | The projection error path and dead letters | `DeadLetterCompliance` |
 | Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
 | Subscriptions | `SubscriptionCompliance` |
+| Single-tenanted slicing of disagreeing tenant ids | `SingleTenantedEventSlicingCompliance` |
+| Composite projections — staging and member teardown | `CompositeProjectionCompliance` |
 
 ### Identity-less boundary aggregates (jasperfx#718)
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/CompositeProjectionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/CompositeProjectionCompliance.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record CompositeCounted(int Amount);
+
+/// <summary>
+/// Stage-1 member of the compliance composite. Additive on purpose: a member that was replayed over
+/// its surviving rows rather than torn down first reads back doubled, which a "last write wins"
+/// aggregate would hide.
+/// </summary>
+public partial class CompositeFirstStageTally
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+    public int EventCount { get; set; }
+
+    public void Apply(CompositeCounted e)
+    {
+        Total += e.Amount;
+        EventCount++;
+    }
+}
+
+/// <summary>
+/// Stage-2 member. Identical shape to the stage-1 member by design — the fact under test is that a
+/// later stage runs at all and sees the same batch, not that it transforms anything differently.
+/// </summary>
+public partial class CompositeSecondStageTally
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+    public int EventCount { get; set; }
+
+    public void Apply(CompositeCounted e)
+    {
+        Total += e.Amount;
+        EventCount++;
+    }
+}
+
+/// <summary>
+/// Composite projections: several members sharing one shard, one progression row and one event batch,
+/// executed in stage order, and torn down together on rebuild.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The behaviour here is shared but the implementation is not: each product owns member teardown on
+/// rebuild — Marten, Polecat's <c>DocumentStore.EventStore.cs</c>, Fisher's
+/// <c>FisherCompositeProjection</c> / <c>CompositeIProjectionSource</c>. Two of the three already carry
+/// a <em>local</em> regression test named for the same class of bug (<c>Bug_439_composite_member_teardown</c>,
+/// <c>composite_member_teardown</c>), which is the usual sign that the behaviour belongs in the shared
+/// suite rather than three times over. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/725" />.
+/// </para>
+/// <para>
+/// It also gives <see href="https://github.com/JasperFx/jasperfx/issues/684" /> — letting unchanged
+/// members keep their tables across a version bump — a baseline to diff against. That is research
+/// rather than a scoped feature today, and this suite is deliberately independent of it: everything
+/// asserted here is current, shipped behaviour.
+/// </para>
+/// <para>
+/// <b>Opt-in.</b> <see cref="IComplianceStoreRegistrar.AddCompositeProjection" /> carries a throwing
+/// default, so a store without composites simply does not enroll.
+/// </para>
+/// <para>
+/// Deliberately <b>no cross-stage enrichment</b>. A stage-2 member reading stage-1 output through
+/// <c>EnrichWith&lt;T&gt;</c> is a real capability, but it is expressed by an imperative call inside a
+/// member's slicing code rather than by anything a store-neutral config can describe, so a portable
+/// fact cannot set it up. What is portable — and what actually broke in the products — is that every
+/// member runs off one batch and is torn down as a unit.
+/// </para>
+/// </remarks>
+public abstract class CompositeProjectionCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    public const string CompositeName = "ComplianceComposite";
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_composite";
+
+        config.AddEventType<CompositeCounted>();
+
+        config.AddCompositeProjection(CompositeName, composite =>
+        {
+            composite.Snapshot<CompositeFirstStageTally>(1);
+            composite.Snapshot<CompositeSecondStageTally>(2);
+        });
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    private void SkipUnlessDaemonIsSupported()
+    {
+        // Composites are async-only -- CompositeProjection.BuildForInline throws -- so a store without
+        // a daemon has no way to run one at all.
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon, which a composite requires");
+    }
+
+    private async Task<Guid> AppendThreeEventsAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var events = EventsFor(session);
+        events.StartStream<CompositeFirstStageTally>(streamId,
+            new CompositeCounted(1), new CompositeCounted(2), new CompositeCounted(4));
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task every_stage_materializes_from_one_async_pass()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await AppendThreeEventsAsync();
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+
+        var first = await LoadDocumentAsync<CompositeFirstStageTally>(query, streamId);
+        first.ShouldNotBeNull();
+        first.EventCount.ShouldBe(3);
+        first.Total.ShouldBe(7);
+
+        // The stage-2 member is the one a store can silently drop: the composite's single shard reports
+        // itself caught up either way, so nothing else notices that a later stage never ran.
+        var second = await LoadDocumentAsync<CompositeSecondStageTally>(query, streamId);
+        second.ShouldNotBeNull();
+        second.EventCount.ShouldBe(3);
+        second.Total.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task rebuilding_the_composite_tears_members_down_rather_than_replaying_over_them()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await AppendThreeEventsAsync();
+
+        var daemon = await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await daemon.RebuildProjectionAsync(CompositeName, Cancellation);
+
+        await using var query = OpenSession();
+
+        // Both members are additive, so a store that replayed the stream over surviving rows instead of
+        // tearing the member down reads back exactly doubled. That is the failure both products already
+        // guard locally, and the reason this suite exists.
+        var first = await LoadDocumentAsync<CompositeFirstStageTally>(query, streamId);
+        first.ShouldNotBeNull();
+        first.EventCount.ShouldBe(3);
+        first.Total.ShouldBe(7);
+
+        var second = await LoadDocumentAsync<CompositeSecondStageTally>(query, streamId);
+        second.ShouldNotBeNull();
+        second.EventCount.ShouldBe(3);
+        second.Total.ShouldBe(7);
+    }
+
+    [Fact]
+    public void a_composite_presents_itself_as_exactly_one_shard()
+    {
+        // Everything else here depends on this: progression, rebuild and teardown all key off a single
+        // shard name composed from the composite's name and version, which is what makes the members
+        // advance in lockstep. A store that expanded a composite into one shard per member would pass
+        // both facts above and still have changed what a composite is.
+        var store = theFixture.EventStore.ShouldBeAssignableTo<IEventStore<TOperations, TQuerySession>>();
+
+        var shards = store.AllShards().Where(x => x.Name.Name == CompositeName).ToArray();
+
+        shards.Length.ShouldBe(1);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/SingleTenantedEventSlicingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/SingleTenantedEventSlicingCompliance.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record TallyIncremented(int Amount);
+
+/// <summary>
+/// A plain self-aggregating snapshot for the single-tenanted slicing suite. Deliberately additive,
+/// so a stream folded once and a stream folded twice produce different numbers rather than the same
+/// one by luck.
+/// </summary>
+public partial class TenantSlicingTally
+{
+    public Guid Id { get; set; }
+    public int Total { get; set; }
+    public int EventCount { get; set; }
+
+    public void Apply(TallyIncremented e)
+    {
+        Total += e.Amount;
+        EventCount++;
+    }
+}
+
+/// <summary>
+/// On a <b>single-tenanted</b> event store, events whose <c>tenant_id</c> values disagree must still
+/// fold into one aggregate. Slicing them per tenant splits one stream into several partial documents,
+/// each having seen only part of its own history.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is wolverine#2053, transferred to
+/// <see href="https://github.com/JasperFx/marten/issues/4085" />: a single-tenanted store whose event
+/// rows carried a mix of tenant ids, written by a client stamping appends inconsistently. The reported
+/// symptom was an <c>Apply</c> receiving a document with every property at its default, as though
+/// <c>Create</c> had never run. Only the <b>async daemon</b> was affected — live and inline aggregation
+/// fold the same events correctly — which is why this suite drives the daemon rather than asserting on
+/// a live aggregate.
+/// </para>
+/// <para>
+/// It is a compliance suite rather than three local tests because the fix reached exactly one store.
+/// JasperFx.Events carries <c>ForceSingleTenancy</c> on <c>TenantedEventSlicer</c>; Marten set it by
+/// overriding <c>BuildSlicer</c>, while Polecat's and Fisher's <c>SingleStreamProjection&lt;TDoc,TId&gt;</c>
+/// are empty class bodies that never did. <see href="https://github.com/JasperFx/jasperfx/issues/723" />
+/// moves the decision into the shared base, and this suite is what holds every store to it.
+/// See <see href="https://github.com/JasperFx/jasperfx/issues/724" />.
+/// </para>
+/// <para>
+/// <b>Opt-in.</b> Unlike the facts that ride along inside an already-enrolled suite, this one is
+/// enrolled deliberately, because the precondition it needs is unusual and a store should adopt it
+/// knowingly rather than discover it in a version bump.
+/// </para>
+/// </remarks>
+public abstract class SingleTenantedEventSlicingCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_single_tenanted_slicing";
+
+        config.AddEventType<TallyIncremented>();
+
+        // No ConjoinedEventTenancy: the store stays on its default single-tenanted event store,
+        // which is the entire precondition under test.
+        config.Snapshot<TenantSlicingTally>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    [Fact]
+    public async Task async_projection_folds_one_stream_despite_disagreeing_tenant_ids()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            var events = EventsFor(session);
+
+            // Stamp the envelopes directly. IEvent.TenantId is settable on the shared interface, which
+            // is what lets a suite reproduce the mixed-tenancy rows the bug report described without
+            // reaching for any store's own append API.
+            var first = events.BuildEvent(new TallyIncremented(1));
+            first.TenantId = StorageConstants.DefaultTenantId;
+
+            var second = events.BuildEvent(new TallyIncremented(2));
+            second.TenantId = "some-other-tenant";
+
+            var third = events.BuildEvent(new TallyIncremented(4));
+            third.TenantId = "some-other-tenant";
+
+            events.Append(streamId, first, second, third);
+            await SaveChangesAsync(session);
+        }
+
+        await SkipUnlessTheStorePersistedDisagreeingTenantIdsAsync(streamId);
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+        var tally = await LoadDocumentAsync<TenantSlicingTally>(query, streamId);
+
+        tally.ShouldNotBeNull();
+
+        // The load-bearing assertion. A store slicing per tenant writes a document that saw only the
+        // events of whichever tenant group landed last, so both numbers come up short rather than
+        // wrong in some exotic way.
+        tally.EventCount.ShouldBe(3);
+        tally.Total.ShouldBe(7);
+    }
+
+    /// <summary>
+    /// Skip rather than pass when the store normalized the tenant ids away on write.
+    /// </summary>
+    /// <remarks>
+    /// Without this the suite is worthless on exactly the stores it cannot test: a store that rewrites
+    /// every event's tenant id to the default on a single-tenanted store never had disagreeing rows to
+    /// mis-slice, so it satisfies the assertion above for a reason that has nothing to do with the
+    /// behavior under test. Vacuous green is worse than a skip, because only one of the two is visible.
+    /// Same reasoning as the recorded hit count in <c>AggregateWriteCacheCompliance</c>.
+    /// </remarks>
+    private async Task SkipUnlessTheStorePersistedDisagreeingTenantIdsAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        var stored = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+
+        var distinctTenants = stored.Select(x => x.TenantId).Distinct().Count();
+
+        Assert.SkipWhen(distinctTenants < 2,
+            $"This event store normalized the appended tenant ids down to {distinctTenants} distinct value(s) " +
+            "on a single-tenanted store, so the mixed-tenancy precondition this suite needs cannot be " +
+            "constructed through the shared surface. The behavior is not being asserted -- see jasperfx#724.");
+    }
+}

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -2,6 +2,7 @@ using JasperFx.Core.Reflection;
 using JasperFx.Events.Daemon;
 using JasperFx.Events.Grouping;
 using JasperFx.Events.Projections;
+using JasperFx.MultiTenancy;
 
 namespace JasperFx.Events.Aggregation;
 
@@ -16,16 +17,18 @@ namespace JasperFx.Events.Aggregation;
 /// <see href="https://github.com/JasperFx/jasperfx/issues/649" />.
 /// </para>
 /// <para>
-/// Concretely, as of Marten 9.23 / Polecat 5.12. Polecat's <c>SingleStreamProjection&lt;TDoc,TId&gt;</c>
-/// is an empty class body, so nothing is lost there. Marten's is not — it adds two behaviors:
+/// Concretely, as of Marten 9.23 / Polecat 5.12. Polecat's and Fisher's
+/// <c>SingleStreamProjection&lt;TDoc,TId&gt;</c> are empty class bodies, so nothing is lost there. Marten's
+/// is not — it adds two behaviors, one of which has since been resolved here:
 /// </para>
 /// <list type="bullet">
 ///   <item>
 ///     <description>
-///     <b><c>BuildSlicer</c></b> returns a <c>TenantedEventSlicer</c> with <c>ForceSingleTenancy</c> taken
-///     from the store's <c>EventGraph.TenancyStyle</c> — the fix for
-///     <see href="https://github.com/JasperFx/wolverine/issues/2053" />. This base returns the same slicer
-///     <em>without</em> it, so taking the base changes event slicing on a single-tenanted Marten store.
+///     <b><c>BuildSlicer</c></b> — <b>resolved as of jasperfx#723.</b> This base now sets
+///     <c>ForceSingleTenancy</c> itself, from <see cref="IEventTenancySource" /> on the session, so the
+///     wolverine#2053 fix no longer depends on which subclass you derive from. Marten's override, where
+///     still present, computes the same answer. A session that does not implement the seam yields the
+///     pre-#723 behavior.
 ///     </description>
 ///   </item>
 ///   <item>
@@ -38,11 +41,11 @@ namespace JasperFx.Events.Aggregation;
 ///   </item>
 /// </list>
 /// <para>
-/// Both are the kind of divergence that produces a wrong answer rather than an error, and both are
-/// invisible until something downstream is already wrong, which is why this warning is here rather than
-/// left to be rediscovered. The <c>BuildSlicer</c> comment below saying the method "needs to be
-/// overridable in Marten" is the other half of the same story: it is a deliberate escape hatch for the
-/// store, not a suggestion that the base is equivalent.
+/// The surviving one — <c>UseVersionFromMatchingStream</c> — is the kind of divergence that produces a
+/// wrong answer rather than an error, and is invisible until something downstream is already wrong, which
+/// is why this warning stays here rather than being left to be rediscovered. It is not hoisted because
+/// doing so needs a shared document-mapping abstraction, which
+/// <see href="https://github.com/JasperFx/jasperfx/issues/647" /> deliberately declined to build.
 /// </para>
 /// <para>
 /// <b>If you are writing one projection to compile against several stores</b>, the routes that work today
@@ -66,14 +69,21 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
         _streamActionSource = StreamAction.CreateAggregateIdentitySource<TId>();
     }
 
-    // This actually does need to be overridable in Marten -- and Marten does override it, to set
-    // ForceSingleTenancy from the store's TenancyStyle (wolverine#2053). A consumer deriving from THIS type
-    // rather than from Marten's subclass gets the slicer below instead, with no compile error and no runtime
-    // failure -- just different slicing on a single-tenanted store. See jasperfx#649 and the class remarks.
+    // ForceSingleTenancy is the wolverine#2053 / marten#4085 fix: on a single-tenanted store, events whose
+    // tenant_id values disagree must still fold into one aggregate. Marten used to be the only store that
+    // set it, by overriding this method -- so a consumer deriving from THIS type, and both other stores
+    // whose subclasses are empty class bodies, silently went without it. Resolving it here from the session
+    // closes that gap for every store at once. See jasperfx#723.
+    //
+    // A session that does not implement IEventTenancySource yields false, which is exactly the behavior
+    // this method had before the seam existed.
     public override IEventSlicer BuildSlicer(TQuerySession session)
     {
-        // Doesn't hurt anything if it's not actually tenanted
-        return new TenantedEventSlicer<TDoc, TId>(new ByStream<TDoc, TId>());
+        return new TenantedEventSlicer<TDoc, TId>(new ByStream<TDoc, TId>())
+        {
+            ForceSingleTenancy = session is IEventTenancySource source
+                                 && source.EventTenancyStyle == TenancyStyle.Single
+        };
     }
 
     Type IAggregatorSource<TQuerySession>.AggregateType => typeof(TDoc);

--- a/src/JasperFx.Events/IEventTenancySource.cs
+++ b/src/JasperFx.Events/IEventTenancySource.cs
@@ -1,0 +1,53 @@
+using JasperFx.MultiTenancy;
+
+namespace JasperFx.Events;
+
+/// <summary>
+/// Optional seam letting a store's query session tell the shared projection bases what tenancy
+/// style its <em>event store</em> is configured for, so behavior that depends on it can live in
+/// JasperFx.Events rather than being reimplemented in each store's projection subclass.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Exists for <see cref="Aggregation.JasperFxSingleStreamProjectionBase{TDoc,TId,TOperations,TQuerySession}.BuildSlicer" />,
+/// which needs to know whether to set <c>ForceSingleTenancy</c> on the slicer it builds. That is the
+/// fix for wolverine#2053 / marten#4085: on a single-tenanted store, events whose <c>tenant_id</c>
+/// values disagree must still fold into one aggregate rather than being sliced per tenant. Marten
+/// implemented it by overriding <c>BuildSlicer</c> in its own <c>SingleStreamProjection&lt;TDoc,TId&gt;</c>;
+/// Polecat's and Fisher's subclasses are empty class bodies, so they never got it. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/723" />.
+/// </para>
+/// <para>
+/// <b>Deliberately not on <c>IEventRegistry</c>.</b> The registry is reachable from
+/// <c>IEventStore.Registry</c>, but not from the <c>TQuerySession</c> that <c>BuildSlicer</c> is
+/// handed, and widening that signature would break every store's override. The session is what the
+/// method actually has. It is also not on <c>IDocumentReadOperations</c>, whose <c>Events</c> accessor
+/// carries a throwing default — a projection cannot afford to probe it.
+/// </para>
+/// <para>
+/// <b>The member is named <c>EventTenancyStyle</c> rather than <c>TenancyStyle</c> on purpose.</b>
+/// All three stores already declare a <c>TenancyStyle</c> property somewhere in their options graph
+/// (Marten on <c>EventGraph</c>, Polecat and Fisher on <c>EventStoreOptions</c>). A member named
+/// <c>TenancyStyle</c> here would bind implicitly on some of them and not others, depending on which
+/// type happens to carry it — silently correct in one store and silently absent in the next, which
+/// is the exact failure mode this interface exists to end. An unmistakable name forces each store to
+/// opt in visibly.
+/// </para>
+/// <para>
+/// <b>Not implementing it is safe.</b> A session that does not implement this interface leaves the
+/// projection bases on the behavior they had before it existed — no forcing — so adopting a JasperFx
+/// version that introduces it changes nothing until a store opts in. Adoption is one line:
+/// </para>
+/// <code>
+/// public TenancyStyle EventTenancyStyle => Options.Events.TenancyStyle;
+/// </code>
+/// </remarks>
+public interface IEventTenancySource
+{
+    /// <summary>
+    /// The tenancy style the <em>event store</em> is configured for — not the document store's, and
+    /// not any single document's. <see cref="TenancyStyle.Single" /> means events are not partitioned
+    /// by tenant, so any tenant id appearing on an event is incidental rather than meaningful.
+    /// </summary>
+    TenancyStyle EventTenancyStyle { get; }
+}


### PR DESCRIPTION
Closes #723. Closes #724. Closes #725.

## #723 — the seam

`JasperFxSingleStreamProjectionBase.BuildSlicer` now sets `ForceSingleTenancy` itself, from a new `IEventTenancySource` on the session.

Marten set the flag by overriding `BuildSlicer`; Polecat's and Fisher's `SingleStreamProjection<TDoc,TId>` are empty class bodies that never did. So the wolverine#2053 / [marten#4085](https://github.com/JasperFx/marten/issues/4085) fix reached one store out of three — and since #722 made the flag actually live on the daemon path, that divergence was about to start producing wrong read models on two stores.

**Why the session, and why that member name.** `BuildSlicer(TQuerySession)` is handed the session and nothing else. `IEventRegistry` carries no tenancy style and is reachable only from `IEventStore.Registry`, not the session; widening `BuildSlicer`'s signature breaks every store's override; and `IDocumentReadOperations.Events` carries a throwing default a projection cannot afford to probe. The member is `EventTenancyStyle` rather than `TenancyStyle` deliberately — all three stores already declare a `TenancyStyle` somewhere in their options graph (Marten on `EventGraph`, Polecat and Fisher on `EventStoreOptions`), so the shorter name would bind implicitly on some and not others depending on which type happens to carry it. Silently correct in one store and silently absent in the next is the exact failure mode this is ending.

**Ships inert.** A session not implementing the seam yields `false` — precisely the pre-#723 behavior — so no store changes on upgrade. Adoption is one line:

```csharp
public TenancyStyle EventTenancyStyle => Options.Events.TenancyStyle;
```

Once adopted, Marten's own override becomes redundant. This is what closes [polecat#526](https://github.com/JasperFx/polecat/issues/526) and [fisher#139](https://github.com/JasperFx/fisher/issues/139).

## #724 — `SingleTenantedEventSlicingCompliance`

Opt-in. Drives the async daemon, because that is the only path the bug ever reached — live and inline aggregation fold the same events correctly, which is what made this invisible for so long.

The fact guards its own precondition. `IEvent.TenantId` is settable on the shared interface, so the suite stamps disagreeing tenant ids and appends. If a store normalizes them away on write, it **skips** with a message rather than passing — an unmixed store satisfies the assertion for a reason with nothing to do with the behavior under test, and vacuous green is worse than a skip because only one of the two is visible. Same reasoning as the recorded hit count in `AggregateWriteCacheCompliance`. That also settles the feasibility question #724 was filed with, by detecting it per store at runtime rather than resolving it up front for three.

## #725 — `CompositeProjectionCompliance`

Opt-in through a new `IComplianceStoreRegistrar.AddCompositeProjection` with a throwing default.

The seam is unavoidable: a composite cannot be constructed by a suite at all. Every product subclasses `CompositeProjection<TOperations,TQuerySession>` and keeps the constructor internal because it needs the store's options, so one only comes into being through that product's own `Projections.CompositeProjectionFor(name, configure)`, typed to its own subclass. Implementations are a forward plus a small adapter — all three expose `Snapshot<T>(int stageNumber)`, and `IComplianceCompositeBuilder` declares its own void-returning member only because Marten's returns a mapping expression while Polecat's and Fisher's return void.

Three facts: every stage materializes from one async pass; **rebuilding tears members down rather than replaying over them**; and a composite presents itself as exactly one shard. The members are additive precisely so the rebuild fact bites — a store that replayed over surviving rows reads back exactly doubled, which a last-write-wins aggregate would hide. Two of the three products already carry a *local* test for that bug (`Bug_439_composite_member_teardown`, `composite_member_teardown`), which is what marks it as shared rather than product-owned.

**Deliberately no cross-stage enrichment.** `EnrichWith<T>` is an imperative call inside a member's slicing code, not anything a store-neutral config can describe, so a portable fact cannot set it up. What is portable — and what actually broke — is that members share one batch and are torn down as a unit. The one-shard fact pins the property #684 will have to preserve.

## Verification

`EventStoreTests` 141/141, including three new tests in `SingleStreamProjectionTenancySeamTests` — forces on `Single`, does not force on `Conjoined`, and stays inert for a session that has not adopted the seam. That last carries the most weight: it is every store on the release that introduces this.

The compliance suites themselves are not executed in this repo (only the *document* suites are), so #724 and #725 are verified on enrollment. Both are opt-in, so neither runs anywhere until a store chooses to enroll it — nothing in this PR changes behavior for a store that does nothing.

README updated for both new suites and the new registrar seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)