### PR TITLE
2.63.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.63.0</JasperFxVersion>
+        <JasperFxVersion>2.63.1</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>


### PR DESCRIPTION
Patch release carrying the #742 Native AOT bootstrap guard (#744), so Wolverine can pin a JasperFx that boots under PublishAot — see JasperFx/wolverine#4287 / JasperFx/wolverine#4298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)