### PR TITLE
EventQuery: time/sequence windows, multi-type, folded tags, ordering contract + event-query CLI + compliance permutations

### DIFF
--- a/src/EventTests/CommandLine/EventQueryInputTests.cs
+++ b/src/EventTests/CommandLine/EventQueryInputTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using JasperFx.Events;
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#737 — the <c>event-query</c> command's flag-to-<see cref="EventQuery"/> mapping,
+/// validation, and <c>--tags</c> JSON parsing, pinned without a host or a database. Store
+/// selection is shared with <c>projection-run</c> and covered by
+/// <see cref="ProjectionRunSourceTests"/>.
+/// </summary>
+public class EventQueryInputTests
+{
+    [Fact]
+    public void an_empty_input_builds_an_unfiltered_default_page_query()
+    {
+        var query = new EventQueryInput().BuildQuery();
+
+        query.SpecifiedFilters.ShouldBe(EventQueryFilters.None);
+        query.PageNumber.ShouldBe(1);
+        query.PageSize.ShouldBe(50);
+        new EventQueryInput().Validate().ShouldBeNull();
+    }
+
+    [Fact]
+    public void every_flag_maps_onto_its_query_field()
+    {
+        var input = new EventQueryInput
+        {
+            StreamFlag = "stream-1",
+            EventTypeFlag = "cargo_loaded",
+            CorrelationIdFlag = "corr-1",
+            CausationIdFlag = "cause-1",
+            UserNameFlag = "helen",
+            TenantFlag = "acme",
+            TimestampFromFlag = "2026-09-01T00:00:00Z",
+            TimestampToFlag = "2026-09-02T00:00:00Z",
+            SequenceFloorFlag = 10,
+            SequenceCeilingFlag = 200,
+            TagsFlag = "{\"ManifestId\":\"m-1\"}",
+            PageFlag = 3,
+            PageSizeFlag = 25
+        };
+
+        input.Validate().ShouldBeNull();
+        var query = input.BuildQuery();
+
+        query.StreamId.ShouldBe("stream-1");
+        query.EventTypeNames.ShouldBe(["cargo_loaded"]);
+        query.EventTypeName.ShouldBeNull();
+        query.CorrelationId.ShouldBe("corr-1");
+        query.CausationId.ShouldBe("cause-1");
+        query.UserName.ShouldBe("helen");
+        query.TenantId.ShouldBe("acme");
+        query.TimestampFrom.ShouldBe(new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero));
+        query.TimestampTo.ShouldBe(new DateTimeOffset(2026, 9, 2, 0, 0, 0, TimeSpan.Zero));
+        query.SequenceFloor.ShouldBe(10);
+        query.SequenceCeiling.ShouldBe(200);
+        query.TagConditions.ShouldNotBeNull();
+        query.PageNumber.ShouldBe(3);
+        query.PageSize.ShouldBe(25);
+
+        query.SpecifiedFilters.ShouldBe(EventQueryFilters.All & ~EventQueryFilters.EventTypeName);
+    }
+
+    [Fact]
+    public void comma_separated_event_types_become_the_list_form()
+    {
+        var query = new EventQueryInput { EventTypeFlag = "cargo_loaded, cargo_unloaded ,," }.BuildQuery();
+
+        // Trimmed, empties dropped, and always through EventTypeNames — the CLI never sets the
+        // single-name member, so CombinedEventTypeNames() is exactly the flag's list.
+        query.EventTypeNames.ShouldBe(["cargo_loaded", "cargo_unloaded"]);
+        query.EventTypeName.ShouldBeNull();
+        query.CombinedEventTypeNames().ShouldBe(["cargo_loaded", "cargo_unloaded"]);
+    }
+
+    [Fact]
+    public void tags_parse_into_or_conditions_with_no_event_type_scope()
+    {
+        var (spec, error) = EventQueryInput.TryParseTags("{\"StudentId\":\"s-1\",\"CourseId\":\"c-2\"}");
+
+        error.ShouldBeNull();
+        spec.ShouldNotBeNull();
+        spec.Conditions.Count.ShouldBe(2);
+
+        spec.Conditions[0].TagType.FullName.ShouldBe("StudentId");
+        spec.Conditions[0].EventType.ShouldBeNull();
+        spec.Conditions[0].TagValue.GetString().ShouldBe("s-1");
+
+        spec.Conditions[1].TagType.FullName.ShouldBe("CourseId");
+        spec.Conditions[1].TagValue.GetString().ShouldBe("c-2");
+    }
+
+    [Fact]
+    public void a_non_string_tag_value_is_passed_through_as_given()
+    {
+        // The store side deserializes the value against the resolved tag type, so the CLI passes
+        // whatever JSON the operator supplied rather than insisting on strings.
+        var (spec, error) = EventQueryInput.TryParseTags("{\"OrderId\":{\"value\":42}}");
+
+        error.ShouldBeNull();
+        spec.ShouldNotBeNull();
+        spec.Conditions.Single().TagValue.ValueKind.ShouldBe(JsonValueKind.Object);
+        spec.Conditions.Single().TagValue.GetProperty("value").GetInt32().ShouldBe(42);
+    }
+
+    [Fact]
+    public void a_missing_tags_flag_is_no_tag_filter()
+    {
+        EventQueryInput.TryParseTags(null).ShouldBe((null, null));
+        EventQueryInput.TryParseTags("").ShouldBe((null, null));
+    }
+
+    [Fact]
+    public void unparseable_tags_json_is_refused()
+    {
+        var (spec, error) = EventQueryInput.TryParseTags("{not json");
+
+        spec.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("--tags is not valid JSON");
+    }
+
+    [Fact]
+    public void tags_that_are_not_an_object_are_refused()
+    {
+        var (spec, error) = EventQueryInput.TryParseTags("[\"StudentId\"]");
+
+        spec.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("must be a JSON object");
+    }
+
+    [Fact]
+    public void an_empty_tags_object_is_refused_rather_than_ignored()
+    {
+        // {} filters nothing; running the query unfiltered would be the silently-ignored-filter
+        // failure mode the whole jasperfx#737 surface is built to refuse.
+        var (spec, error) = EventQueryInput.TryParseTags("{}");
+
+        spec.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("empty JSON object");
+    }
+
+    [Fact]
+    public void a_null_tag_value_is_refused()
+    {
+        var (spec, error) = EventQueryInput.TryParseTags("{\"StudentId\":null}");
+
+        spec.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("StudentId");
+    }
+
+    [Fact]
+    public void tag_errors_surface_through_validate()
+    {
+        new EventQueryInput { TagsFlag = "{}" }.Validate().ShouldNotBeNull();
+        new EventQueryInput { TagsFlag = "{\"ManifestId\":\"m-1\"}" }.Validate().ShouldBeNull();
+    }
+
+    [Fact]
+    public void paging_flags_are_validated()
+    {
+        new EventQueryInput { PageFlag = 0 }.Validate().ShouldBe("--page must be 1 or greater");
+        new EventQueryInput { PageSizeFlag = 0 }.Validate().ShouldBe("--page-size must be greater than zero");
+    }
+
+    [Fact]
+    public void unparseable_timestamps_are_refused_with_the_offending_flag_named()
+    {
+        new EventQueryInput { TimestampFromFlag = "not-a-time" }.Validate()!
+            .ShouldContain("--timestamp-from");
+        new EventQueryInput { TimestampToFlag = "also-not" }.Validate()!
+            .ShouldContain("--timestamp-to");
+    }
+
+    [Fact]
+    public void inverted_windows_are_refused()
+    {
+        new EventQueryInput { TimestampFromFlag = "2026-09-02T00:00:00Z", TimestampToFlag = "2026-09-01T00:00:00Z" }
+            .Validate().ShouldBe("--timestamp-from must be less than or equal to --timestamp-to");
+
+        new EventQueryInput { SequenceFloorFlag = 10, SequenceCeilingFlag = 5 }
+            .Validate().ShouldBe("--sequence-floor must be less than or equal to --sequence-ceiling");
+    }
+
+    [Fact]
+    public void half_open_windows_are_valid()
+    {
+        new EventQueryInput { TimestampFromFlag = "2026-09-01T00:00:00Z" }.Validate().ShouldBeNull();
+        new EventQueryInput { SequenceCeilingFlag = 100 }.Validate().ShouldBeNull();
+    }
+
+    [Fact]
+    public void the_command_name_is_kebab_cased()
+    {
+        // CommandFactory only strips the "Command" suffix and lowercases, so without the explicit
+        // name this would register as "eventquery".
+        var attribute = typeof(EventQueryCommand)
+            .GetCustomAttributes(typeof(JasperFx.CommandLine.DescriptionAttribute), false)
+            .Cast<JasperFx.CommandLine.DescriptionAttribute>()
+            .Single();
+
+        attribute.Name.ShouldBe("event-query");
+    }
+}

