### PR TITLE
gh-728: a projection-run CLI command

### DIFF
--- a/src/EventTests/CommandLine/ProjectionRunCommandParsingTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRunCommandParsingTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using JasperFx.CommandLine;
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#728 — the command line itself. The parser derives one-letter aliases from a flag's first
+/// letter and has NO collision detection, so <c>--stream</c>/<c>--store</c> and <c>--to</c>/<c>--tenant</c>
+/// would silently bind whichever handler was built first. Every flag is long-form only for that
+/// reason, and these tests are what would notice if one lost its <c>longAliasOnly</c>.
+/// </summary>
+public class ProjectionRunCommandParsingTests
+{
+    private static ProjectionRunInput parse(params string[] args)
+    {
+        var command = new ProjectionRunCommand();
+        return (ProjectionRunInput)command.Usages.BuildInput(new Queue<string>(args), new ActivatorCommandCreator());
+    }
+
+    [Fact]
+    public void the_projection_name_is_the_argument()
+    {
+        parse("Trips", "--stream", "trip-1").ProjectionName.ShouldBe("Trips");
+    }
+
+    [Fact]
+    public void stream_and_store_do_not_collide()
+    {
+        var input = parse("Trips", "--stream", "trip-1", "--store", "marten://main");
+
+        input.StreamFlag.ShouldBe("trip-1");
+        input.StoreFlag.ShouldBe("marten://main");
+    }
+
+    [Fact]
+    public void to_and_tenant_do_not_collide()
+    {
+        var input = parse("Trips", "--stream", "trip-1", "--from", "2", "--to", "5", "--tenant", "acme");
+
+        input.FromFlag.ShouldBe(2);
+        input.ToFlag.ShouldBe(5);
+        input.TenantFlag.ShouldBe("acme");
+        input.SourceMode.ShouldBe(ProjectionRunSourceMode.StreamSlice);
+    }
+
+    [Fact]
+    public void tags_are_repeatable_pairs()
+    {
+        var input = parse("Enrollments", "--tag:course", "c-1", "--tag:student", "s-9");
+
+        input.TagFlag["course"].ShouldBe("c-1");
+        input.TagFlag["student"].ShouldBe("s-9");
+        input.SourceMode.ShouldBe(ProjectionRunSourceMode.TagQuery);
+    }
+
+    [Fact]
+    public void json_is_a_boolean_flag()
+    {
+        parse("Trips", "--stream", "trip-1", "--json").JsonFlag.ShouldBeTrue();
+        parse("Trips", "--stream", "trip-1").JsonFlag.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void the_event_cap_defaults_to_a_thousand()
+    {
+        parse("Trips", "--stream", "trip-1").MaxEventsFlag.ShouldBe(1000);
+        parse("Trips", "--stream", "trip-1", "--max-events", "25").MaxEventsFlag.ShouldBe(25);
+    }
+}

--- a/src/EventTests/CommandLine/ProjectionRunInputTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRunInputTests.cs
@@ -1,0 +1,160 @@
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#728 — the source mode is derived from the flags rather than declared, and the per-mode
+/// required-field rules deliberately mirror CritterWatch's <c>RequestProjectionRunHandler</c> so the
+/// local CLI and the console's remote stepper refuse the same inputs for the same reasons.
+/// </summary>
+public class ProjectionRunInputTests
+{
+    private static ProjectionRunInput forStream(string stream = "trip-1")
+        => new() { ProjectionName = "Trips", StreamFlag = stream };
+
+    [Fact]
+    public void a_bare_stream_read_is_stream_mode()
+    {
+        forStream().SourceMode.ShouldBe(ProjectionRunSourceMode.Stream);
+    }
+
+    [Fact]
+    public void a_version_bound_makes_it_a_slice()
+    {
+        var input = forStream();
+        input.FromFlag = 2;
+        input.ToFlag = 5;
+
+        input.SourceMode.ShouldBe(ProjectionRunSourceMode.StreamSlice);
+    }
+
+    [Fact]
+    public void one_half_of_a_bound_is_still_a_slice_so_the_missing_half_can_be_reported()
+    {
+        // If a lone --from fell back to Stream mode the command would quietly replay the WHOLE
+        // stream — an answer to a question nobody asked. It has to stay a slice in order to fail.
+        var input = forStream();
+        input.FromFlag = 2;
+
+        input.SourceMode.ShouldBe(ProjectionRunSourceMode.StreamSlice);
+        input.Validate().ShouldBe("--from and --to are both required for a stream slice");
+    }
+
+    [Fact]
+    public void tags_win_over_everything()
+    {
+        var input = new ProjectionRunInput { ProjectionName = "Enrollments" };
+        input.TagFlag["course"] = "c-1";
+
+        input.SourceMode.ShouldBe(ProjectionRunSourceMode.TagQuery);
+    }
+
+    [Fact]
+    public void a_projection_name_is_required()
+    {
+        new ProjectionRunInput { StreamFlag = "trip-1" }.Validate()
+            .ShouldBe("A projection name is required");
+    }
+
+    [Fact]
+    public void a_stream_is_required_for_a_stream_read()
+    {
+        new ProjectionRunInput { ProjectionName = "Trips" }.Validate().ShouldBe("--stream is required");
+    }
+
+    [Fact]
+    public void a_stream_is_required_for_a_slice()
+    {
+        new ProjectionRunInput { ProjectionName = "Trips", FromFlag = 1, ToFlag = 2 }.Validate()
+            .ShouldBe("--stream is required");
+    }
+
+    [Fact]
+    public void an_inverted_slice_is_refused()
+    {
+        var input = forStream();
+        input.FromFlag = 9;
+        input.ToFlag = 4;
+
+        input.Validate().ShouldBe("--from must be less than or equal to --to");
+    }
+
+    [Fact]
+    public void a_single_version_slice_is_legal()
+    {
+        var input = forStream();
+        input.FromFlag = 4;
+        input.ToFlag = 4;
+
+        input.Validate().ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_stream_cannot_be_combined_with_a_tag_query()
+    {
+        // CritterWatch's handler silently ignores the stream id in tag mode because its UI never
+        // sends both. An operator typing both at a prompt means something, and the command cannot
+        // honor it — so it says so rather than dropping half the request.
+        var input = forStream();
+        input.TagFlag["course"] = "c-1";
+
+        input.Validate().ShouldBe("--stream cannot be combined with --tag; a tag query is not stream-anchored");
+    }
+
+    [Fact]
+    public void version_bounds_cannot_be_combined_with_a_tag_query()
+    {
+        var input = new ProjectionRunInput { ProjectionName = "Enrollments", FromFlag = 1, ToFlag = 2 };
+        input.TagFlag["course"] = "c-1";
+
+        input.Validate()
+            .ShouldBe("--from / --to cannot be combined with --tag; version bounds only apply to a stream slice");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void a_non_positive_event_cap_is_refused(int cap)
+    {
+        // Zero would read nothing and report an empty timeline, which is indistinguishable from a
+        // stream that genuinely has no events.
+        var input = forStream();
+        input.MaxEventsFlag = cap;
+
+        input.Validate().ShouldBe("--max-events must be greater than zero");
+    }
+
+    [Fact]
+    public void source_key_for_a_stream_is_the_stream_id()
+    {
+        forStream().SourceKey.ShouldBe("trip-1");
+    }
+
+    [Fact]
+    public void source_key_for_a_slice_carries_the_bounds()
+    {
+        var input = forStream();
+        input.FromFlag = 2;
+        input.ToFlag = 5;
+
+        input.SourceKey.ShouldBe("trip-1@2..5");
+    }
+
+    [Fact]
+    public void source_key_for_a_tag_query_is_order_independent()
+    {
+        // Two runs of the same query have to produce the same key, and a Dictionary does not promise
+        // an enumeration order.
+        var first = new ProjectionRunInput { ProjectionName = "Enrollments" };
+        first.TagFlag["course"] = "c-1";
+        first.TagFlag["student"] = "s-9";
+
+        var second = new ProjectionRunInput { ProjectionName = "Enrollments" };
+        second.TagFlag["student"] = "s-9";
+        second.TagFlag["course"] = "c-1";
+
+        first.SourceKey.ShouldBe("tags::course=c-1&student=s-9");
+        second.SourceKey.ShouldBe(first.SourceKey);
+    }
+}

--- a/src/EventTests/CommandLine/ProjectionRunReportTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRunReportTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using JasperFx.Descriptors;
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#728 — the report is the contract <c>--json</c> consumers parse, so its shape is pinned
+/// here rather than left to whatever the renderer happens to emit.
+/// </summary>
+public class ProjectionRunReportTests
+{
+    private static JsonElement json(string text) => JsonDocument.Parse(text).RootElement;
+
+    private static EventRecord evt(long version, string type) => new(
+        Guid.NewGuid(), 100 + version, version, "trip-1", type, json("{}"), null,
+        new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero), null, null);
+
+    private static ProjectionTimelineRaw timeline(params ProjectionStepResultRaw[] steps)
+        => new(steps, steps.LastOrDefault()?.After);
+
+    private static ProjectionRunInput theInput
+        => new() { ProjectionName = "Trips", StreamFlag = "trip-1" };
+
+    [Fact]
+    public void identities_are_ordered_so_two_runs_of_a_slice_diff_cleanly()
+    {
+        // MultiAggregateProjectionResult carries a dictionary and promises no order.
+        var result = new MultiAggregateProjectionResult("Trips", new Dictionary<string, ProjectionTimelineRaw>
+        {
+            ["trip-9"] = timeline(),
+            ["trip-1"] = timeline(),
+            ["trip-4"] = timeline()
+        });
+
+        var report = ProjectionRunReport.From(theInput, new Uri("marten://main"), result, 3, false);
+
+        report.Aggregates.Select(x => x.Identity).ShouldBe(["trip-1", "trip-4", "trip-9"]);
+    }
+
+    [Fact]
+    public void steps_are_numbered_from_one_in_apply_order()
+    {
+        var result = new MultiAggregateProjectionResult("Trips", new Dictionary<string, ProjectionTimelineRaw>
+        {
+            ["trip-1"] = timeline(
+                new ProjectionStepResultRaw(evt(1, "TripStarted"), null, json("""{"legs":0}"""), TimeSpan.FromMilliseconds(2), null),
+                new ProjectionStepResultRaw(evt(2, "LegAdded"), json("""{"legs":0}"""), json("""{"legs":1}"""), TimeSpan.FromMilliseconds(1), null))
+        });
+
+        var report = ProjectionRunReport.From(theInput, new Uri("marten://main"), result, 2, false);
+        var steps = report.Aggregates.Single().Steps;
+
+        steps.Select(x => x.Step).ShouldBe([1, 2]);
+        steps.Select(x => x.EventType).ShouldBe(["TripStarted", "LegAdded"]);
+        steps[0].StreamVersion.ShouldBe(1);
+        steps[0].Sequence.ShouldBe(101);
+        steps[0].ElapsedMs.ShouldBe(2);
+    }
+
+    [Fact]
+    public void a_failed_apply_carries_its_message_onto_the_step()
+    {
+        var result = new MultiAggregateProjectionResult("Trips", new Dictionary<string, ProjectionTimelineRaw>
+        {
+            ["trip-1"] = timeline(new ProjectionStepResultRaw(
+                evt(1, "TripStarted"), null, null, TimeSpan.Zero, "Object reference not set"))
+        });
+
+        var report = ProjectionRunReport.From(theInput, new Uri("marten://main"), result, 1, false);
+
+        report.Aggregates.Single().Steps.Single().Error.ShouldBe("Object reference not set");
+        report.Error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void a_failed_run_still_describes_the_slice_it_could_not_replay()
+    {
+        var input = theInput;
+        input.FromFlag = 2;
+        input.ToFlag = 5;
+
+        var report = ProjectionRunReport.Failed(input, new Uri("marten://main"), "No such projection");
+
+        report.Error.ShouldBe("No such projection");
+        report.Aggregates.ShouldBeEmpty();
+        report.EventCount.ShouldBe(0);
+        report.Source.Mode.ShouldBe(ProjectionRunSourceMode.StreamSlice);
+        report.Source.Key.ShouldBe("trip-1@2..5");
+        report.Source.FromVersion.ShouldBe(2);
+        report.Source.ToVersion.ShouldBe(5);
+    }
+
+    [Fact]
+    public void a_tag_query_report_carries_the_tags_and_not_a_stream()
+    {
+        var input = new ProjectionRunInput { ProjectionName = "Enrollments" };
+        input.TagFlag["course"] = "c-1";
+
+        var source = ProjectionRunSourceReport.From(input);
+
+        source.Mode.ShouldBe(ProjectionRunSourceMode.TagQuery);
+        source.StreamId.ShouldBeNull();
+        source.Tags!["course"].ShouldBe("c-1");
+    }
+
+    [Fact]
+    public void a_stream_report_carries_the_stream_and_not_tags()
+    {
+        var source = ProjectionRunSourceReport.From(theInput);
+
+        source.Mode.ShouldBe(ProjectionRunSourceMode.Stream);
+        source.StreamId.ShouldBe("trip-1");
+        source.Tags.ShouldBeNull();
+    }
+
+    [Fact]
+    public void the_truncation_flag_survives_into_the_report()
+    {
+        var result = new MultiAggregateProjectionResult("Trips", new Dictionary<string, ProjectionTimelineRaw>());
+
+        ProjectionRunReport.From(theInput, new Uri("marten://main"), result, 1000, true)
+            .Truncated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void json_is_camel_cased_and_names_the_mode_as_a_string()
+    {
+        // Agents read this; a numeric enum would be an unlabelled 0/1/2.
+        var input = theInput;
+        input.FromFlag = 2;
+        input.ToFlag = 5;
+
+        var text = ProjectionRunView.ToJson(ProjectionRunReport.Failed(input, new Uri("marten://main"), "nope"));
+
+        text.ShouldContain("\"projection\": \"Trips\"");
+        text.ShouldContain("\"eventCount\": 0");
+        text.ShouldContain("\"mode\": \"StreamSlice\"");
+    }
+}

--- a/src/EventTests/CommandLine/ProjectionRunSchemaDiagnosisTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRunSchemaDiagnosisTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Environment;
+using JasperFx.Events.CommandLine;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#728 — projection-run builds the host but never starts it, so nothing that normally
+/// migrates on startup has run. An un-migrated database is therefore a first-class cause of failure
+/// here, and the raw store exception ("relation ... does not exist") says nothing about the fix.
+/// These pin that the command turns that into an actionable message, and that it stays quiet when
+/// storage is fine.
+/// </summary>
+public class ProjectionRunSchemaDiagnosisTests
+{
+    private sealed class Resource(string type, string name, Exception? failure)
+        : StatefulResourceBase(type, name, new Uri("marten://main"), new Uri("marten://main/events"))
+    {
+        public override Task Check(CancellationToken token)
+            => failure == null ? Task.CompletedTask : Task.FromException(failure);
+    }
+
+    private sealed class Part(params IStatefulResource[] resources): ISystemPart
+    {
+        public string Title => "Test";
+        public Uri SubjectUri => new("marten://main");
+        public Task WriteToConsole() => Task.CompletedTask;
+
+        public ValueTask<IReadOnlyList<IStatefulResource>> FindResources()
+            => new(resources);
+
+        public Task AssertEnvironmentAsync(IServiceProvider services, EnvironmentCheckResults results,
+            CancellationToken token) => Task.CompletedTask;
+    }
+
+    private sealed class ThrowingPart: ISystemPart
+    {
+        public string Title => "Broken";
+        public Uri SubjectUri => new("marten://main");
+        public Task WriteToConsole() => Task.CompletedTask;
+
+        public ValueTask<IReadOnlyList<IStatefulResource>> FindResources()
+            => throw new InvalidOperationException("cannot enumerate resources");
+
+        public Task AssertEnvironmentAsync(IServiceProvider services, EnvironmentCheckResults results,
+            CancellationToken token) => Task.CompletedTask;
+    }
+
+    private static IServiceProvider withParts(params ISystemPart[] parts)
+    {
+        var services = new ServiceCollection();
+        foreach (var part in parts) services.AddSingleton(part);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task healthy_storage_produces_no_diagnosis()
+    {
+        // The remedy must not be printed beside an error it has nothing to do with — a projection
+        // that threw for its own reasons is not a schema problem.
+        var services = withParts(new Part(new Resource("Marten", "Event Store", null)));
+
+        var diagnosis = await ProjectionRunSchemaDiagnosis.TryDiagnoseAsync(services, CancellationToken.None);
+
+        diagnosis.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task an_application_with_no_resources_produces_no_diagnosis()
+    {
+        var diagnosis = await ProjectionRunSchemaDiagnosis
+            .TryDiagnoseAsync(withParts(), CancellationToken.None);
+
+        diagnosis.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_failing_check_names_the_resource_and_both_commands()
+    {
+        var services = withParts(new Part(
+            new Resource("Marten", "Event Store", new InvalidOperationException("relation does not exist"))));
+
+        var diagnosis = await ProjectionRunSchemaDiagnosis.TryDiagnoseAsync(services, CancellationToken.None);
+
+        diagnosis.ShouldNotBeNull();
+        diagnosis.ShouldContain("Marten 'Event Store'");
+
+        // resources setup is listed first on purpose: it works on every store, while db-apply only
+        // sees a Polecat store from 5.20.0 (polecat#501).
+        diagnosis.ShouldContain("resources setup");
+        diagnosis.ShouldContain("db-apply");
+
+        // The reason the command does not just migrate for you is part of the message, because
+        // otherwise the obvious "why didn't it fix it?" goes unanswered.
+        diagnosis.ShouldContain("does not migrate anything itself");
+    }
+
+    [Fact]
+    public async Task every_failing_resource_is_named()
+    {
+        var services = withParts(new Part(
+            new Resource("Marten", "Event Store", new Exception("no")),
+            new Resource("WolverineEnvelopeStorage", "Envelopes", new Exception("no")),
+            new Resource("Marten", "Documents", null)));
+
+        var diagnosis = await ProjectionRunSchemaDiagnosis.TryDiagnoseAsync(services, CancellationToken.None);
+
+        diagnosis.ShouldContain("Marten 'Event Store'");
+        diagnosis.ShouldContain("WolverineEnvelopeStorage 'Envelopes'");
+        diagnosis.ShouldNotContain("Marten 'Documents'");
+    }
+
+    [Fact]
+    public async Task a_diagnosis_that_itself_fails_is_simply_absent()
+    {
+        // The caller already has a real error to report. A failure to EXPLAIN it must never replace
+        // it — that would turn a clear store exception into an unrelated one.
+        var diagnosis = await ProjectionRunSchemaDiagnosis
+            .TryDiagnoseAsync(withParts(new ThrowingPart()), CancellationToken.None);
+
+        diagnosis.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task a_hung_check_is_bounded()
+    {
+        // A resource check is a network call, and it is diagnosing a failure that already happened.
+        // It must never cost more than the error it explains.
+        var previous = ProjectionRunSchemaDiagnosis.CheckTimeout;
+        ProjectionRunSchemaDiagnosis.CheckTimeout = TimeSpan.FromMilliseconds(50);
+
+        try
+        {
+            var services = withParts(new Part(new HangingResource()));
+
+            var diagnosis = await ProjectionRunSchemaDiagnosis.TryDiagnoseAsync(services, CancellationToken.None);
+
+            // The cancellation surfaces as a failed check, so the resource is reported rather than
+            // the whole diagnosis being lost.
+            diagnosis.ShouldNotBeNull();
+            diagnosis.ShouldContain("Marten 'Slow'");
+        }
+        finally
+        {
+            ProjectionRunSchemaDiagnosis.CheckTimeout = previous;
+        }
+    }
+
+    private sealed class HangingResource()
+        : StatefulResourceBase("Marten", "Slow", new Uri("marten://main"), new Uri("marten://main/slow"))
+    {
+        public override Task Check(CancellationToken token) => Task.Delay(Timeout.Infinite, token);
+    }
+}

--- a/src/EventTests/CommandLine/ProjectionRunSourceTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRunSourceTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.CommandLine;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#728 — store selection and the source read, exercised against a fake
+/// <see cref="IEventStore"/> so both halves are pinned without a database.
+/// </summary>
+public class ProjectionRunSourceTests
+{
+    private static readonly JsonElement Empty = JsonDocument.Parse("{}").RootElement;
+
+    private static EventRecord evt(long version) => new(
+        Guid.NewGuid(), version, version, "trip-1", $"Event{version}", Empty, null,
+        new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero), null, null);
+
+    private sealed class FakeEventStore(string subject, params EventRecord[] events): IEventStore
+    {
+        public List<string> Calls { get; } = [];
+
+        public Uri Subject { get; } = new(subject);
+
+        public async IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, CancellationToken ct)
+        {
+            Calls.Add($"ReadStreamAsync({streamId})");
+            foreach (var e in events)
+            {
+                await Task.Yield();
+                yield return e;
+            }
+        }
+
+        public async IAsyncEnumerable<EventRecord> QueryByTagsAsync(
+            IReadOnlyDictionary<string, string> tags, CancellationToken ct)
+        {
+            Calls.Add($"QueryByTagsAsync({string.Join(",", tags.Select(x => $"{x.Key}={x.Value}"))})");
+            foreach (var e in events)
+            {
+                await Task.Yield();
+                yield return e;
+            }
+        }
+
+        public Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(int count, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, CancellationToken ct)
+            => throw new NotImplementedException();
+
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private static ProjectionRunInput forStream(string stream = "trip-1")
+        => new() { ProjectionName = "Trips", StreamFlag = stream };
+
+    [Fact]
+    public void the_only_store_is_selected_without_a_flag()
+    {
+        var store = new FakeEventStore("marten://main");
+        var (selected, error) = ProjectionRunSource.SelectStore([store], null);
+
+        selected.ShouldBeSameAs(store);
+        error.ShouldBeNull();
+    }
+
+    [Fact]
+    public void no_stores_is_an_error_not_an_empty_run()
+    {
+        var (selected, error) = ProjectionRunSource.SelectStore([], null);
+
+        selected.ShouldBeNull();
+        error.ShouldBe("No event stores are registered in this application");
+    }
+
+    [Fact]
+    public void more_than_one_store_and_no_flag_is_refused_rather_than_guessed()
+    {
+        // Replaying against the wrong store looks exactly like a broken projection, so a first-match
+        // guess is worse than an error.
+        var (selected, error) = ProjectionRunSource.SelectStore(
+            [new FakeEventStore("marten://main"), new FakeEventStore("marten://reporting")], null);
+
+        selected.ShouldBeNull();
+        error.ShouldContain("specify --store");
+        error.ShouldContain("marten://reporting");
+    }
+
+    [Fact]
+    public void a_store_is_matched_by_subject_uri()
+    {
+        var reporting = new FakeEventStore("marten://reporting");
+        var (selected, _) = ProjectionRunSource.SelectStore(
+            [new FakeEventStore("marten://main"), reporting], "marten://reporting");
+
+        selected.ShouldBeSameAs(reporting);
+    }
+
+    [Fact]
+    public void a_store_is_matched_by_bare_scheme()
+    {
+        var polecat = new FakeEventStore("polecat://main");
+        var (selected, _) = ProjectionRunSource.SelectStore(
+            [new FakeEventStore("marten://main"), polecat], "polecat");
+
+        selected.ShouldBeSameAs(polecat);
+    }
+
+    [Fact]
+    public void an_ambiguous_store_flag_is_refused()
+    {
+        var (selected, error) = ProjectionRunSource.SelectStore(
+            [new FakeEventStore("marten://main"), new FakeEventStore("marten://reporting")], "marten");
+
+        selected.ShouldBeNull();
+        error.ShouldContain("matches more than one event store");
+    }
+
+    [Fact]
+    public void an_unmatched_store_flag_names_what_is_there()
+    {
+        var (selected, error) = ProjectionRunSource.SelectStore([new FakeEventStore("marten://main")], "fisher");
+
+        selected.ShouldBeNull();
+        error.ShouldContain("marten://main");
+    }
+
+    [Fact]
+    public async Task a_stream_read_takes_every_event()
+    {
+        var store = new FakeEventStore("marten://main", evt(1), evt(2), evt(3));
+
+        var result = await ProjectionRunSource.ReadAsync(store, forStream(), CancellationToken.None);
+
+        result.Events.Select(x => x.StreamVersion).ShouldBe([1, 2, 3]);
+        result.Truncated.ShouldBeFalse();
+        store.Calls.ShouldBe(["ReadStreamAsync(trip-1)"]);
+    }
+
+    [Fact]
+    public async Task a_slice_is_bounded_on_both_ends_inclusively()
+    {
+        var store = new FakeEventStore("marten://main", evt(1), evt(2), evt(3), evt(4), evt(5));
+        var input = forStream();
+        input.FromFlag = 2;
+        input.ToFlag = 4;
+
+        var result = await ProjectionRunSource.ReadAsync(store, input, CancellationToken.None);
+
+        result.Events.Select(x => x.StreamVersion).ShouldBe([2, 3, 4]);
+    }
+
+    [Fact]
+    public async Task a_tag_query_reads_by_tags()
+    {
+        var store = new FakeEventStore("marten://main", evt(1), evt(2));
+        var input = new ProjectionRunInput { ProjectionName = "Enrollments" };
+        input.TagFlag["course"] = "c-1";
+
+        var result = await ProjectionRunSource.ReadAsync(store, input, CancellationToken.None);
+
+        result.Events.Count.ShouldBe(2);
+        store.Calls.ShouldBe(["QueryByTagsAsync(course=c-1)"]);
+    }
+
+    [Fact]
+    public async Task the_event_cap_stops_the_read_and_says_so()
+    {
+        // A capped read produces a timeline that looks complete. The flag is the only thing that
+        // stops a truncated replay from reading as the whole story.
+        var store = new FakeEventStore("marten://main", evt(1), evt(2), evt(3), evt(4));
+        var input = forStream();
+        input.MaxEventsFlag = 2;
+
+        var result = await ProjectionRunSource.ReadAsync(store, input, CancellationToken.None);
+
+        result.Events.Count.ShouldBe(2);
+        result.Truncated.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task a_read_that_ends_exactly_on_the_cap_is_not_truncated()
+    {
+        var store = new FakeEventStore("marten://main", evt(1), evt(2));
+        var input = forStream();
+        input.MaxEventsFlag = 2;
+
+        var result = await ProjectionRunSource.ReadAsync(store, input, CancellationToken.None);
+
+        result.Events.Count.ShouldBe(2);
+        result.Truncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task a_null_tenant_reads_store_globally()
+    {
+        // The command always calls the tenant-scoped overload; a null tenant delegates to the
+        // store-global member by contract (jasperfx#503), so there is only one code path here.
+        var store = new FakeEventStore("marten://main", evt(1));
+
+        await ProjectionRunSource.ReadAsync(store, forStream(), CancellationToken.None);
+
+        store.Calls.ShouldBe(["ReadStreamAsync(trip-1)"]);
+    }
+
+    [Fact]
+    public async Task a_tenant_on_a_single_tenant_store_is_refused_rather_than_ignored()
+    {
+        var store = new FakeEventStore("marten://main", evt(1));
+        var input = forStream();
+        input.TenantFlag = "tenant-1";
+
+        await Should.ThrowAsync<NotSupportedException>(
+            () => ProjectionRunSource.ReadAsync(store, input, CancellationToken.None));
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionRunCommand.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunCommand.cs
@@ -62,7 +62,8 @@ public class ProjectionRunCommand: JasperFxAsyncCommand<ProjectionRunInput>
         }
         catch (Exception e)
         {
-            return fail(input, store.Subject, $"Unable to read the source events: {e.Message}");
+            return await failAsync(host, input, store.Subject, $"Unable to read the source events: {e.Message}")
+                .ConfigureAwait(false);
         }
 
         MultiAggregateProjectionResult result;
@@ -74,7 +75,7 @@ public class ProjectionRunCommand: JasperFxAsyncCommand<ProjectionRunInput>
         }
         catch (Exception e)
         {
-            return fail(input, store.Subject, e.Message);
+            return await failAsync(host, input, store.Subject, e.Message).ConfigureAwait(false);
         }
 
         var report = ProjectionRunReport.From(input, store.Subject, result, source.Events.Count, source.Truncated);
@@ -90,6 +91,21 @@ public class ProjectionRunCommand: JasperFxAsyncCommand<ProjectionRunInput>
     private static bool fail(ProjectionRunInput input, Uri? store, string error)
     {
         write(input, ProjectionRunReport.Failed(input, store, error));
+        return false;
+    }
+
+    /// <summary>
+    /// The same, for failures that happened against a built host — those are the ones worth asking
+    /// whether the application's storage was ever migrated. The command builds the host but never
+    /// starts it, so an un-migrated database is a first-class cause here rather than an exotic one,
+    /// and the raw store exception ("relation ... does not exist") says nothing about the fix.
+    /// </summary>
+    private static async Task<bool> failAsync(IHost host, ProjectionRunInput input, Uri? store, string error)
+    {
+        var diagnosis = await ProjectionRunSchemaDiagnosis
+            .TryDiagnoseAsync(host.Services, CancellationToken.None).ConfigureAwait(false);
+
+        write(input, ProjectionRunReport.Failed(input, store, error, diagnosis));
         return false;
     }
 

--- a/src/JasperFx.Events/CommandLine/ProjectionRunCommand.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunCommand.cs
@@ -1,0 +1,107 @@
+using JasperFx.CommandLine;
+using JasperFx.Descriptors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Replays one projection over a source slice and prints the per-event before/after state — the
+/// projection debugger every Marten / Polecat / Fisher application gets without installing a
+/// monitoring console (jasperfx#728). Stateless: nothing is written, and the projection's own
+/// stored state is never touched.
+/// </summary>
+/// <remarks>
+/// This is the local, in-process half of the same capability CritterWatch exposes remotely over
+/// its stepper. Both sit on <see cref="IEventStore.RunMultiStreamProjectionAsync"/>, and the
+/// per-mode validation rules are deliberately identical, so an operator who learns one has learned
+/// the other.
+/// </remarks>
+[Description("Replay a projection over a stream, stream slice, or tag query and show the per-event before/after state")]
+public class ProjectionRunCommand: JasperFxAsyncCommand<ProjectionRunInput>
+{
+    public ProjectionRunCommand()
+    {
+        Usage("Replay a projection over a source slice").Arguments(x => x.ProjectionName);
+    }
+
+    public override async Task<bool> Execute(ProjectionRunInput input)
+    {
+        // Console logging has to go: in --json mode a single stray log line makes the output
+        // unparseable, and even the table is unreadable underneath startup chatter. --verbose is
+        // the deliberate opt back in, and it is refused in --json mode for the same reason.
+        if (input.HostBuilder != null && (!input.VerboseFlag || input.JsonFlag))
+        {
+            input.HostBuilder.ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddDebug();
+            });
+        }
+
+        var validation = input.Validate();
+        if (validation != null)
+        {
+            return fail(input, null, validation);
+        }
+
+        using var host = input.BuildHost();
+
+        var stores = host.Services.GetServices<IEventStore>().ToArray();
+        var (store, storeError) = ProjectionRunSource.SelectStore(stores, input.StoreFlag);
+        if (store == null)
+        {
+            return fail(input, null, storeError!);
+        }
+
+        ProjectionRunSourceEvents source;
+        try
+        {
+            source = await ProjectionRunSource.ReadAsync(store, input, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            return fail(input, store.Subject, $"Unable to read the source events: {e.Message}");
+        }
+
+        MultiAggregateProjectionResult result;
+        try
+        {
+            result = await store
+                .RunMultiStreamProjectionAsync(input.ProjectionName, source.Events, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            return fail(input, store.Subject, e.Message);
+        }
+
+        var report = ProjectionRunReport.From(input, store.Subject, result, source.Events.Count, source.Truncated);
+        write(input, report);
+
+        return true;
+    }
+
+    /// <summary>
+    /// A failed run still writes a report, so <c>--json</c> consumers parse one shape either way
+    /// rather than having to tell an empty result from a crash.
+    /// </summary>
+    private static bool fail(ProjectionRunInput input, Uri? store, string error)
+    {
+        write(input, ProjectionRunReport.Failed(input, store, error));
+        return false;
+    }
+
+    private static void write(ProjectionRunInput input, ProjectionRunReport report)
+    {
+        if (input.JsonFlag)
+        {
+            ProjectionRunView.WriteJson(report);
+        }
+        else
+        {
+            ProjectionRunView.WriteConsole(report);
+        }
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionRunInput.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunInput.cs
@@ -1,0 +1,161 @@
+using JasperFx.CommandLine;
+using JasperFx.Core;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Which source slice the <c>projection-run</c> command feeds into the projection.
+/// Mirrors CritterWatch's <c>ProjectionRunSourceMode</c> so the CLI and the console's
+/// remote stepper agree on the per-mode validation rules (jasperfx#728).
+/// </summary>
+public enum ProjectionRunSourceMode
+{
+    /// <summary>Every event of the stream identified by <c>--stream</c>.</summary>
+    Stream,
+
+    /// <summary>The <c>--stream</c> events bounded by the inclusive <c>--from</c> / <c>--to</c> stream versions.</summary>
+    StreamSlice,
+
+    /// <summary>The (possibly cross-stream) events matching every <c>--tag:name value</c> pair.</summary>
+    TagQuery
+}
+
+/// <summary>
+/// Input for the <c>projection-run</c> command. Every flag is long-form only: the parser
+/// derives one-letter aliases from the first letter and has no collision detection, so
+/// <c>--stream</c> / <c>--store</c> and <c>--to</c> / <c>--tenant</c> would silently bind
+/// whichever handler was built first.
+/// </summary>
+public class ProjectionRunInput: NetCoreInput
+{
+    [Description("Name of the registered projection to replay")]
+    public string ProjectionName { get; set; } = string.Empty;
+
+    [Description("Stream id whose events drive the replay. Required unless --tag is used")]
+    [FlagAlias("stream", longAliasOnly: true)]
+    public string? StreamFlag { get; set; }
+
+    [Description("Inclusive lower bound stream version of the slice. Requires --to")]
+    [FlagAlias("from", longAliasOnly: true)]
+    public long? FromFlag { get; set; }
+
+    [Description("Inclusive upper bound stream version of the slice. Requires --from")]
+    [FlagAlias("to", longAliasOnly: true)]
+    public long? ToFlag { get; set; }
+
+    [Description("DCB tag to match, written as --tag:<name> <value>. Repeatable. Cannot be combined with --stream")]
+    [FlagAlias("tag", longAliasOnly: true)]
+    public Dictionary<string, string> TagFlag { get; set; } = new();
+
+    [Description("Tenant partition to read the source events from. Omit for a store-global read")]
+    [FlagAlias("tenant", longAliasOnly: true)]
+    public string? TenantFlag { get; set; }
+
+    [Description("Subject uri (or bare scheme) of the event store to use. Only needed when the application registers more than one")]
+    [FlagAlias("store", longAliasOnly: true)]
+    public string? StoreFlag { get; set; }
+
+    [Description("Write the timelines to stdout as JSON instead of a console table")]
+    [FlagAlias("json", longAliasOnly: true)]
+    public bool JsonFlag { get; set; }
+
+    [Description("Maximum number of source events to feed into the projection. Default is 1000")]
+    [FlagAlias("max-events", longAliasOnly: true)]
+    public int MaxEventsFlag { get; set; } = 1000;
+
+    /// <summary>
+    /// Source mode implied by the flags. Tags win, then a version bound, then the bare stream read —
+    /// so the mode is never spelled out twice and can never disagree with the flags that drive it.
+    /// </summary>
+    public ProjectionRunSourceMode SourceMode
+    {
+        get
+        {
+            if (TagFlag.Count > 0) return ProjectionRunSourceMode.TagQuery;
+            if (FromFlag.HasValue || ToFlag.HasValue) return ProjectionRunSourceMode.StreamSlice;
+            return ProjectionRunSourceMode.Stream;
+        }
+    }
+
+    /// <summary>
+    /// Per-mode required-field rules, mirroring CritterWatch's <c>RequestProjectionRunHandler</c>.
+    /// Returns the operator-facing message for the first violation, or null when the input is usable.
+    /// </summary>
+    public string? Validate()
+    {
+        if (ProjectionName.IsEmpty())
+        {
+            return "A projection name is required";
+        }
+
+        if (MaxEventsFlag <= 0)
+        {
+            return "--max-events must be greater than zero";
+        }
+
+        switch (SourceMode)
+        {
+            case ProjectionRunSourceMode.TagQuery:
+                // CritterWatch's handler ignores the stream id in tag mode because its UI never sends
+                // both. A CLI operator who types both is expressing an intent the command cannot honor,
+                // so say so rather than silently dropping half of it.
+                if (StreamFlag.IsNotEmpty())
+                {
+                    return "--stream cannot be combined with --tag; a tag query is not stream-anchored";
+                }
+
+                if (FromFlag.HasValue || ToFlag.HasValue)
+                {
+                    return "--from / --to cannot be combined with --tag; version bounds only apply to a stream slice";
+                }
+
+                return null;
+
+            case ProjectionRunSourceMode.StreamSlice:
+                if (StreamFlag.IsEmpty())
+                {
+                    return "--stream is required";
+                }
+
+                if (!FromFlag.HasValue || !ToFlag.HasValue)
+                {
+                    return "--from and --to are both required for a stream slice";
+                }
+
+                if (FromFlag > ToFlag)
+                {
+                    return "--from must be less than or equal to --to";
+                }
+
+                return null;
+
+            default:
+                return StreamFlag.IsEmpty() ? "--stream is required" : null;
+        }
+    }
+
+    /// <summary>
+    /// Stable, human-readable identity of the source slice, using the same per-mode encoding as
+    /// CritterWatch's <c>RequestProjectionRunHandler.BuildSourceKey</c> so a CLI run and a console
+    /// run over the same slice are recognisably the same thing.
+    /// </summary>
+    public string SourceKey =>
+        SourceMode switch
+        {
+            ProjectionRunSourceMode.Stream => StreamFlag ?? string.Empty,
+            ProjectionRunSourceMode.StreamSlice => $"{StreamFlag ?? string.Empty}@{FromFlag}..{ToFlag}",
+            ProjectionRunSourceMode.TagQuery => buildTagSourceKey(),
+            _ => StreamFlag ?? string.Empty
+        };
+
+    private string buildTagSourceKey()
+    {
+        if (TagFlag.Count == 0) return "tags::";
+
+        var pairs = TagFlag
+            .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(kvp => $"{kvp.Key}={kvp.Value}");
+
+        return "tags::" + string.Join("&", pairs);
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionRunReport.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunReport.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// The whole result of one <c>projection-run</c>, in the shape agents and scripts consume from
+/// <c>--json</c>. A failed run is a report too — <see cref="Error"/> is populated and
+/// <see cref="Aggregates"/> is empty — so a consumer never has to distinguish "no output" from
+/// "no aggregates".
+/// </summary>
+/// <param name="Projection">Registered name of the projection that was replayed.</param>
+/// <param name="Store">Subject uri of the event store the source events came from.</param>
+/// <param name="Source">The source slice that was read.</param>
+/// <param name="EventCount">Number of source events fed into the projection.</param>
+/// <param name="Truncated">True when <c>--max-events</c> stopped the source read early.</param>
+/// <param name="Aggregates">One timeline per aggregate identity the projection touched, ordered by identity.</param>
+/// <param name="Error">Operator-facing failure message, or null when the run succeeded.</param>
+public sealed record ProjectionRunReport(
+    string Projection,
+    string? Store,
+    ProjectionRunSourceReport Source,
+    int EventCount,
+    bool Truncated,
+    IReadOnlyList<ProjectionRunAggregateReport> Aggregates,
+    string? Error)
+{
+    /// <summary>
+    /// Fan the per-identity timelines out into report rows. Dictionary order is not guaranteed by
+    /// <see cref="MultiAggregateProjectionResult"/>, so identities are sorted for a stable diff
+    /// between two runs of the same slice.
+    /// </summary>
+    public static ProjectionRunReport From(
+        ProjectionRunInput input, Uri? store, MultiAggregateProjectionResult result, int eventCount, bool truncated)
+    {
+        var aggregates = result.AggregatesByIdentity
+            .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(kvp => new ProjectionRunAggregateReport(
+                kvp.Key,
+                kvp.Value.Steps.Select(toStep).ToArray(),
+                kvp.Value.FinalState))
+            .ToArray();
+
+        return new ProjectionRunReport(input.ProjectionName, store?.ToString(), ProjectionRunSourceReport.From(input),
+            eventCount, truncated, aggregates, null);
+    }
+
+    /// <summary>A run that never reached the projection: the source slice is still worth reporting.</summary>
+    public static ProjectionRunReport Failed(ProjectionRunInput input, Uri? store, string error)
+        => new(input.ProjectionName, store?.ToString(), ProjectionRunSourceReport.From(input), 0, false, [], error);
+
+    private static ProjectionRunStepReport toStep(ProjectionStepResultRaw step, int index)
+        => new(index + 1, step.Event.Sequence, step.Event.StreamVersion, step.Event.StreamId,
+            step.Event.EventTypeName, step.Event.Timestamp, step.Elapsed.TotalMilliseconds,
+            step.Before, step.After, step.Error);
+}
+
+/// <summary>
+/// The source slice a <see cref="ProjectionRunReport"/> was produced from, carried in full so a
+/// stored report is self-describing — the same fields the run would need to be reproduced.
+/// </summary>
+/// <param name="Mode">Source-mode discriminator.</param>
+/// <param name="Key">Stable encoding of the slice, matching CritterWatch's source key.</param>
+/// <param name="StreamId">Stream the events were read from; null in tag-query mode.</param>
+/// <param name="FromVersion">Inclusive lower version bound; null outside slice mode.</param>
+/// <param name="ToVersion">Inclusive upper version bound; null outside slice mode.</param>
+/// <param name="Tags">Tag map that was matched; null outside tag-query mode.</param>
+/// <param name="TenantId">Tenant the source read was scoped to; null for a store-global read.</param>
+public sealed record ProjectionRunSourceReport(
+    ProjectionRunSourceMode Mode,
+    string Key,
+    string? StreamId,
+    long? FromVersion,
+    long? ToVersion,
+    IReadOnlyDictionary<string, string>? Tags,
+    string? TenantId)
+{
+    public static ProjectionRunSourceReport From(ProjectionRunInput input)
+        => new(input.SourceMode, input.SourceKey,
+            input.SourceMode == ProjectionRunSourceMode.TagQuery ? null : input.StreamFlag,
+            input.FromFlag, input.ToFlag,
+            input.SourceMode == ProjectionRunSourceMode.TagQuery ? input.TagFlag : null,
+            input.TenantFlag);
+}
+
+/// <summary>
+/// One aggregate identity's timeline. A single-stream projection produces exactly one of these;
+/// a multi-stream projection produces one per identity the source slice touched.
+/// </summary>
+/// <param name="Identity">String form of the aggregate identity.</param>
+/// <param name="Steps">Per-event steps in apply order.</param>
+/// <param name="FinalState">State after the last applied event, or null when no event produced state.</param>
+public sealed record ProjectionRunAggregateReport(
+    string Identity,
+    IReadOnlyList<ProjectionRunStepReport> Steps,
+    JsonElement? FinalState);
+
+/// <summary>
+/// One step of a timeline: the event that was applied and the state either side of the apply.
+/// </summary>
+/// <param name="Step">1-based position of this step within the timeline.</param>
+/// <param name="Sequence">Store-wide sequence number of the event.</param>
+/// <param name="StreamVersion">Per-stream version of the event.</param>
+/// <param name="StreamId">Stream the event belongs to.</param>
+/// <param name="EventType">Event-type alias from the store's registry.</param>
+/// <param name="Timestamp">Server-assigned append time of the event.</param>
+/// <param name="ElapsedMs">Wall-clock milliseconds spent inside the projection's apply for this step.</param>
+/// <param name="Before">State before the apply.</param>
+/// <param name="After">State after the apply; equal to <paramref name="Before"/> when the apply threw.</param>
+/// <param name="Error">Message of the exception the apply threw, or null when it succeeded.</param>
+public sealed record ProjectionRunStepReport(
+    int Step,
+    long Sequence,
+    long StreamVersion,
+    string StreamId,
+    string EventType,
+    DateTimeOffset Timestamp,
+    double ElapsedMs,
+    JsonElement? Before,
+    JsonElement? After,
+    string? Error);

--- a/src/JasperFx.Events/CommandLine/ProjectionRunReport.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunReport.cs
@@ -16,6 +16,11 @@ namespace JasperFx.Events.CommandLine;
 /// <param name="Truncated">True when <c>--max-events</c> stopped the source read early.</param>
 /// <param name="Aggregates">One timeline per aggregate identity the projection touched, ordered by identity.</param>
 /// <param name="Error">Operator-facing failure message, or null when the run succeeded.</param>
+/// <param name="Diagnosis">
+/// What to do about <paramref name="Error"/> when the cause is known — today, storage that was never
+/// migrated. Null when the failure was not diagnosed. Carried as its own field rather than folded into
+/// <paramref name="Error"/> so an agent can act on the remedy without parsing prose out of the message.
+/// </param>
 public sealed record ProjectionRunReport(
     string Projection,
     string? Store,
@@ -23,7 +28,8 @@ public sealed record ProjectionRunReport(
     int EventCount,
     bool Truncated,
     IReadOnlyList<ProjectionRunAggregateReport> Aggregates,
-    string? Error)
+    string? Error,
+    string? Diagnosis = null)
 {
     /// <summary>
     /// Fan the per-identity timelines out into report rows. Dictionary order is not guaranteed by
@@ -46,8 +52,10 @@ public sealed record ProjectionRunReport(
     }
 
     /// <summary>A run that never reached the projection: the source slice is still worth reporting.</summary>
-    public static ProjectionRunReport Failed(ProjectionRunInput input, Uri? store, string error)
-        => new(input.ProjectionName, store?.ToString(), ProjectionRunSourceReport.From(input), 0, false, [], error);
+    public static ProjectionRunReport Failed(ProjectionRunInput input, Uri? store, string error,
+        string? diagnosis = null)
+        => new(input.ProjectionName, store?.ToString(), ProjectionRunSourceReport.From(input), 0, false, [], error,
+            diagnosis);
 
     private static ProjectionRunStepReport toStep(ProjectionStepResultRaw step, int index)
         => new(index + 1, step.Event.Sequence, step.Event.StreamVersion, step.Event.StreamId,

--- a/src/JasperFx.Events/CommandLine/ProjectionRunSchemaDiagnosis.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunSchemaDiagnosis.cs
@@ -1,0 +1,98 @@
+using JasperFx.CommandLine.Descriptions;
+using JasperFx.Resources;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Works out whether a failed <c>projection-run</c> failed because the application's storage was
+/// never migrated, and says what to run about it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The command builds the host but does not start it, so nothing that normally migrates on startup
+/// has run — no <c>AddResourceSetupOnStartup</c>, no hosted service. Whether that matters depends on
+/// the store: Marten creates document and event tables on demand under the default
+/// <c>AutoCreate.CreateOrUpdate</c>, Polecat creates document tables on demand but takes its event
+/// tables from the resource model, and any deployment on <c>AutoCreate.None</c> creates nothing at
+/// all. So the same command can succeed on one developer's box and fail on the next with a raw
+/// "relation does not exist" that says nothing about what to do.
+/// </para>
+/// <para>
+/// The diagnosis runs on the FAILURE path only. Running it up front would cost a round trip on every
+/// successful run, and would report a broker that happens to be down as though it were the reason a
+/// projection could not be replayed.
+/// </para>
+/// </remarks>
+internal static class ProjectionRunSchemaDiagnosis
+{
+    /// <summary>
+    /// A resource check is a network call. It is diagnosing a failure that already happened, so it
+    /// gets a short leash — a hung check must never be more expensive than the error it explains.
+    /// </summary>
+    public static TimeSpan CheckTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Returns operator-facing guidance when the application's resources are not ready, or null when
+    /// they are fine and the failure was something else. Never throws: a diagnosis that fails is
+    /// simply absent, and the original error is always what gets reported.
+    /// </summary>
+    public static async Task<string?> TryDiagnoseAsync(IServiceProvider services, CancellationToken ct)
+    {
+        List<string> unhealthy;
+
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(CheckTimeout);
+
+            unhealthy = await findUnhealthyResourcesAsync(services, timeout.Token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Diagnosing is best-effort by construction. The caller already has a real error to
+            // report and it must not be replaced by a failure to explain it.
+            return null;
+        }
+
+        if (unhealthy.Count == 0) return null;
+
+        return $"""
+                This application's storage is not ready — 'resources check' fails for: {string.Join(", ", unhealthy)}.
+                That is the usual reason a projection cannot be replayed: projection-run builds the host but
+                never starts it, so nothing that normally migrates on startup has run.
+
+                projection-run does not migrate anything itself, deliberately: a read-only diagnostic that
+                quietly changes a database is worse than one that fails. Apply the schema first, then re-run.
+
+                  dotnet run -- resources setup   (every registered resource; works on every store)
+                  dotnet run -- db-apply          (Weasel schema migration; Marten, and Polecat 5.20+)
+                """;
+    }
+
+    private static async Task<List<string>> findUnhealthyResourcesAsync(IServiceProvider services,
+        CancellationToken ct)
+    {
+        var unhealthy = new List<string>();
+
+        foreach (var part in services.GetServices<ISystemPart>())
+        {
+            var resources = await part.FindResources().ConfigureAwait(false);
+
+            foreach (var resource in resources)
+            {
+                try
+                {
+                    await resource.Check(ct).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // Check() signals "not configured" by throwing; that is its whole contract.
+                    unhealthy.Add($"{resource.Type} '{resource.Name}'");
+                }
+            }
+        }
+
+        return unhealthy;
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionRunSource.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunSource.cs
@@ -1,0 +1,111 @@
+using JasperFx.Core;
+using JasperFx.Descriptors;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Result of reading the source slice for a <c>projection-run</c>. <see cref="Truncated"/> is true
+/// when the read stopped at <c>--max-events</c> rather than at the end of the slice — the caller
+/// must say so, because a silently capped read produces a timeline that looks complete and is not.
+/// </summary>
+/// <param name="Events">Source events in apply order.</param>
+/// <param name="Truncated">True when <c>--max-events</c> stopped the read early.</param>
+internal sealed record ProjectionRunSourceEvents(IReadOnlyList<EventRecord> Events, bool Truncated);
+
+/// <summary>
+/// Resolves the store and reads the source slice for the <c>projection-run</c> command. Split out
+/// from the command itself so both halves are testable against a fake <see cref="IEventStore"/>
+/// without a database or a built host.
+/// </summary>
+internal static class ProjectionRunSource
+{
+    /// <summary>
+    /// Pick the one event store this run targets. Matching mirrors <see cref="ProjectionSelection"/>:
+    /// an absolute uri matches by subject, anything else matches by scheme. Ambiguity is an error
+    /// rather than a first-match guess — replaying against the wrong store would look like a
+    /// projection bug.
+    /// </summary>
+    public static (IEventStore? Store, string? Error) SelectStore(
+        IReadOnlyList<IEventStore> stores, string? storeFlag)
+    {
+        if (stores.Count == 0)
+        {
+            return (null, "No event stores are registered in this application");
+        }
+
+        if (storeFlag.IsEmpty())
+        {
+            return stores.Count == 1
+                ? (stores[0], null)
+                : (null, $"This application registers more than one event store; specify --store. Known stores: {describe(stores)}");
+        }
+
+        var matches = Uri.TryCreate(storeFlag, UriKind.Absolute, out var subjectUri)
+            ? stores.Where(x => x.Subject.Matches(subjectUri!)).ToArray()
+            : stores.Where(x => x.Subject.Scheme.EqualsIgnoreCase(storeFlag)).ToArray();
+
+        return matches.Length switch
+        {
+            1 => (matches[0], null),
+            0 => (null, $"No event store matches --store {storeFlag}. Known stores: {describe(stores)}"),
+            _ => (null, $"--store {storeFlag} matches more than one event store: {describe(matches)}")
+        };
+    }
+
+    /// <summary>
+    /// Read the source events for the input's mode. The tenant-scoped read overloads are always the
+    /// ones called: a null tenant delegates to the store-global member by contract (jasperfx#503/#555),
+    /// so there is no second code path to keep in step.
+    /// </summary>
+    public static async Task<ProjectionRunSourceEvents> ReadAsync(
+        IEventStore store, ProjectionRunInput input, CancellationToken ct)
+    {
+        var events = new List<EventRecord>();
+        var cap = input.MaxEventsFlag;
+
+        switch (input.SourceMode)
+        {
+            case ProjectionRunSourceMode.TagQuery:
+                await foreach (var e in store.QueryByTagsAsync(input.TagFlag, input.TenantFlag, ct).ConfigureAwait(false))
+                {
+                    if (events.Count == cap) return new ProjectionRunSourceEvents(events, true);
+                    events.Add(e);
+                }
+
+                break;
+
+            case ProjectionRunSourceMode.StreamSlice:
+            {
+                // The JasperFx.Events abstraction still only ships a full-stream read, so the version
+                // bounds are applied here. Same in-process filter CritterWatch's handler carries, and
+                // it can leave early because a stream read is ordered by version.
+                var from = input.FromFlag!.Value;
+                var to = input.ToFlag!.Value;
+
+                await foreach (var e in store.ReadStreamAsync(input.StreamFlag!, input.TenantFlag, ct).ConfigureAwait(false))
+                {
+                    if (e.StreamVersion < from) continue;
+                    if (e.StreamVersion > to) break;
+                    if (events.Count == cap) return new ProjectionRunSourceEvents(events, true);
+                    events.Add(e);
+                }
+
+                break;
+            }
+
+            default:
+                await foreach (var e in store.ReadStreamAsync(input.StreamFlag!, input.TenantFlag, ct).ConfigureAwait(false))
+                {
+                    if (events.Count == cap) return new ProjectionRunSourceEvents(events, true);
+                    events.Add(e);
+                }
+
+                break;
+        }
+
+        return new ProjectionRunSourceEvents(events, false);
+    }
+
+    private static string describe(IReadOnlyList<IEventStore> stores)
+        => string.Join(", ", stores.Select(x => x.Subject.ToString()));
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionRunView.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunView.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Core;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Renders a <see cref="ProjectionRunReport"/> — as JSON for agents and scripts, or as a console
+/// table for a human at a terminal.
+/// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: the report is serialized reflectively by System.Text.Json. The projection-run command is a development-time CLI surface, not part of an AOT-published runtime — the same disposition as ProjectionHost.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Same as IL2026 — reflective JSON serialization of the CLI's own report type.")]
+internal static class ProjectionRunView
+{
+    private const int StatePreviewLength = 80;
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        // The source mode is named, not numbered: an agent reading "mode": 1 out of a saved report
+        // has to go and find the enum to know what it ran.
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true
+    };
+
+    public static string ToJson(ProjectionRunReport report) => JsonSerializer.Serialize(report, _json);
+
+    /// <summary>
+    /// Write straight to <see cref="Console.Out"/> rather than through Spectre: the console writer
+    /// wraps and styles its output, which would corrupt JSON a script is piping.
+    /// </summary>
+    public static void WriteJson(ProjectionRunReport report) => Console.Out.WriteLine(ToJson(report));
+
+    public static void WriteConsole(ProjectionRunReport report)
+    {
+        if (report.Error.IsNotEmpty())
+        {
+            AnsiConsole.MarkupLine($"[red]{report.Error!.EscapeMarkup()}[/]");
+            return;
+        }
+
+        AnsiConsole.Write(new Rule($"[bold]{report.Projection.EscapeMarkup()}[/] over {report.Source.Key.EscapeMarkup()}")
+        {
+            Justification = Justify.Left
+        });
+
+        AnsiConsole.MarkupLine(
+            $"Store [blue]{(report.Store ?? "(unknown)").EscapeMarkup()}[/] · {report.EventCount} source event(s)" +
+            (report.Source.TenantId.IsNotEmpty() ? $" · tenant [blue]{report.Source.TenantId!.EscapeMarkup()}[/]" : string.Empty));
+
+        if (report.Truncated)
+        {
+            // A capped read produces a timeline that looks complete, so this cannot be a quiet omission.
+            AnsiConsole.MarkupLine(
+                "[yellow]The source read stopped at --max-events; this timeline is a prefix of the slice, not all of it[/]");
+        }
+
+        if (report.Aggregates.Count == 0)
+        {
+            AnsiConsole.MarkupLine(report.EventCount == 0
+                ? "[yellow]No events matched the source slice[/]"
+                : "[yellow]The projection produced no aggregate identity from these events[/]");
+            return;
+        }
+
+        foreach (var aggregate in report.Aggregates)
+        {
+            writeAggregate(aggregate);
+        }
+    }
+
+    private static void writeAggregate(ProjectionRunAggregateReport aggregate)
+    {
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(new Rule($"[bold]{aggregate.Identity.EscapeMarkup()}[/]") { Justification = Justify.Left });
+
+        var anyErrors = aggregate.Steps.Any(x => x.Error != null);
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("#");
+        table.AddColumn("Version");
+        table.AddColumn("Event");
+        table.AddColumn("Timestamp");
+        table.AddColumn("ms");
+        table.AddColumn("After");
+        if (anyErrors) table.AddColumn("Error");
+
+        foreach (var step in aggregate.Steps)
+        {
+            // Text rather than Markup: a JSON state preview is full of square brackets, which the
+            // markup parser would either eat or choke on.
+            var cells = new List<IRenderable>
+            {
+                new Text(step.Step.ToString()),
+                new Text(step.StreamVersion.ToString()),
+                new Text(step.EventType),
+                new Text(step.Timestamp.ToString("u")),
+                new Text(step.ElapsedMs.ToString("0.###")),
+                new Text(preview(step.After))
+            };
+
+            if (anyErrors) cells.Add(new Text(step.Error ?? string.Empty));
+
+            table.AddRow(cells);
+        }
+
+        AnsiConsole.Write(table);
+
+        if (aggregate.FinalState.HasValue)
+        {
+            AnsiConsole.MarkupLine("[bold]Final state[/]");
+            AnsiConsole.WriteLine(JsonSerializer.Serialize(aggregate.FinalState.Value, _json));
+        }
+        else
+        {
+            AnsiConsole.MarkupLine("[yellow]No final state — the projection produced none for this identity[/]");
+        }
+    }
+
+    private static string preview(JsonElement? state)
+    {
+        if (!state.HasValue) return "(none)";
+
+        var text = state.Value.ToString();
+        return text.Length <= StatePreviewLength ? text : text[..StatePreviewLength] + "…";
+    }
+}

--- a/src/JasperFx.Events/CommandLine/ProjectionRunView.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunView.cs
@@ -41,6 +41,13 @@ internal static class ProjectionRunView
         if (report.Error.IsNotEmpty())
         {
             AnsiConsole.MarkupLine($"[red]{report.Error!.EscapeMarkup()}[/]");
+
+            if (report.Diagnosis.IsNotEmpty())
+            {
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[yellow]{report.Diagnosis!.EscapeMarkup()}[/]");
+            }
+
             return;
         }
 


### PR DESCRIPTION
Closes #728.

`dotnet run -- projection-run <Projection> --stream <id>` replays one projection over a source slice and prints the per-event before/after state. Stateless — nothing is written, and the projection's own stored state is never touched.

The capability already existed on `IEventStore`; what was missing was the local half. JasperFx.CommandLine discovery gives the command to every host referencing JasperFx.Events on a binding roll-forward — no Marten/Polecat/Fisher release involved.

### Source modes

```
projection-run Trips --stream trip-1
projection-run Trips --stream trip-1 --from 3 --to 7
projection-run Enrollments --tag:course c-1 --tag:student s-9
```

Plus `--tenant`, `--store`, `--max-events` (default 1000), and `--json`.

The three modes and their per-mode validation rules are deliberately identical to CritterWatch's `RequestProjectionRunHandler`, so an operator who learns one has learned the other.

### Answering the issue's open questions

- **Multi-bucket vs single-identity.** The issue's caveat is stale: upstream already grew the multi-aggregate surface. This sits on `RunMultiStreamProjectionAsync`, so a multi-stream projection reports one timeline per identity and a single-stream projection reports exactly one. That is also what CritterWatch's handler already calls.
- **Output-size caps.** `--max-events` caps the source read at 1000, and the report carries `truncated` — a capped replay otherwise produces a timeline that looks complete.

### Deliberate deviations from the sketch

- Tags use the parser's native `--tag:name value` dictionary-flag shape rather than a hand-parsed `--tags k=v`.
- Every flag is long-form only. `InputParser` derives one-letter aliases from a flag's first letter and has **no collision detection**, so `--stream`/`--store` and `--to`/`--tenant` would silently bind whichever handler was built first. `ProjectionRunCommandParsingTests` is what would notice a lost `longAliasOnly`.
- `--stream` combined with `--tag` is refused. CritterWatch's handler ignores the stream id in tag mode because its UI never sends both; an operator typing both at a prompt means something the command cannot honor.
- An empty result reports zero aggregates rather than CritterWatch's synthetic single bucket, which exists to keep one tab in the SPA.

### Tenancy

The source read always calls the tenant-scoped overloads: a null tenant delegates to the store-global member by contract (#503/#555), so there is no second code path, and `--tenant` against a single-tenant store is refused rather than silently served from whichever tenant the default session happened to hold. Note the fold itself (`RunMultiStreamProjectionAsync`) carries no tenant parameter upstream, so enrichment/grouping still run against the store's default session.

### Tests

952 EventTests green, 44 new: the validation matrix, store selection (including refusing an ambiguous `--store` rather than guessing), slice bounds and truncation against a fake store, the report shape, and the command line itself parsing every flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm