### PR TITLE
IQueryable<StreamState> on the read tier, the CompactedVersion watermark, stream-query CLI, and StreamStateQueryCompliance

### DIFF
--- a/src/EventTests/CommandLine/StreamQueryInputTests.cs
+++ b/src/EventTests/CommandLine/StreamQueryInputTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Linq;
+using JasperFx.Events;
+using JasperFx.Events.CommandLine;
+using Shouldly;
+
+namespace EventTests.CommandLine;
+
+/// <summary>
+/// jasperfx#740 — the <c>stream-query</c> command's flag-to-predicate mapping, validation,
+/// aggregate-type resolution and stated ordering, pinned against in-memory queryables with no host
+/// or database. Store selection is shared with the sibling commands and covered by
+/// <see cref="ProjectionRunSourceTests"/>; the store-side translation of these predicates is the
+/// compliance suite's job.
+/// </summary>
+public class StreamQueryInputTests
+{
+    private class OrderAggregate;
+
+    private class InvoiceAggregate;
+
+    /// <summary>
+    /// Two distinct types sharing the simple name "Widget", for the ambiguity tests. Nested in
+    /// separate holders so their full names differ while their simple names collide.
+    /// </summary>
+    private static class FirstHolder
+    {
+        public class Widget;
+    }
+
+    private static class SecondHolder
+    {
+        public class Widget;
+    }
+
+    private static StreamState state(
+        long version = 1,
+        long compactedVersion = 0,
+        Type? aggregateType = null,
+        bool archived = false,
+        DateTimeOffset? created = null,
+        DateTimeOffset? lastTimestamp = null,
+        Guid? id = null)
+        => new()
+        {
+            Id = id ?? Guid.NewGuid(),
+            Version = version,
+            CompactedVersion = compactedVersion,
+            AggregateType = aggregateType,
+            IsArchived = archived,
+            Created = created ?? new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero),
+            LastTimestamp = lastTimestamp ?? created ?? new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+
+    private static StreamState[] apply(StreamQueryInput input, Type? aggregateType, params StreamState[] states)
+        => input.ApplyFilters(states.AsQueryable(), aggregateType).ToArray();
+
+    [Fact]
+    public void no_flags_applies_no_filter()
+    {
+        var states = new[] { state(), state(archived: true), state(version: 100) };
+
+        apply(new StreamQueryInput(), null, states).ShouldBe(states);
+        new StreamQueryInput().Validate().ShouldBeNull();
+    }
+
+    [Fact]
+    public void the_aggregate_type_filter_is_equality_against_the_resolved_type()
+    {
+        var order = state(aggregateType: typeof(OrderAggregate));
+        var invoice = state(aggregateType: typeof(InvoiceAggregate));
+        var untyped = state();
+
+        var matched = apply(new StreamQueryInput(), typeof(OrderAggregate), order, invoice, untyped);
+
+        matched.ShouldBe([order]);
+    }
+
+    [Fact]
+    public void min_version_is_inclusive()
+    {
+        var below = state(version: 2);
+        var exactly = state(version: 3);
+        var above = state(version: 4);
+
+        var matched = apply(new StreamQueryInput { MinVersionFlag = 3 }, null, below, exactly, above);
+
+        matched.ShouldBe([exactly, above]);
+    }
+
+    /// <summary>
+    /// The compaction-policy predicate: growth is measured from the watermark, not from zero, so a
+    /// long stream that was recently compacted does not match.
+    /// </summary>
+    [Fact]
+    public void version_above_compacted_measures_growth_since_the_watermark()
+    {
+        var freshlyCompacted = state(version: 100, compactedVersion: 99);   // growth 1
+        var growthAtThreshold = state(version: 8, compactedVersion: 5);     // growth 3, not above
+        var overgrown = state(version: 9, compactedVersion: 5);             // growth 4
+        var neverCompacted = state(version: 4);                             // growth 4
+
+        var matched = apply(new StreamQueryInput { VersionAboveCompactedFlag = 3 }, null,
+            freshlyCompacted, growthAtThreshold, overgrown, neverCompacted);
+
+        // Strictly above the threshold, and raw Version plays no part: the version-100 stream is
+        // excluded while the version-4 one matches.
+        matched.ShouldBe([overgrown, neverCompacted]);
+    }
+
+    [Fact]
+    public void the_archived_flag_is_a_tri_state()
+    {
+        var live = state();
+        var archived = state(archived: true);
+
+        apply(new StreamQueryInput(), null, live, archived).ShouldBe([live, archived]);
+        apply(new StreamQueryInput { ArchivedFlag = true }, null, live, archived).ShouldBe([archived]);
+        apply(new StreamQueryInput { ArchivedFlag = false }, null, live, archived).ShouldBe([live]);
+    }
+
+    [Fact]
+    public void the_created_window_is_inclusive_and_bounds_created_not_last_append()
+    {
+        var early = state(created: new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero));
+        // Created early but appended to recently: the trap for a store or mapping that reads the
+        // wrong column.
+        var earlyButActive = state(
+            created: new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero),
+            lastTimestamp: new DateTimeOffset(2026, 9, 9, 0, 0, 0, TimeSpan.Zero));
+        var onTheBoundary = state(created: new DateTimeOffset(2026, 9, 5, 0, 0, 0, TimeSpan.Zero));
+        var late = state(created: new DateTimeOffset(2026, 9, 7, 0, 0, 0, TimeSpan.Zero));
+
+        var input = new StreamQueryInput
+        {
+            CreatedFromFlag = "2026-09-05T00:00:00Z", CreatedToFlag = "2026-09-07T00:00:00Z"
+        };
+
+        apply(input, null, early, earlyButActive, onTheBoundary, late).ShouldBe([onTheBoundary, late]);
+    }
+
+    [Fact]
+    public void the_updated_window_is_inclusive_and_bounds_last_append()
+    {
+        var stale = state(lastTimestamp: new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero));
+        var onTheBoundary = state(lastTimestamp: new DateTimeOffset(2026, 9, 5, 0, 0, 0, TimeSpan.Zero));
+
+        var input = new StreamQueryInput { UpdatedFromFlag = "2026-09-05T00:00:00Z" };
+
+        apply(input, null, stale, onTheBoundary).ShouldBe([onTheBoundary]);
+    }
+
+    [Fact]
+    public void filters_compose_as_and()
+    {
+        var target = state(version: 9, compactedVersion: 5, aggregateType: typeof(OrderAggregate));
+        var wrongType = state(version: 9, compactedVersion: 5, aggregateType: typeof(InvoiceAggregate));
+        var notGrown = state(version: 6, compactedVersion: 5, aggregateType: typeof(OrderAggregate));
+        var archived = state(version: 9, compactedVersion: 5, aggregateType: typeof(OrderAggregate),
+            archived: true);
+
+        var input = new StreamQueryInput { VersionAboveCompactedFlag = 3, ArchivedFlag = false };
+
+        // The compaction policy's own shape: type AND growth AND not archived; each decoy fails
+        // exactly one predicate.
+        apply(input, typeof(OrderAggregate), target, wrongType, notGrown, archived).ShouldBe([target]);
+    }
+
+    [Fact]
+    public void the_ordering_contract_is_creation_order_with_identity_tiebreak()
+    {
+        var tie = new DateTimeOffset(2026, 9, 3, 0, 0, 0, TimeSpan.Zero);
+        var older = state(created: new DateTimeOffset(2026, 9, 1, 0, 0, 0, TimeSpan.Zero));
+        var tieLowId = state(created: tie, id: Guid.Parse("00000000-0000-0000-0000-000000000001"));
+        var tieHighId = state(created: tie, id: Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+        var newest = state(created: new DateTimeOffset(2026, 9, 5, 0, 0, 0, TimeSpan.Zero));
+
+        var ordered = StreamQueryInput
+            .ApplyOrdering(new[] { newest, tieHighId, tieLowId, older }.AsQueryable())
+            .ToArray();
+
+        ordered.ShouldBe([older, tieLowId, tieHighId, newest]);
+    }
+
+    [Fact]
+    public void paging_flags_are_validated()
+    {
+        new StreamQueryInput { PageFlag = 0 }.Validate().ShouldBe("--page must be 1 or greater");
+        new StreamQueryInput { PageSizeFlag = 0 }.Validate().ShouldBe("--page-size must be greater than zero");
+    }
+
+    [Fact]
+    public void negative_version_thresholds_are_refused()
+    {
+        new StreamQueryInput { MinVersionFlag = -1 }.Validate().ShouldBe("--min-version cannot be negative");
+        new StreamQueryInput { VersionAboveCompactedFlag = -1 }.Validate()
+            .ShouldBe("--version-above-compacted cannot be negative");
+    }
+
+    [Fact]
+    public void unparseable_timestamps_are_refused_with_the_offending_flag_named()
+    {
+        new StreamQueryInput { CreatedFromFlag = "not-a-time" }.Validate()!.ShouldContain("--created-from");
+        new StreamQueryInput { CreatedToFlag = "nope" }.Validate()!.ShouldContain("--created-to");
+        new StreamQueryInput { UpdatedFromFlag = "nope" }.Validate()!.ShouldContain("--updated-from");
+        new StreamQueryInput { UpdatedToFlag = "nope" }.Validate()!.ShouldContain("--updated-to");
+    }
+
+    [Fact]
+    public void inverted_windows_are_refused()
+    {
+        new StreamQueryInput { CreatedFromFlag = "2026-09-02T00:00:00Z", CreatedToFlag = "2026-09-01T00:00:00Z" }
+            .Validate().ShouldBe("--created-from must be less than or equal to --created-to");
+        new StreamQueryInput { UpdatedFromFlag = "2026-09-02T00:00:00Z", UpdatedToFlag = "2026-09-01T00:00:00Z" }
+            .Validate().ShouldBe("--updated-from must be less than or equal to --updated-to");
+    }
+
+    [Fact]
+    public void aggregate_type_resolves_by_full_name_then_simple_name_case_insensitively()
+    {
+        Type[] candidates = [typeof(OrderAggregate), typeof(InvoiceAggregate)];
+
+        StreamQueryInput.ResolveAggregateType(typeof(OrderAggregate).FullName!, candidates)
+            .ShouldBe((typeof(OrderAggregate), null));
+        StreamQueryInput.ResolveAggregateType("orderaggregate", candidates)
+            .ShouldBe((typeof(OrderAggregate), null));
+    }
+
+    [Fact]
+    public void an_unknown_aggregate_type_is_refused_with_guidance()
+    {
+        var (type, error) = StreamQueryInput.ResolveAggregateType("NoSuchAggregate",
+            [typeof(OrderAggregate)]);
+
+        type.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("No loaded type matches --aggregate-type NoSuchAggregate");
+    }
+
+    [Fact]
+    public void an_ambiguous_simple_name_is_refused_naming_the_candidates()
+    {
+        // Two distinct types sharing a simple name — the AppDomain scan will hit this for any
+        // commonly-named aggregate, and querying the wrong one reads exactly like an empty store.
+        var (type, error) = StreamQueryInput.ResolveAggregateType("Widget",
+            [typeof(FirstHolder.Widget), typeof(SecondHolder.Widget)]);
+
+        type.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("ambiguous");
+        error.ShouldContain(typeof(FirstHolder.Widget).FullName!);
+        error.ShouldContain(typeof(SecondHolder.Widget).FullName!);
+    }
+
+    [Fact]
+    public void a_full_name_disambiguates_a_shared_simple_name()
+    {
+        var (type, error) = StreamQueryInput.ResolveAggregateType(typeof(SecondHolder.Widget).FullName!,
+            [typeof(FirstHolder.Widget), typeof(SecondHolder.Widget)]);
+
+        error.ShouldBeNull();
+        type.ShouldBe(typeof(SecondHolder.Widget));
+    }
+
+    [Fact]
+    public void the_command_name_is_kebab_cased()
+    {
+        // CommandFactory only strips the "Command" suffix and lowercases, so without the explicit
+        // name this would register as "streamquery".
+        var attribute = typeof(StreamQueryCommand)
+            .GetCustomAttributes(typeof(JasperFx.CommandLine.DescriptionAttribute), false)
+            .Cast<JasperFx.CommandLine.DescriptionAttribute>()
+            .Single();
+
+        attribute.Name.ShouldBe("stream-query");
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -198,6 +198,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | The projection error path and dead letters | `DeadLetterCompliance` |
 | Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
 | The cross-stream event query (`QueryEventsAsync`) | `EventQueryCompliance` |
+| The stream-state queryable (`QueryStreamStates`) | `StreamStateQueryCompliance` |
 | Subscriptions | `SubscriptionCompliance` |
 | Single-tenanted slicing of disagreeing tenant ids | `SingleTenantedEventSlicingCompliance` |
 | Composite projections — staging and member teardown | `CompositeProjectionCompliance` |

--- a/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ConjoinedEventTenancyCompliance.cs
@@ -301,4 +301,42 @@ public abstract class ConjoinedEventTenancyCompliance<TFixture, TOperations, TQu
         result.Events.Select(x => ((ConsignmentBooked)x.Data!).Destination)
             .OrderBy(x => x).ShouldBe(["Boston", "Chicago"]);
     }
+
+    /// <summary>
+    /// <c>QueryStreamStates(tenantId)</c> scopes the streams table to one tenant (jasperfx#740).
+    /// Lives here rather than in <c>StreamStateQueryCompliance</c> because this suite owns the
+    /// conjoined-tenancy store configuration — the same division of labor as the event-query and
+    /// explorer tenant coverage. Reuses one stream id across both tenants, this suite's sharpest
+    /// trick: under conjoined tenancy the identity of a stream is (tenant, id), so a store keying
+    /// on id alone returns one tenant's stream metadata to the other.
+    /// </summary>
+    [Fact]
+    public async Task query_stream_states_scoped_to_a_tenant()
+    {
+        var shared = Guid.NewGuid();
+        var onlyA = Guid.NewGuid();
+
+        await appendAsync(TenantA, shared, new ConsignmentBooked("Boston"), new ConsignmentScanned("Depot"));
+        await appendAsync(TenantA, onlyA, new ConsignmentBooked("Chicago"));
+        await appendAsync(TenantB, shared, new ConsignmentBooked("Lisbon"));
+
+        var readOnly = theFixture.EventStore.OpenReadOnlyEventStore();
+
+        var forA = await Documents.DocumentQueryableExtensions.ToListAsync(
+            readOnly.QueryStreamStates(TenantA), Cancellation);
+
+        // Both directions, as everywhere in this suite: tenant A's two streams are there, tenant
+        // B's copy of the shared id is not — its version would bleed through as a wrong Version on
+        // the shared stream, so assert the version too.
+        forA.Count.ShouldBe(2);
+        forA.Select(x => x.Id).OrderBy(x => x).ShouldBe(new[] { shared, onlyA }.OrderBy(x => x));
+        forA.Single(x => x.Id == shared).Version.ShouldBe(2);
+
+        var forB = await Documents.DocumentQueryableExtensions.ToListAsync(
+            readOnly.QueryStreamStates(TenantB), Cancellation);
+
+        var bStream = forB.ShouldHaveSingleItem();
+        bStream.Id.ShouldBe(shared);
+        bStream.Version.ShouldBe(1);
+    }
 }

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamStateQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamStateQueryCompliance.cs
@@ -1,0 +1,521 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Stream state query events and aggregates
+
+public record FreighterLaunched(string Name);
+
+public record FreighterDocked(string Port);
+
+public record FreighterScrapped;
+
+public partial class ComplianceFreighter
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Dockings { get; set; }
+
+    public static ComplianceFreighter Create(FreighterLaunched e) => new() { Name = e.Name };
+
+    public void Apply(FreighterDocked _) => Dockings++;
+
+    public void Apply(FreighterScrapped _)
+    {
+    }
+}
+
+/// <summary>
+/// A second aggregate type over the same events, so the aggregate-type facts have a decoy that
+/// differs ONLY in type.
+/// </summary>
+public partial class ComplianceTugboat
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Dockings { get; set; }
+
+    public static ComplianceTugboat Create(FreighterLaunched e) => new() { Name = e.Name };
+
+    public void Apply(FreighterDocked _) => Dockings++;
+}
+
+#endregion
+
+/// <summary>
+/// <c>IReadOnlyEventStore.QueryStreamStates()</c> — the streams table as an
+/// <see cref="IQueryable{T}"/> of <see cref="StreamState"/>, executed through the shared
+/// <see cref="DocumentQueryableExtensions"/> terminators. See jasperfx#740.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Same discipline as <c>EventQueryCompliance</c>, and for the same reason: every predicate fact
+/// asserts exact expected membership against seeded data with decoys that fail only that
+/// predicate — never merely that the call succeeds — because a silently-dropped <c>Where</c>
+/// clause returns unfiltered streams that read as filtered. One fact per public get member of
+/// <see cref="StreamState"/>, including the jasperfx#740 <see cref="StreamState.CompactedVersion"/>
+/// watermark and the <c>x.AggregateType == typeof(X)</c> form, which is exactly the Stream
+/// Compaction Policy's selector.
+/// </para>
+/// <para>
+/// Like <c>DocumentQueryCompliance</c>, this is not a LINQ conformance suite: what is pinned is
+/// the minimum translatable set the contract promises — <c>Where</c> over every member,
+/// <c>OrderBy</c>/<c>ThenBy</c>, <c>Skip</c>/<c>Take</c>, and the async terminators. A member a
+/// provider cannot translate must fail the query naming that member, never silently match all
+/// rows; that refusal shape cannot be pinned here (both current stores translate everything), so
+/// it lives in the contract's xml-doc and each store's own tests.
+/// </para>
+/// <para>
+/// The tenant-scoped overload (<c>QueryStreamStates(tenantId)</c>) is deliberately not exercised
+/// here — it belongs with <c>ConjoinedEventTenancyCompliance</c>, which owns the tenant-scoped
+/// store configuration, and it has a fact there.
+/// </para>
+/// </remarks>
+public abstract class StreamStateQueryCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_stream_query";
+
+        config.AddEventType<FreighterLaunched>();
+        config.AddEventType<FreighterDocked>();
+        config.AddEventType<FreighterScrapped>();
+
+        // Inline snapshots so both aggregate types are registered store-side: the
+        // AggregateType == typeof(X) translation resolves the typeof constant against the store's
+        // known aggregate identities.
+        config.Snapshot<ComplianceFreighter>(SnapshotLifecycle.Inline);
+        config.Snapshot<ComplianceTugboat>(SnapshotLifecycle.Inline);
+    };
+
+    /// <summary>
+    /// Stream identity is a store-level setting, so the <see cref="StreamState.Key"/> fact needs
+    /// its own string-identified store — the same split as <c>StreamCompactingCompliance</c>.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _stringConfiguration = config =>
+    {
+        config.SchemaName = "compliance_stream_query_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+
+        config.AddEventType<FreighterLaunched>();
+        config.AddEventType<FreighterDocked>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private IQueryable<StreamState> Streams
+        => theFixture.EventStore.OpenReadOnlyEventStore().QueryStreamStates();
+
+    /// <summary>
+    /// Start a freighter stream with a launch plus <paramref name="docks"/> docking events, one
+    /// save, and return its id.
+    /// </summary>
+    private async Task<Guid> aFreighterAsync(int docks = 0)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var events = new object[] { new FreighterLaunched("Cargolux") }
+            .Concat(Enumerable.Range(0, docks).Select(object (i) => new FreighterDocked($"Port {i}")))
+            .ToArray();
+        EventsFor(session).StartStream<ComplianceFreighter>(streamId, events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task<Guid> aTugboatAsync(int docks = 0)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        var events = new object[] { new FreighterLaunched("Pushy") }
+            .Concat(Enumerable.Range(0, docks).Select(object (i) => new FreighterDocked($"Port {i}")))
+            .ToArray();
+        EventsFor(session).StartStream<ComplianceTugboat>(streamId, events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task appendDockingAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        EventsFor(session).Append(streamId, new FreighterDocked("Later port"));
+        await SaveChangesAsync(session);
+    }
+
+    private async Task archiveAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        EventsFor(session).ArchiveStream(streamId);
+        await SaveChangesAsync(session);
+    }
+
+    private async Task compactAsync(Guid streamId, long? throughVersion = null)
+    {
+        await using var session = OpenSession();
+        await EventsFor(session).CompactStreamAsync<ComplianceFreighter>(streamId,
+            throughVersion is { } v ? x => x.Version = v : null);
+        await SaveChangesAsync(session);
+    }
+
+    // ---- one Where() fact per public get member ----
+
+    [Fact]
+    public async Task where_on_id()
+    {
+        await aFreighterAsync();
+        var target = await aFreighterAsync();
+        await aFreighterAsync();
+
+        (await Streams.CountAsync(Cancellation)).ShouldBe(3);
+
+        var matched = await Streams.Where(x => x.Id == target).ToListAsync(Cancellation);
+
+        matched.ShouldHaveSingleItem().Id.ShouldBe(target);
+    }
+
+    [Fact]
+    public async Task where_on_key_for_a_string_identified_store()
+    {
+        await theFixture.ConfigureAsync(_stringConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream("freighter-a", new FreighterLaunched("A"));
+            EventsFor(session).StartStream("freighter-b", new FreighterLaunched("B"), new FreighterDocked("Kiel"));
+            await SaveChangesAsync(session);
+        }
+
+        var matched = await Streams.Where(x => x.Key == "freighter-b").ToListAsync(Cancellation);
+
+        var state = matched.ShouldHaveSingleItem();
+        state.Key.ShouldBe("freighter-b");
+        state.Version.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task where_on_version()
+    {
+        await aFreighterAsync(docks: 0);                       // version 1
+        var three = await aFreighterAsync(docks: 2);           // version 3
+        var five = await aFreighterAsync(docks: 4);            // version 5
+
+        var matched = await Streams.Where(x => x.Version >= 3).ToListAsync(Cancellation);
+
+        // Inclusive at the bound: the version-3 stream is the one an exclusive comparison loses.
+        matched.Count.ShouldBe(2);
+        matched.Select(x => x.Id).OrderBy(x => x).ShouldBe(new[] { three, five }.OrderBy(x => x));
+    }
+
+    /// <summary>
+    /// The compaction policy's selector, in exactly the form CritterWatch will issue: equality
+    /// against a <c>typeof</c> constant, translated to the stored aggregate-type identity.
+    /// </summary>
+    [Fact]
+    public async Task where_on_aggregate_type_typeof_equality()
+    {
+        var first = await aFreighterAsync();
+        var second = await aFreighterAsync();
+        await aTugboatAsync();
+
+        // A stream started with no aggregate type at all: the null-cell decoy.
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(Guid.NewGuid(), new FreighterLaunched("Untyped"));
+            await SaveChangesAsync(session);
+        }
+
+        var matched = await Streams
+            .Where(x => x.AggregateType == typeof(ComplianceFreighter))
+            .ToListAsync(Cancellation);
+
+        matched.Count.ShouldBe(2);
+        matched.Select(x => x.Id).OrderBy(x => x).ShouldBe(new[] { first, second }.OrderBy(x => x));
+        matched.ShouldAllBe(x => x.AggregateType == typeof(ComplianceFreighter));
+    }
+
+    [Fact]
+    public async Task where_on_created()
+    {
+        var early = await aFreighterAsync();
+        await Task.Delay(40, Cancellation);
+        var late = await aFreighterAsync();
+
+        // Appended AFTER the late stream was created, so the early stream's LastTimestamp is the
+        // newest in the store while its Created stays the oldest — the trap for a provider mapping
+        // Created onto the wrong column.
+        await appendDockingAsync(early);
+
+        var states = await Streams.ToListAsync(Cancellation);
+        var lateCreated = states.Single(x => x.Id == late).Created;
+
+        var matched = await Streams.Where(x => x.Created >= lateCreated).ToListAsync(Cancellation);
+
+        matched.ShouldHaveSingleItem().Id.ShouldBe(late);
+    }
+
+    [Fact]
+    public async Task where_on_last_timestamp()
+    {
+        var active = await aFreighterAsync();
+        await Task.Delay(40, Cancellation);
+        var idle = await aFreighterAsync();
+        await Task.Delay(40, Cancellation);
+        await appendDockingAsync(active);
+
+        var states = await Streams.ToListAsync(Cancellation);
+        var activeLast = states.Single(x => x.Id == active).LastTimestamp;
+
+        var matched = await Streams.Where(x => x.LastTimestamp >= activeLast).ToListAsync(Cancellation);
+
+        // The OLDER stream by creation is the one that matches, because it was appended to last —
+        // a provider reading Created here returns the idle stream instead.
+        matched.ShouldHaveSingleItem().Id.ShouldBe(active);
+        matched.Single().Id.ShouldNotBe(idle);
+    }
+
+    [Fact]
+    public async Task where_on_is_archived_in_both_directions()
+    {
+        var liveOne = await aFreighterAsync();
+        var liveTwo = await aFreighterAsync();
+        var archived = await aFreighterAsync();
+        await archiveAsync(archived);
+
+        var archivedOnly = await Streams.Where(x => x.IsArchived).ToListAsync(Cancellation);
+        archivedOnly.ShouldHaveSingleItem().Id.ShouldBe(archived);
+
+        var liveOnly = await Streams.Where(x => !x.IsArchived).ToListAsync(Cancellation);
+        liveOnly.Count.ShouldBe(2);
+        liveOnly.Select(x => x.Id).OrderBy(x => x).ShouldBe(new[] { liveOne, liveTwo }.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task where_on_compacted_version()
+    {
+        var compacted = await aFreighterAsync(docks: 8);       // version 9
+        await compactAsync(compacted, throughVersion: 5);
+        var untouched = await aFreighterAsync(docks: 8);       // version 9, never compacted
+
+        // Equality in both directions, so the watermark has to be surfaced exactly — a store
+        // hardcoding zero passes one half and fails the other.
+        var atFive = await Streams.Where(x => x.CompactedVersion == 5).ToListAsync(Cancellation);
+        atFive.ShouldHaveSingleItem().Id.ShouldBe(compacted);
+
+        var never = await Streams.Where(x => x.CompactedVersion == 0).ToListAsync(Cancellation);
+        never.ShouldHaveSingleItem().Id.ShouldBe(untouched);
+    }
+
+    /// <summary>
+    /// The watermark on the fetch path agrees with the queryable: <c>FetchStreamStateAsync</c>
+    /// reports the same <see cref="StreamState.CompactedVersion"/>, and a full compaction sets the
+    /// watermark to the stream's version so the un-compacted growth reads zero.
+    /// </summary>
+    [Fact]
+    public async Task fetch_stream_state_carries_the_compaction_watermark()
+    {
+        var partial = await aFreighterAsync(docks: 8);         // version 9
+        await compactAsync(partial, throughVersion: 5);
+
+        var full = await aFreighterAsync(docks: 8);            // version 9
+        await compactAsync(full);
+
+        var fresh = await aFreighterAsync();
+
+        await using var session = OpenSession();
+
+        var partialState = await EventsFor(session).FetchStreamStateAsync(partial, Cancellation);
+        partialState.ShouldNotBeNull();
+        partialState.Version.ShouldBe(9);
+        partialState.CompactedVersion.ShouldBe(5);
+        (partialState.Version - partialState.CompactedVersion).ShouldBe(4);
+
+        var fullState = await EventsFor(session).FetchStreamStateAsync(full, Cancellation);
+        fullState.ShouldNotBeNull();
+        fullState.CompactedVersion.ShouldBe(9);
+        (fullState.Version - fullState.CompactedVersion).ShouldBe(0);
+
+        var freshState = await EventsFor(session).FetchStreamStateAsync(fresh, Cancellation);
+        freshState.ShouldNotBeNull();
+        freshState.CompactedVersion.ShouldBe(0);
+    }
+
+    // ---- combinations ----
+
+    /// <summary>
+    /// The Stream Compaction Policy's own predicate, verbatim: aggregate type AND un-compacted
+    /// growth above a threshold AND not archived. Two matchers and four decoys, each decoy failing
+    /// exactly one conjunct.
+    /// </summary>
+    [Fact]
+    public async Task the_compaction_policy_shape()
+    {
+        var overgrown = await aFreighterAsync(docks: 8);       // version 9
+        await compactAsync(overgrown, throughVersion: 5);      // growth 4 -> match
+
+        var neverCompacted = await aFreighterAsync(docks: 8);  // growth 9 -> match
+
+        var freshlyCompacted = await aFreighterAsync(docks: 8);
+        await compactAsync(freshlyCompacted);                  // growth 0 -> fails growth (raw Version 9!)
+
+        await aFreighterAsync(docks: 2);                       // growth 3, at threshold -> fails growth
+
+        await aTugboatAsync(docks: 8);                         // growth 9 -> fails type
+
+        var mothballed = await aFreighterAsync(docks: 8);      // growth 9 -> fails archived
+        await archiveAsync(mothballed);
+
+        var matched = await Streams
+            .Where(x => x.AggregateType == typeof(ComplianceFreighter)
+                        && x.Version - x.CompactedVersion > 3
+                        && !x.IsArchived)
+            .ToListAsync(Cancellation);
+
+        // The freshly-compacted stream is the load-bearing decoy: its raw Version is 9, so a store
+        // thresholding on Version instead of growth includes it and fails here. That distinction is
+        // the entire reason the watermark exists.
+        matched.Count.ShouldBe(2);
+        matched.Select(x => x.Id).OrderBy(x => x)
+            .ShouldBe(new[] { overgrown, neverCompacted }.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task version_bound_combines_with_aggregate_type()
+    {
+        var bigFreighter = await aFreighterAsync(docks: 4);    // version 5
+        await aFreighterAsync();                               // version 1 -> fails version
+        await aTugboatAsync(docks: 4);                         // version 5 -> fails type
+
+        var matched = await Streams
+            .Where(x => x.AggregateType == typeof(ComplianceFreighter) && x.Version >= 3)
+            .ToListAsync(Cancellation);
+
+        matched.ShouldHaveSingleItem().Id.ShouldBe(bigFreighter);
+    }
+
+    // ---- ordering, paging, terminators ----
+
+    /// <summary>
+    /// The stated ordering for deterministic pages — the one the <c>stream-query</c> command uses:
+    /// creation order (oldest first), ties broken by stream identity. Pinned here as
+    /// <c>OrderBy(Created).ThenBy(Id)</c> + <c>Skip</c>/<c>Take</c>: pages are disjoint, complete,
+    /// and ordered across page boundaries, and <c>CountAsync</c> over the same filter reports the
+    /// total the pages walk.
+    /// </summary>
+    [Fact]
+    public async Task paging_walks_the_stated_ordering()
+    {
+        var created = new List<Guid>();
+        for (var i = 0; i < 5; i++)
+        {
+            created.Add(await aFreighterAsync());
+            await Task.Delay(25, Cancellation);
+        }
+
+        var ordered = StreamQueryOrdered();
+
+        (await Streams.CountAsync(Cancellation)).ShouldBe(5);
+
+        var pages = new List<IReadOnlyList<StreamState>>();
+        for (var page = 0; page < 3; page++)
+        {
+            pages.Add(await ordered.Skip(page * 2).Take(2).ToListAsync(Cancellation));
+        }
+
+        pages[0].Count.ShouldBe(2);
+        pages[1].Count.ShouldBe(2);
+        pages[2].Count.ShouldBe(1);
+
+        // Disjoint, complete, and in creation order across the page boundaries.
+        pages.SelectMany(x => x).Select(x => x.Id).ShouldBe(created);
+
+        // A page past the end is empty, while the count stays truthful.
+        (await ordered.Skip(20).Take(2).ToListAsync(Cancellation)).ShouldBeEmpty();
+        (await Streams.CountAsync(Cancellation)).ShouldBe(5);
+
+        IOrderedQueryable<StreamState> StreamQueryOrdered()
+            => Streams.OrderBy(x => x.Created).ThenBy(x => x.Id);
+    }
+
+    [Fact]
+    public async Task the_shared_terminators_dispatch_against_this_queryable()
+    {
+        var oldest = await aFreighterAsync(docks: 4);
+        await Task.Delay(25, Cancellation);
+        await aFreighterAsync();
+
+        // Every shared terminator, on the events-side queryable: the whole point of reusing the
+        // document execution hook is that none of these needed anything new.
+        (await Streams.CountAsync(x => x.Version >= 3, Cancellation)).ShouldBe(1);
+        (await Streams.AnyAsync(Cancellation)).ShouldBeTrue();
+        (await Streams.AnyAsync(x => x.IsArchived, Cancellation)).ShouldBeFalse();
+
+        var first = await Streams.OrderBy(x => x.Created).FirstOrDefaultAsync(Cancellation);
+        first.ShouldNotBeNull();
+        first.Id.ShouldBe(oldest);
+    }
+
+    /// <summary>
+    /// The shape fact, mirroring <c>DocumentQueryCompliance</c>: a real <see cref="IQueryable{T}"/>
+    /// composes across statements, because real consumer code — the compaction policy evaluator
+    /// included — adds clauses conditionally to a query held in a local.
+    /// </summary>
+    [Fact]
+    public async Task a_queryable_composes_across_statements()
+    {
+        var firstBig = await aFreighterAsync(docks: 4);        // version 5, live
+        var secondBig = await aFreighterAsync(docks: 4);       // version 5, live
+        await aFreighterAsync();                               // version 1 -> dropped by the first clause
+
+        var archived = await aFreighterAsync(docks: 4);        // version 5 -> dropped by the second
+        await archiveAsync(archived);
+
+        var query = Streams;
+        query = query.Where(x => x.Version >= 3);
+        query = query.Where(x => !x.IsArchived);
+
+        var matched = await query.ToListAsync(Cancellation);
+
+        matched.Count.ShouldBe(2);
+        matched.Select(x => x.Id).OrderBy(x => x).ShouldBe(new[] { firstBig, secondBig }.OrderBy(x => x));
+    }
+
+    // ---- truthful zeros ----
+
+    [Fact]
+    public async Task every_predicate_returns_an_empty_answer_when_nothing_matches()
+    {
+        await aFreighterAsync(docks: 2);
+
+        var nonMatching = new (string Name, IQueryable<StreamState> Query)[]
+        {
+            ("Id", Streams.Where(x => x.Id == Guid.NewGuid())),
+            ("Version", Streams.Where(x => x.Version > 1000)),
+            ("AggregateType", Streams.Where(x => x.AggregateType == typeof(ComplianceTugboat))),
+            ("IsArchived", Streams.Where(x => x.IsArchived)),
+            ("CompactedVersion", Streams.Where(x => x.CompactedVersion > 0)),
+            ("Created", Streams.Where(x => x.Created > DateTimeOffset.UtcNow.AddYears(10))),
+            ("LastTimestamp", Streams.Where(x => x.LastTimestamp > DateTimeOffset.UtcNow.AddYears(10)))
+        };
+
+        foreach (var (name, query) in nonMatching)
+        {
+            (await query.ToListAsync(Cancellation)).ShouldBeEmpty($"the {name} predicate should have matched nothing");
+            (await query.CountAsync(Cancellation)).ShouldBe(0);
+            (await query.AnyAsync(Cancellation)).ShouldBeFalse();
+        }
+    }
+}

--- a/src/JasperFx.Events/CommandLine/StreamQueryCommand.cs
+++ b/src/JasperFx.Events/CommandLine/StreamQueryCommand.cs
@@ -1,0 +1,141 @@
+using JasperFx.CommandLine;
+using JasperFx.Events.Documents;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Queries the streams table of the application's own event store through
+/// <see cref="IReadOnlyEventStore.QueryStreamStates"/> (jasperfx#740) — the CLI face of the Stream
+/// Compaction Policy questions: "every stream of aggregate type X whose un-compacted growth
+/// exceeds N". Sits beside <c>event-query</c> and <c>projection-run</c> with the same honesty
+/// rules: a filter the store cannot honor is refused by name, and an empty result with a truthful
+/// total is a real answer.
+/// </summary>
+/// <remarks>
+/// Ordering contract: streams are returned in creation order (oldest first), ties broken by stream
+/// identity, so pages are deterministic — see <see cref="StreamQueryInput.ApplyOrdering"/>.
+/// </remarks>
+// Name is explicit because CommandFactory.CommandNameFor only strips the "Command" suffix and
+// lowercases — it does not split PascalCase — so this would otherwise be "streamquery".
+[Description("Query event stream metadata (version, aggregate type, compaction watermark, archive flag) with filters and paging",
+    Name = "stream-query")]
+public class StreamQueryCommand: JasperFxAsyncCommand<StreamQueryInput>
+{
+    public StreamQueryCommand()
+    {
+        Usage("Query the event streams of the application's event store");
+    }
+
+    public override async Task<bool> Execute(StreamQueryInput input)
+    {
+        // Console logging has to go: in the default JSON mode a single stray log line makes the
+        // output unparseable. --verbose opts back in, but only for --format text, matching the
+        // sibling commands.
+        if (input.HostBuilder != null && (!input.VerboseFlag || input.FormatFlag == EventQueryFormat.Json))
+        {
+            input.HostBuilder.ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddDebug();
+            });
+        }
+
+        var validation = input.Validate();
+        if (validation != null)
+        {
+            return fail(input, null, null, validation);
+        }
+
+        using var host = input.BuildHost();
+
+        var stores = host.Services.GetServices<IEventStore>().ToArray();
+        var (store, storeError) = ProjectionRunSource.SelectStore(stores, input.StoreFlag);
+        if (store == null)
+        {
+            return fail(input, null, null, storeError!);
+        }
+
+        // Resolved after the host is built: building the store is what loads the assemblies the
+        // application's aggregates live in.
+        Type? aggregateType = null;
+        if (input.AggregateTypeFlag != null)
+        {
+            (aggregateType, var typeError) = StreamQueryInput.ResolveAggregateType(input.AggregateTypeFlag);
+            if (aggregateType == null)
+            {
+                return fail(input, null, store.Subject, typeError!);
+            }
+        }
+
+        IReadOnlyList<StreamState> page;
+        int totalCount;
+        try
+        {
+            var filtered = input.ApplyFilters(
+                store.OpenReadOnlyEventStore().QueryStreamStates(input.TenantFlag), aggregateType);
+
+            totalCount = await filtered.CountAsync(CancellationToken.None).ConfigureAwait(false);
+
+            page = await StreamQueryInput.ApplyOrdering(filtered)
+                .Skip((input.PageFlag - 1) * input.PageSizeFlag)
+                .Take(input.PageSizeFlag)
+                .ToListAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (NotSupportedException e)
+        {
+            // A tenant on a store with no tenant dimension, or a StreamState member the provider
+            // cannot translate, refusing by name per the jasperfx#737 rule. Say so plainly — the
+            // one thing this must never become is an empty result.
+            return fail(input, aggregateType, store.Subject,
+                $"This event store does not support part of the query: {e.Message}");
+        }
+        catch (Exception e)
+        {
+            return await failAsync(host, input, aggregateType, store.Subject, e.Message).ConfigureAwait(false);
+        }
+
+        write(input, StreamQueryReport.From(input, aggregateType, store.Subject, page, totalCount));
+
+        // An empty page with TotalCount 0 lands here: a real answer, reported as one.
+        return true;
+    }
+
+    /// <summary>
+    /// A failed run still writes a report, so JSON consumers parse one shape either way rather
+    /// than having to tell an empty result from a crash.
+    /// </summary>
+    private static bool fail(StreamQueryInput input, Type? aggregateType, Uri? store, string error)
+    {
+        write(input, StreamQueryReport.Failed(input, aggregateType, store, error));
+        return false;
+    }
+
+    /// <summary>
+    /// The same, for failures against a built host — worth asking whether the application's
+    /// storage was ever migrated, exactly as the sibling commands do.
+    /// </summary>
+    private static async Task<bool> failAsync(IHost host, StreamQueryInput input, Type? aggregateType,
+        Uri? store, string error)
+    {
+        var diagnosis = await ProjectionRunSchemaDiagnosis
+            .TryDiagnoseAsync(host.Services, CancellationToken.None).ConfigureAwait(false);
+
+        write(input, StreamQueryReport.Failed(input, aggregateType, store, error, diagnosis));
+        return false;
+    }
+
+    private static void write(StreamQueryInput input, StreamQueryReport report)
+    {
+        if (input.FormatFlag == EventQueryFormat.Json)
+        {
+            StreamQueryView.WriteJson(report);
+        }
+        else
+        {
+            StreamQueryView.WriteConsole(report);
+        }
+    }
+}

--- a/src/JasperFx.Events/CommandLine/StreamQueryInput.cs
+++ b/src/JasperFx.Events/CommandLine/StreamQueryInput.cs
@@ -1,0 +1,263 @@
+using System.Reflection;
+using JasperFx.CommandLine;
+using JasperFx.Core;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Input for the <c>stream-query</c> command. Every flag is long-form only for the same reason as
+/// <see cref="ProjectionRunInput"/> and <see cref="EventQueryInput"/>: the parser derives
+/// one-letter aliases from the first letter with no collision detection, and this surface has
+/// <c>--store</c>/<c>--stream</c>-adjacent spellings plus four timestamp flags competing for the
+/// same letters.
+/// </summary>
+public class StreamQueryInput: NetCoreInput
+{
+    [Description("Aggregate type the streams were started as — a CLR type name (simple or full), resolved against the application's loaded types")]
+    [FlagAlias("aggregate-type", longAliasOnly: true)]
+    public string? AggregateTypeFlag { get; set; }
+
+    [Description("Only streams whose version (event count) is at least this")]
+    [FlagAlias("min-version", longAliasOnly: true)]
+    public long? MinVersionFlag { get; set; }
+
+    [Description("Only streams whose un-compacted growth exceeds this: Version - CompactedVersion > N, the compaction-policy predicate")]
+    [FlagAlias("version-above-compacted", longAliasOnly: true)]
+    public long? VersionAboveCompactedFlag { get; set; }
+
+    [Description("Filter on the archived flag: 'true' for archived streams only, 'false' for live only. Omit for both")]
+    [FlagAlias("archived", longAliasOnly: true)]
+    public bool? ArchivedFlag { get; set; }
+
+    [Description("Inclusive lower bound on the stream's creation time, any DateTimeOffset format (e.g. 2026-09-01T00:00:00Z)")]
+    [FlagAlias("created-from", longAliasOnly: true)]
+    public string? CreatedFromFlag { get; set; }
+
+    [Description("Inclusive upper bound on the stream's creation time")]
+    [FlagAlias("created-to", longAliasOnly: true)]
+    public string? CreatedToFlag { get; set; }
+
+    [Description("Inclusive lower bound on the stream's last-append time")]
+    [FlagAlias("updated-from", longAliasOnly: true)]
+    public string? UpdatedFromFlag { get; set; }
+
+    [Description("Inclusive upper bound on the stream's last-append time")]
+    [FlagAlias("updated-to", longAliasOnly: true)]
+    public string? UpdatedToFlag { get; set; }
+
+    [Description("Tenant partition to scope the query to. Omit for a store-global read")]
+    [FlagAlias("tenant", longAliasOnly: true)]
+    public string? TenantFlag { get; set; }
+
+    [Description("1-based page number. Default is 1")]
+    [FlagAlias("page", longAliasOnly: true)]
+    public int PageFlag { get; set; } = 1;
+
+    [Description("Page size. Default is 50")]
+    [FlagAlias("page-size", longAliasOnly: true)]
+    public int PageSizeFlag { get; set; } = 50;
+
+    [Description("Subject uri (or bare scheme) of the event store to query. Only needed when the application registers more than one")]
+    [FlagAlias("store", longAliasOnly: true)]
+    public string? StoreFlag { get; set; }
+
+    [Description("Output rendering: json (default, for agents and scripts) or text (a console table)")]
+    [FlagAlias("format", longAliasOnly: true)]
+    public EventQueryFormat FormatFlag { get; set; } = EventQueryFormat.Json;
+
+    /// <summary>
+    /// Operator-facing message for the first invalid flag, or null when the input is usable.
+    /// </summary>
+    public string? Validate()
+    {
+        if (PageFlag < 1)
+        {
+            return "--page must be 1 or greater";
+        }
+
+        if (PageSizeFlag < 1)
+        {
+            return "--page-size must be greater than zero";
+        }
+
+        if (MinVersionFlag is < 0)
+        {
+            return "--min-version cannot be negative";
+        }
+
+        if (VersionAboveCompactedFlag is < 0)
+        {
+            return "--version-above-compacted cannot be negative";
+        }
+
+        if (CreatedFromFlag.IsNotEmpty() && !DateTimeOffset.TryParse(CreatedFromFlag, out _))
+        {
+            return $"--created-from '{CreatedFromFlag}' is not a recognizable timestamp";
+        }
+
+        if (CreatedToFlag.IsNotEmpty() && !DateTimeOffset.TryParse(CreatedToFlag, out _))
+        {
+            return $"--created-to '{CreatedToFlag}' is not a recognizable timestamp";
+        }
+
+        if (UpdatedFromFlag.IsNotEmpty() && !DateTimeOffset.TryParse(UpdatedFromFlag, out _))
+        {
+            return $"--updated-from '{UpdatedFromFlag}' is not a recognizable timestamp";
+        }
+
+        if (UpdatedToFlag.IsNotEmpty() && !DateTimeOffset.TryParse(UpdatedToFlag, out _))
+        {
+            return $"--updated-to '{UpdatedToFlag}' is not a recognizable timestamp";
+        }
+
+        if (parseTimestamp(CreatedFromFlag) is { } createdFrom && parseTimestamp(CreatedToFlag) is { } createdTo &&
+            createdFrom > createdTo)
+        {
+            return "--created-from must be less than or equal to --created-to";
+        }
+
+        if (parseTimestamp(UpdatedFromFlag) is { } updatedFrom && parseTimestamp(UpdatedToFlag) is { } updatedTo &&
+            updatedFrom > updatedTo)
+        {
+            return "--updated-from must be less than or equal to --updated-to";
+        }
+
+        return null;
+    }
+
+    public DateTimeOffset? CreatedFrom => parseTimestamp(CreatedFromFlag);
+    public DateTimeOffset? CreatedTo => parseTimestamp(CreatedToFlag);
+    public DateTimeOffset? UpdatedFrom => parseTimestamp(UpdatedFromFlag);
+    public DateTimeOffset? UpdatedTo => parseTimestamp(UpdatedToFlag);
+
+    /// <summary>
+    /// Compose the flags onto the stream-state queryable as <c>Where</c> clauses. Pure queryable
+    /// composition — no execution — so the mapping is unit-testable against an in-memory
+    /// <see cref="IQueryable{T}"/> with no store.
+    /// </summary>
+    /// <param name="queryable">The source, from <see cref="IReadOnlyEventStore.QueryStreamStates"/>.</param>
+    /// <param name="aggregateType">
+    /// The resolved CLR type for <see cref="AggregateTypeFlag"/>, or null when the flag was not
+    /// supplied. Resolution is the caller's job (see <see cref="ResolveAggregateType"/>) because it
+    /// can fail and the failure is an input error, not a query result.
+    /// </param>
+    public IQueryable<StreamState> ApplyFilters(IQueryable<StreamState> queryable, Type? aggregateType)
+    {
+        if (aggregateType != null)
+        {
+            // The compaction-policy selector form, and the exact shape the compliance suite pins:
+            // equality against a typeof constant, translated by the provider to the stored
+            // aggregate-type identity.
+            queryable = queryable.Where(x => x.AggregateType == aggregateType);
+        }
+
+        if (MinVersionFlag is { } minVersion)
+        {
+            queryable = queryable.Where(x => x.Version >= minVersion);
+        }
+
+        if (VersionAboveCompactedFlag is { } growth)
+        {
+            queryable = queryable.Where(x => x.Version - x.CompactedVersion > growth);
+        }
+
+        if (ArchivedFlag is { } archived)
+        {
+            queryable = queryable.Where(x => x.IsArchived == archived);
+        }
+
+        if (CreatedFrom is { } createdFrom)
+        {
+            queryable = queryable.Where(x => x.Created >= createdFrom);
+        }
+
+        if (CreatedTo is { } createdTo)
+        {
+            queryable = queryable.Where(x => x.Created <= createdTo);
+        }
+
+        if (UpdatedFrom is { } updatedFrom)
+        {
+            queryable = queryable.Where(x => x.LastTimestamp >= updatedFrom);
+        }
+
+        if (UpdatedTo is { } updatedTo)
+        {
+            queryable = queryable.Where(x => x.LastTimestamp <= updatedTo);
+        }
+
+        return queryable;
+    }
+
+    /// <summary>
+    /// The command's stated ordering contract: creation order (oldest stream first), ties broken by
+    /// stream identity so pages are deterministic. The identity member that does not apply to the
+    /// store's identity style holds its default (<see cref="Guid.Empty"/> / null) on every row, so
+    /// its tiebreak is a stable constant.
+    /// </summary>
+    public static IOrderedQueryable<StreamState> ApplyOrdering(IQueryable<StreamState> queryable)
+        => queryable.OrderBy(x => x.Created).ThenBy(x => x.Id).ThenBy(x => x.Key);
+
+    /// <summary>
+    /// Resolve <c>--aggregate-type</c> to a CLR <see cref="Type"/> against the application's loaded
+    /// assemblies, matching full name first and simple name second, case-insensitively. Ambiguity is
+    /// refused rather than guessed — querying the wrong aggregate type would read exactly like an
+    /// empty store.
+    /// </summary>
+    /// <remarks>
+    /// Loaded-assembly scanning rather than a store registry because no shared surface exposes the
+    /// store's aggregate-type graph (it hangs off each product's own options type). The command runs
+    /// in-process on the application host, where building the store has already loaded the
+    /// assemblies its aggregates live in.
+    /// </remarks>
+    public static (Type? Type, string? Error) ResolveAggregateType(string name)
+        => ResolveAggregateType(name, AppDomain.CurrentDomain.GetAssemblies()
+            .Where(x => !x.IsDynamic)
+            .SelectMany(x =>
+            {
+                try
+                {
+                    return x.GetTypes();
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    return e.Types.Where(t => t != null).Select(t => t!);
+                }
+            }));
+
+    /// <summary>
+    /// The testable core of <see cref="ResolveAggregateType(string)"/>: resolve against an explicit
+    /// candidate set.
+    /// </summary>
+    public static (Type? Type, string? Error) ResolveAggregateType(string name, IEnumerable<Type> candidates)
+    {
+        var materialized = candidates.Where(x => x.IsClass && !x.IsAbstract).ToArray();
+
+        var byFullName = materialized
+            .Where(x => string.Equals(x.FullName, name, StringComparison.OrdinalIgnoreCase))
+            .Distinct()
+            .ToArray();
+
+        if (byFullName.Length == 1)
+        {
+            return (byFullName[0], null);
+        }
+
+        var bySimpleName = materialized
+            .Where(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase))
+            .Distinct()
+            .ToArray();
+
+        return bySimpleName.Length switch
+        {
+            1 => (bySimpleName[0], null),
+            0 => (null,
+                $"No loaded type matches --aggregate-type {name}. Use the aggregate's simple or full CLR type name"),
+            _ => (null,
+                $"--aggregate-type {name} is ambiguous across: {string.Join(", ", bySimpleName.Select(x => x.FullName))}. Use the full type name")
+        };
+    }
+
+    private static DateTimeOffset? parseTimestamp(string? flag)
+        => flag.IsNotEmpty() && DateTimeOffset.TryParse(flag, out var parsed) ? parsed : null;
+}

--- a/src/JasperFx.Events/CommandLine/StreamQueryReport.cs
+++ b/src/JasperFx.Events/CommandLine/StreamQueryReport.cs
@@ -1,0 +1,109 @@
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// The whole result of one <c>stream-query</c> run, in the shape agents and scripts consume from
+/// the default JSON output. A failed run is a report too — <see cref="Error"/> is populated and
+/// <see cref="Streams"/> is empty — and an empty page with <see cref="TotalCount"/> 0 and a null
+/// <see cref="Error"/> is a real answer, not a failure.
+/// </summary>
+/// <param name="Query">Echo of the effective filters, so a stored report is self-describing and reproducible.</param>
+/// <param name="Store">Subject uri of the event store that answered.</param>
+/// <param name="Streams">The requested page, in the command's stated ordering: creation order (oldest first), ties broken by stream identity.</param>
+/// <param name="TotalCount">Total matching streams across every page.</param>
+/// <param name="PageNumber">Echo of the requested page number.</param>
+/// <param name="PageSize">Echo of the requested page size.</param>
+/// <param name="HasMore">True when pages after this one still hold matching streams.</param>
+/// <param name="Error">Operator-facing failure message, or null when the query ran.</param>
+/// <param name="Diagnosis">
+/// What to do about <paramref name="Error"/> when the cause is known — today, storage that was
+/// never migrated. Same disposition as <see cref="ProjectionRunReport.Diagnosis"/>.
+/// </param>
+public sealed record StreamQueryReport(
+    StreamQueryFilterReport Query,
+    string? Store,
+    IReadOnlyList<StreamQueryStreamReport> Streams,
+    int TotalCount,
+    int PageNumber,
+    int PageSize,
+    bool HasMore,
+    string? Error,
+    string? Diagnosis = null)
+{
+    public static StreamQueryReport From(
+        StreamQueryInput input, Type? aggregateType, Uri? store,
+        IReadOnlyList<StreamState> page, int totalCount)
+    {
+        var streams = page.Select(StreamQueryStreamReport.From).ToArray();
+
+        return new StreamQueryReport(
+            StreamQueryFilterReport.From(input, aggregateType), store?.ToString(), streams,
+            totalCount, input.PageFlag, input.PageSizeFlag,
+            HasMore: (long)input.PageFlag * input.PageSizeFlag < totalCount, Error: null);
+    }
+
+    /// <summary>A run that never produced a page: the filters are still worth echoing.</summary>
+    public static StreamQueryReport Failed(StreamQueryInput input, Type? aggregateType, Uri? store,
+        string error, string? diagnosis = null)
+        => new(StreamQueryFilterReport.From(input, aggregateType), store?.ToString(), [], 0,
+            input.PageFlag, input.PageSizeFlag, false, error, diagnosis);
+}
+
+/// <summary>
+/// The effective filters a <see cref="StreamQueryReport"/> was produced under, carried in full so
+/// a stored report is self-describing — the same fields the run would need to be reproduced.
+/// </summary>
+/// <param name="AggregateType">Full CLR name of the resolved aggregate type filter, or null.</param>
+/// <param name="MinVersion">Inclusive lower bound on the stream version, or null.</param>
+/// <param name="VersionAboveCompacted">The compaction-policy growth threshold (Version - CompactedVersion must exceed it), or null.</param>
+/// <param name="Archived">The archived-flag filter, or null when both archived and live streams were included.</param>
+/// <param name="CreatedFrom">Inclusive lower bound on the creation time, or null.</param>
+/// <param name="CreatedTo">Inclusive upper bound on the creation time, or null.</param>
+/// <param name="UpdatedFrom">Inclusive lower bound on the last-append time, or null.</param>
+/// <param name="UpdatedTo">Inclusive upper bound on the last-append time, or null.</param>
+/// <param name="TenantId">Tenant the query was scoped to, or null for store-global.</param>
+public sealed record StreamQueryFilterReport(
+    string? AggregateType,
+    long? MinVersion,
+    long? VersionAboveCompacted,
+    bool? Archived,
+    DateTimeOffset? CreatedFrom,
+    DateTimeOffset? CreatedTo,
+    DateTimeOffset? UpdatedFrom,
+    DateTimeOffset? UpdatedTo,
+    string? TenantId)
+{
+    public static StreamQueryFilterReport From(StreamQueryInput input, Type? aggregateType)
+        => new(aggregateType?.FullName, input.MinVersionFlag, input.VersionAboveCompactedFlag,
+            input.ArchivedFlag, input.CreatedFrom, input.CreatedTo, input.UpdatedFrom, input.UpdatedTo,
+            input.TenantFlag);
+}
+
+/// <summary>
+/// One stream of a <see cref="StreamQueryReport"/> page.
+/// </summary>
+/// <param name="StreamId">String form of the stream identity (Guid or string key).</param>
+/// <param name="Version">Current version of the stream — its event count high-water.</param>
+/// <param name="CompactedVersion">The compaction watermark; 0 when the stream has never been compacted.</param>
+/// <param name="VersionsSinceCompaction">
+/// <paramref name="Version"/> minus <paramref name="CompactedVersion"/> — the un-compacted growth
+/// the compaction policy thresholds on, precomputed so a consumer never re-derives it.
+/// </param>
+/// <param name="AggregateType">Full CLR name of the aggregate type the stream was started as, or null.</param>
+/// <param name="Created">When the stream was created.</param>
+/// <param name="LastTimestamp">When the stream was last appended to.</param>
+/// <param name="IsArchived">Whether the stream is archived.</param>
+public sealed record StreamQueryStreamReport(
+    string StreamId,
+    long Version,
+    long CompactedVersion,
+    long VersionsSinceCompaction,
+    string? AggregateType,
+    DateTimeOffset Created,
+    DateTimeOffset LastTimestamp,
+    bool IsArchived)
+{
+    public static StreamQueryStreamReport From(StreamState state)
+        => new(state.Key ?? state.Id.ToString(), state.Version, state.CompactedVersion,
+            state.Version - state.CompactedVersion, state.AggregateType?.FullName,
+            state.Created, state.LastTimestamp, state.IsArchived);
+}

--- a/src/JasperFx.Events/CommandLine/StreamQueryView.cs
+++ b/src/JasperFx.Events/CommandLine/StreamQueryView.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JasperFx.Core;
+using Spectre.Console;
+
+namespace JasperFx.Events.CommandLine;
+
+/// <summary>
+/// Renders a <see cref="StreamQueryReport"/> — as JSON for agents and scripts (the default), or as
+/// a console table for a human at a terminal (<c>--format text</c>).
+/// </summary>
+[UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+    Justification = "Class-level: the report is serialized reflectively by System.Text.Json. The stream-query command is a development-time CLI surface, not part of an AOT-published runtime — the same disposition as ProjectionRunView and EventQueryView.")]
+[UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+    Justification = "Same as IL2026 — reflective JSON serialization of the CLI's own report type.")]
+internal static class StreamQueryView
+{
+    private static readonly JsonSerializerOptions _json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true,
+        // The echoed filters are all optional; an agent reading the report cares about the ones
+        // that were set, not a wall of nulls.
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string ToJson(StreamQueryReport report) => JsonSerializer.Serialize(report, _json);
+
+    /// <summary>
+    /// Write straight to <see cref="Console.Out"/> rather than through Spectre: the console writer
+    /// wraps and styles its output, which would corrupt JSON a script is piping.
+    /// </summary>
+    public static void WriteJson(StreamQueryReport report) => Console.Out.WriteLine(ToJson(report));
+
+    public static void WriteConsole(StreamQueryReport report)
+    {
+        if (report.Error.IsNotEmpty())
+        {
+            AnsiConsole.MarkupLine($"[red]{report.Error!.EscapeMarkup()}[/]");
+
+            if (report.Diagnosis.IsNotEmpty())
+            {
+                AnsiConsole.WriteLine();
+                AnsiConsole.MarkupLine($"[yellow]{report.Diagnosis!.EscapeMarkup()}[/]");
+            }
+
+            return;
+        }
+
+        AnsiConsole.MarkupLine(
+            $"Store [blue]{(report.Store ?? "(unknown)").EscapeMarkup()}[/] · {report.TotalCount} matching stream(s)" +
+            $" · page {report.PageNumber} ({report.Streams.Count} shown)" +
+            (report.Query.TenantId.IsNotEmpty() ? $" · tenant [blue]{report.Query.TenantId!.EscapeMarkup()}[/]" : string.Empty));
+
+        if (report.Streams.Count == 0)
+        {
+            // A real answer, not a failure: the filters matched nothing (or the page is past the end).
+            AnsiConsole.MarkupLine(report.TotalCount == 0
+                ? "[yellow]No streams matched the query[/]"
+                : "[yellow]This page is past the end of the matches[/]");
+            return;
+        }
+
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Stream");
+        table.AddColumn("Type");
+        table.AddColumn("Version");
+        table.AddColumn("Compacted");
+        table.AddColumn("Growth");
+        table.AddColumn("Created");
+        table.AddColumn("Last append");
+        table.AddColumn("Archived");
+
+        foreach (var stream in report.Streams)
+        {
+            table.AddRow(
+                new Text(stream.StreamId),
+                new Text(stream.AggregateType ?? "(none)"),
+                new Text(stream.Version.ToString()),
+                new Text(stream.CompactedVersion == 0 ? "never" : stream.CompactedVersion.ToString()),
+                new Text(stream.VersionsSinceCompaction.ToString()),
+                new Text(stream.Created.ToString("u")),
+                new Text(stream.LastTimestamp.ToString("u")),
+                new Text(stream.IsArchived ? "yes" : string.Empty));
+        }
+
+        AnsiConsole.Write(table);
+
+        if (report.HasMore)
+        {
+            AnsiConsole.MarkupLine($"[yellow]More matches remain — rerun with --page {report.PageNumber + 1}[/]");
+        }
+    }
+}

--- a/src/JasperFx.Events/Documents/DocumentQueryableExtensions.cs
+++ b/src/JasperFx.Events/Documents/DocumentQueryableExtensions.cs
@@ -4,7 +4,9 @@ namespace JasperFx.Events.Documents;
 
 /// <summary>
 /// Store-agnostic asynchronous terminators for a document <see cref="IQueryable{T}" /> returned by
-/// <see cref="IDocumentReadOperations.Query{T}" />.
+/// <see cref="IDocumentReadOperations.Query{T}" /> — and, since jasperfx#740, for the stream-state
+/// queryable returned by <see cref="IReadOnlyEventStore.QueryStreamStates" />, which dispatches
+/// through the same <see cref="IDocumentQueryExecutor" /> hook.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -128,6 +130,6 @@ public static class DocumentQueryableExtensions
         }
 
         throw new NotSupportedException(
-            $"The LINQ provider '{queryable.Provider.GetType().FullName}' does not implement {nameof(IDocumentQueryExecutor)}, so this query cannot be executed asynchronously. Queryables passed to {nameof(DocumentQueryableExtensions)} must originate from {nameof(IDocumentReadOperations)}.{nameof(IDocumentReadOperations.Query)}<T>() on a document store that supports the JasperFx document contract.");
+            $"The LINQ provider '{queryable.Provider.GetType().FullName}' does not implement {nameof(IDocumentQueryExecutor)}, so this query cannot be executed asynchronously. Queryables passed to {nameof(DocumentQueryableExtensions)} must originate from a store surface that supports the shared execution hook — {nameof(IDocumentReadOperations)}.{nameof(IDocumentReadOperations.Query)}<T>() on the document contract, or {nameof(IReadOnlyEventStore)}.{nameof(IReadOnlyEventStore.QueryStreamStates)}() on the event store read tier.");
     }
 }

--- a/src/JasperFx.Events/IReadOnlyEventStore.cs
+++ b/src/JasperFx.Events/IReadOnlyEventStore.cs
@@ -43,4 +43,46 @@ public interface IReadOnlyEventStore
     /// See jasperfx#737.
     /// </remarks>
     Task<PagedEvents> QueryEventsAsync(EventQuery query, CancellationToken token = default);
+
+    /// <summary>
+    /// The streams table as a composable <see cref="IQueryable{T}"/> of <see cref="StreamState"/> —
+    /// the store-agnostic way to ask questions like "every stream of aggregate type X whose
+    /// un-compacted growth exceeds N" (the Stream Compaction Policy selector, jasperfx#740).
+    /// </summary>
+    /// <param name="tenantId">
+    /// Tenant partition to scope the streams to. Null means store-global (the default session's
+    /// scope). A store without a tenant dimension MUST refuse a non-null tenant with a
+    /// <see cref="NotSupportedException"/> naming it, never silently return the global set — the
+    /// same rule <see cref="QueryEventsAsync"/> applies to <see cref="EventQuery.TenantId"/>.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <c>Where()</c> must translate against every public get member of <see cref="StreamState"/> —
+    /// <see cref="StreamState.Id"/>, <see cref="StreamState.Key"/>, <see cref="StreamState.Version"/>,
+    /// <see cref="StreamState.AggregateType"/> (equality against a <c>typeof(X)</c> constant,
+    /// translated to the stored aggregate-type identity), <see cref="StreamState.LastTimestamp"/>,
+    /// <see cref="StreamState.Created"/>, <see cref="StreamState.IsArchived"/> and
+    /// <see cref="StreamState.CompactedVersion"/> — plus <c>OrderBy</c>/<c>ThenBy</c>, <c>Skip</c>
+    /// and <c>Take</c> over the same members. A member a provider cannot translate MUST fail the
+    /// query with an exception naming that member (normally at translation time), never silently
+    /// match all rows or drop the clause: an ignored predicate returns unfiltered streams that read
+    /// as filtered, the jasperfx#737 failure mode this surface exists to refuse.
+    /// </para>
+    /// <para>
+    /// Execute with the shared asynchronous terminators in
+    /// <see cref="Documents.DocumentQueryableExtensions"/> (<c>ToListAsync</c>, <c>CountAsync</c>,
+    /// <c>AnyAsync</c>, <c>FirstOrDefaultAsync</c>): the returned queryable's LINQ provider
+    /// implements <see cref="Documents.IDocumentQueryExecutor"/>, the same execution hook the
+    /// document read tier uses, so stores implement exactly one async dispatch for both surfaces.
+    /// </para>
+    /// <para>
+    /// Deliberately abstract rather than a throwing default implementation: the compile break on
+    /// the next package bump is what forces every store to implement in the same wave, mirroring
+    /// <see cref="QueryEventsAsync"/>. And unlike the old rationale for keeping
+    /// <c>QueryAllRawEvents</c> off the shared read tier — store-specific queryable types — this
+    /// contract is expressible abstractly, because <see cref="StreamState"/> is a
+    /// JasperFx.Events-owned type.
+    /// </para>
+    /// </remarks>
+    IQueryable<StreamState> QueryStreamStates(string? tenantId = null);
 }