--- a/src/EventTests/EventQueryTests.cs
+++ b/src/EventTests/EventQueryTests.cs
@@ -1,0 +1,190 @@
+using System.Text.Json;
+using JasperFx.Events;
+using JasperFx.Events.Tags;
+using Shouldly;
+
+namespace EventTests;
+
+// Coverage for jasperfx#737: the broadened EventQuery — time/sequence windows, multiple event
+// type names, folded tag conditions — and its guard rail, AssertFiltersAreSupported, which is
+// what keeps a store from silently ignoring a filter it has not implemented. The behavioral
+// (does-it-actually-filter) half lives in the shared compliance suite, EventQueryCompliance.
+public class EventQueryTests
+{
+    private record QueryManifest(string Value);
+
+    private record ManifestOpened(string Name);
+
+    [Fact]
+    public void specified_filters_is_none_on_an_empty_query()
+    {
+        new EventQuery().SpecifiedFilters.ShouldBe(EventQueryFilters.None);
+    }
+
+    [Fact]
+    public void paging_is_not_a_filter()
+    {
+        var query = new EventQuery { PageNumber = 7, PageSize = 3 };
+
+        query.SpecifiedFilters.ShouldBe(EventQueryFilters.None);
+
+        // And therefore never trips the guard rail, even against a store declaring nothing.
+        Should.NotThrow(() => query.AssertFiltersAreSupported(EventQueryFilters.None));
+    }
+
+    [Fact]
+    public void specified_filters_reflects_each_supplied_field()
+    {
+        new EventQuery { EventTypeName = "a" }.SpecifiedFilters.ShouldBe(EventQueryFilters.EventTypeName);
+        new EventQuery { EventTypeNames = ["a", "b"] }.SpecifiedFilters.ShouldBe(EventQueryFilters.EventTypeNames);
+        new EventQuery { StreamId = "s" }.SpecifiedFilters.ShouldBe(EventQueryFilters.StreamId);
+        new EventQuery { CorrelationId = "c" }.SpecifiedFilters.ShouldBe(EventQueryFilters.CorrelationId);
+        new EventQuery { CausationId = "c" }.SpecifiedFilters.ShouldBe(EventQueryFilters.CausationId);
+        new EventQuery { UserName = "u" }.SpecifiedFilters.ShouldBe(EventQueryFilters.UserName);
+        new EventQuery { TenantId = "t" }.SpecifiedFilters.ShouldBe(EventQueryFilters.TenantId);
+        new EventQuery { TimestampFrom = DateTimeOffset.UtcNow }.SpecifiedFilters.ShouldBe(EventQueryFilters.TimestampFrom);
+        new EventQuery { TimestampTo = DateTimeOffset.UtcNow }.SpecifiedFilters.ShouldBe(EventQueryFilters.TimestampTo);
+        new EventQuery { SequenceFloor = 1 }.SpecifiedFilters.ShouldBe(EventQueryFilters.SequenceFloor);
+        new EventQuery { SequenceCeiling = 100 }.SpecifiedFilters.ShouldBe(EventQueryFilters.SequenceCeiling);
+
+        var spec = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")));
+        new EventQuery { TagConditions = spec }.SpecifiedFilters.ShouldBe(EventQueryFilters.TagConditions);
+    }
+
+    [Fact]
+    public void a_fully_loaded_query_specifies_all()
+    {
+        var query = new EventQuery
+        {
+            EventTypeName = "a",
+            EventTypeNames = ["b"],
+            StreamId = "s",
+            CorrelationId = "corr",
+            CausationId = "cause",
+            UserName = "u",
+            TenantId = "t",
+            TimestampFrom = DateTimeOffset.UtcNow.AddDays(-1),
+            TimestampTo = DateTimeOffset.UtcNow,
+            SequenceFloor = 1,
+            SequenceCeiling = 100,
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")))
+        };
+
+        query.SpecifiedFilters.ShouldBe(EventQueryFilters.All);
+
+        // A fully implemented store declares All and takes anything.
+        Should.NotThrow(() => query.AssertFiltersAreSupported(EventQueryFilters.All));
+    }
+
+    [Fact]
+    public void baseline_is_exactly_the_pre_737_surface()
+    {
+        EventQueryFilters.Baseline.ShouldBe(
+            EventQueryFilters.EventTypeName | EventQueryFilters.StreamId | EventQueryFilters.CorrelationId |
+            EventQueryFilters.CausationId | EventQueryFilters.UserName | EventQueryFilters.TenantId);
+
+        EventQueryFilters.TimestampWindow.ShouldBe(EventQueryFilters.TimestampFrom | EventQueryFilters.TimestampTo);
+        EventQueryFilters.SequenceWindow.ShouldBe(EventQueryFilters.SequenceFloor | EventQueryFilters.SequenceCeiling);
+    }
+
+    [Fact]
+    public void passes_when_every_supplied_filter_is_declared()
+    {
+        var query = new EventQuery { EventTypeName = "a", StreamId = "s" };
+
+        Should.NotThrow(() => query.AssertFiltersAreSupported(EventQueryFilters.Baseline));
+    }
+
+    [Fact]
+    public void throws_not_supported_naming_exactly_the_unsupported_fields()
+    {
+        var query = new EventQuery
+        {
+            StreamId = "s",
+            TimestampFrom = DateTimeOffset.UtcNow,
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")))
+        };
+
+        // A store still on the pre-737 surface: StreamId is fine, the two new filters are not.
+        var ex = Should.Throw<NotSupportedException>(
+            () => query.AssertFiltersAreSupported(EventQueryFilters.Baseline));
+
+        ex.Message.ShouldContain("EventQuery.TimestampFrom");
+        ex.Message.ShouldContain("EventQuery.TagConditions");
+        ex.Message.ShouldNotContain("EventQuery.StreamId");
+    }
+
+    [Fact]
+    public void an_empty_event_type_names_list_is_no_filter()
+    {
+        // The default instance list must not read as a supplied filter, or every old caller
+        // would suddenly trip guard rails on stores that have not implemented the new field.
+        new EventQuery { EventTypeNames = [] }.SpecifiedFilters.ShouldBe(EventQueryFilters.None);
+        new EventQuery().CombinedEventTypeNames().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void combined_event_type_names_folds_the_single_name_into_the_list()
+    {
+        new EventQuery { EventTypeName = "a" }.CombinedEventTypeNames().ShouldBe(["a"]);
+        new EventQuery { EventTypeNames = ["b", "c"] }.CombinedEventTypeNames().ShouldBe(["b", "c"]);
+
+        // Both supplied: the union, single name first, so one code path serves both spellings.
+        new EventQuery { EventTypeName = "a", EventTypeNames = ["b", "c"] }
+            .CombinedEventTypeNames().ShouldBe(["a", "b", "c"]);
+    }
+
+    [Fact]
+    public void combined_event_type_names_is_distinct()
+    {
+        new EventQuery { EventTypeName = "a", EventTypeNames = ["a", "b", "b"] }
+            .CombinedEventTypeNames().ShouldBe(["a", "b"]);
+    }
+
+    [Fact]
+    public void round_trips_through_json_as_a_wire_shape()
+    {
+        var original = new EventQuery
+        {
+            EventTypeNames = ["manifest_opened"],
+            StreamId = "stream-1",
+            TenantId = "tenant-1",
+            TimestampFrom = new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero),
+            TimestampTo = new DateTimeOffset(2026, 9, 2, 0, 0, 0, TimeSpan.Zero),
+            SequenceFloor = 10,
+            SequenceCeiling = 200,
+            PageNumber = 2,
+            PageSize = 25,
+            TagConditions = EventTagQuerySpec.From(
+                new EventTagQuery().Or<ManifestOpened, QueryManifest>(new QueryManifest("m-1")))
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var query = JsonSerializer.Deserialize<EventQuery>(json);
+
+        query.ShouldNotBeNull();
+        query.EventTypeNames.ShouldBe(["manifest_opened"]);
+        query.StreamId.ShouldBe("stream-1");
+        query.TenantId.ShouldBe("tenant-1");
+        query.TimestampFrom.ShouldBe(original.TimestampFrom);
+        query.TimestampTo.ShouldBe(original.TimestampTo);
+        query.SequenceFloor.ShouldBe(10);
+        query.SequenceCeiling.ShouldBe(200);
+        query.PageNumber.ShouldBe(2);
+        query.PageSize.ShouldBe(25);
+
+        query.SpecifiedFilters.ShouldBe(original.SpecifiedFilters);
+
+        // The folded tag conditions survive the hop and resolve back to CLR types, exactly as
+        // EventTagQuerySpec promises on its own (jasperfx#545) — folding it into EventQuery must
+        // not cost that.
+        query.TagConditions.ShouldNotBeNull();
+        var resolver = EventTagQuerySpec.ResolverFor([typeof(QueryManifest), typeof(ManifestOpened)]);
+        var rehydrated = query.TagConditions.Resolve(resolver);
+
+        var condition = rehydrated.Conditions.ShouldHaveSingleItem();
+        condition.EventType.ShouldBe(typeof(ManifestOpened));
+        condition.TagType.ShouldBe(typeof(QueryManifest));
+        condition.TagValue.ShouldBe(new QueryManifest("m-1"));
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -66,6 +66,15 @@ public sealed class ComplianceStoreConfig
     public bool EnableCorrelationTracking { get; set; }
 
     /// <summary>
+    /// Persist the session's user name (last-modified-by) metadata onto appended events. Off by
+    /// default in both products and spelled differently in each — Marten's
+    /// <c>Events.MetadataConfig.UserNameEnabled</c>, Polecat's <c>Events.EnableUserName</c> — so the
+    /// fixture resolves it, exactly like <see cref="EnableCorrelationTracking"/>. Added for the
+    /// jasperfx#737 event query suite.
+    /// </summary>
+    public bool EnableUserNameTracking { get; set; }
+
+    /// <summary>
     /// Persist per-event header dictionaries. Off by default in both products and spelled
     /// differently in each — Marten's <c>Events.MetadataConfig.HeadersEnabled</c>, Polecat's
     /// <c>Events.EnableHeaders</c> — so the fixture resolves it, exactly like

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -112,6 +112,17 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     public abstract void SetCorrelationId(TOperations session, string? correlationId);
 
     /// <summary>
+    /// Assign the session's user name (last-modified-by) metadata, which the store stamps onto
+    /// appended events when user name metadata is enabled.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the same reason as <see cref="SetCorrelationId"/>: both products hang the member
+    /// off their own session type and <see cref="IStorageOperations"/> deliberately stays narrow.
+    /// Added for the jasperfx#737 event query suite, which filters on the user name column.
+    /// </remarks>
+    public abstract void SetUserName(TOperations session, string? userName);
+
+    /// <summary>
     /// The store itself, as the shared <see cref="IEventStore"/> surface. Suites reach for this on
     /// store-level contracts — the rebuild concurrency cap, usage descriptors — never for anything
     /// session-scoped.

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -54,6 +54,9 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
     protected void SetCorrelationId(TOperations session, string? correlationId)
         => theFixture.SetCorrelationId(session, correlationId);
 
+    protected void SetUserName(TOperations session, string? userName)
+        => theFixture.SetUserName(session, userName);
+
     protected Task SaveChangesAsync(TOperations session) => theFixture.SaveChangesAsync(session, Cancellation);
 
     protected Task<T?> LoadDocumentAsync<T>(TQuerySession session, object id) where T : class

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -197,6 +197,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Projection rebuild and catch-up semantics | `RebuildAndCatchUpCompliance` |
 | The projection error path and dead letters | `DeadLetterCompliance` |
 | Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
+| The cross-stream event query (`QueryEventsAsync`) | `EventQueryCompliance` |
 | Subscriptions | `SubscriptionCompliance` |
 | Single-tenanted slicing of disagreeing tenant ids | `SingleTenantedEventSlicingCompliance` |
 | Composite projections — staging and member teardown | `CompositeProjectionCompliance` |

--- a/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
@@ -242,4 +242,36 @@ public abstract class ConjoinedEventTenancyCompliance<TFixture, TOperations, TQu
         state.ShouldNotBeNull();
         state.Version.ShouldBe(1);
     }
+
+    /// <summary>
+    /// The <see cref="EventQuery.TenantId"/> filter on the cross-stream query surface. Lives here
+    /// rather than in <see cref="EventQueryCompliance{TFixture,TOperations,TQuerySession}"/> because
+    /// this suite owns the conjoined-tenancy store configuration — the same division of labor as
+    /// the explorer suite's per-tenant overloads. See jasperfx#737.
+    /// </summary>
+    [Fact]
+    public async Task query_events_filtered_by_tenant_id()
+    {
+        await appendAsync(TenantA, Guid.NewGuid(), new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+        await appendAsync(TenantB, Guid.NewGuid(), new ConsignmentBooked("Lisbon"));
+
+        var readOnly = theFixture.EventStore.OpenReadOnlyEventStore();
+
+        var result = await readOnly.QueryEventsAsync(
+            new EventQuery { TenantId = TenantA, PageSize = 1000 }, Cancellation);
+
+        // Both directions, as everywhere in this suite: tenant A's events are all there, and
+        // tenant B's event is not — a leak still returns correct answers for the tenant that
+        // happens to own the data.
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.TenantId == TenantA);
+
+        var other = await readOnly.QueryEventsAsync(
+            new EventQuery { TenantId = TenantB, PageSize = 1000 }, Cancellation);
+
+        other.TotalCount.ShouldBe(1);
+        other.Events.Single().TenantId.ShouldBe(TenantB);
+        other.Events.Single().Data.ShouldBeOfType<ConsignmentBooked>().Destination.ShouldBe("Lisbon");
+    }
 }

--- a/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
@@ -274,4 +274,31 @@ public abstract class ConjoinedEventTenancyCompliance<TFixture, TOperations, TQu
         other.Events.Single().TenantId.ShouldBe(TenantB);
         other.Events.Single().Data.ShouldBeOfType<ConsignmentBooked>().Destination.ShouldBe("Lisbon");
     }
+
+    /// <summary>
+    /// The tenant filter AND-composes with the other <see cref="EventQuery"/> filters rather than
+    /// replacing them. Decoys in both directions: the matching tenant holds a non-matching event
+    /// type, and the other tenant holds a matching one — so dropping either filter changes the
+    /// answer. (Deliberately a type filter rather than a tag condition: tag types are not part of
+    /// this suite's store configuration, and tags-under-conjoined-tenancy is DCB-suite territory.)
+    /// </summary>
+    [Fact]
+    public async Task query_events_composes_the_tenant_filter_with_other_filters()
+    {
+        await appendAsync(TenantA, Guid.NewGuid(), new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+        await appendAsync(TenantA, Guid.NewGuid(), new ConsignmentBooked("Chicago"));
+        await appendAsync(TenantB, Guid.NewGuid(), new ConsignmentBooked("Lisbon"));
+
+        var result = await theFixture.EventStore.OpenReadOnlyEventStore().QueryEventsAsync(
+            new EventQuery
+            {
+                TenantId = TenantA, EventTypeName = EventTypeNameFor<ConsignmentBooked>(), PageSize = 1000
+            },
+            Cancellation);
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.TenantId == TenantA);
+        result.Events.Select(x => ((ConsignmentBooked)x.Data!).Destination)
+            .OrderBy(x => x).ShouldBe(["Boston", "Chicago"]);
+    }
 }

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
@@ -421,4 +421,780 @@ public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
         result.TotalCount.ShouldBe(1);
         result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("grain");
     }
