### PR TITLE
gh-730: honor [BoundaryAggregate] on the Evolve path, and stop failing silently

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/AggregateEvolverGeneratorTests.cs
@@ -426,6 +426,111 @@ public class Subscribed { }
         generated.ShouldContain("snapshot.Apply(data)");
     }
 
+    // #730: the Evolve path had no [BoundaryAggregate] fallback of its own, so an Evolve-only
+    // boundary aggregate fell through BOTH paths -- the Evolve analyzer bailed at the identity
+    // check, and the Apply/Create analyzer returned at its "no conventional methods" guard before
+    // ever reaching the opt-in. Nothing was emitted and nothing was reported; the failure first
+    // showed up as InvalidProjectionException from FetchForWritingByTags<T> at fetch time.
+    [Fact]
+    public void generates_string_keyed_evolver_for_boundary_aggregate_using_evolve()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+
+namespace Test;
+
+[BoundaryAggregate]
+public class EvolveSubscriptionState
+{
+    public int Capacity { get; set; }
+
+    public void Evolve(IEvent e)
+    {
+        switch (e.Data)
+        {
+            case CourseCreated created: Capacity = created.Capacity; break;
+            case CourseCapacityChanged changed: Capacity = changed.Capacity; break;
+        }
+    }
+}
+
+public class CourseCreated { public int Capacity { get; set; } }
+public class CourseCapacityChanged { public int Capacity { get; set; } }
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        generatedSources.Length.ShouldBeGreaterThan(0);
+        var generated = generatedSources[0];
+        // _String is the TId disambiguation suffix (the type has no Id of its own), and the trailing
+        // Evolve marks the Evolve-based dispatch mode.
+        generated.ShouldContain("EvolveSubscriptionState_StringEvolveEvolver");
+        // Keyed on string, matching the SingleStreamProjection<T, string> the DCB aggregator builds.
+        generated.ShouldContain("global::JasperFx.Events.Aggregation.IGeneratedSyncEvolver<global::Test.EvolveSubscriptionState, string>");
+        generated.ShouldContain("[assembly: global::JasperFx.Events.Aggregation.GeneratedEvolver(typeof(global::Test.EvolveSubscriptionState)");
+
+        diagnostics.ShouldNotContain(d => d.Id == "JFXEVT007");
+    }
+
+    // The Evolve path keeps the same opt-in discipline as the Apply/Create path: identity-less
+    // WITHOUT the marker still emits nothing, because a missing Id is far more likely a forgotten
+    // Id than an intentional boundary aggregate.
+    [Fact]
+    public void skips_identity_less_evolve_aggregate_without_boundary_attribute()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+
+namespace Test;
+
+public class EvolveSubscriptionState
+{
+    public int Capacity { get; set; }
+
+    public void Evolve(IEvent e)
+    {
+        if (e.Data is CourseCreated created) Capacity = created.Capacity;
+    }
+}
+
+public class CourseCreated { public int Capacity { get; set; } }
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        generatedSources.ShouldBeEmpty();
+        diagnostics.ShouldNotContain(d => d.Id == "JFXEVT007");
+    }
+
+    // #730: a [BoundaryAggregate] with nothing to fold events with is unambiguously wrong, because
+    // the attribute is an explicit opt-in. Silence here is what let the Evolve gap go unnoticed.
+    [Fact]
+    public void reports_a_diagnostic_for_a_boundary_aggregate_with_nothing_to_fold_with()
+    {
+        var source = @"
+using System;
+using JasperFx.Events;
+using JasperFx.Events.Aggregation;
+
+namespace Test;
+
+[BoundaryAggregate]
+public class EmptyBoundaryState
+{
+    public int Capacity { get; set; }
+}
+";
+        var (diagnostics, generatedSources) = RunGenerator(source);
+
+        generatedSources.ShouldBeEmpty();
+
+        var diagnostic = diagnostics.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe("JFXEVT007");
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Error);
+        diagnostic.GetMessage().ShouldContain("EmptyBoundaryState");
+    }
+
     // Negative half of #324: the marker is required. An identity-less aggregate
     // WITHOUT [BoundaryAggregate] still emits nothing — a bare no-Id aggregate is far
     // more likely a forgot-the-Id mistake than an intentional boundary aggregate, and

