### PR TITLE
The projection-run command shipped as "projectionrun" — name it, and bump to 2.60.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.60.0</JasperFxVersion>
+        <JasperFxVersion>2.60.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>

--- a/src/EventTests/CommandLine/ProjectionRunCommandParsingTests.cs
+++ b/src/EventTests/CommandLine/ProjectionRunCommandParsingTests.cs
@@ -20,6 +20,15 @@ public class ProjectionRunCommandParsingTests
     }
 
     [Fact]
+    public void the_command_is_named_projection_run()
+    {
+        // CommandFactory.CommandNameFor strips the "Command" suffix and lowercases; it does NOT
+        // split PascalCase. Without an explicit Name this is "projectionrun", which is what
+        // shipped in 2.60.0 — a one-word sibling (ProjectionsCommand) is why it went unnoticed.
+        CommandFactory.CommandNameFor(typeof(ProjectionRunCommand)).ShouldBe("projection-run");
+    }
+
+    [Fact]
     public void the_projection_name_is_the_argument()
     {
         parse("Trips", "--stream", "trip-1").ProjectionName.ShouldBe("Trips");

--- a/src/JasperFx.Events/CommandLine/ProjectionRunCommand.cs
+++ b/src/JasperFx.Events/CommandLine/ProjectionRunCommand.cs
@@ -18,7 +18,10 @@ namespace JasperFx.Events.CommandLine;
 /// per-mode validation rules are deliberately identical, so an operator who learns one has learned
 /// the other.
 /// </remarks>
-[Description("Replay a projection over a stream, stream slice, or tag query and show the per-event before/after state")]
+// Name is explicit because CommandFactory.CommandNameFor only strips the "Command" suffix and
+// lowercases — it does not split PascalCase — so this would otherwise be "projectionrun".
+[Description("Replay a projection over a stream, stream slice, or tag query and show the per-event before/after state",
+    Name = "projection-run")]
 public class ProjectionRunCommand: JasperFxAsyncCommand<ProjectionRunInput>
 {
     public ProjectionRunCommand()


### PR DESCRIPTION
Found while authoring the ai-skills projection-troubleshooting skill (JasperFx/ai-skills#127) against a real Fisher host.

## The bug

The command #728 added is invoked as **`dotnet run -- projectionrun`** — not `projection-run`, as the issue, the PR and the help text all imply.

```
  projectionrun   Replay a projection over a stream, stream slice, or tag
  projections     Asynchronous projection and projection rebuilds
```

`CommandFactory.CommandNameFor` only strips the `Command` suffix and lowercases — **it does not split PascalCase** — so `ProjectionRunCommand` becomes `projectionrun`.

Every other multi-word command in the tree already sets the name explicitly (`check-env`, `codegen`, `say-name`). The reason this slipped through review is that its nearest neighbour is `ProjectionsCommand` — a single word that needs no override, so nothing in the surrounding code looked like it was missing anything.

## The fix

The same `[Description(..., Name = "...")]` the others use, plus a regression test that asserts **`CommandNameFor`** rather than the attribute — the attribute is the mechanism, the resolved name is the contract, and the resolved name is what a user types.

51 EventTests green.

## Why 2.60.1 now rather than waiting

2.60.0 is published and carries the wrong name. **Polecat and Fisher are about to bump their `JasperFx.Events` floor specifically so this command reaches their users** — both currently resolve **2.59.0**, where it does not exist at all:

| store | current `JasperFx.Events` floor | `projection-run` present? |
|---|---|---|
| Marten 9.31.0 | 2.60.0 | ✅ (as `projectionrun`) |
| Polecat 5.21.1 | 2.59.0 | ❌ |
| Fisher 1.0.6 | 2.59.0 | ❌ |

It would be silly to have them pin a version whose command is named something nobody is going to document. Verified end-to-end on a real Fisher host: at 2.59.0 the command is absent; lifting `JasperFx.Events` to 2.60.0 makes it appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVQ4LcDmK6cmvnY792tUEm