+
+    // ---- filter permutations ----
+    //
+    // Real queries combine filters, and every combination is a fresh chance for one store to
+    // AND-compose where another intersects wrongly or drops a filter under the presence of a
+    // second. Each test still asserts exact expected membership and TotalCount — the assertions
+    // that fail against a silently-dropped filter — never that the call succeeded.
+
+    /// <summary>
+    /// Three saves separated by real wall-clock gaps, read back through the store so the returned
+    /// timestamps carry the store's own precision. Order: [0] Loaded (batch 1), [1] Inspected and
+    /// [2] Loaded (batch 2, one save), [3] Unloaded (batch 3). The type overlap across batches is
+    /// the point — a timestamp window and a type filter each exclude something the other keeps.
+    /// </summary>
+    private async Task<IReadOnlyList<IEvent>> seedTimedBatchesAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await appendAsync(streamId, new CargoLoaded("one"));
+        await Task.Delay(40, Cancellation);
+        await appendAsync(streamId, new CargoInspected("two-a"), new CargoLoaded("two-b"));
+        await Task.Delay(40, Cancellation);
+        await appendAsync(streamId, new CargoUnloaded("three"));
+
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(4);
+        return all.Events;
+    }
+
+    [Fact]
+    public async Task filters_by_event_type_and_stream_together()
+    {
+        var (streamOne, _) = await seedInterleavedAsync();
+
+        // Decoys in both directions: streamOne holds a non-Loaded event, streamTwo holds a Loaded.
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            StreamId = streamOne.ToString(),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("grain");
+    }
+
+    [Fact]
+    public async Task filters_by_event_type_and_timestamp_window_together()
+    {
+        var timed = await seedTimedBatchesAsync();
+
+        // The window admits batch 2 only; the type filter then drops its Inspected event. The
+        // Loaded event of batch 1 is the trap for a store that applies the type filter and drops
+        // the window.
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            TimestampFrom = timed[1].Timestamp,
+            TimestampTo = timed[2].Timestamp,
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(timed[2].Sequence);
+    }
+
+    [Fact]
+    public async Task filters_by_event_type_and_sequence_window_together()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        // Window admits positions 1..3 (Loaded, Inspected, Inspected); the type filter keeps the
+        // two Inspected events. The Inspected at position 2 and 3 both survive, nothing else.
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoInspected>(),
+            SequenceFloor = sequences[1],
+            SequenceCeiling = sequences[3],
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Select(x => x.Sequence).ShouldBe([sequences[2], sequences[3]]);
+    }
+
+    [Fact]
+    public async Task filters_by_stream_and_sequence_window_together()
+    {
+        var (streamOne, _) = await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        // The window spans positions 1..4; streamOne owns positions 2 and 4 of that span. Its
+        // position-0 event is the trap for a dropped window; streamTwo's in-window events are the
+        // trap for a dropped stream filter.
+        var result = await queryAsync(new EventQuery
+        {
+            StreamId = streamOne.ToString(),
+            SequenceFloor = sequences[1],
+            SequenceCeiling = sequences[4],
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Select(x => x.Sequence).ShouldBe([sequences[2], sequences[4]]);
+    }
+
+    [Fact]
+    public async Task filters_by_correlation_id_and_event_type_together()
+    {
+        var matching = $"corr-{Guid.NewGuid():N}";
+
+        await using (var session = OpenSession())
+        {
+            SetCorrelationId(session, matching);
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("grain"), new CargoInspected("alice"));
+            await SaveChangesAsync(session);
+        }
+
+        // Same type as the expected match, wrong correlation — the trap for a dropped correlation
+        // filter; the matching session's Inspected event is the trap for a dropped type filter.
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("coal"));
+
+        var result = await queryAsync(new EventQuery
+        {
+            CorrelationId = matching,
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("grain");
+    }
+
+    [Fact]
+    public async Task filters_by_correlation_id_and_timestamp_window_together()
+    {
+        var matching = $"corr-{Guid.NewGuid():N}";
+        var other = $"corr-{Guid.NewGuid():N}";
+
+        async Task appendWithCorrelationAsync(string correlationId, object @event)
+        {
+            await using var session = OpenSession();
+            SetCorrelationId(session, correlationId);
+            EventsFor(session).Append(Guid.NewGuid(), @event);
+            await SaveChangesAsync(session);
+        }
+
+        await appendWithCorrelationAsync(matching, new CargoLoaded("early"));
+        await Task.Delay(40, Cancellation);
+        await appendWithCorrelationAsync(matching, new CargoInspected("late"));
+        await appendWithCorrelationAsync(other, new CargoLoaded("late-other"));
+
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(3);
+
+        // The window admits the two late events; the correlation filter keeps one of them. The
+        // early matching event is the trap for a dropped window, the late other-correlation event
+        // for a dropped correlation filter.
+        var result = await queryAsync(new EventQuery
+        {
+            CorrelationId = matching,
+            TimestampFrom = all.Events[1].Timestamp,
+            TimestampTo = all.Events[2].Timestamp,
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(all.Events[1].Sequence);
+    }
+
+    [Fact]
+    public async Task filters_by_tags_and_sequence_window_together()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("tagged-early"), manifest);
+        await appendAsync(Guid.NewGuid(), new CargoInspected("untagged"));
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoUnloaded("tagged-late"), manifest);
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("untagged-late"));
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        // The window admits positions 1..3; the tag matches positions 0 and 2. Intersection: 2.
+        var result = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(manifest)),
+            SequenceFloor = sequences[1],
+            SequenceCeiling = sequences[3],
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(sequences[2]);
+        result.Events.Single().Data.ShouldBeOfType<CargoUnloaded>();
+    }
+
+    [Fact]
+    public async Task filters_by_user_name_and_event_type_together()
+    {
+        await using (var session = OpenSession())
+        {
+            SetUserName(session, "helen");
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("grain"), new CargoInspected("alice"));
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            SetUserName(session, "greta");
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("coal"));
+            await SaveChangesAsync(session);
+        }
+
+        var result = await queryAsync(new EventQuery
+        {
+            UserName = "helen",
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("grain");
+    }
+
+    [Fact]
+    public async Task filters_by_multiple_event_types_and_stream_together()
+    {
+        var (streamOne, _) = await seedInterleavedAsync();
+
+        // streamTwo's Loaded is the trap for a dropped stream filter, streamOne's Inspected for a
+        // dropped type list.
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeNames = [EventTypeNameFor<CargoLoaded>(), EventTypeNameFor<CargoUnloaded>()],
+            StreamId = streamOne.ToString(),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.ShouldContain(x => x.Data is CargoLoaded);
+        result.Events.ShouldContain(x => x.Data is CargoUnloaded);
+    }
+
+    /// <summary>
+    /// Three filters whose pairwise intersections all differ from the three-way one, so a store
+    /// that applies any two and drops the third fails on membership.
+    /// </summary>
+    [Fact]
+    public async Task type_and_both_windows_intersect_as_and()
+    {
+        var timed = await seedTimedBatchesAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            // Batches 2 and 3...
+            TimestampFrom = timed[1].Timestamp,
+            TimestampTo = timed[3].Timestamp,
+            // ...intersected with batches 1 and 2...
+            SequenceFloor = timed[0].Sequence,
+            SequenceCeiling = timed[2].Sequence,
+            // ...is batch 2, whose Loaded event is [2].
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(timed[2].Sequence);
+    }
+
+    /// <summary>
+    /// Every filter the suite's store configuration can express, at once — all of
+    /// <see cref="EventQueryFilters.All"/> except <see cref="EventQueryFilters.TenantId"/>, which
+    /// belongs to the conjoined tenancy suite. Exactly one seeded event satisfies everything, and
+    /// each decoy fails a different single filter, so any dropped filter changes the answer.
+    /// </summary>
+    [Fact]
+    public async Task a_kitchen_sink_query_isolates_exactly_one_event()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+        var correlation = $"sink-{Guid.NewGuid():N}";
+
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        var parent = new Activity("sink-parent").Start();
+        var child = new Activity("sink-child").Start();
+
+        string? causation;
+        try
+        {
+            await using var session = OpenSession();
+            causation = CausationIdFor(session);
+            SetCorrelationId(session, correlation);
+            SetUserName(session, "sink-user");
+
+            var target = EventsFor(session).BuildEvent(new CargoLoaded("bullseye"));
+            target.WithTag(manifest);
+            EventsFor(session).Append(streamId, target);
+
+            // Fails only the event type filter.
+            var wrongType = EventsFor(session).BuildEvent(new CargoInspected("decoy"));
+            wrongType.WithTag(manifest);
+            EventsFor(session).Append(streamId, wrongType);
+
+            // Fails only the stream filter.
+            var wrongStream = EventsFor(session).BuildEvent(new CargoLoaded("wrong-stream"));
+            wrongStream.WithTag(manifest);
+            EventsFor(session).Append(Guid.NewGuid(), wrongStream);
+
+            await SaveChangesAsync(session);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+
+        causation.ShouldNotBeNull();
+
+        // Fails the tag, correlation, causation and user filters at once.
+        await appendAsync(streamId, new CargoLoaded("untagged"));
+
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(4);
+
+        var result = await queryAsync(new EventQuery
+        {
+            StreamId = streamId.ToString(),
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            EventTypeNames = [EventTypeNameFor<CargoUnloaded>()],
+            CorrelationId = correlation,
+            CausationId = causation,
+            UserName = "sink-user",
+            // The windows span everything seeded: present, honored, and deliberately not the
+            // thing that decides — the dedicated window tests own that.
+            TimestampFrom = all.Events[0].Timestamp,
+            TimestampTo = all.Events[^1].Timestamp,
+            SequenceFloor = all.Events[0].Sequence,
+            SequenceCeiling = all.Events[^1].Sequence,
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(manifest)),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("bullseye");
+    }
+
+    // ---- window edge permutations ----
+
+    [Fact]
+    public async Task timestamp_from_alone_is_a_half_open_window()
+    {
+        var timed = await seedTimedBatchesAsync();
+
+        var result = await queryAsync(new EventQuery { TimestampFrom = timed[1].Timestamp, PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(3);
+        result.Events.Select(x => x.Sequence).ShouldBe(timed.Skip(1).Select(x => x.Sequence).ToList());
+    }
+
+    [Fact]
+    public async Task timestamp_to_alone_is_a_half_open_window()
+    {
+        var timed = await seedTimedBatchesAsync();
+
+        var result = await queryAsync(new EventQuery { TimestampTo = timed[2].Timestamp, PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(3);
+        result.Events.Select(x => x.Sequence).ShouldBe(timed.Take(3).Select(x => x.Sequence).ToList());
+    }
+
+    [Fact]
+    public async Task sequence_floor_alone_is_a_half_open_window()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        var result = await queryAsync(new EventQuery { SequenceFloor = sequences[2], PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(3);
+        result.Events.Select(x => x.Sequence).ShouldBe(sequences.Skip(2).ToList());
+    }
+
+    [Fact]
+    public async Task sequence_ceiling_alone_is_a_half_open_window()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        var result = await queryAsync(new EventQuery { SequenceCeiling = sequences[2], PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(3);
+        result.Events.Select(x => x.Sequence).ShouldBe(sequences.Take(3).ToList());
+    }
+
+    [Fact]
+    public async Task a_sequence_window_of_one_sequence_returns_exactly_that_event()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var target = all.Events[2];
+
+        var result = await queryAsync(new EventQuery
+        {
+            SequenceFloor = target.Sequence,
+            SequenceCeiling = target.Sequence,
+            PageSize = 1000
+        });
+
+        // Fails on either exclusive end: an exclusive floor or ceiling makes this empty.
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(target.Sequence);
+    }
+
+    [Fact]
+    public async Task a_timestamp_window_of_one_instant_returns_exactly_the_events_at_it()
+    {
+        var timed = await seedTimedBatchesAsync();
+
+        // Batch 3 is a single event separated from its neighbors by real wall-clock gaps, so its
+        // read-back timestamp identifies it alone at the store's own precision.
+        var target = timed[3];
+
+        var result = await queryAsync(new EventQuery
+        {
+            TimestampFrom = target.Timestamp,
+            TimestampTo = target.Timestamp,
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(target.Sequence);
+    }
+
+    /// <summary>
+    /// Inclusive-boundary proof at both extremes of the store: windows pinned to the first and
+    /// last events return everything. A store excluding either end loses exactly one event here.
+    /// </summary>
+    [Fact]
+    public async Task windows_pinned_to_the_first_and_last_events_are_inclusive_at_both_extremes()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        var bySequence = await queryAsync(new EventQuery
+        {
+            SequenceFloor = sequences[0],
+            SequenceCeiling = sequences[^1],
+            PageSize = 1000
+        });
+
+        bySequence.TotalCount.ShouldBe(5);
+        bySequence.Events.Select(x => x.Sequence).ShouldBe(sequences);
+
+        var byTimestamp = await queryAsync(new EventQuery
+        {
+            TimestampFrom = all.Events[0].Timestamp,
+            TimestampTo = all.Events[^1].Timestamp,
+            PageSize = 1000
+        });
+
+        byTimestamp.TotalCount.ShouldBe(5);
+        byTimestamp.Events.Select(x => x.Sequence).ShouldBe(sequences);
+    }
+
+    [Fact]
+    public async Task a_window_matching_nothing_is_an_empty_answer_not_an_error()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        var maxSequence = all.Events[^1].Sequence;
+
+        var bySequence = await queryAsync(new EventQuery
+        {
+            SequenceFloor = maxSequence + 1000,
+            SequenceCeiling = maxSequence + 2000,
+            PageSize = 1000
+        });
+
+        bySequence.TotalCount.ShouldBe(0);
+        bySequence.Events.ShouldBeEmpty();
+
+        var byTimestamp = await queryAsync(new EventQuery
+        {
+            TimestampFrom = DateTimeOffset.UtcNow.AddYears(10),
+            PageSize = 1000
+        });
+
+        byTimestamp.TotalCount.ShouldBe(0);
+        byTimestamp.Events.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// The documented contract on <see cref="EventQuery"/>: an inverted window is a well-formed
+    /// range that contains nothing — an empty page, never an error.
+    /// </summary>
+    [Fact]
+    public async Task an_inverted_window_matches_nothing_by_contract()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+
+        var bySequence = await queryAsync(new EventQuery
+        {
+            SequenceFloor = all.Events[^1].Sequence,
+            SequenceCeiling = all.Events[0].Sequence,
+            PageSize = 1000
+        });
+
+        bySequence.TotalCount.ShouldBe(0);
+        bySequence.Events.ShouldBeEmpty();
+
+        var byTimestamp = await queryAsync(new EventQuery
+        {
+            TimestampFrom = all.Events[^1].Timestamp.AddDays(1),
+            TimestampTo = all.Events[0].Timestamp,
+            PageSize = 1000
+        });
+
+        byTimestamp.TotalCount.ShouldBe(0);
+        byTimestamp.Events.ShouldBeEmpty();
+    }
+
+    // ---- paging × filtering ----
+
+    /// <summary>
+    /// Paging applies to the FILTERED, sequence-ordered result: pages are disjoint, complete and
+    /// ordered across page boundaries, TotalCount is the filtered total on every page, the last
+    /// page is short, and a page past the end is empty with the total intact.
+    /// </summary>
+    [Fact]
+    public async Task paging_composes_with_filtering()
+    {
+        // Seven Inspected events interleaved with three Loaded, across streams, one save each —
+        // so the Inspected sequences are non-contiguous and a store paging BEFORE filtering
+        // produces short or bleeding pages.
+        for (var i = 0; i < 10; i++)
+        {
+            object @event = i % 3 == 0 ? new CargoLoaded($"noise-{i}") : new CargoInspected($"match-{i}");
+            await appendAsync(Guid.NewGuid(), @event);
+        }
+
+        var unpaged = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoInspected>(), PageSize = 1000
+        });
+        unpaged.TotalCount.ShouldBe(7);
+
+        var pages = new List<PagedEvents>();
+        for (var pageNumber = 1; pageNumber <= 3; pageNumber++)
+        {
+            pages.Add(await queryAsync(new EventQuery
+            {
+                EventTypeName = EventTypeNameFor<CargoInspected>(),
+                PageNumber = pageNumber,
+                PageSize = 3
+            }));
+        }
+
+        foreach (var page in pages)
+        {
+            page.TotalCount.ShouldBe(7);
+            page.Events.ShouldAllBe(x => x.Data is CargoInspected);
+        }
+
+        pages[0].Events.Count.ShouldBe(3);
+        pages[1].Events.Count.ShouldBe(3);
+        pages[2].Events.Count.ShouldBe(1);
+
+        pages.SelectMany(x => x.Events).Select(x => x.Sequence)
+            .ShouldBe(unpaged.Events.Select(x => x.Sequence));
+
+        var pastTheEnd = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoInspected>(),
+            PageNumber = 10,
+            PageSize = 3
+        });
+
+        // An empty page, but a truthful total — a consumer walking pages needs the count to know
+        // it overshot rather than that nothing matched.
+        pastTheEnd.Events.ShouldBeEmpty();
+        pastTheEnd.TotalCount.ShouldBe(7);
+    }
+
+    // ---- multi-type permutations ----
+
+    [Fact]
+    public async Task an_unknown_event_type_name_unions_quietly_with_known_ones()
+    {
+        await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeNames = [EventTypeNameFor<CargoLoaded>(), "no_such_event_type"],
+            PageSize = 1000
+        });
+
+        // The unknown name contributes nothing; it is not an error and it must not damage the
+        // half of the union that matches.
+        result.TotalCount.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.Data is CargoLoaded);
+    }
+
+    [Fact]
+    public async Task duplicate_event_type_names_do_not_double_count()
+    {
+        await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeNames =
+                [EventTypeNameFor<CargoInspected>(), EventTypeNameFor<CargoInspected>()],
+            PageSize = 1000
+        });
+
+        // Two spellings of one condition: the same two events, once each — a UNION ALL shape
+        // (or a doubled join) reads back four and fails both assertions.
+        result.TotalCount.ShouldBe(2);
+        result.Events.Select(x => x.Sequence).Distinct().Count().ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task a_single_name_overlapping_the_list_dedupes()
+    {
+        await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            EventTypeNames = [EventTypeNameFor<CargoLoaded>(), EventTypeNameFor<CargoUnloaded>()],
+            PageSize = 1000
+        });
+
+        // The union of {Loaded} and {Loaded, Unloaded} is three events, with the two Loaded
+        // events appearing once each.
+        result.TotalCount.ShouldBe(3);
+        result.Events.Count(x => x.Data is CargoLoaded).ShouldBe(2);
+        result.Events.Count(x => x.Data is CargoUnloaded).ShouldBe(1);
+    }
+
+    // ---- tag permutations ----
+
+    [Fact]
+    public async Task overlapping_tag_conditions_do_not_duplicate_events()
+    {
+        var first = new ManifestId(Guid.NewGuid());
+        var second = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        // Carries BOTH tags, so both OR conditions match it.
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("both"), first, second);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("first-only"), first);
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("untagged"));
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(first).Or(second)),
+            PageSize = 1000
+        });
+
+        // The doubly-tagged event appears once. TotalCount counts distinct events, not condition
+        // hits — a tag-table join without a distinct reads three rows here.
+        result.TotalCount.ShouldBe(2);
+        result.Events.Select(x => x.Sequence).Distinct().Count().ShouldBe(2);
+        result.Events.ShouldContain(x => x.Data is CargoLoaded);
+        result.Events.ShouldContain(x => x.Data is CargoInspected);
+    }
+
+    [Fact]
+    public async Task a_tag_condition_scoped_to_an_event_type_narrows_the_unscoped_match()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("grain"), manifest);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("alice"), manifest);
+
+        var unscoped = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(manifest)),
+            PageSize = 1000
+        });
+
+        unscoped.TotalCount.ShouldBe(2);
+
+        // The same tag value, but the condition itself carries the event type — the
+        // EventTagQueryConditionSpec.EventType slot, distinct from EventQuery's own type filter.
+        var scoped = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(
+                new EventTagQuery().Or<CargoLoaded, ManifestId>(manifest)),
+            PageSize = 1000
+        });
+
+        scoped.TotalCount.ShouldBe(1);
+        scoped.Events.Single().Data.ShouldBeOfType<CargoLoaded>();
+    }
+
+    [Fact]
+    public async Task tagged_events_across_streams_return_in_global_sequence_order()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("first"), manifest);
+        await appendAsync(Guid.NewGuid(), new CargoInspected("noise-1"));
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("second"), manifest);
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("noise-2"));
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoUnloaded("third"), manifest);
+
+        var all = await queryAllAsync();
+        var taggedSequences = new[] { all.Events[0], all.Events[2], all.Events[4] }
+            .Select(x => x.Sequence).ToList();
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(manifest)),
+            PageSize = 1000
+        });
+
+        // Three streams, so a per-stream or per-tag-table ordering shows here where the
+        // single-stream tests cannot see it.
+        result.TotalCount.ShouldBe(3);
+        result.Events.Select(x => x.Sequence).ShouldBe(taggedSequences);
+    }
+
+    // ---- filters against data that contains none of it ----
+
+    /// <summary>
+    /// Every filter, one at a time, against seeded data that matches none of it: a truthful zero
+    /// each time, never a throw. The mirror image of the guard rail — "I support this filter and
+    /// nothing matches" must stay distinguishable from "I ignored this filter".
+    /// </summary>
+    [Fact]
+    public async Task every_filter_alone_returns_an_empty_answer_when_nothing_matches()
+    {
+        await seedInterleavedAsync();
+
+        var nonMatching = new EventQuery[]
+        {
+            new() { EventTypeName = "no_such_event_type" },
+            new() { EventTypeNames = ["no_such_event_type", "nor_this_one"] },
+            new() { StreamId = Guid.NewGuid().ToString() },
+            new() { CorrelationId = $"corr-{Guid.NewGuid():N}" },
+            new() { CausationId = $"cause-{Guid.NewGuid():N}" },
+            new() { UserName = $"user-{Guid.NewGuid():N}" },
+            new() { TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new ManifestId(Guid.NewGuid()))) }
+        };
+
+        foreach (var query in nonMatching)
+        {
+            query.PageSize = 1000;
+            var result = await queryAsync(query);
+
+            result.TotalCount.ShouldBe(0,
+                $"the {query.SpecifiedFilters} filter should have matched nothing");
+            result.Events.ShouldBeEmpty();
+        }
+    }
 }

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
@@ -1,0 +1,424 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Tags;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Event query events and tag
+
+public record CargoLoaded(string Cargo);
+
+public record CargoInspected(string Inspector);
+
+public record CargoUnloaded(string Port);
+
+/// <summary>
+/// Strong-typed tag identity for the folded tag-condition filter.
+/// </summary>
+public record ManifestId(Guid Value);
+
+#endregion
+
+/// <summary>
+/// The cross-stream query surface — <c>IReadOnlyEventStore.QueryEventsAsync(EventQuery)</c>: every
+/// filter field, the sequence-ascending ordering contract, and the paging contract. See
+/// jasperfx#737.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every filter test here asserts the filter <em>actually filters</em> — that the result is a
+/// strict subset of the unfiltered result with the right membership — never merely that the call
+/// succeeds. The failure mode this suite exists to prevent is a silently-ignored filter: an
+/// implementation that drops a filter it does not understand returns unfiltered results that read
+/// as filtered, and a call-succeeds test is green against exactly that bug. The abstraction-side
+/// guard rail is <see cref="EventQuery.AssertFiltersAreSupported"/>; this suite is the
+/// behavior-side proof for stores that do declare a filter.
+/// </para>
+/// <para>
+/// The <see cref="EventQuery.TenantId"/> filter is deliberately not exercised here — it belongs
+/// with <see cref="ConjoinedEventTenancyCompliance{TFixture,TOperations,TQuerySession}"/>, which
+/// owns the tenant-scoped store configuration, and it has a test there.
+/// </para>
+/// </remarks>
+public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_event_query";
+
+        config.AddEventType<CargoLoaded>();
+        config.AddEventType<CargoInspected>();
+        config.AddEventType<CargoUnloaded>();
+
+        // The metadata filters (CorrelationId, CausationId, UserName) are only honored when the
+        // store captures the columns, so the suite turns the capture on.
+        config.EnableCorrelationTracking = true;
+        config.EnableUserNameTracking = true;
+
+        // No aggregate association: the tag is used purely as a query dimension here.
+        config.RegisterTagType<ManifestId>("manifest");
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private Task<PagedEvents> queryAsync(EventQuery query)
+        => theFixture.EventStore.OpenReadOnlyEventStore().QueryEventsAsync(query, Cancellation);
+
+    /// <summary>
+    /// Everything the store currently holds, in the contract ordering, sized so nothing pages out.
+    /// </summary>
+    private Task<PagedEvents> queryAllAsync() => queryAsync(new EventQuery { PageSize = 1000 });
+
+    /// <summary>
+    /// One save per call, so consecutive calls occupy strictly increasing sequence ranges.
+    /// </summary>
+    private async Task appendAsync(Guid streamId, params object[] events)
+    {
+        await using var session = OpenSession();
+        EventsFor(session).Append(streamId, events);
+        await SaveChangesAsync(session);
+    }
+
+    /// <summary>
+    /// The standard five-event seed: streamOne holds Loaded/Inspected/Unloaded, streamTwo holds
+    /// Loaded/Inspected, interleaved save-by-save so the global sequence alternates between the
+    /// streams.
+    /// </summary>
+    private async Task<(Guid StreamOne, Guid StreamTwo)> seedInterleavedAsync()
+    {
+        var streamOne = Guid.NewGuid();
+        var streamTwo = Guid.NewGuid();
+
+        await appendAsync(streamOne, new CargoLoaded("grain"));
+        await appendAsync(streamTwo, new CargoLoaded("coal"));
+        await appendAsync(streamOne, new CargoInspected("alice"));
+        await appendAsync(streamTwo, new CargoInspected("bob"));
+        await appendAsync(streamOne, new CargoUnloaded("Lisbon"));
+
+        return (streamOne, streamTwo);
+    }
+
+    [Fact]
+    public async Task results_are_ordered_by_sequence_ascending_across_streams()
+    {
+        var (streamOne, streamTwo) = await seedInterleavedAsync();
+
+        var result = await queryAllAsync();
+
+        result.Events.Count.ShouldBe(5);
+
+        // Strictly ascending, so the ordering is total and by the store-global sequence.
+        result.Events.Select(x => x.Sequence)
+            .ShouldBe(result.Events.Select(x => x.Sequence).OrderBy(x => x).ToList());
+        result.Events.Select(x => x.Sequence).Distinct().Count().ShouldBe(5);
+
+        // The seed interleaved the two streams save-by-save, so a sequence-ascending result
+        // alternates between them. A result grouped by stream (or ordered per-stream) fails here.
+        result.Events.Select(x => x.StreamId)
+            .ShouldBe([streamOne, streamTwo, streamOne, streamTwo, streamOne]);
+    }
+
+    [Fact]
+    public async Task paging_walks_the_sequence_ordering_and_reports_the_total()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(5);
+
+        var pages = new List<PagedEvents>();
+        for (var pageNumber = 1; pageNumber <= 3; pageNumber++)
+        {
+            pages.Add(await queryAsync(new EventQuery { PageNumber = pageNumber, PageSize = 2 }));
+        }
+
+        foreach (var page in pages)
+        {
+            // TotalCount is the match count across every page, identical on each of them.
+            page.TotalCount.ShouldBe(5);
+            page.PageSize.ShouldBe(2);
+        }
+
+        pages[0].PageNumber.ShouldBe(1);
+        pages[1].PageNumber.ShouldBe(2);
+        pages[2].PageNumber.ShouldBe(3);
+
+        pages[0].Events.Count.ShouldBe(2);
+        pages[1].Events.Count.ShouldBe(2);
+        pages[2].Events.Count.ShouldBe(1);
+
+        // The pages, concatenated, are exactly the unpaged result: disjoint, complete, and in the
+        // same sequence-ascending order.
+        pages.SelectMany(x => x.Events).Select(x => x.Sequence)
+            .ShouldBe(all.Events.Select(x => x.Sequence));
+    }
+
+    [Fact]
+    public async Task filters_by_a_single_event_type_name()
+    {
+        await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoInspected>(), PageSize = 1000
+        });
+
+        // Fewer than the five seeded events, so the filter demonstrably filtered.
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.Data is CargoInspected);
+    }
+
+    [Fact]
+    public async Task filters_by_multiple_event_type_names()
+    {
+        await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeNames = [EventTypeNameFor<CargoLoaded>(), EventTypeNameFor<CargoUnloaded>()],
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(3);
+        result.Events.Count.ShouldBe(3);
+        result.Events.ShouldAllBe(x => x.Data is CargoLoaded || x.Data is CargoUnloaded);
+        result.Events.ShouldContain(x => x.Data is CargoUnloaded);
+    }
+
+    /// <summary>
+    /// The documented semantics when both spellings are supplied: the single name unions into the
+    /// list. See <see cref="EventQuery.CombinedEventTypeNames"/>.
+    /// </summary>
+    [Fact]
+    public async Task the_single_event_type_name_unions_into_the_list()
+    {
+        await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            EventTypeNames = [EventTypeNameFor<CargoUnloaded>()],
+            PageSize = 1000
+        });
+
+        // Union, not intersection (no event is two types at once) and not either-one-wins: both
+        // Loaded and Unloaded events return, Inspected does not.
+        result.TotalCount.ShouldBe(3);
+        result.Events.ShouldContain(x => x.Data is CargoLoaded);
+        result.Events.ShouldContain(x => x.Data is CargoUnloaded);
+        result.Events.ShouldAllBe(x => !(x.Data is CargoInspected));
+    }
+
+    [Fact]
+    public async Task filters_by_stream_id()
+    {
+        var (streamOne, _) = await seedInterleavedAsync();
+
+        var result = await queryAsync(new EventQuery { StreamId = streamOne.ToString(), PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(3);
+        result.Events.Count.ShouldBe(3);
+        result.Events.ShouldAllBe(x => x.StreamId == streamOne);
+    }
+
+    [Fact]
+    public async Task filters_by_correlation_id()
+    {
+        var matching = $"corr-{Guid.NewGuid():N}";
+        var other = $"corr-{Guid.NewGuid():N}";
+
+        await using (var session = OpenSession())
+        {
+            SetCorrelationId(session, matching);
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("grain"), new CargoInspected("alice"));
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            SetCorrelationId(session, other);
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("coal"));
+            await SaveChangesAsync(session);
+        }
+
+        var result = await queryAsync(new EventQuery { CorrelationId = matching, PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.CorrelationId == matching);
+    }
+
+    [Fact]
+    public async Task filters_by_causation_id()
+    {
+        // Causation is seeded from the ambient activity at session construction, the same way
+        // ActivityCorrelationCompliance drives it -- there is deliberately no SetCausationId seam.
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        var parent = new Activity("event-query-parent").Start();
+        var child = new Activity("event-query-child").Start();
+
+        string? matching;
+        try
+        {
+            await using var session = OpenSession();
+            matching = CausationIdFor(session);
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("grain"), new CargoInspected("alice"));
+            await SaveChangesAsync(session);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+
+        matching.ShouldNotBeNull();
+
+        // Appended outside the activity scope, so it carries a different (or no) causation id.
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("coal"));
+
+        var result = await queryAsync(new EventQuery { CausationId = matching, PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.CausationId == matching);
+    }
+
+    [Fact]
+    public async Task filters_by_user_name()
+    {
+        await using (var session = OpenSession())
+        {
+            SetUserName(session, "helen");
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("grain"), new CargoInspected("alice"));
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            SetUserName(session, "greta");
+            EventsFor(session).Append(Guid.NewGuid(), new CargoLoaded("coal"));
+            await SaveChangesAsync(session);
+        }
+
+        var result = await queryAsync(new EventQuery { UserName = "helen", PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldAllBe(x => x.UserName == "helen");
+    }
+
+    [Fact]
+    public async Task timestamp_window_is_inclusive_and_filters()
+    {
+        var streamId = Guid.NewGuid();
+
+        // Three saves separated by real wall-clock gaps, so the middle save's server-assigned
+        // timestamps are strictly between its neighbors'.
+        await appendAsync(streamId, new CargoLoaded("grain"));
+        await Task.Delay(30, Cancellation);
+        await appendAsync(streamId, new CargoInspected("alice"), new CargoInspected("carol"));
+        await Task.Delay(30, Cancellation);
+        await appendAsync(streamId, new CargoUnloaded("Lisbon"));
+
+        // The window bounds come from the store's own read-back, so whatever precision the store
+        // persists at is the precision the bounds carry -- and because both bounds equal actual
+        // event timestamps, an exclusive comparison on either end loses an event and fails.
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(4);
+        var middle = all.Events.Skip(1).Take(2).ToList();
+
+        var result = await queryAsync(new EventQuery
+        {
+            TimestampFrom = middle[0].Timestamp,
+            TimestampTo = middle[1].Timestamp,
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Select(x => x.Sequence).ShouldBe(middle.Select(x => x.Sequence));
+        result.Events.ShouldAllBe(x => x.Data is CargoInspected);
+    }
+
+    [Fact]
+    public async Task sequence_window_is_inclusive_and_filters()
+    {
+        await seedInterleavedAsync();
+
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(5);
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        var result = await queryAsync(new EventQuery
+        {
+            SequenceFloor = sequences[1],
+            SequenceCeiling = sequences[3],
+            PageSize = 1000
+        });
+
+        // Both bounds are actual event sequences, so an exclusive comparison on either end drops
+        // an endpoint event and fails the exact-membership assertion.
+        result.TotalCount.ShouldBe(3);
+        result.Events.Select(x => x.Sequence).ShouldBe(sequences.Skip(1).Take(3).ToList());
+    }
+
+    [Fact]
+    public async Task filters_by_tag_conditions()
+    {
+        var matching = new ManifestId(Guid.NewGuid());
+        var other = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("grain"), matching);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("alice"), matching);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("coal"), other);
+
+        // And one event carrying no tag at all, so "returned everything" cannot pass.
+        await appendAsync(Guid.NewGuid(), new CargoUnloaded("Lisbon"));
+
+        var spec = EventTagQuerySpec.From(new EventTagQuery().Or(matching));
+
+        var result = await queryAsync(new EventQuery { TagConditions = spec, PageSize = 1000 });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldContain(x => x.Data is CargoLoaded);
+        result.Events.ShouldContain(x => x.Data is CargoInspected);
+    }
+
+    /// <summary>
+    /// The tag conditions select events, and that selection is AND-combined with every other
+    /// filter — the documented composition on <see cref="EventQuery.TagConditions"/>.
+    /// </summary>
+    [Fact]
+    public async Task tag_conditions_combine_with_the_other_filters_as_and()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("grain"), manifest);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("alice"), manifest);
+
+        // Same event type as the expected match, but untagged -- caught if the type filter runs
+        // and the tag filter is dropped.
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("coal"));
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(manifest)),
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("grain");
+    }
+}

