### PR TITLE
Lift CompositeIProjectionSource into JasperFx.Events.Projections.Composite

### DIFF
--- a/src/EventTests/Projections/Composite/CompositeProjectionSourceTests.cs
+++ b/src/EventTests/Projections/Composite/CompositeProjectionSourceTests.cs
@@ -1,0 +1,255 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Projections.Composite;
+using JasperFx.Events.Subscriptions;
+using NSubstitute;
+using Shouldly;
+
+namespace EventTests.Projections.Composite;
+
+public class CompositeProjectionSourceTests
+{
+    [Fact]
+    public void wraps_a_bare_projection_with_defaults()
+    {
+        var source = new CompositeProjectionSource<FakeOps, FakeQuerySession>(new BareProjection());
+
+        source.Name.ShouldBe(nameof(BareProjection));
+        source.Version.ShouldBe(1u);
+        source.Lifecycle.ShouldBe(ProjectionLifecycle.Async);
+        ((ISubscriptionSource)source).Type.ShouldBe(SubscriptionType.EventProjection);
+        source.ImplementationType.ShouldBe(typeof(BareProjection));
+
+        // A raw projection that is not a ProjectionBase declares neither storage nor teardown,
+        // so there is nothing to adopt.
+        source.PublishedTypes().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void reads_the_projection_version_attribute()
+    {
+        var source = new CompositeProjectionSource<FakeOps, FakeQuerySession>(new VersionedProjection());
+
+        source.Version.ShouldBe(3u);
+    }
+
+    [Fact]
+    public void adopts_options_and_published_types_from_a_projection_base_member()
+    {
+        // polecat#439 / marten#5175 / fisher#63: without adopting the member's options and published
+        // types, a composite rebuild's teardown queues nothing for this member and the rebuild
+        // replays onto the previous run's surviving rows.
+        var projection = new ProjectionBaseMember();
+
+        var source = new CompositeProjectionSource<FakeOps, FakeQuerySession>(projection);
+
+        source.Options.ShouldBeSameAs(projection.Options);
+        source.PublishedTypes().ShouldBe([typeof(FakeView)]);
+
+        // Name and Version are deliberately NOT adopted: they compose this member's ShardName.Identity,
+        // and changing them would orphan every existing progression row.
+        source.Name.ShouldBe(nameof(ProjectionBaseMember));
+        source.Version.ShouldBe(1u);
+    }
+
+    [Fact]
+    public void shard_names_are_the_projection_name_with_the_all_key()
+    {
+        var source = new CompositeProjectionSource<FakeOps, FakeQuerySession>(new BareProjection());
+
+        var shardName = source.ShardNames().Single();
+        shardName.Name.ShouldBe(nameof(BareProjection));
+        shardName.ShardKey.ShouldBe(ShardName.All);
+
+        var shard = source.Shards().Single();
+        shard.Name.Identity.ShouldBe(shardName.Identity);
+        shard.Options.ShouldBeSameAs(source.Options);
+    }
+
+    [Fact]
+    public void does_not_support_inline_execution()
+    {
+        IProjectionSource<FakeOps, FakeQuerySession> source =
+            new CompositeProjectionSource<FakeOps, FakeQuerySession>(new BareProjection());
+
+        Should.Throw<NotSupportedException>(() => source.BuildForInline());
+    }
+
+    [Fact]
+    public void builds_no_replay_executor()
+    {
+        IProjectionSource<FakeOps, FakeQuerySession> source =
+            new CompositeProjectionSource<FakeOps, FakeQuerySession>(new BareProjection());
+
+        source.TryBuildReplayExecutor(null!, null!, out var executor).ShouldBeFalse();
+        executor.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task execution_applies_events_per_tenant_through_the_batch_session()
+    {
+        var projection = new RecordingProjection();
+        var execution = new CompositeProjectionSourceExecution<FakeOps, FakeQuerySession>(
+            projection, ShardName.Compose("Recording"));
+
+        var batch = new RecordingBatch();
+        var range = new EventRange(ShardName.Compose("Cmp"), 0, 3, Substitute.For<ISubscriptionAgent>())
+        {
+            Events =
+            [
+                new Event<AEvent>(new AEvent()) { TenantId = "t1" },
+                new Event<AEvent>(new AEvent()) { TenantId = "t2" },
+                new Event<AEvent>(new AEvent()) { TenantId = "t1" }
+            ],
+            ActiveBatch = batch
+        };
+
+        await execution.ProcessRangeAsync(range);
+
+        projection.Applied.Count.ShouldBe(2);
+        projection.Applied[batch.Sessions["t1"]].Count.ShouldBe(2);
+        projection.Applied[batch.Sessions["t2"]].Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task execution_does_not_dispose_the_shared_batch_but_does_dispose_its_sessions()
+    {
+        // THE invariant: every stage of a composite writes into one batch so the whole composite
+        // commits together. A stage disposing the batch it is handed would commit the earlier stages
+        // and leave the later ones writing into a disposed session.
+        var execution = new CompositeProjectionSourceExecution<FakeOps, FakeQuerySession>(
+            new RecordingProjection(), ShardName.Compose("Recording"));
+
+        var batch = new RecordingBatch();
+        var range = new EventRange(ShardName.Compose("Cmp"), 0, 1, Substitute.For<ISubscriptionAgent>())
+        {
+            Events = [new Event<AEvent>(new AEvent()) { TenantId = "t1" }],
+            ActiveBatch = batch
+        };
+
+        await execution.ProcessRangeAsync(range);
+
+        batch.WasDisposed.ShouldBeFalse();
+        batch.Sessions["t1"].WasDisposed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task execution_is_a_no_op_without_a_matching_active_batch()
+    {
+        var projection = new RecordingProjection();
+        var execution = new CompositeProjectionSourceExecution<FakeOps, FakeQuerySession>(
+            projection, ShardName.Compose("Recording"));
+
+        var range = new EventRange(ShardName.Compose("Cmp"), 0, 1, Substitute.For<ISubscriptionAgent>())
+        {
+            Events = [new Event<AEvent>(new AEvent())],
+            ActiveBatch = null
+        };
+
+        await execution.ProcessRangeAsync(range);
+
+        projection.Applied.ShouldBeEmpty();
+    }
+
+    public class FakeQuerySession;
+
+    public class FakeOps : FakeQuerySession, IStorageOperations
+    {
+        public bool WasDisposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            WasDisposed = true;
+            return new ValueTask();
+        }
+
+        public Task<IProjectionStorage<TDoc, TId>> FetchProjectionStorageAsync<TDoc, TId>(string tenantId,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool EnableSideEffectsOnInlineProjections => false;
+
+        public ValueTask<IMessageSink> GetOrStartMessageSink()
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public class BareProjection : IJasperFxProjection<FakeOps>
+    {
+        public Task ApplyAsync(FakeOps operations, IReadOnlyList<IEvent> events, CancellationToken cancellation)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    [ProjectionVersion(3)]
+    public class VersionedProjection : BareProjection;
+
+    public class FakeView;
+
+    public class ProjectionBaseMember : ProjectionBase, IJasperFxProjection<FakeOps>
+    {
+        public ProjectionBaseMember()
+        {
+            RegisterPublishedType(typeof(FakeView));
+        }
+
+        public Task ApplyAsync(FakeOps operations, IReadOnlyList<IEvent> events, CancellationToken cancellation)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    public class RecordingProjection : IJasperFxProjection<FakeOps>
+    {
+        public Dictionary<FakeOps, List<IEvent>> Applied { get; } = new();
+
+        public Task ApplyAsync(FakeOps operations, IReadOnlyList<IEvent> events, CancellationToken cancellation)
+        {
+            Applied[operations] = events.ToList();
+            return Task.CompletedTask;
+        }
+    }
+
+    public class RecordingBatch : IProjectionBatch<FakeOps, FakeQuerySession>
+    {
+        public Dictionary<string, FakeOps> Sessions { get; } = new();
+        public bool WasDisposed { get; private set; }
+
+        public FakeOps SessionForTenant(string tenantId)
+        {
+            var session = new FakeOps();
+            Sessions[tenantId] = session;
+            return session;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            WasDisposed = true;
+            return new ValueTask();
+        }
+
+        public Task ExecuteAsync(CancellationToken token) => Task.CompletedTask;
+
+        public void QuickAppendEventWithVersion(StreamAction action, IEvent @event)
+        {
+        }
+
+        public void UpdateStreamVersion(StreamAction action)
+        {
+        }
+
+        public void QuickAppendEvents(StreamAction action)
+        {
+        }
+
+        public Task PublishMessageAsync(object message, string tenantId) => Task.CompletedTask;
+
+        public ValueTask RecordProgress(EventRange range) => new();
+    }
+}

--- a/src/JasperFx.Events/Projections/Composite/CompositeProjectionSource.cs
+++ b/src/JasperFx.Events/Projections/Composite/CompositeProjectionSource.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics.CodeAnalysis;
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Aggregation;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Subscriptions;
+using Microsoft.Extensions.Logging;
+
+namespace JasperFx.Events.Projections.Composite;
+
+/// <summary>
+///     Presents a bare <see cref="IJasperFxProjection{TOperations}" /> as something a
+///     <see cref="CompositeProjection{TOperations,TQuerySession}" /> stage can hold.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="IJasperFxProjection{TOperations}" /> applies events and nothing else. A composite
+///         stage holds an <see cref="IProjectionSource{TOperations,TQuerySession}" />, which also knows
+///         its shards, its version and how to build an execution. This supplies all of that around the
+///         projection. Lifted from the identical <c>CompositeIProjectionSource</c> types that lived in
+///         Marten, Polecat and Fisher; the stores' versions are thin closings of this type over their
+///         own session pairs.
+///     </para>
+///     <para>
+///         <b>The execution deliberately does not dispose the batch it is handed.</b> Every stage of a
+///         composite writes into one batch so the whole composite commits together — the composite owns
+///         that lifecycle, and a stage disposing it would commit the earlier stages and leave the later
+///         ones writing into a disposed session.
+///     </para>
+/// </remarks>
+public class CompositeProjectionSource<TOperations, TQuerySession> :
+    ProjectionBase,
+    IProjectionSource<TOperations, TQuerySession>,
+    ISubscriptionFactory<TOperations, TQuerySession>
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private readonly IJasperFxProjection<TOperations> _projection;
+
+    public CompositeProjectionSource(IJasperFxProjection<TOperations> projection)
+    {
+        _projection = projection;
+        Lifecycle = ProjectionLifecycle.Async;
+        Name = projection.GetType().Name;
+        Version = 1;
+        if (_projection.GetType().TryGetAttribute<ProjectionVersionAttribute>(out var att))
+        {
+            Version = att.Version;
+        }
+
+        // polecat#439 / marten#5175 / fisher#63: adopt the wrapped projection's options and published
+        // types when it has any, the way ProjectionWrapper and ScopedProjectionWrapper both do. Without
+        // this the wrapper keeps the empty AsyncOptions it was constructed with, and a composite
+        // rebuild -- whose teardown reads each member's PublishedTypes() and Options.CleanUps --
+        // queues NOTHING for this member. The rebuild then restarts from sequence zero (its
+        // progression row IS deleted) and replays onto the previous run's surviving rows, which is a
+        // silent double-count.
+        //
+        // Name and Version are deliberately NOT adopted: they compose this member's
+        // ShardName.Identity, and changing them would orphan every existing progression row.
+        //
+        // A raw projection that is not a ProjectionBase declares neither storage nor teardown, so
+        // there is nothing to adopt and nothing this wrapper can invent. Declare it at registration
+        // instead -- each store's composite exposes an Add(projection, Action<AsyncOptions>) overload
+        // for exactly that.
+        if (projection is ProjectionBase source)
+        {
+            replaceOptions(source.Options);
+
+            foreach (var publishedType in source.PublishedTypes())
+            {
+                RegisterPublishedType(publishedType);
+            }
+        }
+    }
+
+    public SubscriptionType Type => SubscriptionType.EventProjection;
+    public ShardName[] ShardNames() => [new ShardName(Name, ShardName.All, Version)];
+    public Type ImplementationType => _projection.GetType();
+    public SubscriptionDescriptor Describe(IEventStore store) => new(this, store);
+
+    public IReadOnlyList<AsyncShard<TOperations, TQuerySession>> Shards()
+    {
+        return
+        [
+            new AsyncShard<TOperations, TQuerySession>(Options, ShardRole.Projection,
+                new ShardName(Name, ShardName.All, Version), this, this)
+        ];
+    }
+
+    public bool TryBuildReplayExecutor(IEventStore<TOperations, TQuerySession> store, IEventDatabase database,
+        [NotNullWhen(true)] out IReplayExecutor? executor)
+    {
+        executor = default;
+        return false;
+    }
+
+    IInlineProjection<TOperations> IProjectionSource<TOperations, TQuerySession>.BuildForInline()
+    {
+        throw new NotSupportedException($"{GetType().NameInCode()} does not support inline execution");
+    }
+
+    public ISubscriptionExecution BuildExecution(IEventStore<TOperations, TQuerySession> store,
+        IEventDatabase database, ILoggerFactory loggerFactory, ShardName shardName)
+    {
+        return new CompositeProjectionSourceExecution<TOperations, TQuerySession>(_projection, shardName);
+    }
+
+    public ISubscriptionExecution BuildExecution(IEventStore<TOperations, TQuerySession> store,
+        IEventDatabase database, ILogger logger, ShardName shardName)
+    {
+        return new CompositeProjectionSourceExecution<TOperations, TQuerySession>(_projection, shardName);
+    }
+}
+
+/// <summary>
+///     One stage's execution for a bare <see cref="IJasperFxProjection{TOperations}" /> running inside a
+///     composite: apply the range's events, per tenant, into the composite's shared batch.
+/// </summary>
+/// <remarks>
+///     <b>The execution deliberately does not dispose the batch it is handed.</b> Every stage of a
+///     composite writes into one batch so the whole composite commits together — the composite owns
+///     that lifecycle, and a stage disposing it would commit the earlier stages and leave the later
+///     ones writing into a disposed session.
+/// </remarks>
+public class CompositeProjectionSourceExecution<TOperations, TQuerySession> : ISubscriptionExecution
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private readonly IJasperFxProjection<TOperations> _projection;
+
+    public CompositeProjectionSourceExecution(IJasperFxProjection<TOperations> projection, ShardName shardName)
+    {
+        _projection = projection;
+        ShardName = shardName;
+    }
+
+    public ShardName ShardName { get; }
+    public ShardExecutionMode Mode { get; set; }
+
+    public async Task ProcessRangeAsync(EventRange range)
+    {
+        var batch = range.ActiveBatch as IProjectionBatch<TOperations, TQuerySession>;
+        if (batch == null) return;
+
+        var groups = range.Events.GroupBy(x => x.TenantId).ToArray();
+        foreach (var group in groups)
+        {
+            await using var session = batch.SessionForTenant(group.Key);
+            await _projection.ApplyAsync(session, group.ToList(), CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    public ValueTask EnqueueAsync(EventPage page, ISubscriptionAgent subscriptionAgent) => new();
+    public Task StopAndDrainAsync(CancellationToken token) => Task.CompletedTask;
+    public Task HardStopAsync() => Task.CompletedTask;
+
+    public bool TryBuildReplayExecutor([NotNullWhen(true)] out IReplayExecutor? executor)
+    {
+        executor = default;
+        return false;
+    }
+
+    public Task ProcessImmediatelyAsync(SubscriptionAgent subscriptionAgent, EventPage events,
+        CancellationToken cancellation) => Task.CompletedTask;
+
+    public bool TryGetAggregateCache<TId, TDoc>([NotNullWhen(true)] out IAggregateCaching<TId, TDoc>? caching)
+    {
+        caching = null;
+        return false;
+    }
+
+    public ValueTask DisposeAsync() => new();
+}


### PR DESCRIPTION
Closes #750. Stoat plan `internals-lifting-2026-09`, node `jfx-composite-source`.

Polecat's and Fisher's `CompositeIProjectionSource` files (both ported from Marten's) diff to nothing but namespace and comments — including the identical batch-lifecycle invariant and the same bug fixed twice (polecat#439 / marten#5175, fisher#63). This lifts the one missing piece of the composite family into `src/JasperFx.Events/Projections/Composite/`:

- **`CompositeProjectionSource<TOperations, TQuerySession>`** — wraps a bare `IJasperFxProjection<TOperations>` as an `IProjectionSource` + `ISubscriptionFactory` a composite stage can hold. Genericized identically to `CompositeProjection` / `ProjectionStage` (`where TOperations : TQuerySession, IStorageOperations`), so each store's version becomes a thin closing: since each store's `IProjection : IJasperFxProjection<IDocumentSession>`, `internal class CompositeIProjectionSource : CompositeProjectionSource<IDocumentSession, IQuerySession>` (or a direct use) is all a store needs.
- **`CompositeProjectionSourceExecution<TOperations, TQuerySession>`** — the per-tenant apply into the composite's shared batch.

What is deliberately preserved from the store copies:

- The non-obvious invariant, on both types: **the execution deliberately does not dispose the batch it is handed** — the composite owns the batch lifecycle, and a stage disposing it would commit the earlier stages and leave later ones writing into a disposed session.
- The #439/#5175/#63 adoption: a `ProjectionBase` member's `Options` and `PublishedTypes()` are adopted (otherwise composite rebuild teardown queues nothing for the member and the rebuild replays onto surviving rows); `Name` and `Version` are deliberately **not** adopted, because they compose the member's `ShardName.Identity`.
- `ProjectionVersionAttribute` honored on the wrapped projection; inline execution refused by name.

Drift found between the store copies: none in code — only comments, and Polecat's `Shards()` spelled the shard key as the `"All"` literal where its `ShardNames()` used `ShardName.All`; the lifted type uses `ShardName.All` in both places.

Unit tests added in `EventTests/Projections/Composite/CompositeProjectionSourceTests.cs` (8 tests), covering the adoption rule both ways, the version attribute, the no-inline refusal, per-tenant application through `SessionForTenant`, and the batch-not-disposed / sessions-disposed invariant. Full EventTests run: 1013 passed, 0 failed (net10.0).

Store-side adoption is gated on the next publish node and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)