### PR TITLE
DetermineCallingAssembly anchors on its own call chain, not stale frames

### DIFF
--- a/src/CoreTests/JasperFxOptionsTests.cs
+++ b/src/CoreTests/JasperFxOptionsTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using Shouldly;
+using Widgets1;
 using RunnerFrame = xunit.v3.stackwalk.standin.RunnerFrame;
 
 namespace CoreTests;
@@ -390,6 +391,29 @@ public class JasperFxOptionsTests
         var assembly = RunnerFrame.Invoke(JasperFxOptions.DetermineCallingAssembly);
 
         assembly.ShouldBe(GetType().Assembly);
+    }
+
+    [Fact]
+    public void anchors_on_its_own_call_chain_not_a_stale_jasperfx_frame_deeper_in_the_stack()
+    {
+        // Deterministic reconstruction of the stale-anchor layout that made Wolverine's identical walk
+        // suite-order-dependent (JasperFx/wolverine#4299): the stack does not always end at the
+        // registering caller. A callback invoked from JasperFx code -- or, in the wild, an async
+        // continuation chain a completing JasperFx task ran inline straight into the next piece of
+        // synchronous registration -- leaves a JasperFx frame DEEPER in the stack than the caller.
+        // Anchoring at the last JasperFx frame anywhere jumped past the real caller and resolved
+        // whoever invoked the OUTER JasperFx code: the test assembly here, and at AddJasperFx that
+        // poisoned answer can seed the process-wide RememberedApplicationAssembly pin.
+        //
+        // Each() is declared in the JasperFx assembly, so this call chain is, innermost first:
+        // [JasperFx: DetermineCallingAssembly] [Widgets1: Invoke] [CoreTests: lambda] [JasperFx: Each]
+        // [CoreTests: this test]. The anchor must stay on the innermost contiguous JasperFx run and
+        // resolve Widgets1 regardless of the stale Each frame below.
+        Assembly? captured = null;
+        new[] { 0 }.Each(_ => captured = WidgetRegistrationFrame.Invoke(JasperFxOptions.DetermineCallingAssembly));
+
+        captured.ShouldBe(typeof(WidgetRegistrationFrame).Assembly);
+        captured.ShouldNotBe(GetType().Assembly);
     }
 
     [Fact]

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -228,10 +228,37 @@ public class JasperFxOptions : SystemPartBase
         
         var stack = new StackTrace();
         var frames = stack.GetFrames();
-        var jasperfxFrame = frames.LastOrDefault(x =>
-            x.HasMethod() && x.GetMethod()?.DeclaringType?.Assembly.GetName().Name == "JasperFx");
 