--- a/src/JasperFx.Events/CommandLine/EventQueryCommand.cs
+++ b/src/JasperFx.Events/CommandLine/EventQueryCommand.cs
@@ -1,0 +1,119 @@
+using JasperFx.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Queries events across all streams of the application's own event store through the broadened
+/// <see cref="EventQuery"/> surface (jasperfx#737) — every filter field, sequence-ascending
+/// ordering, offset paging. The local, in-process twin of CritterWatch's <c>query_events</c> MCP
+/// tool, the same relationship <c>projection-run</c> has to the console's stepper (jasperfx#728):
+/// both sit on <see cref="IReadOnlyEventStore.QueryEventsAsync"/>, so an operator or agent that
+/// learns one has learned the other.
+/// </summary>
+// Name is explicit because CommandFactory.CommandNameFor only strips the "Command" suffix and
+// lowercases — it does not split PascalCase — so this would otherwise be "eventquery".
+[Description("Query events across all streams with filters, ordered by sequence ascending, paged",
+    Name = "event-query")]
+public class EventQueryCommand: JasperFxAsyncCommand<EventQueryInput>
+{
+    public EventQueryCommand()
+    {
+        Usage("Query events across all streams of the application's event store");
+    }
+
+    public override async Task<bool> Execute(EventQueryInput input)
+    {
+        // Console logging has to go: in the default JSON mode a single stray log line makes the
+        // output unparseable. --verbose opts back in, but only for --format text, matching
+        // projection-run's disposition.
+        if (input.HostBuilder != null && (!input.VerboseFlag || input.FormatFlag == EventQueryFormat.Json))
+        {
+            input.HostBuilder.ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddDebug();
+            });
+        }
+
+        var validation = input.Validate();
+        if (validation != null)
+        {
+            return fail(input, null, validation);
+        }
+
+        var query = input.BuildQuery();
+
+        using var host = input.BuildHost();
+
+        var stores = host.Services.GetServices<IEventStore>().ToArray();
+        var (store, storeError) = ProjectionRunSource.SelectStore(stores, input.StoreFlag);
+        if (store == null)
+        {
+            return fail(input, null, storeError!);
+        }
+
+        PagedEvents page;
+        try
+        {
+            page = await store.OpenReadOnlyEventStore()
+                .QueryEventsAsync(query, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (NotSupportedException e)
+        {
+            // The jasperfx#737 guard rail (or a tenant filter on a store with no tenant dimension)
+            // refusing a filter it does not honor. Say so plainly — the one thing this must never
+            // become is an empty result.
+            return fail(input, store.Subject,
+                $"This event store does not support part of the query: {e.Message}");
+        }
+        catch (Exception e)
+        {
+            return await failAsync(host, input, store.Subject, e.Message).ConfigureAwait(false);
+        }
+
+        write(input, EventQueryReport.From(query, store.Subject, page, includePayloads: !input.NoPayloadsFlag));
+
+        // An empty page with TotalCount 0 lands here: a real answer, reported as one.
+        return true;
+    }
+
+    /// <summary>
+    /// A failed run still writes a report, so JSON consumers parse one shape either way rather
+    /// than having to tell an empty result from a crash.
+    /// </summary>
+    private static bool fail(EventQueryInput input, Uri? store, string error)
+    {
+        write(input, EventQueryReport.Failed(input.BuildQuery(), store, error));
+        return false;
+    }
+
+    /// <summary>
+    /// The same, for failures against a built host — worth asking whether the application's
+    /// storage was ever migrated, exactly as <c>projection-run</c> does: the command never starts
+    /// the host, so an un-migrated database is a first-class cause and the raw store exception
+    /// ("relation ... does not exist") says nothing about the fix.
+    /// </summary>
+    private static async Task<bool> failAsync(IHost host, EventQueryInput input, Uri? store, string error)
+    {
+        var diagnosis = await ProjectionRunSchemaDiagnosis
+            .TryDiagnoseAsync(host.Services, CancellationToken.None).ConfigureAwait(false);
+
+        write(input, EventQueryReport.Failed(input.BuildQuery(), store, error, diagnosis));
+        return false;
+    }
+
+    private static void write(EventQueryInput input, EventQueryReport report)
+    {
+        if (input.FormatFlag == EventQueryFormat.Json)
+        {
+            EventQueryView.WriteJson(report);
+        }
+        else
+        {
+            EventQueryView.WriteConsole(report);
+        }
+    }
+}

