### PR TITLE
gh-747: a Native AOT publish stops reporting warnings out of JasperFx

### DIFF
--- a/src/CodegenTests/TypeLoaderTests.cs
+++ b/src/CodegenTests/TypeLoaderTests.cs
@@ -14,6 +14,36 @@ public class TypeLoaderTests
         rules.Loader.ShouldBeOfType<DynamicTypeLoader>();
     }
 
+    // wolverine#4232. Native AOT cannot emit a type into its image, so neither the dynamic loader nor the
+    // auto loader's fallback to it can work there. Auto exists to adapt to the platform, so it adapts;
+    // Dynamic asked for something the platform cannot do, and saying so beats the obscure failure it used
+    // to reach later. This is also what keeps the trimmer's IL2026/IL3050 out of a consumer's publish --
+    // ILC substitutes RuntimeFeature.IsDynamicCodeSupported with false and removes the branch that
+    // constructs them.
+    [Fact]
+    public void without_dynamic_code_auto_mode_falls_back_to_the_static_loader()
+    {
+        GenerationRules.DefaultLoaderFor(TypeLoadMode.Auto, dynamicCodeSupported: false)
+            .ShouldBeOfType<StaticTypeLoader>();
+    }
+
+    [Fact]
+    public void without_dynamic_code_static_mode_is_unchanged()
+    {
+        GenerationRules.DefaultLoaderFor(TypeLoadMode.Static, dynamicCodeSupported: false)
+            .ShouldBeOfType<StaticTypeLoader>();
+    }
+
+    [Fact]
+    public void without_dynamic_code_dynamic_mode_says_so_instead_of_failing_later()
+    {
+        var ex = Should.Throw<PlatformNotSupportedException>(() =>
+            GenerationRules.DefaultLoaderFor(TypeLoadMode.Dynamic, dynamicCodeSupported: false));
+
+        // The message has to name the way out, not just the wall.
+        ex.Message.ShouldContain(nameof(TypeLoadMode.Static));
+    }
+
     [Fact]
     public void default_loader_for_static_mode_is_StaticTypeLoader()
     {

--- a/src/JasperFx/CodeGeneration/GenerationRules.cs
+++ b/src/JasperFx/CodeGeneration/GenerationRules.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using JasperFx.CodeGeneration.Model;
 using JasperFx.CodeGeneration.Services;
 using JasperFx.Core;
@@ -141,15 +143,44 @@ public class GenerationRules
         }
     }
 
+    // wolverine#4232: the two dynamic loaders are RequiresUnreferencedCode + RequiresDynamicCode, and the
+    // #pragma that used to sit here only silenced the analyzer while JasperFx itself compiled. Trim and AOT
+    // analysis runs over IL in the CONSUMER's publish, where a pragma means nothing, so every app publishing
+    // AOT saw both warnings out of a method it does not call.
+    //
+    // The guard is not a suppression dressed up as a branch -- it is also simply true: neither loader can
+    // emit a type into a Native AOT image. Auto exists to adapt to the platform, so it adapts; Dynamic was
+    // asked for something the platform cannot do, and saying so here beats the obscure failure it used to
+    // reach later. The suppressions sit on the split overload below, where the constructions are.
     private static ITypeLoader DefaultLoaderFor(TypeLoadMode mode)
