### PR TITLE
gh-733: fold event constructors into the self-aggregating DetermineAction switch

### DIFF
--- a/src/JasperFx.Events.SourceGenerator.Tests/EventConstructorWithShouldDeleteTests.cs
+++ b/src/JasperFx.Events.SourceGenerator.Tests/EventConstructorWithShouldDeleteTests.cs
@@ -1,0 +1,89 @@
+using Shouldly;
+
+namespace JasperFx.Events.SourceGenerator.Tests;
+
+/// <summary>
+/// #733: a self-aggregating type whose Create handler is an event-shaped constructor
+/// (`public T(Created e)`) rather than a named `static Create` lost that arm entirely once the type
+/// also declared ShouldDelete. The Evolve emitters fold <c>info.EventConstructors</c> into their
+/// dispatch; DetermineAction built its switch from <c>info.Methods</c> alone, so the Create event
+/// had no case at all. Nothing failed loudly — the first Apply-only event that arrived instead
+/// built the aggregate through GetUninitializedObject, leaving every constructor-initialized member
+/// at its CLR default.
+/// </summary>
+public class EventConstructorWithShouldDeleteTests
+{
+    private const string Aggregate = @"
+using System;
+using System.Collections.Generic;
+using JasperFx.Events;
+
+namespace Test;
+
+public sealed record Created(Guid Id, string Name);
+public sealed record TagAdded(Guid Id, string Tag);
+public sealed record Deleted(Guid Id);
+
+public sealed class TempGuidAggregate
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = """";
+    public List<string> Tags { get; set; } = new();
+
+    public TempGuidAggregate(Created @event)
+    {
+        Id = @event.Id;
+        Name = @event.Name;
+    }
+
+    public void Apply(TagAdded @event) { Tags.Add(@event.Tag); }
+
+    public bool ShouldDelete(Deleted _) => true;
+}
+";
+
+    [Fact]
+    public void event_constructor_create_is_dispatched_alongside_should_delete()
+    {
+        var (diagnostics, generatedSources) = GeneratorHarness.Run(Aggregate);
+        var generated = generatedSources.Single(s => s.Contains("TempGuidAggregate"));
+
+        generated.ShouldContain("IGeneratedSyncDetermineAction");
+
+        // The Create event needs its own arm invoking the constructor, not a fall-through to
+        // the uninitialized-object path.
+        generated.ShouldContain("case global::Test.Created data:");
+        generated.ShouldContain("snapshot = new global::Test.TempGuidAggregate(data);");
+
+        diagnostics.ShouldBeEmpty();
+        GeneratorHarness.GeneratedCodeErrors(Aggregate).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void event_constructor_type_is_listed_in_event_types()
+    {
+        var (_, generatedSources) = GeneratorHarness.Run(Aggregate);
+        var generated = generatedSources.Single(s => s.Contains("TempGuidAggregate"));
+
+        // EventTypes drives which events the projection is even asked about; omitting the
+        // constructor's event type is how a stream that opens with Created gets skipped.
+        generated.ShouldContain("typeof(global::Test.Created)");
+    }
+
+    /// <summary>
+    /// Same shape without ShouldDelete, which routes to EmitSelfAggregatingEvolve. The dispatch
+    /// there was already correct; EventTypes was not, so this guards the half of #733 that the
+    /// non-delete path shares.
+    /// </summary>
+    [Fact]
+    public void event_constructor_type_is_listed_in_event_types_without_should_delete()
+    {
+        var source = Aggregate.Replace("    public bool ShouldDelete(Deleted _) => true;", "");
+
+        var (_, generatedSources) = GeneratorHarness.Run(source);
+        var generated = generatedSources.Single(s => s.Contains("TempGuidAggregate"));
+
+        generated.ShouldContain("snapshot = new global::Test.TempGuidAggregate(data);");
+        generated.ShouldContain("typeof(global::Test.Created)");
+    }
+}

--- a/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
+++ b/src/JasperFx.Events.SourceGenerator/EvolverCodeEmitter.cs
@@ -1402,7 +1402,14 @@ internal static class EvolverCodeEmitter
 
     private static void EmitEventTypesProperty(StringBuilder sb, CandidateInfo info)
     {
-        var eventTypes = info.Methods.Select(m => Fqn(m.EventType)).Distinct().ToList();
+        // Event-shaped constructors (Bucket 1) are Create handlers just as much as a named
+        // `static Create` is, so their event types belong here too. Leaving them out kept the
+        // creating event off the projection's event filter even where the dispatch switch handled
+        // it correctly. See #733. EventConstructors is only populated for self-aggregating types;
+        // the projection-class path passes an empty list and is unaffected.
+        var eventTypes = info.Methods.Select(m => Fqn(m.EventType))
+            .Concat(info.EventConstructors.Select(c => Fqn(c.EventType)))
+            .Distinct().ToList();
         sb.Append("    public global::System.Type[] EventTypes => [");
         sb.Append(string.Join(", ", eventTypes.Select(t => $"typeof({t})")));
         sb.AppendLine("];");
@@ -1867,12 +1874,15 @@ internal static class EvolverCodeEmitter
             var deleteApply = applyMethods.FirstOrDefault(m =>
                 SymbolEqualityComparer.Default.Equals(m.EventType, method.EventType));
 
-            if (deleteCreate != null || deleteApply != null)
+            var deleteCtor = info.EventConstructors.FirstOrDefault(c =>
+                SymbolEqualityComparer.Default.Equals(c.EventType, method.EventType));
+
+            if (deleteCreate != null || deleteApply != null || deleteCtor != null)
             {
                 sb.AppendLine("                    else");
                 sb.AppendLine("                    {");
                 EmitSelfAggregatingCreateApplyStatements(sb, info, deleteCreate, deleteApply,
-                    "                        ");
+                    "                        ", deleteCtor != null);
                 sb.AppendLine("                    }");
             }
 
@@ -1883,9 +1893,14 @@ internal static class EvolverCodeEmitter
         var handledDeleteTypes = new HashSet<ITypeSymbol>(shouldDeleteMethods.Select(m => m.EventType),
             SymbolEqualityComparer.Default);
 
+        // Event-shaped constructors are folded in the same way the Evolve emitters do. Building this
+        // set from info.Methods alone dropped an event whose ONLY handler is `public T(SomeEvent e)`:
+        // no case arm at all, so the ctor never ran and the next Apply-only event built the aggregate
+        // through GetUninitializedObject instead, leaving field initializers unrun. See #733.
         var applyAndCreateTypes = info.Methods
             .Where(m => m.MethodName != "ShouldDelete")
             .Select(m => m.EventType)
+            .Concat(info.EventConstructors.Select(c => c.EventType))
             .Distinct<ITypeSymbol>(SymbolEqualityComparer.Default)
             .Where(t => !handledDeleteTypes.Contains(t!))
             .OrderByDescending(t => GetTypeDepth(t!))
@@ -1898,6 +1913,8 @@ internal static class EvolverCodeEmitter
                 SymbolEqualityComparer.Default.Equals(m.EventType, eventType)).ToList();
             var applies = applyMethods.Where(m =>
                 SymbolEqualityComparer.Default.Equals(m.EventType, eventType)).ToList();
+            var eventCtor = info.EventConstructors.FirstOrDefault(c =>
+                SymbolEqualityComparer.Default.Equals(c.EventType, eventType));
 
             sb.AppendLine($"                case {eventTypeName} data:");
 
@@ -1908,6 +1925,19 @@ internal static class EvolverCodeEmitter
                 sb.Append("                        snapshot = ");
                 EmitSelfAggregatingCreateCall(sb, create, "data");
                 sb.AppendLine(";");
+
+                if (applies.Count > 0)
+                {
+                    sb.AppendLine("                    else");
+                    sb.Append("                        ");
+                    EmitSelfAggregatingApplyCall(sb, applies[0], "data");
+                }
+            }
+            else if (eventCtor != null)
+            {
+                // Implicit Create via public T(EventType) constructor.
+                sb.AppendLine("                    if (snapshot == null)");
+                sb.AppendLine($"                        snapshot = new {Fqn(info.AggregateType!)}(data);");
 
                 if (applies.Count > 0)
                 {
@@ -1960,15 +1990,26 @@ internal static class EvolverCodeEmitter
     /// event type as plain statements at <paramref name="indent"/>, for use inside a delete arm.
     /// </summary>
     private static void EmitSelfAggregatingCreateApplyStatements(StringBuilder sb, CandidateInfo info,
-        ConventionalMethodInfo? create, ConventionalMethodInfo? apply, string indent)
+        ConventionalMethodInfo? create, ConventionalMethodInfo? apply, string indent,
+        bool hasEventConstructor = false)
     {
-        if (create != null)
+        if (create != null || hasEventConstructor)
         {
             sb.AppendLine($"{indent}if (snapshot == null)");
             sb.AppendLine($"{indent}{{");
-            sb.Append($"{indent}    snapshot = ");
-            EmitSelfAggregatingCreateCall(sb, create, "data");
-            sb.AppendLine(";");
+            if (create != null)
+            {
+                sb.Append($"{indent}    snapshot = ");
+                EmitSelfAggregatingCreateCall(sb, create, "data");
+                sb.AppendLine(";");
+            }
+            else
+            {
+                // Implicit Create via public T(EventType) constructor, for an event type that is
+                // also covered by a ShouldDelete predicate returning false. See #733.
+                sb.AppendLine($"{indent}    snapshot = new {Fqn(info.AggregateType!)}(data);");
+            }
+
             sb.AppendLine($"{indent}}}");
 
             if (apply != null)


### PR DESCRIPTION
Fixes #733.

## The bug

A self-aggregating type may declare its Create handler as an event-shaped constructor, `public Foo(FooCreated e)`, instead of a named `static Create`. `EmitSelfAggregatingEvolve` / `EmitSelfAggregatingEvolveAsync` have always folded `info.EventConstructors` into their dispatch. `EmitSelfAggregatingDetermineAction` — the emitter selected as soon as the type also declares `ShouldDelete` — built its switch from `info.Methods` alone.

An event whose only handler was a constructor therefore got **no case arm at all**, and nothing said so. The code compiled, the constructor never ran, and the next Apply-only event built the aggregate through `GetUninitializedObject`, leaving every field initializer unrun. The reporter saw a `NullReferenceException` out of an `Apply` appending to a collection property; the quieter symptom is a silently blank aggregate.

Generated before, for the reporter's aggregate:

```csharp
public global::System.Type[] EventTypes => [typeof(TagAdded), typeof(Deleted)];
// ...
case Deleted data: /* ShouldDelete */ break;
case TagAdded data:
    snapshot ??= (TempGuidAggregate)RuntimeHelpers.GetUninitializedObject(typeof(TempGuidAggregate));
    snapshot.Apply(data);
    break;
// no arm for Created
```

## The fix

Three changes, all mirroring what the Evolve path already does:

1. `EmitSelfAggregatingDetermineAction`'s event-type set now concats `EventConstructors`, and a type whose only Create is a constructor emits `snapshot = new T(data);` under the same `snapshot == null` guard.
2. `EmitSelfAggregatingCreateApplyStatements` takes the constructor too, so an event covered by *both* a constructor and a `ShouldDelete` predicate that returns false still folds in the delete arm's `else` — the #652 shape, which had the same gap.
3. `EmitEventTypesProperty` folds constructors in as well. That omission was wider than the reported bug: it dropped the creating event from the generated `EventTypes` on **every** self-aggregating path, including the ones whose dispatch was already correct. `EventConstructors` is only populated for self-aggregating candidates, so the projection-class path is unaffected.

## Tests

`EventConstructorWithShouldDeleteTests` covers the dispatch arm, `EventTypes` with `ShouldDelete`, and `EventTypes` without it (point 3, which the non-delete path shares). All three fail on `main`.

- Source generator suite: 62/62
- EventTests: 959/959 on net9.0 and net10.0

## End-to-end against Marten

Packed locally as a 2.61.0 prerelease and run against a Marten branch carrying the reporter's shape (JasperFx/marten#5322, draft until 2.61.0 publishes):

- The new Marten suite fails 4/4 on JasperFx 2.60.0 with the reported `ApplyEventException` -> `NullReferenceException`, and passes 4/4 on this build, across inline, async and live aggregation.
- `EventSourcingTests` 2002/2002, `DaemonTests` 319/319.

## Noted, not fixed here

`EmitSelfAggregatingEvolver` checks `HasShouldDelete` before `HasAnyAsync`, so a self-aggregating type with an async `Apply` *and* a `ShouldDelete` takes the sync `DetermineAction` branch. That is a separate pre-existing question from #733 and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)