--- a/src/JasperFx.Events/CommandLine/EventQueryInput.cs
+++ b/src/JasperFx.Events/CommandLine/EventQueryInput.cs
@@ -1,0 +1,224 @@
+using System.Text.Json;
+using JasperFx.CommandLine;
+using JasperFx.Core;
+using JasperFx.Descriptors;
+using JasperFx.Events.Tags;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Output rendering for the <c>event-query</c> command. JSON is the default deliberately — the
+/// command is agent-first, the same disposition as the CritterWatch MCP tool it twins.
+/// </summary>
+public enum EventQueryFormat
+{
+    Json,
+    Text
+}
+
+/// <summary>
+/// Input for the <c>event-query</c> command. Every flag is long-form only for the same reason as
+/// <see cref="ProjectionRunInput"/>: the parser derives one-letter aliases from the first letter
+/// with no collision detection, and this surface has <c>--stream</c>/<c>--store</c>/<c>--sequence-*</c>,
+/// <c>--timestamp-*</c>/<c>--tenant</c>/<c>--tags</c> all competing for the same letters.
+/// </summary>
+public class EventQueryInput: NetCoreInput
+{
+    [Description("Stream id (string form) whose events to return. Omit for a cross-stream query")]
+    [FlagAlias("stream", longAliasOnly: true)]
+    public string? StreamFlag { get; set; }
+
+    [Description("Event type alias(es) to match, comma-separated for more than one (exact match)")]
+    [FlagAlias("event-type", longAliasOnly: true)]
+    public string? EventTypeFlag { get; set; }
+
+    [Description("Exact-match filter on the correlation id metadata column")]
+    [FlagAlias("correlation-id", longAliasOnly: true)]
+    public string? CorrelationIdFlag { get; set; }
+
+    [Description("Exact-match filter on the causation id metadata column")]
+    [FlagAlias("causation-id", longAliasOnly: true)]
+    public string? CausationIdFlag { get; set; }
+
+    [Description("Exact-match filter on the user name metadata column")]
+    [FlagAlias("user-name", longAliasOnly: true)]
+    public string? UserNameFlag { get; set; }
+
+    [Description("Inclusive lower bound on the event timestamp, any DateTimeOffset format (e.g. 2026-09-01T00:00:00Z)")]
+    [FlagAlias("timestamp-from", longAliasOnly: true)]
+    public string? TimestampFromFlag { get; set; }
+
+    [Description("Inclusive upper bound on the event timestamp, any DateTimeOffset format")]
+    [FlagAlias("timestamp-to", longAliasOnly: true)]
+    public string? TimestampToFlag { get; set; }
+
+    [Description("Inclusive lower bound on the store-global event sequence")]
+    [FlagAlias("sequence-floor", longAliasOnly: true)]
+    public long? SequenceFloorFlag { get; set; }
+
+    [Description("Inclusive upper bound on the store-global event sequence")]
+    [FlagAlias("sequence-ceiling", longAliasOnly: true)]
+    public long? SequenceCeilingFlag { get; set; }
+
+    [Description("Tag conditions as a JSON object of tag type name to tag value, e.g. '{\"StudentId\":\"s-1\"}'. Conditions are OR'd, then AND-combined with the other filters")]
+    [FlagAlias("tags", longAliasOnly: true)]
+    public string? TagsFlag { get; set; }
+
+    [Description("Tenant partition to scope the query to. Omit for a store-global read")]
+    [FlagAlias("tenant", longAliasOnly: true)]
+    public string? TenantFlag { get; set; }
+
+    [Description("1-based page number into the sequence-ascending ordering. Default is 1")]
+    [FlagAlias("page", longAliasOnly: true)]
+    public int PageFlag { get; set; } = 1;
+
+    [Description("Page size. Default is 50")]
+    [FlagAlias("page-size", longAliasOnly: true)]
+    public int PageSizeFlag { get; set; } = 50;
+
+    [Description("Subject uri (or bare scheme) of the event store to query. Only needed when the application registers more than one")]
+    [FlagAlias("store", longAliasOnly: true)]
+    public string? StoreFlag { get; set; }
+
+    [Description("Output rendering: json (default, for agents and scripts) or text (a console table)")]
+    [FlagAlias("format", longAliasOnly: true)]
+    public EventQueryFormat FormatFlag { get; set; } = EventQueryFormat.Json;
+
+    [Description("Omit the event payloads from the output, leaving only the envelope metadata")]
+    [FlagAlias("no-payloads", longAliasOnly: true)]
+    public bool NoPayloadsFlag { get; set; }
+
+    /// <summary>
+    /// Operator-facing message for the first invalid flag, or null when the input is usable.
+    /// </summary>
+    public string? Validate()
+    {
+        if (PageFlag < 1)
+        {
+            return "--page must be 1 or greater";
+        }
+
+        if (PageSizeFlag < 1)
+        {
+            return "--page-size must be greater than zero";
+        }
+
+        if (TimestampFromFlag.IsNotEmpty() && !DateTimeOffset.TryParse(TimestampFromFlag, out _))
+        {
+            return $"--timestamp-from '{TimestampFromFlag}' is not a recognizable timestamp";
+        }
+
+        if (TimestampToFlag.IsNotEmpty() && !DateTimeOffset.TryParse(TimestampToFlag, out _))
+        {
+            return $"--timestamp-to '{TimestampToFlag}' is not a recognizable timestamp";
+        }
+
+        if (parseTimestamp(TimestampFromFlag) is { } from && parseTimestamp(TimestampToFlag) is { } to && from > to)
+        {
+            return "--timestamp-from must be less than or equal to --timestamp-to";
+        }
+
+        if (SequenceFloorFlag.HasValue && SequenceCeilingFlag.HasValue && SequenceFloorFlag > SequenceCeilingFlag)
+        {
+            return "--sequence-floor must be less than or equal to --sequence-ceiling";
+        }
+
+        var (_, tagError) = TryParseTags(TagsFlag);
+        return tagError;
+    }
+
+    /// <summary>
+    /// The <see cref="EventQuery"/> these flags describe. Call after <see cref="Validate"/> has
+    /// returned null; an invalid member is dropped rather than guessed at here.
+    /// </summary>
+    public EventQuery BuildQuery()
+    {
+        var query = new EventQuery
+        {
+            StreamId = StreamFlag,
+            CorrelationId = CorrelationIdFlag,
+            CausationId = CausationIdFlag,
+            UserName = UserNameFlag,
+            TenantId = TenantFlag,
+            TimestampFrom = parseTimestamp(TimestampFromFlag),
+            TimestampTo = parseTimestamp(TimestampToFlag),
+            SequenceFloor = SequenceFloorFlag,
+            SequenceCeiling = SequenceCeilingFlag,
+            PageNumber = PageFlag,
+            PageSize = PageSizeFlag,
+            TagConditions = TryParseTags(TagsFlag).Spec
+        };
+
+        if (EventTypeFlag.IsNotEmpty())
+        {
+            // Always the list form, even for one alias — CombinedEventTypeNames() folds the two
+            // spellings together on the store side, so the CLI never needs the single-name member.
+            query.EventTypeNames = EventTypeFlag!
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    /// Parse the <c>--tags</c> JSON object into the wire-serializable <see cref="EventTagQuerySpec"/>.
+    /// Each property becomes one tag-only condition (any event type carrying the tag); the property
+    /// name is the tag type as the store's registered tag graph knows it, and the value is passed
+    /// through as-is for the store side to deserialize against the resolved tag type.
+    /// </summary>
+    /// <returns>The spec, or the operator-facing error. A missing flag is (null, null): no tag filter.</returns>
+    public static (EventTagQuerySpec? Spec, string? Error) TryParseTags(string? json)
+    {
+        if (json.IsEmpty())
+        {
+            return (null, null);
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json!);
+        }
+        catch (JsonException e)
+        {
+            return (null, $"--tags is not valid JSON: {e.Message}");
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return (null, "--tags must be a JSON object of tag type name to tag value, e.g. '{\"StudentId\":\"s-1\"}'");
+            }
+
+            var conditions = new List<EventTagQueryConditionSpec>();
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.Null)
+                {
+                    return (null, $"--tags value for '{property.Name}' is null; a tag condition needs a value");
+                }
+
+                // Clone: the element must outlive the parsed document.
+                conditions.Add(new EventTagQueryConditionSpec(
+                    EventType: null,
+                    TagType: new TypeDescriptor(property.Name, property.Name, string.Empty),
+                    TagValue: property.Value.Clone()));
+            }
+
+            if (conditions.Count == 0)
+            {
+                // An empty object filters nothing, and a tag filter that filters nothing is far more
+                // likely a mangled invocation than an intent — refuse it rather than quietly running
+                // the query unfiltered.
+                return (null, "--tags is an empty JSON object; supply at least one tag condition or omit the flag");
+            }
+
+            return (new EventTagQuerySpec(conditions), null);
+        }
+    }
+
+    private static DateTimeOffset? parseTimestamp(string? flag)
+        => flag.IsNotEmpty() && DateTimeOffset.TryParse(flag, out var parsed) ? parsed : null;
+}

