### PR TITLE
Fix the paging_composes_with_filtering compliance seed (3 noise / 7 matches)

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
@@ -972,9 +972,14 @@ public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
         // Seven Inspected events interleaved with three Loaded, across streams, one save each —
         // so the Inspected sequences are non-contiguous and a store paging BEFORE filtering
         // produces short or bleeding pages.
+        //
+        // ⚠️ The noise predicate must yield exactly 3 noise / 7 matches over 0..9: `i % 3 == 0`
+        // yields FOUR noise events (0, 3, 6, 9) and made this fact unpassable on every store —
+        // caught independently by the Marten and Fisher enrollments, both answering the correct 6
+        // against the asserted 7.
         for (var i = 0; i < 10; i++)
         {
-            object @event = i % 3 == 0 ? new CargoLoaded($"noise-{i}") : new CargoInspected($"match-{i}");
+            object @event = i % 3 == 2 ? new CargoLoaded($"noise-{i}") : new CargoInspected($"match-{i}");
             await appendAsync(Guid.NewGuid(), @event);
         }
 


### PR DESCRIPTION
One-line seed fix in `EventQueryCompliance.paging_composes_with_filtering`: `i % 3 == 0` over 0..9 produces **four** noise events (0, 3, 6, 9) and six matches, while every assertion in the fact — and its own comment — expects seven matches and three noise. The fact was unpassable on any store.

Caught independently by both downstream enrollments running against a local pack of merged main: Marten (JasperFx/marten#5330, 40/41) and Fisher (JasperFx/fisher#148, 40/41), each answering the arithmetically-correct 6 against the asserted 7. Noise on `i % 3 == 2` yields the intended 3/7. The fact asserts only counts, type membership, and paged-vs-unpaged sequence-set equality, so nothing else moves.

Wants to land before the real 2.62.0 ships so the three store enrollments go 41/41 on the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)