--- a/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateAnalyzer.cs
@@ -21,7 +21,15 @@ internal enum CandidateMode
     /// Only needs published type registration, not method generation.
     /// See https://github.com/JasperFx/marten/issues/4166
     /// </summary>
-    EventProjectionTypeRegistrationOnly
+    EventProjectionTypeRegistrationOnly,
+
+    /// <summary>
+    /// A type marked [BoundaryAggregate] that the generator cannot emit an evolver for, because it
+    /// declares neither an Evolve method nor any conventional Apply/Create methods. Carried through
+    /// the pipeline solely so the generator can report JFXEVT007 — nothing is emitted for it.
+    /// See https://github.com/JasperFx/jasperfx/issues/730
+    /// </summary>
+    InvalidBoundaryAggregate
 }
 
 internal sealed class ConventionalMethodInfo
@@ -251,12 +259,27 @@ internal static class AggregateAnalyzer
         CancellationToken ct)
     {
         // Check for Evolve/EvolveAsync methods first — these take priority
-        var evolveResult = AnalyzeSelfAggregatingEvolve(classDecl, classSymbol, ct);
+        var evolveResult = AnalyzeSelfAggregatingEvolve(classDecl, classSymbol, semanticModel, ct);
         if (evolveResult != null) return evolveResult;
 
         var methods = DiscoverConventionalMethods(classSymbol, classSymbol, null);
         var eventCtors = DiscoverEventConstructors(classSymbol);
-        if (methods.Count == 0 && eventCtors.Count == 0) return null;
+        if (methods.Count == 0 && eventCtors.Count == 0)
+        {
+            // Nothing to fold events with. Silent for an ordinary type, but [BoundaryAggregate] is an
+            // explicit opt-in, so a type carrying it and generating nothing is unambiguously wrong and
+            // the runtime failure lands far away (#730).
+            return HasBoundaryAggregateAttribute(classSymbol)
+                ? new CandidateInfo
+                {
+                    Mode = CandidateMode.InvalidBoundaryAggregate,
+                    ClassSymbol = classSymbol,
+                    ClassSyntax = classDecl,
+                    IsPartial = classDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
+                    AggregateType = classSymbol
+                }
+                : null;
+        }
 
         // Infer TId from Id property or AggregateIdentityAttribute
         var idType = InferIdentityType(classSymbol);
@@ -335,13 +358,26 @@ internal static class AggregateAnalyzer
     private static CandidateInfo? AnalyzeSelfAggregatingEvolve(
         TypeDeclarationSyntax classDecl,
         INamedTypeSymbol classSymbol,
+        SemanticModel semanticModel,
         CancellationToken ct)
     {
         var evolveMethod = FindEvolveMethod(classSymbol);
         if (evolveMethod == null) return null;
 
         var idType = InferIdentityType(classSymbol);
-        if (idType == null) return null;
+        if (idType == null)
+        {
+            // Identity-less "boundary" aggregate (DCB), same opt-in as the Apply/Create path below.
+            // This branch used to be a bare `return null`, which made an Evolve-only boundary
+            // aggregate unreachable: the Evolve path bailed here, and the Apply/Create path — the
+            // only one that knew about [BoundaryAggregate] — then returned null at its "no
+            // conventional methods" guard before ever reaching the opt-in. So the attribute was
+            // honoured for Apply/Create and silently ignored for Evolve, and the consequence did not
+            // surface until FetchForWritingByTags<T> threw "No source-generated dispatcher found" at
+            // fetch time. See #730.
+            if (!HasBoundaryAggregateAttribute(classSymbol)) return null;
+            idType = semanticModel.Compilation.GetSpecialType(SpecialType.System_String);
+        }
 
         // Extract event types from the method body
         var methodSyntax = evolveMethod.Symbol.DeclaringSyntaxReferences

--- a/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
+++ b/src/JasperFx.Events.SourceGenerator/AggregateEvolverGenerator.cs
@@ -67,8 +67,42 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
         if (node is ClassDeclarationSyntax or RecordDeclarationSyntax)
         {
             var typeDecl = (TypeDeclarationSyntax)node;
-            return typeDecl.Members.OfType<MethodDeclarationSyntax>()
-                .Any(m => m.Identifier.ValueText is "Apply" or "Create" or "ShouldDelete" or "Project" or "Transform" or "Evolve" or "EvolveAsync" or "ApplyAsync");
+            if (typeDecl.Members.OfType<MethodDeclarationSyntax>()
+                .Any(m => m.Identifier.ValueText is "Apply" or "Create" or "ShouldDelete" or "Project" or "Transform" or "Evolve" or "EvolveAsync" or "ApplyAsync"))
+            {
+                return true;
+            }
+
+            // A [BoundaryAggregate] with no conventional method at all is admitted purely so the
+            // analyzer can report JFXEVT007 on it. The attribute is an explicit opt-in, so silence
+            // for such a type is a bug rather than a courtesy — and the runtime failure it causes
+            // arrives at fetch time naming neither the type nor the reason. See #730.
+            return HasBoundaryAggregateAttributeSyntax(typeDecl);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Syntactic, name-only check for <c>[BoundaryAggregate]</c>. Deliberately not semantic: this runs
+    /// in the syntax predicate, which must stay cheap and has no semantic model. A false positive here
+    /// costs one extra symbol-level analysis that then declines the type.
+    /// </summary>
+    private static bool HasBoundaryAggregateAttributeSyntax(TypeDeclarationSyntax typeDecl)
+    {
+        foreach (var list in typeDecl.AttributeLists)
+        {
+            foreach (var attribute in list.Attributes)
+            {
+                var name = attribute.Name switch
+                {
+                    QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText,
+                    SimpleNameSyntax simple => simple.Identifier.ValueText,
+                    _ => null
+                };
+
+                if (name is "BoundaryAggregate" or "BoundaryAggregateAttribute") return true;
+            }
         }
 
         return false;
@@ -401,6 +435,18 @@ public sealed class AggregateEvolverGenerator : IIncrementalGenerator
 
             case CandidateMode.EventProjectionTypeRegistrationOnly:
                 EmitEventProjectionTypeRegistration(context, info);
+                break;
+
+            case CandidateMode.InvalidBoundaryAggregate:
+                // [BoundaryAggregate] is an explicit opt-in, so a type carrying it that generates
+                // nothing is unambiguously wrong — unlike a bare no-Id aggregate, where silence is
+                // correct because a missing Id is more likely a mistake than an intentional boundary
+                // aggregate. Without this the failure first appears as an InvalidProjectionException
+                // from FetchForWritingByTags<T>, naming neither the type nor the reason. See #730.
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.BoundaryAggregateWithoutEvolver,
+                    info.ClassSyntax.Identifier.GetLocation(),
+                    info.ClassSymbol.Name));
                 break;
 
             case CandidateMode.None:

--- a/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
+++ b/src/JasperFx.Events.SourceGenerator/DiagnosticDescriptors.cs
@@ -61,4 +61,26 @@ internal static class DiagnosticDescriptors
         category: "JasperFx.Events",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// A type carries <c>[BoundaryAggregate]</c> but the generator found nothing to fold events with,
+    /// so no evolver is emitted and <c>FetchForWritingByTags&lt;T&gt;</c> will throw
+    /// <c>InvalidProjectionException: No source-generated dispatcher found</c> the first time the type
+    /// is fetched.
+    /// </summary>
+    /// <remarks>
+    /// Error rather than warning, and unlike a bare no-<c>Id</c> aggregate — where silence is correct,
+    /// because a missing <c>Id</c> is far more likely a mistake than an intentional boundary aggregate
+    /// (#324) — this attribute is an explicit opt-in. A type carrying it and generating nothing is
+    /// unambiguously wrong, and the runtime failure it produces arrives at fetch time naming neither
+    /// the type nor the reason. See #730.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor BoundaryAggregateWithoutEvolver = new(
+        id: "JFXEVT007",
+        title: "Boundary aggregate has nothing to fold events with",
+        messageFormat:
+            "'{0}' is marked [BoundaryAggregate] but declares no Evolve method and no conventional Apply/Create methods, so no evolver can be generated and fetching it by tags will fail at runtime",
+        category: "JasperFx.Events",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
Closes #730.

## The bug

A `[BoundaryAggregate]` folded by `Evolve(IEvent)` got **no evolver and no diagnostic**, while its `Apply`/`Create` sibling in the same compilation generated fine. The asymmetry was the whole bug: only the Apply/Create path knew about the attribute.

`AnalyzeSelfAggregating` tries Evolve first and returns early on success, but `AnalyzeSelfAggregatingEvolve` bailed with a bare `return null` when it could not infer an identity. Control then fell through to the Apply/Create path, which returned at its *"no conventional methods"* guard — because an Evolve-only type has none — so the `[BoundaryAggregate]` opt-in sitting below that guard was never reached.

The consequence surfaced far away and late: `FetchForWritingByTags<T>` throwing `InvalidProjectionException: No source-generated dispatcher found` at **fetch** time, naming neither the type nor the reason.

## The fix

The Evolve path takes the same fallback the Apply/Create path already had — on `idType == null`, honour `[BoundaryAggregate]` and default `TId` to `string`, matching the `SingleStreamProjection<T, string>` the DCB aggregator builds (#324).

The opt-in discipline is unchanged and is covered by a test: identity-less **without** the marker still emits nothing, because a missing `Id` is far more likely a forgotten `Id` than an intentional boundary aggregate.

## The diagnostic

New **JFXEVT007**, an *error*, for a `[BoundaryAggregate]` that declares neither an Evolve method nor any conventional Apply/Create methods.

Silence is correct for a bare no-`Id` aggregate. It is wrong here: the attribute is an explicit opt-in, so a type carrying it and generating nothing is unambiguously a mistake, and the runtime failure it produces arrives at fetch time naming nothing useful.

Reporting it needed one more change, which is worth a look during review. `IsCandidateClass` admitted only types declaring a conventionally-named method, so a type carrying the attribute **and nothing else** never entered the pipeline and could not be reported on. It is now also admitted on a cheap syntactic attribute-name check — deliberately name-only, since the syntax predicate has no semantic model; a false positive costs one extra symbol-level analysis that then declines the type.

## Tests

`JasperFx.Events.SourceGenerator.Tests` — **59 passed**, 3 new:

| Test | Asserts |
|---|---|
| `generates_string_keyed_evolver_for_boundary_aggregate_using_evolve` | the fix — emits `IGeneratedSyncEvolver<T, string>` plus the assembly-level `[GeneratedEvolver]`, and reports no JFXEVT007 |
| `skips_identity_less_evolve_aggregate_without_boundary_attribute` | the opt-in still holds on the Evolve path |
| `reports_a_diagnostic_for_a_boundary_aggregate_with_nothing_to_fold_with` | JFXEVT007 fires, as an error, naming the type |

`EventStoreTests` 141/141 and the compliance package still build clean.

## Why it matters beyond DCB

Per #730, the AI skills are about to recommend `Evolve()` over typed `Apply` overloads for new code. That guidance was correct everywhere *except* boundary aggregates, where following it silently produced a projection that throws at first fetch. This closes the gap rather than forcing the skills to carve out an exception that would read as arbitrary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)