--- a/src/JasperFx.Events/CommandLine/EventQueryReport.cs
+++ b/src/JasperFx.Events/CommandLine/EventQueryReport.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// The whole result of one <c>event-query</c> run, in the shape agents and scripts consume from
+/// the default JSON output. A failed run is a report too — <see cref="Error"/> is populated and
+/// <see cref="Events"/> is empty — so a consumer never has to distinguish "no output" from "no
+/// matches". An empty page with <see cref="TotalCount"/> 0 and a null <see cref="Error"/> is a
+/// real answer, not a failure.
+/// </summary>
+/// <param name="Query">Echo of the query that ran, so a stored report is self-describing and reproducible.</param>
+/// <param name="Store">Subject uri of the event store that answered.</param>
+/// <param name="Events">The requested page, ordered by store-global sequence ascending.</param>
+/// <param name="TotalCount">Total matching events across every page.</param>
+/// <param name="PageNumber">Echo of the requested page number.</param>
+/// <param name="PageSize">Echo of the requested page size.</param>
+/// <param name="HasMore">True when pages after this one still hold matching events.</param>
+/// <param name="Error">Operator-facing failure message, or null when the query ran.</param>
+/// <param name="Diagnosis">
+/// What to do about <paramref name="Error"/> when the cause is known — today, storage that was
+/// never migrated. Same disposition as <see cref="ProjectionRunReport.Diagnosis"/>.
+/// </param>
+public sealed record EventQueryReport(
+    EventQuery Query,
+    string? Store,
+    IReadOnlyList<EventQueryEventReport> Events,
+    int TotalCount,
+    int PageNumber,
+    int PageSize,
+    bool HasMore,
+    string? Error,
+    string? Diagnosis = null)
+{
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "Reflective JSON serialization of arbitrary event payloads. The event-query command is a development-time CLI surface, not part of an AOT-published runtime — same disposition as ProjectionRunView.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "Same as IL2026.")]
+    public static EventQueryReport From(EventQuery query, Uri? store, PagedEvents page, bool includePayloads)
+    {
+        var events = page.Events.Select(e => new EventQueryEventReport(
+            e.Sequence,
+            e.StreamKey ?? e.StreamId.ToString(),
+            e.Version,
+            e.EventTypeName,
+            e.Timestamp,
+            e.TenantId,
+            e.CorrelationId,
+            e.CausationId,
+            e.UserName,
+            includePayloads && e.Data != null
+                ? JsonSerializer.SerializeToElement(e.Data, e.Data.GetType())
+                : null)).ToArray();
+
+        return new EventQueryReport(query, store?.ToString(), events, page.TotalCount, page.PageNumber,
+            page.PageSize, HasMore: (long)page.PageNumber * page.PageSize < page.TotalCount, Error: null);
+    }
+
+    /// <summary>A run that never produced a page: the query is still worth echoing.</summary>
+    public static EventQueryReport Failed(EventQuery query, Uri? store, string error, string? diagnosis = null)
+        => new(query, store?.ToString(), [], 0, query.PageNumber, query.PageSize, false, error, diagnosis);
+}
+
+/// <summary>
+/// One event of an <see cref="EventQueryReport"/> page: the shared envelope, with the payload
+/// included unless the run asked for metadata only.
+/// </summary>
+/// <param name="Sequence">Store-global sequence number.</param>
+/// <param name="StreamId">String form of the stream identity (Guid or string key).</param>
+/// <param name="Version">Per-stream version of the event.</param>
+/// <param name="EventType">Event-type alias from the store's registry.</param>
+/// <param name="Timestamp">Server-assigned append time.</param>
+/// <param name="TenantId">Tenant the event belongs to.</param>
+/// <param name="CorrelationId">Correlation id metadata, when captured.</param>
+/// <param name="CausationId">Causation id metadata, when captured.</param>
+/// <param name="UserName">User name metadata, when captured.</param>
+/// <param name="Data">The event payload, or null when <c>--no-payloads</c> omitted it.</param>
+public sealed record EventQueryEventReport(
+    long Sequence,
+    string StreamId,
+    long Version,
+    string EventType,
+    DateTimeOffset Timestamp,
+    string? TenantId,
+    string? CorrelationId,
+    string? CausationId,
+    string? UserName,
+    JsonElement? Data);