-        var index = Array.IndexOf(frames, jasperfxFrame);
+        // Anchor at the end of the INNERMOST contiguous run of JasperFx frames — the call chain that
+        // led here — never at the last JasperFx frame anywhere in the stack. The stack does not always
+        // end at the registering caller: any JasperFx frame deeper in the stack (a callback invoked
+        // from JasperFx code, or an async continuation chain a completing JasperFx task ran inline)
+        // pulled a whole-stack anchor past the real caller, so the walk resolved whoever invoked the
+        // OUTER JasperFx code instead — or fell through to Assembly.GetEntryAssembly() when nothing
+        // adoptable remained beyond the stale frame. Wolverine's identical walk was caught doing
+        // exactly this in a full test-suite run (JasperFx/wolverine#4299): a prior test's completing
+        // tracked session ran its continuations inline straight through xunit into the next test's
+        // synchronous registration, leaving a stale framework frame 200+ frames down for LastOrDefault
+        // to anchor on. Here the poisoned result is worse than a wrong warning: at AddJasperFx it can
+        // seed the process-wide RememberedApplicationAssembly pin for the first host.
+        var index = -1;
+        for (var i = 0; i < frames.Length; i++)
+        {
+            if (!frames[i].HasMethod() || frames[i].GetMethod() is not { } method)
+            {
+                // A native transition or metadata-less frame neither extends nor ends the run
+                continue;
+            }
+
+            if (method.DeclaringType?.Assembly.GetName().Name == "JasperFx")
+            {
+                index = i;
+                continue;
+            }
+
+            // First method-bearing frame outside JasperFx: the contiguous run has ended
+            break;
+        }
 
         for (var i = index + 1; i < frames.Length; i++)
         {

--- a/src/Widgets1/WidgetRegistrationFrame.cs
+++ b/src/Widgets1/WidgetRegistrationFrame.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+
+namespace Widgets1;
+
+/// <summary>
+/// Stands in for an application's composition root in the one respect that matters to
+/// <c>JasperFxOptions.DetermineCallingAssembly</c>: it owns the frame the walk should resolve, in an
+/// assembly that is neither the test assembly nor anything the walk filters out. Pairing it with a
+/// JasperFx-owned frame deeper in the stack (e.g. a callback invoked through <c>Each</c>) reproduces the
+/// stale-anchor layout deterministically. See the anchor commentary in
+/// <c>JasperFxOptions.DetermineCallingAssembly</c>.
+/// </summary>
+public static class WidgetRegistrationFrame
+{
+    /// <summary>
+    /// Invokes <paramref name="walk" /> so that this assembly — "Widgets1" — owns the calling frame.
+    /// Pass a method group rather than a lambda: a lambda's closure method belongs to the caller's
+    /// assembly and would put the caller straight back on top of the stack.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static T Invoke<T>(Func<T> walk)
+    {
+        var result = walk();
+
+        // Keeps the JIT from turning the call above into a tail call, which would drop this frame and
+        // defeat the whole point of the stand-in.
+        GC.KeepAlive(walk);
+
+        return result;
+    }
+}


### PR DESCRIPTION
Ports the fix from JasperFx/wolverine#4299, where the identical walk was caught in the act.

## The defect

`JasperFxOptions.DetermineCallingAssembly` anchored its walk at the **last** frame in assembly `JasperFx` *anywhere* in the stack. The stack does not always end at the registering caller: a callback invoked from JasperFx code, or an async continuation chain that a completing JasperFx task ran inline, leaves JasperFx frames *deeper* in the stack. The anchor then jumped past the real caller and resolved whoever invoked the outer JasperFx code — or fell through to `Assembly.GetEntryAssembly()` when nothing adoptable remained beyond the stale frame.

Wolverine's copy of this walk produced a suite-order-dependent test failure exactly this way, captured live with instrumentation: a prior test's completing tracked session ran its continuations inline on the thread-pool thread, straight through xunit and into the next test's synchronous registration, planting a stale framework frame 200+ frames down for `LastOrDefault` to anchor on.

## Why it matters more here

In Wolverine the poisoned value fed `RegistrationCallingAssembly` and the GH-3521 divergence warning. Here, `AddJasperFx` additionally uses the walk's result to **seed the process-wide `RememberedApplicationAssembly` pin** when it is still null — so a poisoned capture at the first registration in a process mis-pins the application assembly that drives code generation and type discovery for every later implicit host.

## The fix

The walk now anchors at the end of the **innermost contiguous run** of JasperFx frames — the call chain that actually led to the capture — so stale JasperFx frames deeper in the stack can never pull it past the registering caller. (`CallingAssembly.Find` walks from frame 0 with no anchor and was never affected.)

The new regression test reconstructs the poisoned layout deterministically: it invokes the walk through a `Widgets1`-owned frame (`WidgetRegistrationFrame.Invoke`, mirroring `RunnerFrame`'s NoInlining/KeepAlive discipline) from inside a callback that `Each()` — a JasperFx-assembly method — is invoking. On the old anchor it fails with the wrong-assembly shape observed in the wild (resolving the test assembly instead of the composition root); on the new anchor it passes.

## Verification

- Red baseline: with the fix reverted, the new test fails (`Widgets1` expected, `CoreTests` returned); everything else stays green.
- `./build.sh test` fully green: Core, Codegen (+F#), CommandLine, Events, EventStore, SourceGenerators, Aspire, and the AOT smoke, on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)