--- a/src/JasperFx.Events/StreamState.cs
+++ b/src/JasperFx.Events/StreamState.cs
@@ -63,4 +63,25 @@ public class StreamState
     /// Is this event stream marked as archived.
     /// </summary>
     public bool IsArchived { get; set; }
+
+    /// <summary>
+    /// The stream version through which events have been folded into a <c>Compacted&lt;T&gt;</c>
+    /// snapshot — the compaction watermark. 0 means the stream has never been compacted.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what makes an "events since last compaction" policy expressible: <see cref="Version"/>
+    /// keeps growing forever, so a <c>Version &gt; N</c> threshold would re-fire on every evaluation
+    /// after the first compaction, while <c>(Version - CompactedVersion) &gt; N</c> measures only the
+    /// growth since the last one. A stream compacted through version 9 that has since received two
+    /// appends reads <c>Version</c> 11, <c>CompactedVersion</c> 9, un-compacted growth 2. See
+    /// jasperfx#740.
+    /// </para>
+    /// <para>
+    /// Stores surface this from their streams-table metadata, both here and on the results of
+    /// <see cref="IReadOnlyEventStore.QueryStreamStates"/>, where it participates in <c>Where()</c>
+    /// translation like every other member.
+    /// </para>
+    /// </remarks>
+    public long CompactedVersion { get; set; }
 }