--- a/src/JasperFx.Events/CommandLine/EventQueryView.cs
+++ b/src/JasperFx.Events/CommandLine/EventQueryView.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Core;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Renders an <see cref="EventQueryReport"/> — as JSON for agents and scripts (the default), or as
+/// a console table for a human at a terminal (<c>--format text</c>).
+/// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: the report is serialized reflectively by System.Text.Json. The event-query command is a development-time CLI surface, not part of an AOT-published runtime — the same disposition as ProjectionRunView.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Same as IL2026 — reflective JSON serialization of the CLI's own report type.")]
+internal static class EventQueryView
+{
+    private const int PayloadPreviewLength = 60;
+
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        // The echoed query is full of optional members; an agent reading the report cares about the
+        // filters that were set, not a wall of nulls.
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string ToJson(EventQueryReport report) => JsonSerializer.Serialize(report, _json);
+
+    /// <summary>
+    /// Write straight to <see cref="Console.Out"/> rather than through Spectre: the console writer
+    /// wraps and styles its output, which would corrupt JSON a script is piping.
+    /// </summary>
+    public static void WriteJson(EventQueryReport report) => Console.Out.WriteLine(ToJson(report));
+
+    public static void WriteConsole(EventQueryReport report)
+    {
+        if (report.Error.IsNotEmpty())
+        {
+            AnsiConsole.MarkupLine($"[red]{report.Error!.EscapeMarkup()}[/]");
+
+            if (report.Diagnosis.IsNotEmpty())
+            {
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[yellow]{report.Diagnosis!.EscapeMarkup()}[/]");
+            }
+
+            return;
+        }
+
+        AnsiConsole.MarkupLine(
+            $"Store [blue]{(report.Store ?? "(unknown)").EscapeMarkup()}[/] · {report.TotalCount} matching event(s)" +
+            $" · page {report.PageNumber} ({report.Events.Count} shown)" +
+            (report.Query.TenantId.IsNotEmpty() ? $" · tenant [blue]{report.Query.TenantId!.EscapeMarkup()}[/]" : string.Empty));
+
+        if (report.Events.Count == 0)
+        {
+            // A real answer, not a failure: the filters matched nothing (or the page is past the end).
+            AnsiConsole.MarkupLine(report.TotalCount == 0
+                ? "[yellow]No events matched the query[/]"
+                : "[yellow]This page is past the end of the matches[/]");
+            return;
+        }
+
+        var showPayloads = report.Events.Any(x => x.Data.HasValue);
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Seq");
+        table.AddColumn("Stream");
+        table.AddColumn("Ver");
+        table.AddColumn("Event");
+        table.AddColumn("Timestamp");
+        if (showPayloads) table.AddColumn("Data");
+
+        foreach (var e in report.Events)
+        {
+            // Text rather than Markup: a JSON payload preview is full of square brackets, which the
+            // markup parser would either eat or choke on.
+            var cells = new List<IRenderable>
+            {
+                new Text(e.Sequence.ToString()),
+                new Text(e.StreamId),
+                new Text(e.Version.ToString()),
+                new Text(e.EventType),
+                new Text(e.Timestamp.ToString("u"))
+            };
+
+            if (showPayloads) cells.Add(new Text(preview(e.Data)));
+
+            table.AddRow(cells);
+        }
+
+        AnsiConsole.Write(table);
+
+        if (report.HasMore)
+        {
+            AnsiConsole.MarkupLine($"[yellow]More matches remain — rerun with --page {report.PageNumber + 1}[/]");
+        }
+    }
+
+    private static string preview(JsonElement? data)
+    {
+        if (!data.HasValue) return "(omitted)";
+
+        var text = data.Value.ToString();
+        return text.Length <= PayloadPreviewLength ? text : text[..PayloadPreviewLength] + "…";
+    }
+}

--- a/src/JasperFx.Events/EventQuery.cs
+++ b/src/JasperFx.Events/EventQuery.cs
@@ -14,6 +14,14 @@ namespace JasperFx.Events;
 /// that ordering. See <see cref="IReadOnlyEventStore.QueryEventsAsync"/>.
 /// </para>
 /// <para>
+/// <b>Window semantics:</b> both windows are inclusive at both ends. A half-open window (one bound
+/// null) is valid. An inverted window — a floor above its ceiling — is a well-formed range that
+/// contains nothing: it matches no events and returns an empty page with
+/// <see cref="PagedEvents.TotalCount"/> 0, the same as any other filter that matches nothing. It is
+/// never an error. Likewise an entry in <see cref="EventTypeNames"/> that matches no stored events
+/// simply contributes nothing to the union.
+/// </para>
+/// <para>
 /// <b>Guard rail (jasperfx#737):</b> an implementation that does not honor a supplied filter MUST
 /// refuse it with a <see cref="NotSupportedException"/> naming the field — never silently ignore
 /// it, because a silently-ignored filter returns unfiltered results that read as filtered. Call

--- a/src/JasperFx.Events/EventQuery.cs
+++ b/src/JasperFx.Events/EventQuery.cs
@@ -1,10 +1,58 @@
+using JasperFx.Events.Tags;
+
 namespace JasperFx.Events;
 
