### PR TITLE
Lift the per-store event exception types into JasperFx.Events

### DIFF
--- a/src/EventTests/LiftedStoreExceptionTests.cs
+++ b/src/EventTests/LiftedStoreExceptionTests.cs
@@ -1,0 +1,205 @@
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Shouldly;
+
+namespace EventTests;
+
+// jasperfx#751: the six event exception types that were declared separately per store (Marten,
+// Polecat, Fisher), lifted beside EventStreamUnexpectedMaxEventIdException / EmptyEventStreamException
+// / DcbConcurrencyException. The messages pinned here are the canonical ones the store copies had
+// converged on; a store whose copy diverged keeps its wording through the protected
+// message-overriding constructors, which the subclass tests below exercise.
+public class LiftedStoreExceptionTests
+{
+    [Fact]
+    public void unknown_event_type_carries_the_alias_and_the_registration_hint()
+    {
+        var ex = new UnknownEventTypeException("trip_started");
+
+        ex.EventTypeName.ShouldBe("trip_started");
+        ex.Message.ShouldBe(
+            "Unknown event type name alias 'trip_started'. You may need to register this event type through StoreOptions.Events.AddEventType(type)");
+
+        // The single-argument ctor is the "no row in hand" spelling — the sentinel the stores'
+        // event read paths already used for "the sequence could not be determined".
+        ex.Sequence.ShouldBe(UnknownEventTypeException.UnknownSequence);
+        ex.Sequence.ShouldBe(-1);
+    }
+
+    [Fact]
+    public void unknown_event_type_is_an_event_failure_context()
+    {
+        // marten#5048 / jasperfx#565: a shard paused by an unregistered event type names the event
+        // that stopped it, and the category is deliberately distinct from EventSerialization —
+        // a deployment fix, not a data fix.
+        IEventFailureContext context = new UnknownEventTypeException("trip_started", 42);
+
+        context.Category.ShouldBe(ShardFailureCategory.UnknownEventType);
+        context.Sequence.ShouldBe(42);
+        context.EventTypeName.ShouldBe("trip_started");
+
+        // The type never resolved, so no event was materialized to read these from.
+        context.EventId.ShouldBeNull();
+        context.StreamId.ShouldBeNull();
+        context.StreamKey.ShouldBeNull();
+        context.TenantId.ShouldBeNull();
+        context.Version.ShouldBeNull();
+    }
+
+    [Fact]
+    public void event_deserialization_failure_carries_sequence_alias_and_inner()
+    {
+        var inner = new InvalidOperationException("boom");
+        var ex = new EventDeserializationFailureException(42, "trip_started", inner);
+
+        ex.Message.ShouldBe("Event deserialization error on sequence = 42 for event type trip_started");
+        ex.Sequence.ShouldBe(42);
+        ex.EventTypeName.ShouldBe("trip_started");
+        ex.InnerException.ShouldBeSameAs(inner);
+
+        IEventFailureContext context = ex;
+        context.Category.ShouldBe(ShardFailureCategory.EventSerialization);
+        context.EventId.ShouldBeNull();
+        context.StreamId.ShouldBeNull();
+        context.StreamKey.ShouldBeNull();
+        context.TenantId.ShouldBeNull();
+        context.Version.ShouldBeNull();
+    }
+
+    [Fact]
+    public void event_deserialization_failure_accepts_an_event_type()
+    {
+        // Marten's ctor shape: hand over the IEventType and let the exception take the alias.
+        var eventType = new FakeEventType { EventTypeName = "trip_started" };
+
+        var ex = new EventDeserializationFailureException(7, eventType, new Exception("boom"));
+
+        ex.EventTypeName.ShouldBe(eventType.EventTypeName);
+        ex.Message.ShouldContain(eventType.EventTypeName);
+    }
+
+    [Fact]
+    public void event_deserialization_failure_builds_a_correlatable_dead_letter()
+    {
+        // Lifted from Marten's internal ToDeadLetterEvent: the id is pre-assigned (version 7) so the
+        // creating process can correlate the ShardFailure it reports with the background, retried
+        // dead letter write.
+        var ex = new EventDeserializationFailureException(42, "trip_started", new Exception("boom"));
+
+        var deadLetter = ex.ToDeadLetterEvent(new ShardName("Trip", "All", 2));
+
+        deadLetter.Id.ShouldNotBe(Guid.Empty);
+        deadLetter.Id.Version.ShouldBe(7);
+        deadLetter.EventSequence.ShouldBe(42);
+        deadLetter.ExceptionMessage.ShouldBe(ex.Message);
+        deadLetter.ExceptionType.ShouldBe("JasperFx.Events.EventDeserializationFailureException");
+        deadLetter.ProjectionName.ShouldBe("Trip");
+        deadLetter.ShardName.ShouldBe("All");
+    }
+
+    [Fact]
+    public void non_existent_stream_names_the_id()
+    {
+        var id = Guid.NewGuid();
+        var ex = new NonExistentStreamException(id);
+
+        ex.Id.ShouldBe(id);
+        ex.Message.ShouldBe($"Attempt to append to a nonexistent event stream '{id}'");
+    }
+
+    [Fact]
+    public void existing_stream_id_collision_names_the_id()
+    {
+        var ex = new ExistingStreamIdCollisionException("stream-1");
+
+        ex.Id.ShouldBe("stream-1");
+        ex.AggregateType.ShouldBeNull();
+        ex.Message.ShouldBe("Stream with id 'stream-1' already exists.");
+    }
+
+    [Fact]
+    public void existing_stream_id_collision_can_carry_the_aggregate_type()
+    {
+        // Marten's shape: the aggregate type the stream was being started for.
+        var ex = new ExistingStreamIdCollisionException("stream-1", typeof(AEvent));
+
+        ex.AggregateType.ShouldBe(typeof(AEvent));
+    }
+
+    [Fact]
+    public void stream_locked_carries_the_stream_id_and_optional_inner()
+    {
+        var inner = new TimeoutException("lock wait timeout");
+        var ex = new StreamLockedException(13, inner);
+
+        ex.StreamId.ShouldBe(13);
+        ex.InnerException.ShouldBeSameAs(inner);
+        ex.Message.ShouldBe("Stream '13' may be locked for updates");
+
+        // Polecat passes a nullable inner; that stays expressible.
+        new StreamLockedException(13, null).InnerException.ShouldBeNull();
+    }
+
+    [Fact]
+    public void default_tenant_usage_disabled_has_the_standard_message()
+    {
+        new DefaultTenantUsageDisabledException().Message.ShouldBe(
+            "Default tenant *DEFAULT* usage is disabled. Ensure to create a session by explicitly passing a non-default tenant in the method arg or SessionOptions.");
+    }
+
+    [Fact]
+    public void default_tenant_usage_disabled_appends_to_the_prefix()
+    {
+        // Both store copies APPEND the caller's text to the standard prefix rather than replacing it.
+        new DefaultTenantUsageDisabledException("Use a tenant-specific daemon instead.").Message.ShouldBe(
+            "Default tenant *DEFAULT* usage is disabled. Use a tenant-specific daemon instead.");
+    }
+
+    [Fact]
+    public void a_store_subclass_can_keep_its_diverged_message()
+    {
+        // The protected message-overriding ctors exist so a store whose copy diverged (Marten's
+        // collision message, Fisher's unknown-event-type message) can subclass without breaking the
+        // tests that pin its wording.
+        var collision = new MartenishCollisionException(5, typeof(AEvent));
+        collision.Message.ShouldBe("Stream #5 already exists in the database");
+        collision.Id.ShouldBe(5);
+        collision.AggregateType.ShouldBe(typeof(AEvent));
+
+        var unknown = new FisherishUnknownEventTypeException("trip_started", 42);
+        unknown.Message.ShouldContain("at sequence 42");
+        unknown.EventTypeName.ShouldBe("trip_started");
+        unknown.Sequence.ShouldBe(42);
+        ((IEventFailureContext)unknown).Category.ShouldBe(ShardFailureCategory.UnknownEventType);
+    }
+
+    private class MartenishCollisionException : ExistingStreamIdCollisionException
+    {
+        public MartenishCollisionException(object id, Type aggregateType)
+            : base($"Stream #{id} already exists in the database", id, aggregateType)
+        {
+        }
+    }
+
+    private class FisherishUnknownEventTypeException : UnknownEventTypeException
+    {
+        public FisherishUnknownEventTypeException(string? eventTypeName, long sequence)
+            : base($"Unknown event type '{eventTypeName}' at sequence {sequence}.", eventTypeName, sequence)
+        {
+        }
+    }
+
+    private class FakeEventType : IEventType
+    {
+        public Type EventType => typeof(AEvent);
+        public string DotNetTypeName { get; set; } = typeof(AEvent).FullName!;
+        public string EventTypeName { get; set; } = "a_event";
+        public string Alias => EventTypeName;
+
+        public IEvent Wrap(object eventData)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/JasperFx.Events/DefaultTenantUsageDisabledException.cs
+++ b/src/JasperFx.Events/DefaultTenantUsageDisabledException.cs
@@ -1,0 +1,25 @@
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when a session or projection daemon is created against the default tenant while the
+///     store's default tenant usage is disabled — which is the automatic state once a
+///     database-per-tenant tenancy is configured.
+/// </summary>
+/// <remarks>
+///     Lifted from the byte-identically-messaged exceptions in Marten and Polecat. Stores subclass
+///     or type-forward to this. The single-argument constructor deliberately <em>appends</em> to the
+///     standard prefix rather than replacing it, exactly as both store copies did.
+/// </remarks>
+public class DefaultTenantUsageDisabledException : Exception
+{
+    public DefaultTenantUsageDisabledException()
+        : base(
+            $"Default tenant {StorageConstants.DefaultTenantId} usage is disabled. Ensure to create a session by explicitly passing a non-default tenant in the method arg or SessionOptions.")
+    {
+    }
+
+    public DefaultTenantUsageDisabledException(string message)
+        : base($"Default tenant {StorageConstants.DefaultTenantId} usage is disabled. {message}")
+    {
+    }
+}

--- a/src/JasperFx.Events/EventDeserializationFailureException.cs
+++ b/src/JasperFx.Events/EventDeserializationFailureException.cs
@@ -1,0 +1,96 @@
+using JasperFx.Core.Reflection;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when a store cannot deserialize (or upcast) a persisted event body out of its events
+///     table.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Lifted from the identically-shaped exceptions in Marten and Polecat. Stores subclass or
+///         type-forward to this.
+///     </para>
+///     <para>
+///         jasperfx#565: this exception declares its own <see cref="ShardFailureCategory" /> through
+///         <see cref="IEventFailureContext" />, which is how a paused shard reports <em>why</em> it is
+///         down. The daemon deliberately has no fallback — it never sniffs a store's exception type
+///         names — so without this a corrupted event body classified as
+///         <see cref="ShardFailureCategory.Other" /> with no event details at all. A body the store
+///         could not deserialize is a serializer or data problem — governed by
+///         <c>SkipSerializationErrors</c> — which is a different operator action from an unregistered
+///         event type; see <see cref="UnknownEventTypeException" />.
+///     </para>
+/// </remarks>
+public class EventDeserializationFailureException : Exception, IEventFailureContext
+{
+    public EventDeserializationFailureException(long sequence, string? eventTypeName, Exception innerException)
+        : this($"Event deserialization error on sequence = {sequence} for event type {eventTypeName}",
+            sequence, eventTypeName, innerException)
+    {
+    }
+
+    public EventDeserializationFailureException(long sequence, IEventType eventType, Exception innerException)
+        : this(sequence, eventType.EventTypeName, innerException)
+    {
+    }
+
+    /// <summary>
+    ///     For store subclasses whose message diverges from the canonical one (and whose tests may
+    ///     assert on that message).
+    /// </summary>
+    protected EventDeserializationFailureException(string message, long sequence, string? eventTypeName,
+        Exception innerException) : base(message, innerException)
+    {
+        Sequence = sequence;
+        EventTypeName = eventTypeName;
+    }
+
+    /// <summary>
+    ///     Store-wide sequence number of the event whose body could not be read.
+    /// </summary>
+    public long Sequence { get; }
+
+    /// <summary>
+    ///     The event store's type alias for the failing event (e.g. <c>trip_started</c>), when the row
+    ///     supplied one. Retained as data rather than being buried in the message string so the daemon
+    ///     can report it on <see cref="ShardFailure" />.
+    /// </summary>
+    public string? EventTypeName { get; }
+
+    public ShardFailureCategory Category => ShardFailureCategory.EventSerialization;
+
+    // Everything below is raised while reading an events-table row, BEFORE there is an IEvent to
+    // inspect, so nothing but the sequence and the stored type alias is knowable here.
+    // IEventFailureContext makes every one of these nullable for exactly this case.
+    Guid? IEventFailureContext.EventId => null;
+    Guid? IEventFailureContext.StreamId => null;
+    string? IEventFailureContext.StreamKey => null;
+    string? IEventFailureContext.TenantId => null;
+    long? IEventFailureContext.Version => null;
+
+    /// <summary>
+    ///     Build the <see cref="DeadLetterEvent" /> row recording this failure for the named shard.
+    ///     Lifted from Marten's internal helper — it was built entirely from shared types.
+    /// </summary>
+    public DeadLetterEvent ToDeadLetterEvent(ShardName name)
+    {
+        return new DeadLetterEvent
+        {
+            // marten#5048 / jasperfx#565: assign the id here rather than leaving it to document identity
+            // generation at write time, so the creating process knows the dead letter's id BEFORE the
+            // (background, retried) write lands and can correlate it with the ShardFailure it reported.
+            // Stores only generate an id when the value is empty, so pre-assigning changes nothing about
+            // how the row persists. Version 7 keeps ids time-ordered, matching what jasperfx's
+            // DeadLetterEvent constructor does on the ApplyEventException path.
+            Id = Guid.CreateVersion7(),
+            EventSequence = Sequence,
+            ExceptionMessage = Message,
+            ExceptionType = GetType().FullNameInCode(),
+            ProjectionName = name.Name,
+            ShardName = name.ShardKey
+        };
+    }
+}

--- a/src/JasperFx.Events/ExistingStreamIdCollisionException.cs
+++ b/src/JasperFx.Events/ExistingStreamIdCollisionException.cs
@@ -1,0 +1,41 @@
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when attempting to start a new event stream with an id that already exists in the
+///     database.
+/// </summary>
+/// <remarks>
+///     Lifted from the per-store exceptions of the same name. The <see cref="AggregateType" /> is
+///     Marten's addition and is nullable here because Polecat and Fisher throw without one; the
+///     message is Polecat's/Fisher's, and Marten's diverged wording
+///     (<c>Stream #... already exists in the database</c>) stays expressible through the protected
+///     message-overriding constructor. Stores subclass or type-forward to this.
+/// </remarks>
+public class ExistingStreamIdCollisionException : Exception
+{
+    public ExistingStreamIdCollisionException(object id) : this(id, null)
+    {
+    }
+
+    public ExistingStreamIdCollisionException(object id, Type? aggregateType)
+        : this($"Stream with id '{id}' already exists.", id, aggregateType)
+    {
+    }
+
+    /// <summary>
+    ///     For store subclasses whose message diverges from the canonical one (and whose tests may
+    ///     assert on that message).
+    /// </summary>
+    protected ExistingStreamIdCollisionException(string message, object id, Type? aggregateType) : base(message)
+    {
+        Id = id;
+        AggregateType = aggregateType;
+    }
+
+    public object Id { get; }
+
+    /// <summary>
+    ///     The aggregate type the colliding stream was being started for, when the throw site knew it.
+    /// </summary>
+    public Type? AggregateType { get; }
+}

--- a/src/JasperFx.Events/NonExistentStreamException.cs
+++ b/src/JasperFx.Events/NonExistentStreamException.cs
@@ -1,0 +1,30 @@
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when appending to a stream that does not exist, from an append that had to read the
+///     stream's current state first — the optimistic and exclusive append paths. A plain
+///     <c>Append</c> does not throw this; it queues the events and lets the write fail at save time,
+///     because there is nothing to read up front.
+/// </summary>
+/// <remarks>
+///     Lifted from the identically-shaped exceptions in Marten, Polecat and Fisher. Stores subclass
+///     or type-forward to this.
+/// </remarks>
+public class NonExistentStreamException : Exception
+{
+    public NonExistentStreamException(object id)
+        : this($"Attempt to append to a nonexistent event stream '{id}'", id)
+    {
+    }
+
+    /// <summary>
+    ///     For store subclasses whose message diverges from the canonical one (and whose tests may
+    ///     assert on that message).
+    /// </summary>
+    protected NonExistentStreamException(string message, object id) : base(message)
+    {
+        Id = id;
+    }
+
+    public object Id { get; }
+}

--- a/src/JasperFx.Events/StreamLockedException.cs
+++ b/src/JasperFx.Events/StreamLockedException.cs
@@ -1,0 +1,30 @@
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when a stream cannot be locked for exclusive access, typically because another
+///     transaction holds a lock on the stream row.
+/// </summary>
+/// <remarks>
+///     Lifted from the identically-messaged exceptions in Marten and Polecat. The
+///     <see cref="StreamId" /> property and the nullable inner exception are Polecat's supersets of
+///     Marten's shape. Stores subclass or type-forward to this.
+/// </remarks>
+public class StreamLockedException : Exception
+{
+    public StreamLockedException(object streamId, Exception? innerException)
+        : this($"Stream '{streamId}' may be locked for updates", streamId, innerException)
+    {
+    }
+
+    /// <summary>
+    ///     For store subclasses whose message diverges from the canonical one (and whose tests may
+    ///     assert on that message).
+    /// </summary>
+    protected StreamLockedException(string message, object streamId, Exception? innerException)
+        : base(message, innerException)
+    {
+        StreamId = streamId;
+    }
+
+    public object StreamId { get; }
+}

--- a/src/JasperFx.Events/UnknownEventTypeException.cs
+++ b/src/JasperFx.Events/UnknownEventTypeException.cs
@@ -1,0 +1,78 @@
+using JasperFx.Events.Daemon;
+
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when an event's persisted .NET type name or alias resolves to no known event type in
+///     this deployment.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Lifted from the per-store exceptions of the same name in Marten, Polecat and Fisher, which
+///         had converged on the same shape (jasperfx#565 gave all three the
+///         <see cref="IEventFailureContext" /> contract). Stores subclass or type-forward to this; a
+///         store whose tests pin a diverged message keeps it through the protected message-overriding
+///         constructor.
+///     </para>
+///     <para>
+///         Kept deliberately distinct from <see cref="ShardFailureCategory.EventSerialization" />. An
+///         alias that resolves to no known .NET type is normally a missing registration or a
+///         deployment rolled back past the event type's introduction — a deployment fix, not a data
+///         fix — so an operator responds to it differently.
+///     </para>
+/// </remarks>
+public class UnknownEventTypeException : Exception, IEventFailureContext
+{
+    /// <summary>
+    ///     The sequence reported when the throw site had no event row in hand — e.g. resolving a .NET
+    ///     type name outside the event read path. <see cref="IEventFailureContext.Sequence" /> is
+    ///     non-nullable by contract, so a sentinel is unavoidable, and -1 is already how the stores'
+    ///     event read paths spell "the sequence could not be determined".
+    /// </summary>
+    public const long UnknownSequence = -1;
+
+    public UnknownEventTypeException(string? eventTypeName) : this(eventTypeName, UnknownSequence)
+    {
+    }
+
+    /// <summary>
+    ///     marten#5048 / jasperfx#565: carry the store-wide sequence of the offending event row when the
+    ///     throw site knows it, so a shard paused by an unregistered event type can name the event that
+    ///     stopped it instead of only its alias.
+    /// </summary>
+    public UnknownEventTypeException(string? eventTypeName, long sequence) : this(
+        $"Unknown event type name alias '{eventTypeName}'. You may need to register this event type through StoreOptions.Events.AddEventType(type)",
+        eventTypeName, sequence)
+    {
+    }
+
+    /// <summary>
+    ///     For store subclasses whose message diverges from the canonical one (and whose tests may
+    ///     assert on that message).
+    /// </summary>
+    protected UnknownEventTypeException(string message, string? eventTypeName, long sequence) : base(message)
+    {
+        EventTypeName = eventTypeName;
+        Sequence = sequence;
+    }
+
+    /// <summary>
+    ///     Store-wide sequence of the offending event row, or <see cref="UnknownSequence" /> when the
+    ///     throw site had no row.
+    /// </summary>
+    public long Sequence { get; }
+
+    /// <summary>
+    ///     The unresolvable type name as stored.
+    /// </summary>
+    public string? EventTypeName { get; }
+
+    public ShardFailureCategory Category => ShardFailureCategory.UnknownEventType;
+
+    // The type never resolved, so no event was ever materialized to read these from.
+    Guid? IEventFailureContext.EventId => null;
+    Guid? IEventFailureContext.StreamId => null;
+    string? IEventFailureContext.StreamKey => null;
+    string? IEventFailureContext.TenantId => null;
+    long? IEventFailureContext.Version => null;
+}


### PR DESCRIPTION
Closes #751. Stoat plan `internals-lifting-2026-09`, node `jfx-event-exceptions`.

Adds canonical versions of the six event exception types that were declared separately per store, beside the already-shared `EventStreamUnexpectedMaxEventIdException` / `EmptyEventStreamException` / `DcbConcurrencyException` in the `JasperFx.Events` root namespace. Store copies compared: Marten `master` (via `git show`, since the local checkout sits on 8.0), plus the live Polecat and Fisher checkouts. Store-side adoption (subclass or type-forward) is gated on the publish node and out of scope here.

### Design
- **Superset shapes** so every store's current usage stays expressible: `ExistingStreamIdCollisionException` keeps Marten's `AggregateType` (nullable, since Polecat/Fisher throw without one); `StreamLockedException` keeps Polecat's `StreamId` property and nullable inner (Marten's shape had neither); `EventDeserializationFailureException` has both Polecat's `(long, string?, Exception)` and Marten's `(long, IEventType, Exception)` ctors, and Marten's `ToDeadLetterEvent(ShardName)` helper is lifted with it (it was built entirely from shared types, pre-assigned v7 Guid comment included).
- **Protected message-overriding ctors** on the types whose copies diverged in wording, so a store can subclass and keep the message its tests pin (exercised in the new tests with Marten-style and Fisher-style subclasses).
- `UnknownEventTypeException` and `EventDeserializationFailureException` implement `IEventFailureContext` exactly as the store copies did (jasperfx#565): own `ShardFailureCategory`, `UnknownSequence = -1` sentinel, explicit-interface null members for everything unknowable at the throw site.
- No `SerializationInfo` ctors: Marten's copies still carry the obsolete (`SYSLIB0051`) protected serialization ctors; those stay on Marten's side if it wants them — the existing shared exceptions here don't have them either.
- Base class is `Exception`, matching the existing shared exceptions. Note for the adoption node: Marten's copies derive from `MartenException`, and a Marten subclass of these shared types cannot also be a `MartenException` — same tradeoff already taken when `DcbConcurrencyException` was lifted onto `ConcurrencyException`.

### Message drift found between store copies (canonical pick flagged per type)
- **`UnknownEventTypeException`** — Marten: `Unknown event type name alias 'x.' You may need to register...` (note the period *inside* the quotes — a long-standing typo); Polecat: same text with the period outside (`'x'.`); Fisher: entirely different message (`Unknown event type 'x' at sequence N. Register it through StoreOptions.Events.AddEventType(type), or configure the projection to skip unknown events.`). **Picked Polecat's** (Marten's minus the typo). Marten adopting the canonical message silently fixes its typo; Fisher keeps its wording via the protected ctor if desired.
- **`ExistingStreamIdCollisionException`** — Marten: `Stream #{id} already exists in the database`; Polecat/Fisher: `Stream with id '{id}' already exists.` **Picked Polecat/Fisher's** (2 of 3). Marten's wording remains expressible via the protected ctor.
- **`NonExistentStreamException`** — Marten/Polecat: `Attempt to append to a nonexistent event stream '{id}'`; Fisher adds a trailing period. **Picked Marten/Polecat's** (2 of 3).
- `EventDeserializationFailureException`, `StreamLockedException`, `DefaultTenantUsageDisabledException` — messages byte-identical across the stores that declare them; no pick needed. (`DefaultTenantUsageDisabledException(string)` deliberately *appends* to the standard prefix rather than replacing it, exactly as both store copies did.)

### Tests
`src/EventTests/LiftedStoreExceptionTests.cs` (11 tests): canonical messages, properties, `IEventFailureContext` contracts, the `UnknownSequence` sentinel, `ToDeadLetterEvent` correlation mapping (v7 id, sequence, projection/shard names), the append-to-prefix behavior, and the diverged-message subclass path. Full EventTests run: 1016 passed, 0 failed (net10.0); full `jasperfx.slnx` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)