### PR DESCRIPTION
Closes #740. The second broadening wave after #737/#738 — the upstream half of CritterWatch's 1.1 Stream Compaction Policies (JasperFx/CritterWatch#1199).

Two commits, additive, targeting the next minor:

1. **`IQueryable<StreamState>` on the read tier + the compaction watermark.** `IReadOnlyEventStore.QueryStreamStates(string? tenantId = null)` — **abstract**, beside `QueryEventsAsync`, the deliberate compile-break that keeps the three stores synchronized on the bump. The queryable executes through the existing `JasperFx.Events.Documents` machinery verbatim: the store's LINQ provider implements the shared `IDocumentQueryExecutor` hook and the existing `DocumentQueryableExtensions` terminators dispatch through it — zero new terminator code, one async hook per store serves both surfaces. The xml-doc states the full `Where()`-translatable member set, the must-throw-naming-the-member rule for untranslatable members, the must-refuse rule for a non-null tenant on a tenantless store, and why the old `QueryAllRawEvents` exclusion rationale doesn't apply (`StreamState` is a JasperFx.Events-owned type). `StreamState.CompactedVersion` (`long`, 0 = never) carries the policy arithmetic in its doc: `Version - CompactedVersion` = un-compacted growth; partial compaction records the cutoff version, full compaction records the stream version.
2. **`stream-query` CLI + `StreamStateQueryCompliance`.** The CLI sits beside `event-query`/`projection-run` (long-form flags: `--aggregate-type` resolved against loaded assemblies after `BuildHost()`, `--min-version`, `--version-above-compacted` — the compaction-policy predicate — tri-state `--archived`, created/updated windows, `--tenant`, `--store` via the shared `SelectStore`, paging, `--format json|text`; refusal-by-name on `NotSupportedException`, empty-with-truthful-total is a real answer; 18 input-mapping unit tests). The compliance suite adds **15 facts** — one `Where()` per public get member with single-predicate decoys (including `AggregateType == typeof(X)`, the policy selector), the fetch-path watermark fact (partial/full/never), the compaction-policy shape itself with a freshly-compacted high-raw-Version stream as the load-bearing decoy, paging over the stated ordering contract (`Created` ascending, `Id` tiebreak) with past-the-end truthfulness, an all-terminators fact, and looped truthful zeros — plus `query_stream_states_scoped_to_a_tenant` in the conjoined-tenancy suite.