+/// <summary>
+/// Store-agnostic, wire-serializable description of a cross-stream event query, consumed by
+/// <see cref="IReadOnlyEventStore.QueryEventsAsync"/>. Every filter member is optional; a null
+/// (or empty) member applies no filter. All supplied filters are combined with AND.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Ordering contract:</b> results are always ordered by the store-global event sequence,
+/// ascending — oldest first — and <see cref="PageNumber"/>/<see cref="PageSize"/> page through
+/// that ordering. See <see cref="IReadOnlyEventStore.QueryEventsAsync"/>.
+/// </para>
+/// <para>
+/// <b>Guard rail (jasperfx#737):</b> an implementation that does not honor a supplied filter MUST
+/// refuse it with a <see cref="NotSupportedException"/> naming the field — never silently ignore
+/// it, because a silently-ignored filter returns unfiltered results that read as filtered. Call
+/// <see cref="AssertFiltersAreSupported"/> first thing in an implementation to get that behavior
+/// consistently.
+/// </para>
+/// </remarks>
 public class EventQuery
 {
+    /// <summary>
+    /// Optional exact-match filter on a single event type name (the store's persisted alias for the
+    /// event type). Null applies no filter. When <see cref="EventTypeNames"/> is also supplied, the
+    /// effective filter is the union of this name and that list — see
+    /// <see cref="CombinedEventTypeNames"/>.
+    /// </summary>
     public string? EventTypeName { get; set; }
+
+    /// <summary>
+    /// Optional filter on multiple event type names (the store's persisted aliases, exact match).
+    /// An event matches when its type name equals any entry. Empty applies no filter. When
+    /// <see cref="EventTypeName"/> is also supplied, the effective filter is the union of the two —
+    /// see <see cref="CombinedEventTypeNames"/>. See jasperfx#737.
+    /// </summary>
+    public List<string> EventTypeNames { get; set; } = new();
+
+    /// <summary>
+    /// Optional exact-match filter on the string form of the stream identity (Guid or string key).
+    /// Null applies no filter.
+    /// </summary>
     public string? StreamId { get; set; }
+
+    /// <summary>
+    /// 1-based page number into the sequence-ascending ordering.
+    /// </summary>
     public int PageNumber { get; set; } = 1;
+
+    /// <summary>
+    /// Page size for the paged result.
+    /// </summary>
     public int PageSize { get; set; } = 50;
 
     /// <summary>
@@ -36,12 +84,212 @@ public class EventQuery
     /// jasperfx#555 (companion to the jasperfx#503 stream-read overloads).
     /// </summary>
     public string? TenantId { get; set; }
+
+    /// <summary>
+    /// Optional inclusive lower bound on the event's server-assigned timestamp: events at exactly this
+    /// timestamp are included. Null applies no floor. Pairs with <see cref="TimestampTo"/> to form a
+    /// time window. See jasperfx#737.
+    /// </summary>
+    public DateTimeOffset? TimestampFrom { get; set; }
+
+    /// <summary>
+    /// Optional inclusive upper bound on the event's server-assigned timestamp: events at exactly this
+    /// timestamp are included. Null applies no ceiling. Pairs with <see cref="TimestampFrom"/> to form
+    /// a time window. See jasperfx#737.
+    /// </summary>
+    public DateTimeOffset? TimestampTo { get; set; }
+
+    /// <summary>
+    /// Optional inclusive lower bound on the store-global event sequence: the event at exactly this
+    /// sequence is included. Null applies no floor. Pairs with
+    /// <c>IEventDatabase.FindEventStoreFloorAtTimeAsync</c>, which produces a sequence number this
+    /// member can consume. See jasperfx#737.
+    /// </summary>
+    public long? SequenceFloor { get; set; }
+
+    /// <summary>
+    /// Optional inclusive upper bound on the store-global event sequence: the event at exactly this
+    /// sequence is included. Null applies no ceiling. See jasperfx#737.
+    /// </summary>
+    public long? SequenceCeiling { get; set; }
+
+    /// <summary>
+    /// Optional tag conditions in the wire-serializable <see cref="EventTagQuerySpec"/> form
+    /// (jasperfx#545): the spec's OR'd conditions select the events, and that selection is then
+    /// AND-combined with every other filter on this query. Null applies no tag filter. Folded into
+    /// <see cref="EventQuery"/> deliberately rather than shipped as a parallel read-tier method — one
+    /// abstraction method, one wire shape, one compliance surface. See jasperfx#737.
+    /// </summary>
+    public EventTagQuerySpec? TagConditions { get; set; }
+
+    /// <summary>
+    /// The effective event type name filter: the union of <see cref="EventTypeName"/> and
+    /// <see cref="EventTypeNames"/>, distinct, in declaration order with the single name first.
+    /// Empty means no event type filter. Implementations should consume this rather than reading
+    /// the two members separately, so both spellings share one code path.
+    /// </summary>
+    public IReadOnlyList<string> CombinedEventTypeNames()
+    {
+        if (EventTypeName == null && EventTypeNames.Count == 0)
+        {
+            return [];
+        }
+
+        var names = new List<string>(EventTypeNames.Count + 1);
+        if (EventTypeName != null)
+        {
+            names.Add(EventTypeName);
+        }
+
+        foreach (var name in EventTypeNames)
+        {
+            if (!names.Contains(name))
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// The filters actually supplied on this query — the fields an implementation must either honor
+    /// or refuse. Paging (<see cref="PageNumber"/>/<see cref="PageSize"/>) and the sequence-ascending
+    /// ordering are unconditional contract, not filters, so they never appear here.
+    /// </summary>
+    public EventQueryFilters SpecifiedFilters
+    {
+        get
+        {
+            var filters = EventQueryFilters.None;
+
+            if (EventTypeName != null) filters |= EventQueryFilters.EventTypeName;
+            if (EventTypeNames.Count > 0) filters |= EventQueryFilters.EventTypeNames;
+            if (StreamId != null) filters |= EventQueryFilters.StreamId;
+            if (CorrelationId != null) filters |= EventQueryFilters.CorrelationId;
+            if (CausationId != null) filters |= EventQueryFilters.CausationId;
+            if (UserName != null) filters |= EventQueryFilters.UserName;
+            if (TenantId != null) filters |= EventQueryFilters.TenantId;
+            if (TimestampFrom != null) filters |= EventQueryFilters.TimestampFrom;
+            if (TimestampTo != null) filters |= EventQueryFilters.TimestampTo;
+            if (SequenceFloor != null) filters |= EventQueryFilters.SequenceFloor;
+            if (SequenceCeiling != null) filters |= EventQueryFilters.SequenceCeiling;
+            if (TagConditions != null) filters |= EventQueryFilters.TagConditions;
+
+            return filters;
+        }
+    }
+
+    private static readonly (EventQueryFilters Filter, string Name)[] _filterNames =
+    [
+        (EventQueryFilters.EventTypeName, nameof(EventTypeName)),
+        (EventQueryFilters.EventTypeNames, nameof(EventTypeNames)),
+        (EventQueryFilters.StreamId, nameof(StreamId)),
+        (EventQueryFilters.CorrelationId, nameof(CorrelationId)),
+        (EventQueryFilters.CausationId, nameof(CausationId)),
+        (EventQueryFilters.UserName, nameof(UserName)),
+        (EventQueryFilters.TenantId, nameof(TenantId)),
+        (EventQueryFilters.TimestampFrom, nameof(TimestampFrom)),
+        (EventQueryFilters.TimestampTo, nameof(TimestampTo)),
+        (EventQueryFilters.SequenceFloor, nameof(SequenceFloor)),
+        (EventQueryFilters.SequenceCeiling, nameof(SequenceCeiling)),
+        (EventQueryFilters.TagConditions, nameof(TagConditions))
+    ];
+
+    /// <summary>
+    /// The jasperfx#737 guard rail, centralized: throw <see cref="NotSupportedException"/> naming
+    /// every supplied filter that is not in <paramref name="supportedFilters"/>. An implementation
+    /// of <see cref="IReadOnlyEventStore.QueryEventsAsync"/> calls this first thing, declaring the
+    /// fields it honors (typically <see cref="EventQueryFilters.All"/> once fully implemented), so
+    /// a query carrying a filter the store has not implemented fails loudly instead of returning
+    /// unfiltered results that read as filtered.
+    /// </summary>
+    /// <param name="supportedFilters">The set of filters the calling implementation honors.</param>
+    /// <exception cref="NotSupportedException">A filter was supplied that the implementation did not declare.</exception>
+    public void AssertFiltersAreSupported(EventQueryFilters supportedFilters)
+    {
+        var unsupported = SpecifiedFilters & ~supportedFilters;
+        if (unsupported == EventQueryFilters.None)
+        {
+            return;
+        }
+
+        var names = _filterNames
+            .Where(x => unsupported.HasFlag(x.Filter))
+            .Select(x => $"{nameof(EventQuery)}.{x.Name}");
+
+        throw new NotSupportedException(
+            $"This event store does not support the supplied event query filter(s) {string.Join(", ", names)}. " +
+            "A supplied filter must be honored or refused, never silently ignored — unfiltered results would read as filtered. See jasperfx#737.");
+    }
 }
 
+/// <summary>
+/// The individual filter fields of an <see cref="EventQuery"/>, as flags, so an implementation of
+/// <see cref="IReadOnlyEventStore.QueryEventsAsync"/> can declare which fields it honors through
+/// <see cref="EventQuery.AssertFiltersAreSupported"/>. See jasperfx#737.
+/// </summary>
+[Flags]
+public enum EventQueryFilters
+{
+    None = 0,
+    EventTypeName = 1 << 0,
+    StreamId = 1 << 1,
+    CorrelationId = 1 << 2,
+    CausationId = 1 << 3,
+    UserName = 1 << 4,
+    TenantId = 1 << 5,
+    EventTypeNames = 1 << 6,
+    TimestampFrom = 1 << 7,
+    TimestampTo = 1 << 8,
+    SequenceFloor = 1 << 9,
+    SequenceCeiling = 1 << 10,
+    TagConditions = 1 << 11,
+
+    /// <summary>
+    /// Both halves of the inclusive timestamp window.
+    /// </summary>
+    TimestampWindow = TimestampFrom | TimestampTo,
+
+    /// <summary>
+    /// Both halves of the inclusive sequence window.
+    /// </summary>
+    SequenceWindow = SequenceFloor | SequenceCeiling,
+
+    /// <summary>
+    /// The pre-jasperfx#737 exact-match surface.
+    /// </summary>
+    Baseline = EventTypeName | StreamId | CorrelationId | CausationId | UserName | TenantId,
+
+    /// <summary>
+    /// Every filter <see cref="EventQuery"/> can carry. What a fully implemented store declares.
+    /// </summary>
+    All = Baseline | EventTypeNames | TimestampWindow | SequenceWindow | TagConditions
+}
+
+/// <summary>
+/// The paged result of <see cref="IReadOnlyEventStore.QueryEventsAsync"/>.
+/// </summary>
 public class PagedEvents
 {
+    /// <summary>
+    /// The requested page of matching events, ordered by store-global sequence ascending.
+    /// </summary>
     public IReadOnlyList<IEvent> Events { get; set; } = [];
+
+    /// <summary>
+    /// The total number of events matching the query's filters across every page, not the size of
+    /// this page and not the size of the store.
+    /// </summary>
     public int TotalCount { get; set; }
+
+    /// <summary>
+    /// Echo of <see cref="EventQuery.PageNumber"/>.
+    /// </summary>
     public int PageNumber { get; set; }
+
+    /// <summary>
+    /// Echo of <see cref="EventQuery.PageSize"/>.
+    /// </summary>
     public int PageSize { get; set; }
 }

--- a/src/JasperFx.Events/IReadOnlyEventStore.cs
+++ b/src/JasperFx.Events/IReadOnlyEventStore.cs
@@ -29,7 +29,18 @@ public interface IReadOnlyEventStore
     Task<StreamState?> FetchStreamStateAsync(string streamKey, CancellationToken token = default);
 
     /// <summary>
-    /// Query events across all streams with filtering and pagination
+    /// Query events across all streams with filtering and pagination. Results are ordered by the
+    /// store-global event sequence, ascending — oldest first — and the query's paging walks that
+    /// ordering, with <see cref="PagedEvents.TotalCount"/> reporting the total number of matching
+    /// events across every page.
     /// </summary>
+    /// <remarks>
+    /// Implementations MUST either honor every filter supplied on <paramref name="query"/> or refuse
+    /// the query with a <see cref="NotSupportedException"/> naming the unsupported field — never
+    /// silently ignore a filter, because unfiltered results read as filtered. Call
+    /// <see cref="EventQuery.AssertFiltersAreSupported"/> first thing, declaring the
+    /// <see cref="EventQueryFilters"/> the implementation honors, to get that behavior consistently.
+    /// See jasperfx#737.
+    /// </remarks>
     Task<PagedEvents> QueryEventsAsync(EventQuery query, CancellationToken token = default);
 }


### PR DESCRIPTION
Closes #737.

Four commits, additive, targeting a minor bump:

1. **`EventQuery` broadening** — `TimestampFrom`/`TimestampTo` and `SequenceFloor`/`SequenceCeiling` (inclusive both ends; half-open valid; an inverted window matches nothing — empty page, `TotalCount` 0, never an error), `EventTypeNames` (union with the single `EventTypeName` via `CombinedEventTypeNames()`; unknown names contribute nothing), `TagConditions` (`EventTagQuerySpec?` — the #545 wire form folded in, OR-within-spec, AND with every other filter), and a stated sequence-ascending ordering contract on `QueryEventsAsync`/`PagedEvents`.
2. **The must-throw guard rail** — `EventQueryFilters` flags + `EventQuery.AssertFiltersAreSupported(supported)`: a store that receives a filter it does not honor throws `NotSupportedException` naming each field, because a silently-ignored filter returns unfiltered results that read as filtered. Paging and ordering are deliberately unconditional contract, not flags.
3. **`event-query` CLI command** beside `projection-run` — the CLI twin of CritterWatch's `query_events` MCP tool (CritterWatch#1186), running on the application host against its own store(s). Full flag surface incl. `--tags` (JSON → `EventTagQuerySpec`), `--store` (reuses `ProjectionRunSource.SelectStore` so both commands resolve stores identically), `--format json|text`, `--no-payloads`. `NotSupportedException` surfaces as "this store does not support part of the query"; an empty page with `totalCount: 0` prints as a real answer.
4. **`EventQueryCompliance` at 41 facts** (+2 in `ConjoinedEventTenancyCompliance`) — every filter asserted to *actually filter* (exact membership + `TotalCount`, never call-succeeds): nine pairwise AND combinations with per-side decoys, a three-way and a kitchen-sink query, all four half-open windows, inclusive-boundary proofs at both store extremes, truthful zeros for match-nothing and inverted windows, paging×filtering across pages with stable totals, type-name union/dedupe/unknown permutations, OR-tag overlap with distinct-count pinning, type-scoped vs unscoped tag conditions.

**Judgment calls to review:**

- Union semantics for `EventTypeName` + `EventTypeNames` (rather than validate-and-throw), pinned by test and compliance.
- Two consumer-visible seams in the compliance package: abstract `SetUserName(TOperations, string?)` on `EventStoreComplianceFixture` (deliberately compile-breaking on bump, mirroring `SetCorrelationId`) and `ComplianceStoreConfig.EnableUserNameTracking` (opt-in like correlation).
- No capability gate on the new suite (no `SupportsEventQuery` flag) — enrolling it reds a store until it implements, matching the "suites keep the stores synchronized" direction.
- The CLI refuses an inverted window (`--sequence-floor > --sequence-ceiling`) as probable operator error, while the store contract treats inverted as match-nothing — the CLI is deliberately stricter than the wire.
- tags×tenant compliance became tenant×type in the conjoined suite: tag registration isn't in that suite's store config, and tags-under-conjoined-tenancy would pin a new cross-feature contract beyond #737 (noted in the test's xml-doc).

**Tests:** `EventTests` 986/986 on net9.0 and net10.0 (incl. 16 new CLI input tests); `EventStoreTests` 141/141 both TFMs; full `jasperfx.slnx` 0 errors. The compliance additions execute downstream in the stores' own harnesses.

**Downstream:** Marten/Polecat/Fisher implement against this and enroll `EventQueryCompliance`; CritterWatch#1186's `query_events` tool (v1 already shipped against 2.60.0) lights up the new filters on the next matched-set pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