+        => DefaultLoaderFor(mode, RuntimeFeature.IsDynamicCodeSupported);
+
+    // Split for testability, the same way JasperFxOptions.CannotBeApplicationAssembly is: the
+    // dynamic-code-unsupported branch cannot be reached from a CoreCLR test process.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "The dynamic loaders are only constructed on the dynamicCodeSupported branch, which a Native AOT image never takes; RuntimeFeature.IsDynamicCodeSupported is the only production caller's argument.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "The dynamic loaders are only constructed on the dynamicCodeSupported branch, which a Native AOT image never takes; RuntimeFeature.IsDynamicCodeSupported is the only production caller's argument.")]
+    internal static ITypeLoader DefaultLoaderFor(TypeLoadMode mode, bool dynamicCodeSupported)
     {
+        if (!dynamicCodeSupported)
+        {
+            if (mode == TypeLoadMode.Dynamic)
+            {
+                throw new PlatformNotSupportedException(
+                    $"{nameof(TypeLoadMode)}.{nameof(TypeLoadMode.Dynamic)} generates and loads types at runtime, which a Native AOT image cannot do. " +
+                    $"Use {nameof(TypeLoadMode)}.{nameof(TypeLoadMode.Static)} with types generated ahead of time by the 'codegen write' command, " +
+                    $"or assign {nameof(GenerationRules)}.{nameof(Loader)} your own {nameof(ITypeLoader)}.");
+            }
+
+            return new StaticTypeLoader();
+        }
+
         return mode switch
         {
             TypeLoadMode.Static => new StaticTypeLoader(),
-#pragma warning disable IL2026, IL3050
             TypeLoadMode.Dynamic => new DynamicTypeLoader(),
             TypeLoadMode.Auto => new AutoTypeLoader(),
-#pragma warning restore IL2026, IL3050
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
     }

--- a/src/JasperFx/CodeGeneration/Services/EnumerableSingletons.cs
+++ b/src/JasperFx/CodeGeneration/Services/EnumerableSingletons.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using JasperFx.Core.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -45,6 +46,14 @@ internal static class EnumerableSingletons
     /// non-keyed registration of <paramref name="elementType"/>, sharing that registration's
     /// singleton instance (GetServices honors each registration's own lifetime).
     /// </summary>
+    // wolverine#4232: GetServices(IServiceProvider, Type) is RequiresDynamicCode because, in the general
+    // case, the IEnumerable<T> it resolves may have to be constructed at runtime. It does not have to be
+    // here. A mirror is only ever minted for a family the application registered and that something in the
+    // application injects as IEnumerable<elementType> -- that injection is what made ArrayPlan build the
+    // mirror at all -- so the closed generic is already rooted in the image by the code being mirrored.
+    // Annotating this instead would hand every AOT consumer a warning for a path that works.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "IEnumerable<elementType> is rooted by the registration and injection this mirror shadows; a mirror is never minted for a family the application does not already resolve.")]
     public static ServiceDescriptor KeyedMirror(Type elementType, int nonKeyedOrdinal)
     {
         var ordinal = nonKeyedOrdinal;

--- a/src/JasperFx/Core/Reflection/TypeExtensions.cs
+++ b/src/JasperFx/Core/Reflection/TypeExtensions.cs
@@ -235,6 +235,11 @@ public static class TypeExtensions
 
     [UnconditionalSuppressMessage("Trimming", "IL2072:DynamicallyAccessedMembers",
         Justification = "Walks the interface chain via @interface.Closes(openType). Interfaces returned from GetInterfaces() don't statically carry DAM; the recursive walk is bounded by the interface hierarchy of `type`, which itself has [DAM(Interfaces)].")]
+    // wolverine#4232: the recursion actually reports IL2062, not the IL2072 the suppression above names --
+    // same cause, same justification, different diagnostic id -- so that suppression never applied and the
+    // warning reached every consumer's AOT publish.
+    [UnconditionalSuppressMessage("Trimming", "IL2062:DynamicallyAccessedMembers",
+        Justification = "Same recursion as above: the interface comes from GetInterfaces() on a type that already carries [DAM(Interfaces)], so every interface the walk visits is preserved along with it.")]
     public static bool Closes(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type? type,
         Type openType)

--- a/src/JasperFx/Core/TypeScanning/AssemblyFinder.cs
+++ b/src/JasperFx/Core/TypeScanning/AssemblyFinder.cs
@@ -67,6 +67,11 @@ public static class AssemblyFinder
         return assemblies.TopologicalSort((Func<Assembly, Assembly[]>)FindDependencies, false);
     }
 
+    // wolverine#4232: every public entry point into this walk already carries the attribute; the private
+    // iterator did not, so the trimmer reported the LoadFromAssemblyPath call from inside the generated
+    // MoveNext -- a warning a consumer could neither act on nor suppress. Annotating it puts the diagnostic
+    // where the decision actually is, on the public FindAssemblies overloads.
+    [RequiresUnreferencedCode("Scans a directory and loads each assembly it finds by name or path. The trimmer cannot statically reason about which types those assemblies contribute; AOT-publishing apps should rely on explicit assembly references and source-generated type lists instead.")]
     private static IEnumerable<Assembly> findAssemblies(string assemblyPath, Action<string> logFailure,
         bool includeExeFiles)
     {

--- a/src/JasperFx/JasperFxOptions.cs
+++ b/src/JasperFx/JasperFxOptions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using JasperFx.CodeGeneration;
 using JasperFx.CommandLine;
@@ -320,6 +321,13 @@ public class JasperFxOptions : SystemPartBase
         => CannotBeApplicationAssembly(assembly, LocationDistinguishesAssemblies);
 
     // Split for testability: the single-file case cannot be reproduced in a test process.
+    //
+    // wolverine#4232: IL3000 warns that Location is empty for a bundled assembly, which is precisely the
+    // condition this method is built around -- an empty Location is READ as a signal, never used as a path,
+    // and LocationDistinguishesAssemblies below turns the whole test off the moment the process is bundled.
+    // AppContext.BaseDirectory, which the diagnostic suggests, answers a different question entirely.
+    [UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "Location is used as a signal, not a path, and the single-file case is exactly what LocationDistinguishesAssemblies detects and disables.")]
     internal static bool CannotBeApplicationAssembly(Assembly assembly, bool locationDistinguishesAssemblies)
     {
         if (assembly.IsDynamic)
@@ -336,8 +344,16 @@ public class JasperFxOptions : SystemPartBase
     // looking for. The entry assembly is the cheap tell: if even IT has no Location, we are bundled.
     // The walk then matches nothing and falls through to Assembly.GetEntryAssembly(), which is the right
     // answer for a single-file app anyway.
-    internal static readonly bool LocationDistinguishesAssemblies =
-        !string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location);
+    internal static readonly bool LocationDistinguishesAssemblies = determineLocationDistinguishesAssemblies();
+
+    // wolverine#4232: read through a method rather than straight into the field initializer. A suppression
+    // on a field does not reach the static constructor the initializer compiles into, so IL3000 was reported
+    // against ".cctor()" -- a member no one can annotate. Reading an empty Location here IS the detection the
+    // diagnostic is describing, so it is suppressed where the read actually happens.
+    [UnconditionalSuppressMessage("SingleFile", "IL3000",
+        Justification = "An empty Location on the entry assembly is the single-file signal this method exists to capture; it is never used as a path.")]
+    private static bool determineLocationDistinguishesAssemblies()
+        => !string.IsNullOrEmpty(Assembly.GetEntryAssembly()?.Location);
 
     // GH-600: under an async test fixture the frames between JasperFx and the test class belong to the
     // test *runner*, not the test assembly, so the walk above would otherwise adopt something like


### PR DESCRIPTION
Closes #747 — the warnings half of [wolverine#4232](https://github.com/JasperFx/wolverine/issues/4232) ("Build should produce no warnings"). #742 was the crash half.

Reproduced against `main` with a real `PublishAot`: **every IL warning in a Wolverine AOT publish came from JasperFx, none from Wolverine**, and none was one the consumer could act on or suppress — they are raised against JasperFx's IL, not theirs.

## What each one was

**Two IL3000 on `Assembly.Location` in `JasperFxOptions`.** The empty `Location` is *read as a signal* there, never used as a path, and `LocationDistinguishesAssemblies` already turns the whole test off the moment the process is bundled — the diagnostic describes the exact case the code was written for. Suppressed with that as the justification. The second was reported against `.cctor()`, because a suppression on a field does not reach the static constructor its initializer compiles into; the read now happens in a method that can carry the attribute.

**Two IL2026 in `GenerationRules.DefaultLoaderFor`.** A `#pragma warning disable IL2026, IL3050` sat there, which only silenced the analyzer while *JasperFx itself* compiled. Trim and AOT analysis runs over IL in the **consumer's** publish, where a pragma means nothing — so every AOT-publishing app saw both.

Replaced with a `RuntimeFeature.IsDynamicCodeSupported` guard, which is not a suppression dressed up as a branch: neither `DynamicTypeLoader` nor `AutoTypeLoader`'s fallback to it can emit a type into a Native AOT image. `Auto` exists to adapt to the platform, so it adapts; `Dynamic` asked for something the platform cannot do, and a `PlatformNotSupportedException` naming `Static` and `codegen write` beats the obscure failure it used to reach later. Split for testability the same way `JasperFxOptions.CannotBeApplicationAssembly` is, since a CoreCLR test process cannot reach that branch.

**One IL2026 in `AssemblyFinder.findAssemblies`.** Every *public* entry point into the walk already carries `[RequiresUnreferencedCode]`; the private iterator did not, so the `LoadFromAssemblyPath` call was reported from inside the compiler-generated `MoveNext`. Annotating it puts the diagnostic where the decision actually is.

**Two more that were always there, collapsed behind the IL2104/IL3053 rollup:**

- `TypeExtensions.Closes` already carried an `[UnconditionalSuppressMessage]` with the correct justification — naming **IL2072**. The recursion reports **IL2062**, so it never applied. One line.
- `EnumerableSingletons.KeyedMirror`'s `GetServices(IServiceProvider, Type)` (IL3050). A mirror is only minted for a family the application registered *and* injects as `IEnumerable<elementType>` — that injection is what made `ArrayPlan` build the mirror at all — so the closed generic is already rooted by the code being mirrored. Annotating it instead would hand every AOT consumer a warning for a path that works.

## Verification

Not just at the analyzer. JasperFx packed locally into a feed and consumed by a Wolverine app published with `PublishAot --use-current-runtime`:

- **Zero IL warnings**, with `-p:TrimmerSingleWarn=false` so nothing hides behind the assembly rollup. Against `main` today that same publish reports seven.
- On the [wolverine#4287](https://github.com/JasperFx/wolverine/pull/4298) branch the resulting native binary **boots Wolverine and starts its listeners**. (It then fails on a closed `EmptyMessageRouter<T>` for the test app's own message type — the app-side rooting story #743 is about, which that PR's own smoke project handles with `[DynamicDependency]`.)
- `CodegenTests` 436/436, three of them new and covering the no-dynamic-code branch. `CoreTests` 599 passed / 1 skipped.

## Deliberately out of scope

The IL2070/IL2075 sites in `DocumentIdentity`, `MethodCall` and `TypeNameExtensions`, `GeneratedExtensionManifest`'s two `Assembly.GetType` calls, and `CallingAssembly`'s `StackFrame.GetMethod` — none is reachable from a Wolverine AOT publish, and annotating them properly is a larger piece of work than making the reported build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)