**Judgment calls for review:**

- Tenant scoping as the `QueryStreamStates(string? tenantId = null)` parameter rather than a `TenantId` member on `StreamState` — the type has no tenant member, so the *source* is scoped; null = store-global.
- The CLI tiebreak orders `ThenBy(Id).ThenBy(Key)`; the inapplicable identity member is a constant per store and documented as a stable constant sort. Compliance pins only `ThenBy(Id)` on Guid seeds, deliberately not forcing constant-column translation.
- `--archived` omitted means both archived and live (unfiltered-by-default symmetry with `event-query`).
- Full compaction sets the watermark to the stream version (growth 0) — pinned; the issue implied but did not state it.
- Aggregate-type resolution scans loaded assemblies (full name beats simple, ambiguity refused naming candidates) because no shared surface exposes the aggregate-type graph.
- The unsupported-member throw is contract-by-documentation: compliance cannot pin a refusal on stores that translate everything, so each store's own tests own that pin (the downstream issues say so).

**Tests:** `EventTests` 1004/1004 and `EventStoreTests` 141/141 on net9.0 and net10.0; full `jasperfx.slnx` 0 errors; the compliance source package compiles at its C#13 floor and executes downstream.

**Downstream (already in flight, on the `stream-compaction` Stoat plan):** marten#5333 / polecat#534 / fisher#151 are being implemented against a local pack of this branch; note the watermark is a write-side change per store (`CompactStreamAsync` records it; streams-table schema additions expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
