### PR TITLE
2.63.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.63.1</JasperFxVersion>
+        <JasperFxVersion>2.63.2</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>


### PR DESCRIPTION
Bumps `JasperFxVersion` for the 2.63.2 release. Two fixes have landed since 2.63.1, both in the Native AOT chain:

- **#748** (closes #747) — a Native AOT publish stops reporting warnings out of JasperFx. Seven IL warnings down to **zero**, verified against a real `PublishAot` binary consuming a locally packed JasperFx with `TrimmerSingleWarn=false` so nothing hid behind the assembly rollup.
- **#746** — `DetermineCallingAssembly` anchors on its own call chain, not stale frames.

Cutting this unblocks [wolverine#4232](https://github.com/JasperFx/wolverine/issues/4232): with 2.63.2 pinned, a Wolverine `PublishAot` application builds warning-free, and (together with the already-merged wolverine#4298) the `Wolverine.AotSmoke.Publish` smoke stops matching its tolerated-blocker signature and starts asserting the full native boot + dispatch on every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)