### PR TITLE
Shared event upcasting contract + compliance suite

### DIFF
--- a/src/EventTests/Upcasting/upcasting_contract_tests.cs
+++ b/src/EventTests/Upcasting/upcasting_contract_tests.cs
@@ -1,0 +1,344 @@
+using System.Text.Json;
+using JasperFx.Events;
+using JasperFx.Events.Upcasting;
+using Shouldly;
+
+namespace EventTests.Upcasting;
+
+#region Test events
+
+public record CartOpenedV1(Guid CartId, Guid ClientId);
+
+public record CartOpenedV2(Guid CartId, Guid ClientId, string Status);
+
+#endregion
+
+/// <summary>
+/// A minimal in-memory store stand-in: the payload is JSON in memory, "the store's serializer" is
+/// System.Text.Json, and the accessors record which read path a transformation actually took.
+/// </summary>
+public class StubUpcastPayload : IUpcastPayload
+{
+    private readonly string _json;
+
+    public StubUpcastPayload(object data)
+    {
+        _json = JsonSerializer.Serialize(data, data.GetType());
+    }
+
+    public int SyncReads { get; private set; }
+    public int AsyncReads { get; private set; }
+
+    public T As<T>() where T : notnull
+    {
+        SyncReads++;
+        return JsonSerializer.Deserialize<T>(_json)!;
+    }
+
+    public ValueTask<T> AsAsync<T>(CancellationToken token) where T : notnull
+    {
+        AsyncReads++;
+        return new ValueTask<T>(JsonSerializer.Deserialize<T>(_json)!);
+    }
+
+    public JsonDocument AsJsonDocument()
+    {
+        SyncReads++;
+        return JsonDocument.Parse(_json);
+    }
+
+    public ValueTask<JsonDocument> AsJsonDocumentAsync(CancellationToken token)
+    {
+        AsyncReads++;
+        return new ValueTask<JsonDocument>(JsonDocument.Parse(_json));
+    }
+}
+
+public class UpcastTransformationTests
+{
+    private static readonly Guid theCartId = Guid.NewGuid();
+    private static readonly Guid theClientId = Guid.NewGuid();
+
+    private static StubUpcastPayload aV1Payload() => new(new CartOpenedV1(theCartId, theClientId));
+
+    [Fact]
+    public void typed_transformation_claims_the_old_types_conventional_event_type_name()
+    {
+        var transformation = UpcastTransformation.For<CartOpenedV1, CartOpenedV2>(
+            old => new CartOpenedV2(old.CartId, old.ClientId, "Opened"));
+
+        transformation.EventTypeName.ShouldBe(EventTypeExtensions.GetEventTypeName<CartOpenedV1>());
+        transformation.EventType.ShouldBe(typeof(CartOpenedV2));
+    }
+
+    [Fact]
+    public void typed_transformation_honors_an_explicit_event_type_name()
+    {
+        var transformation = UpcastTransformation.For<CartOpenedV1, CartOpenedV2>(
+            old => new CartOpenedV2(old.CartId, old.ClientId, "Opened"), "cart_opened_v1");
+
+        transformation.EventTypeName.ShouldBe("cart_opened_v1");
+    }
+
+    [Fact]
+    public void typed_transformation_upcasts_through_the_sync_path()
+    {
+        var transformation = UpcastTransformation.For<CartOpenedV1, CartOpenedV2>(
+            old => new CartOpenedV2(old.CartId, old.ClientId, "Opened"));
+
+        var payload = aV1Payload();
+        var upcast = transformation.Upcast(payload).ShouldBeOfType<CartOpenedV2>();
+
+        upcast.CartId.ShouldBe(theCartId);
+        upcast.ClientId.ShouldBe(theClientId);
+        upcast.Status.ShouldBe("Opened");
+        payload.SyncReads.ShouldBe(1);
+        payload.AsyncReads.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task typed_transformation_uses_the_async_accessor_on_the_async_path()
+    {
+        var transformation = UpcastTransformation.For<CartOpenedV1, CartOpenedV2>(
+            old => new CartOpenedV2(old.CartId, old.ClientId, "Opened"));
+
+        var payload = aV1Payload();
+        var upcast = (await transformation.UpcastAsync(payload, CancellationToken.None))
+            .ShouldBeOfType<CartOpenedV2>();
+
+        upcast.Status.ShouldBe("Opened");
+        payload.AsyncReads.ShouldBe(1);
+        payload.SyncReads.ShouldBe(0);
+    }
+
+    [Fact]
+    public void async_only_typed_transformation_throws_on_the_sync_path()
+    {
+        var transformation = UpcastTransformation.For<CartOpenedV1, CartOpenedV2>(
+            (old, _) => Task.FromResult(new CartOpenedV2(old.CartId, old.ClientId, "Opened")));
+
+        Should.Throw<UpcastingException>(() => transformation.Upcast(aV1Payload()));
+    }
+
+    [Fact]
+    public async Task async_only_typed_transformation_works_on_the_async_path()
+    {
+        var transformation = UpcastTransformation.For<CartOpenedV1, CartOpenedV2>(
+            (old, _) => Task.FromResult(new CartOpenedV2(old.CartId, old.ClientId, "Opened")));
+
+        var upcast = (await transformation.UpcastAsync(aV1Payload(), CancellationToken.None))
+            .ShouldBeOfType<CartOpenedV2>();
+
+        upcast.CartId.ShouldBe(theCartId);
+    }
+
+    [Fact]
+    public void raw_json_transformation_defaults_to_the_new_types_event_type_name()
+    {
+        var transformation = UpcastTransformation.FromJson(
+            document => new CartOpenedV2(
+                document.RootElement.GetProperty("CartId").GetGuid(),
+                document.RootElement.GetProperty("ClientId").GetGuid(),
+                "Opened"));
+
+        // The "same name, older JSON schema" case, matching Marten's SystemTextJson upcasters.
+        transformation.EventTypeName.ShouldBe(EventTypeExtensions.GetEventTypeName<CartOpenedV2>());
+    }
+
+    [Fact]
+    public void raw_json_transformation_upcasts_from_the_stored_json()
+    {
+        var transformation = UpcastTransformation.FromJson(
+            document => new CartOpenedV2(
+                document.RootElement.GetProperty("CartId").GetGuid(),
+                document.RootElement.GetProperty("ClientId").GetGuid(),
+                "Opened"),
+            "cart_opened_v1");
+
+        var upcast = transformation.Upcast(aV1Payload()).ShouldBeOfType<CartOpenedV2>();
+
+        upcast.CartId.ShouldBe(theCartId);
+        upcast.ClientId.ShouldBe(theClientId);
+    }
+
+    [Fact]
+    public void async_only_raw_json_transformation_throws_on_the_sync_path()
+    {
+        var transformation = UpcastTransformation.FromJson(
+            (JsonDocument document, CancellationToken _) => Task.FromResult(
+                new CartOpenedV2(theCartId, theClientId, "Opened")));
+
+        Should.Throw<UpcastingException>(() => transformation.Upcast(aV1Payload()));
+    }
+
+    [Fact]
+    public async Task async_only_raw_json_transformation_works_on_the_async_path()
+    {
+        var transformation = UpcastTransformation.FromJson(
+            (JsonDocument document, CancellationToken _) => Task.FromResult(
+                new CartOpenedV2(
+                    document.RootElement.GetProperty("CartId").GetGuid(),
+                    document.RootElement.GetProperty("ClientId").GetGuid(),
+                    "Opened")));
+
+        var upcast = (await transformation.UpcastAsync(aV1Payload(), CancellationToken.None))
+            .ShouldBeOfType<CartOpenedV2>();
+
+        upcast.ClientId.ShouldBe(theClientId);
+    }
+}
+
+public class ClassBasedUpcasterTests
+{
+    public class CartOpenedUpcaster : EventUpcaster<CartOpenedV1, CartOpenedV2>
+    {
+        protected override CartOpenedV2 Upcast(CartOpenedV1 oldEvent) =>
+            new(oldEvent.CartId, oldEvent.ClientId, "Opened");
+    }
+
+    public class AsyncOnlyCartOpenedUpcaster : AsyncOnlyEventUpcaster<CartOpenedV1, CartOpenedV2>
+    {
+        protected override Task<CartOpenedV2> UpcastAsync(CartOpenedV1 oldEvent, CancellationToken token) =>
+            Task.FromResult(new CartOpenedV2(oldEvent.CartId, oldEvent.ClientId, "Opened"));
+    }
+
+    public class RawJsonCartOpenedUpcaster : JasperFx.Events.Upcasting.SystemTextJson.EventUpcaster<CartOpenedV2>
+    {
+        public override string EventTypeName => "cart_opened_v1";
+
+        protected override CartOpenedV2 Upcast(JsonDocument oldEvent) =>
+            new(oldEvent.RootElement.GetProperty("CartId").GetGuid(),
+                oldEvent.RootElement.GetProperty("ClientId").GetGuid(),
+                "Opened");
+    }
+
+    private static readonly Guid theCartId = Guid.NewGuid();
+
+    private static StubUpcastPayload aV1Payload() =>
+        new(new CartOpenedV1(theCartId, Guid.NewGuid()));
+
+    [Fact]
+    public void typed_upcaster_uses_the_old_types_conventional_name_and_the_new_clr_type()
+    {
+        var upcaster = new CartOpenedUpcaster();
+
+        upcaster.EventTypeName.ShouldBe(EventTypeExtensions.GetEventTypeName<CartOpenedV1>());
+        upcaster.EventType.ShouldBe(typeof(CartOpenedV2));
+    }
+
+    [Fact]
+    public void typed_upcaster_transforms_in_both_paths()
+    {
+        var upcaster = new CartOpenedUpcaster();
+
+        upcaster.Upcast(aV1Payload()).ShouldBeOfType<CartOpenedV2>().CartId.ShouldBe(theCartId);
+        upcaster.UpcastAsync(aV1Payload(), CancellationToken.None).Result
+            .ShouldBeOfType<CartOpenedV2>().CartId.ShouldBe(theCartId);
+    }
+
+    [Fact]
+    public async Task async_only_upcaster_throws_sync_and_works_async()
+    {
+        var upcaster = new AsyncOnlyCartOpenedUpcaster();
+
+        Should.Throw<UpcastingException>(() => upcaster.Upcast(aV1Payload()));
+
+        (await upcaster.UpcastAsync(aV1Payload(), CancellationToken.None))
+            .ShouldBeOfType<CartOpenedV2>().CartId.ShouldBe(theCartId);
+    }
+
+    [Fact]
+    public async Task raw_json_upcaster_transforms_from_the_stored_json()
+    {
+        var upcaster = new RawJsonCartOpenedUpcaster();
+
+        upcaster.EventTypeName.ShouldBe("cart_opened_v1");
+        upcaster.Upcast(aV1Payload()).ShouldBeOfType<CartOpenedV2>().CartId.ShouldBe(theCartId);
+        (await upcaster.UpcastAsync(aV1Payload(), CancellationToken.None))
+            .ShouldBeOfType<CartOpenedV2>().CartId.ShouldBe(theCartId);
+    }
+}
+
+public class UpcastingRegistryTests
+{
+    private readonly UpcastingRegistry theRegistry = new();
+
+    private static readonly string theOldName = EventTypeExtensions.GetEventTypeName<CartOpenedV1>();
+
+    [Fact]
+    public void starts_empty()
+    {
+        theRegistry.HasAny.ShouldBeFalse();
+        theRegistry.TryFindTransformation(theOldName, out _).ShouldBeFalse();
+        theRegistry.IsUpcastSource(theOldName).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void registers_a_typed_upcast_under_the_old_types_name()
+    {
+        theRegistry.Upcast<CartOpenedV1, CartOpenedV2>(
+            old => new CartOpenedV2(old.CartId, old.ClientId, "Opened"));
+
+        theRegistry.HasAny.ShouldBeTrue();
+        theRegistry.IsUpcastSource(theOldName).ShouldBeTrue();
+
+        theRegistry.TryFindTransformation(theOldName, out var transformation).ShouldBeTrue();
+        transformation!.EventType.ShouldBe(typeof(CartOpenedV2));
+    }
+
+    [Fact]
+    public void registration_is_last_wins_per_event_type_name()
+    {
+        theRegistry.Upcast<CartOpenedV1, CartOpenedV2>("cart_opened",
+            old => new CartOpenedV2(old.CartId, old.ClientId, "First"));
+
+        theRegistry.Upcast<CartOpenedV1, CartOpenedV2>("cart_opened",
+            old => new CartOpenedV2(old.CartId, old.ClientId, "Second"));
+
+        theRegistry.TryFindTransformation("cart_opened", out var transformation).ShouldBeTrue();
+
+        var payload = new StubUpcastPayload(new CartOpenedV1(Guid.NewGuid(), Guid.NewGuid()));
+        transformation!.Upcast(payload).ShouldBeOfType<CartOpenedV2>().Status.ShouldBe("Second");
+
+        // Both registrations remain visible for stores pre-registering target types.
+        theRegistry.AllTransformations.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void registers_class_based_upcasters()
+    {
+        theRegistry.Upcast<ClassBasedUpcasterTests.CartOpenedUpcaster>();
+
+        theRegistry.IsUpcastSource(theOldName).ShouldBeTrue();
+        theRegistry.TryFindTransformation(theOldName, out var transformation).ShouldBeTrue();
+        transformation!.EventType.ShouldBe(typeof(CartOpenedV2));
+    }
+
+    [Fact]
+    public void registers_upcaster_instances()
+    {
+        theRegistry.Upcast(new ClassBasedUpcasterTests.RawJsonCartOpenedUpcaster());
+
+        theRegistry.IsUpcastSource("cart_opened_v1").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void raw_json_registration_defaults_to_the_new_types_name()
+    {
+        theRegistry.Upcast(document => new CartOpenedV2(
+            document.RootElement.GetProperty("CartId").GetGuid(),
+            document.RootElement.GetProperty("ClientId").GetGuid(),
+            "Opened"));
+
+        theRegistry.IsUpcastSource(EventTypeExtensions.GetEventTypeName<CartOpenedV2>()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void the_shared_event_registry_exposes_an_upcasting_registry()
+    {
+        var registry = new EventRegistry();
+
+        registry.Upcasters.ShouldNotBeNull();
+        registry.Upcasters.ShouldBeSameAs(registry.Upcasters);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -258,6 +258,22 @@ public sealed class ComplianceStoreConfig
     }
 
     /// <summary>
+    /// Event upcast transformations the suite asked the store to register.
+    /// </summary>
+    public List<JasperFx.Events.Upcasting.UpcastTransformation> Upcasts { get; } = new();
+
+    /// <summary>
+    /// Register an event upcast transformation.
+    /// </summary>
+    /// <inheritdoc cref="IComplianceStoreRegistrar.Upcast" path="/remarks"/>
+    public ComplianceStoreConfig Upcast(JasperFx.Events.Upcasting.UpcastTransformation transformation)
+    {
+        Upcasts.Add(transformation);
+        _registrations.Add(registrar => registrar.Upcast(transformation));
+        return this;
+    }
+
+    /// <summary>
     /// Register the shared compliance subscription with the store's async daemon.
     /// </summary>
     /// <inheritdoc cref="IComplianceStoreRegistrar.Subscribe" path="/remarks"/>

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -245,6 +245,29 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// </remarks>
     public virtual bool SupportsFlatTableProjections => true;
 
+    /// <summary>
+    /// True in a store that has implemented the shared event upcasting contract
+    /// (<c>JasperFx.Events.Upcasting</c>) — routing its read paths through
+    /// <c>EventRegistry.Upcasters</c> and implementing <c>IUpcastPayload</c> over its own reader
+    /// and serializer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to false, unlike the other gates, because the contract is being defined ahead of
+    /// any store implementing it (jasperfx#752): a consumer that enrolls
+    /// <c>UpcastingCompliance</c> today skips it wholesale and stays green, then flips this when
+    /// the store's read path honors the registry. Like
+    /// <see cref="SupportsFlatTableProjections" />, the suite is the specification a store
+    /// implements against, and the gate is meant to be flipped rather than lived with.
+    /// </para>
+    /// <para>
+    /// The gate also short-circuits configuration, not just facts: the suite never replays its
+    /// upcast registrations through <see cref="IComplianceStoreRegistrar.Upcast" /> (which has a
+    /// throwing default) while this is false.
+    /// </para>
+    /// </remarks>
+    public virtual bool SupportsUpcasting => false;
+
 
     public virtual ValueTask InitializeAsync() => default;
 

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -165,6 +165,29 @@ public interface IComplianceStoreRegistrar
             $"{GetType().FullName} does not implement AddCompositeProjection, so it cannot run the composite projection compliance suite.");
 
     /// <summary>
+    /// Register an event upcast transformation. Maps to the shared
+    /// <c>EventRegistry.Upcasters.Register(transformation)</c>, plus whatever per-store wiring
+    /// makes the store's read path honor it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One member covers every registration shape — typed sync, typed async-only, raw
+    /// <c>JsonDocument</c> — because <c>JasperFx.Events.Upcasting.UpcastTransformation</c> is the
+    /// shared carrier all of them funnel into; the suite builds transformations through the shared
+    /// factories, so the registrar never needs the generic overload family.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default for the same reason as <see cref="UseBinarySerializer{TEvent}" />:
+    /// upcasting is gated (<c>SupportsUpcasting</c>, default false, see jasperfx#752), so a store
+    /// that has not implemented it never reaches this member and keeps compiling against a newer
+    /// compliance package.
+    /// </para>
+    /// </remarks>
+    void Upcast(JasperFx.Events.Upcasting.UpcastTransformation transformation)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement Upcast, so it cannot run the event upcasting compliance suite.");
+
+    /// <summary>
     /// Register the shared compliance subscription with the store's async daemon.
     /// </summary>
     /// <remarks>

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -146,6 +146,21 @@ normalised them away, because an unmixed store satisfies the assertion for a rea
 do with the behaviour under test. Vacuous green is worse than a skip, since only one of the two is
 visible.
 
+`UpcastingCompliance` (jasperfx#752) is opt-in twice over, because it is the first suite written
+*ahead of* any store implementing the behavior. The seam member —
+`IComplianceStoreRegistrar.Upcast(UpcastTransformation)` — carries the usual throwing default, and
+the suite is additionally gated on `SupportsUpcasting`, the one capability flag that defaults to
+**false**: an enrolled store skips every fact (including configuration, so the throwing default is
+never reached) until it routes its read paths through the shared
+`JasperFx.Events.Upcasting.UpcastingRegistry` and implements `IUpcastPayload` over its own reader
+and serializer, then flips the gate and works the facts to green — the same
+declare-the-surface-then-implement ordering as `SupportsFlatTableProjections`. Most facts write
+rows through a "legacy" store configuration that has never heard of the upcasts, then read them
+back through the migrated configuration, because that is what a real schema migration looks like;
+the one single-store fact pins the marten#4680 authority rule — a typed append of the *old* CLR
+type, whose stored dotnet-type hint would otherwise swap the mapping back, must still read through
+the upcaster.
+
 ## Capability gates
 
 Where a store genuinely cannot support a behavior, override the `virtual bool Supports...` flags on
@@ -202,6 +217,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Subscriptions | `SubscriptionCompliance` |
 | Single-tenanted slicing of disagreeing tenant ids | `SingleTenantedEventSlicingCompliance` |
 | Composite projections — staging and member teardown | `CompositeProjectionCompliance` |
+| Event upcasting — old stored schemas read as the current types | `UpcastingCompliance` |
 
 ### Identity-less boundary aggregates (jasperfx#718)
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/UpcastingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/UpcastingCompliance.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using JasperFx.Events.Upcasting;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Upcasting events and aggregate
+
+/// <summary>
+/// The v1 event schema — what an application appended before the migration. Only the "legacy"
+/// store configuration knows these types; the upcasting configuration deliberately does not,
+/// because the whole point of an upcast is that application code drops the old type.
+/// </summary>
+public record UpcastCartOpened(Guid CartId, Guid ClientId);
+
+public record UpcastCouponClipped(Guid CartId, int Percent);
+
+public record UpcastGiftNoted(Guid CartId, string Note);
+
+/// <summary>
+/// The v2 event schema — what aggregations and projections are written against after the
+/// migration.
+/// </summary>
+public record UpcastCartInitialized(Guid CartId, Guid ClientId, string Status);
+
+public record UpcastDiscountApplied(Guid CartId, double Fraction);
+
+public record UpcastGiftRecorded(Guid CartId, string Note, int Length);
+
+/// <summary>
+/// Folds exclusively over the NEW event types. That is the property upcasting exists to provide:
+/// once a transformation is registered, no read path — stream fetch, live aggregation,
+/// FetchForWriting, the daemon — ever hands application code the old schema.
+/// </summary>
+public partial class UpcastCartSummary
+{
+    public Guid Id { get; set; }
+    public Guid ClientId { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public double Discount { get; set; }
+    public int GiftCount { get; set; }
+
+    public static UpcastCartSummary Create(UpcastCartInitialized e) =>
+        new() { ClientId = e.ClientId, Status = e.Status };
+
+    public void Apply(UpcastDiscountApplied e) => Discount = e.Fraction;
+
+    public void Apply(UpcastGiftRecorded e) => GiftCount++;
+}
+
+#endregion
+
+/// <summary>
+/// The shared event upcasting contract (jasperfx#752): transformations registered against
+/// <c>EventRegistry.Upcasters</c> reinterpret old stored event schemas as the current CLR event
+/// types on every read path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gated on <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsUpcasting"/>,
+/// which defaults to FALSE — the one gate that ships closed, because the contract is being defined
+/// ahead of any store implementing it. A store enrolls, implements
+/// <c>IComplianceStoreRegistrar.Upcast</c> and its own <c>IUpcastPayload</c> adapter, then flips
+/// the gate and makes the facts pass. The gate also short-circuits store configuration in
+/// <see cref="InitializeAsync"/>, so an enrolled-but-unimplemented store never reaches the
+/// registrar member's throwing default.
+/// </para>
+/// <para>
+/// Most facts run in two phases against one schema: a "legacy" store configuration (old event
+/// types, no upcasts) writes the rows, then the standard configuration (upcasts, no old types)
+/// reads them back. That is the honest reproduction of the migration story — the old rows really
+/// were written by a store that had never heard of the transformation.
+/// </para>
+/// <para>
+/// The exception is <see cref="a_typed_append_of_the_old_event_type_does_not_shadow_the_upcaster"/>,
+/// which pins the marten#4680 semantics inside a single store: a registered transformation is the
+/// authoritative interpretation of its source event type name, and a typed append of the old CLR
+/// type — which records a stored-CLR-type hint alongside the name in stores that keep one — must
+/// not shadow it on read.
+/// </para>
+/// </remarks>
+public abstract class UpcastingCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly string _couponEventTypeName =
+        EventTypeExtensions.GetEventTypeName<UpcastCouponClipped>();
+
+    /// <summary>
+    /// The store as it existed before the migration: old event types, no upcasts.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _legacyConfiguration = config =>
+    {
+        config.SchemaName = "compliance_upcasting";
+
+        config.AddEventType<UpcastCartOpened>();
+        config.AddEventType<UpcastCouponClipped>();
+        config.AddEventType<UpcastGiftNoted>();
+    };
+
+    /// <summary>
+    /// The store after the migration. One transformation per registration shape: typed sync, raw
+    /// <see cref="JsonDocument"/> (no old CLR type involved), and async-only typed.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_upcasting";
+
+        config.Upcast(UpcastTransformation.For<UpcastCartOpened, UpcastCartInitialized>(
+            old => new UpcastCartInitialized(old.CartId, old.ClientId, "Opened")));
+
+        config.Upcast(UpcastTransformation.FromJson(
+            document =>
+            {
+                var root = document.RootElement;
+                return new UpcastDiscountApplied(
+                    root.GetProperty("CartId").GetGuid(),
+                    root.GetProperty("Percent").GetInt32() / 100.0);
+            },
+            _couponEventTypeName));
+
+        config.Upcast(UpcastTransformation.For<UpcastGiftNoted, UpcastGiftRecorded>(
+            (old, _) => Task.FromResult(new UpcastGiftRecorded(old.CartId, old.Note, old.Note.Length))));
+
+        config.Snapshot<UpcastCartSummary>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Capability gate. xunit v3's declarative SkipUnless needs a static property, which cannot
+    /// consult a per-store fixture instance, so the gate runs as a dynamic skip instead.
+    /// </summary>
+    private void SkipUnlessUpcastingIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsUpcasting,
+            "This event store has not implemented the shared event upcasting contract");
+    }
+
+    /// <summary>
+    /// Skips configuration entirely while the gate is closed — the registrar's <c>Upcast</c>
+    /// member has a throwing default, and reaching it from an unimplemented store would turn every
+    /// skip into a failure.
+    /// </summary>
+    public override async ValueTask InitializeAsync()
+    {
+        await theFixture.InitializeAsync().ConfigureAwait(false);
+
+        if (!theFixture.SupportsUpcasting)
+        {
+            return;
+        }
+
+        await theFixture.ConfigureAsync(Configuration).ConfigureAwait(false);
+        await theFixture.CleanEventDataAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Write rows the way the pre-migration application really wrote them: through a store built
+    /// from <see cref="_legacyConfiguration"/>, then hand the schema back to the upcasting store.
+    /// </summary>
+    private async Task<Guid> appendLegacyEventsAsync(params object[] events)
+    {
+        await theFixture.ConfigureAsync(_legacyConfiguration);
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId, events);
+            await SaveChangesAsync(session);
+        }
+
+        await theFixture.ConfigureAsync(_configuration);
+
+        return streamId;
+    }
+
+    [Fact]
+    public async Task an_event_stored_under_the_old_name_deserializes_as_the_new_type()
+    {
+        SkipUnlessUpcastingIsSupported();
+
+        var clientId = Guid.NewGuid();
+        var streamId = await appendLegacyEventsAsync(new UpcastCartOpened(Guid.NewGuid(), clientId));
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        var initialized = events.ShouldHaveSingleItem().Data.ShouldBeOfType<UpcastCartInitialized>();
+        initialized.ClientId.ShouldBe(clientId);
+        initialized.Status.ShouldBe("Opened");
+    }
+
+    [Fact]
+    public async Task a_raw_json_transformation_upcasts_without_the_old_clr_type()
+    {
+        SkipUnlessUpcastingIsSupported();
+
+        var streamId = await appendLegacyEventsAsync(new UpcastCouponClipped(Guid.NewGuid(), 25));
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        // The transformation only ever saw the stored JSON — UpcastCouponClipped as a CLR type
+        // plays no part in the upcasting store's configuration.
+        events.ShouldHaveSingleItem().Data.ShouldBeOfType<UpcastDiscountApplied>()
+            .Fraction.ShouldBe(0.25);
+    }
+
+    [Fact]
+    public async Task an_async_only_upcast_applies_on_the_async_read_path()
+    {
+        SkipUnlessUpcastingIsSupported();
+
+        var streamId = await appendLegacyEventsAsync(new UpcastGiftNoted(Guid.NewGuid(), "happy birthday"));
+
+        // FetchStreamAsync is the asynchronous read path, so the contract requires the async
+        // transformation to run here. A store routing its async reads through the synchronous
+        // delegate fails with UpcastingException instead — by design.
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        var recorded = events.ShouldHaveSingleItem().Data.ShouldBeOfType<UpcastGiftRecorded>();
+        recorded.Note.ShouldBe("happy birthday");
+        recorded.Length.ShouldBe("happy birthday".Length);
+    }
+
+    [Fact]
+    public async Task upcasting_applies_in_live_aggregation()
+    {
+        SkipUnlessUpcastingIsSupported();
+
+        var clientId = Guid.NewGuid();
+        var streamId = await appendLegacyEventsAsync(
+            new UpcastCartOpened(Guid.NewGuid(), clientId),
+            new UpcastCouponClipped(Guid.NewGuid(), 40));
+
+        await using var session = OpenSession();
+        var summary = await EventsFor(session)
+            .AggregateStreamAsync<UpcastCartSummary>(streamId, token: Cancellation);
+
+        // The aggregate has no Apply for any v1 type, so folding succeeds only if every event was
+        // upcast before the aggregation saw it.
+        summary.ShouldNotBeNull();
+        summary.ClientId.ShouldBe(clientId);
+        summary.Status.ShouldBe("Opened");
+        summary.Discount.ShouldBe(0.4);
+    }
+
+    [Fact]
+    public async Task upcasting_applies_in_fetch_for_writing()
+    {
+        SkipUnlessUpcastingIsSupported();
+
+        var streamId = await appendLegacyEventsAsync(new UpcastCartOpened(Guid.NewGuid(), Guid.NewGuid()));
+
+        await using (var session = OpenSession())
+        {
+            var stream = await EventsFor(session).FetchForWriting<UpcastCartSummary>(streamId, Cancellation);
+
+            stream.Aggregate.ShouldNotBeNull();
+            stream.Aggregate.Status.ShouldBe("Opened");
+
+            // The write handle keeps working over an upcast stream: new-schema events append
+            // against the version the old-schema rows established.
+            stream.AppendOne(new UpcastDiscountApplied(streamId, 0.1));
+            await SaveChangesAsync(session);
+        }
+
+        await using var verify = OpenSession();
+        var summary = await EventsFor(verify)
+            .AggregateStreamAsync<UpcastCartSummary>(streamId, token: Cancellation);
+
+        summary.ShouldNotBeNull();
+        summary.Discount.ShouldBe(0.1);
+    }
+
+    [Fact]
+    public async Task upcasting_applies_in_async_daemon_projections()
+    {
+        SkipUnlessUpcastingIsSupported();
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        var clientId = Guid.NewGuid();
+        var streamId = await appendLegacyEventsAsync(
+            new UpcastCartOpened(Guid.NewGuid(), clientId),
+            new UpcastGiftNoted(Guid.NewGuid(), "bow"),
+            new UpcastCouponClipped(Guid.NewGuid(), 15));
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var query = OpenSession();
+        var summary = await LoadDocumentAsync<UpcastCartSummary>(query, streamId);
+
+        summary.ShouldNotBeNull();
+        summary.ClientId.ShouldBe(clientId);
+        summary.GiftCount.ShouldBe(1);
+        summary.Discount.ShouldBe(0.15);
+    }
+
+    [Fact]
+    public async Task a_typed_append_of_the_old_event_type_does_not_shadow_the_upcaster()
+    {
+        SkipUnlessUpcastingIsSupported();
+
+        // marten#4680, in one store: the old CLR type is appended TYPED into the store that
+        // carries the upcaster, so the row records both the source event type name and — in stores
+        // that keep one — a stored-CLR-type hint pointing at UpcastCartOpened. The registered
+        // transformation is the authoritative interpretation of that name, so the read must still
+        // upcast; a store that lets the hint pick the old CLR type back has the exact bug the
+        // issue documented.
+        var clientId = Guid.NewGuid();
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream(streamId, new UpcastCartOpened(Guid.NewGuid(), clientId));
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.ShouldHaveSingleItem().Data.ShouldBeOfType<UpcastCartInitialized>()
+            .ClientId.ShouldBe(clientId);
+    }
+}

--- a/src/JasperFx.Events/IEventRegistry.cs
+++ b/src/JasperFx.Events/IEventRegistry.cs
@@ -90,6 +90,15 @@ public class EventRegistry : IEventRegistry
     public virtual AggregateWriteCacheOptions AggregateWriteCaching { get; } = new();
 
     /// <summary>
+    ///     Event upcasting registrations — transformations from old stored event schemas to the
+    ///     current CLR event types, applied by the store's read path. See
+    ///     <see cref="Upcasting.UpcastingRegistry" /> for the resolution semantics a store must
+    ///     honor, including the marten#4680 authority rule.
+    /// </summary>
+    [IgnoreDescription]
+    public virtual Upcasting.UpcastingRegistry Upcasters { get; } = new();
+
+    /// <summary>
     ///     Keep recently fetched snapshots of <typeparamref name="T" /> in a node-local cache so that
     ///     a subsequent <c>FetchForWriting</c> can skip loading the stored snapshot and read only the
     ///     events after it. Effectively an identity map for aggregates with a lifetime longer than a

--- a/src/JasperFx.Events/Upcasting/EventUpcaster.cs
+++ b/src/JasperFx.Events/Upcasting/EventUpcaster.cs
@@ -1,0 +1,139 @@
+using JasperFx.Core.Reflection;
+using static JasperFx.Events.EventTypeExtensions;
+
+namespace JasperFx.Events.Upcasting;
+
+/// <summary>
+/// The class-based event payload transformation contract. Upcasting transforms an old stored event
+/// schema into the new one on read: for a specific stored event type name, an upcaster produces
+/// the new CLR event type, so aggregations and projections only ever see the new type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The store-agnostic promotion of Marten's
+/// <c>Marten.Services.Json.Transformations.IEventUpcaster</c>. The shape is deliberately kept as
+/// close to Marten's as portability allows — same members, same sync/async split — with the
+/// store-specific <c>(ISerializer, DbDataReader, index)</c> triple replaced by
+/// <see cref="IUpcastPayload"/>.
+/// </para>
+/// <para>
+/// Prefer deriving from the built-in bases (<see cref="EventUpcaster{TOldEvent,TEvent}"/>,
+/// <see cref="AsyncOnlyEventUpcaster{TOldEvent,TEvent}"/>, or the raw-JSON variants in
+/// <c>JasperFx.Events.Upcasting.SystemTextJson</c>) over implementing this interface directly.
+/// </para>
+/// </remarks>
+public interface IEventUpcaster
+{
+    /// <summary>
+    /// The stored event type name this upcaster claims — the SOURCE name of the transformation.
+    /// </summary>
+    string EventTypeName { get; }
+
+    /// <summary>
+    /// The new CLR event type this upcaster maps to.
+    /// </summary>
+    Type EventType { get; }
+
+    /// <summary>
+    /// Transform the stored payload in the synchronous read path.
+    /// </summary>
+    object Upcast(IUpcastPayload payload);
+
+    /// <summary>
+    /// Transform the stored payload in the asynchronous read path.
+    /// </summary>
+    ValueTask<object> UpcastAsync(IUpcastPayload payload, CancellationToken token);
+}
+
+/// <summary>
+/// Base implementation of <see cref="IEventUpcaster"/>. Implement at least the synchronous
+/// <see cref="Upcast"/>; <see cref="UpcastAsync"/> delegates to it unless overridden.
+/// </summary>
+public abstract class EventUpcaster : IEventUpcaster
+{
+    public abstract Type EventType { get; }
+
+    /// <summary>
+    /// The stored event type name to transform. Defaults to the conventional event type name of
+    /// <see cref="EventType"/>.
+    /// </summary>
+    public virtual string EventTypeName => EventType.GetEventTypeName();
+
+    public abstract object Upcast(IUpcastPayload payload);
+
+    public virtual ValueTask<object> UpcastAsync(IUpcastPayload payload, CancellationToken token)
+    {
+        return new ValueTask<object>(Upcast(payload));
+    }
+}
+
+/// <summary>
+/// Base implementation of <see cref="EventUpcaster"/> for a known new CLR event type.
+/// </summary>
+/// <typeparam name="TEvent">The new CLR event type.</typeparam>
+public abstract class EventUpcaster<TEvent> : EventUpcaster where TEvent : notnull
+{
+    public override Type EventType => typeof(TEvent);
+}
+
+/// <summary>
+/// Typed upcaster: deserializes the stored payload as <typeparamref name="TOldEvent"/> through
+/// the store's serializer and maps it to <typeparamref name="TEvent"/> via <see cref="Upcast(TOldEvent)"/>.
+/// The stored event type name defaults to <typeparamref name="TOldEvent"/>'s conventional name,
+/// which is what makes previously stored rows of the old type flow through the upcast.
+/// </summary>
+/// <typeparam name="TOldEvent">The old CLR event type.</typeparam>
+/// <typeparam name="TEvent">The new CLR event type.</typeparam>
+public abstract class EventUpcaster<TOldEvent, TEvent> : EventUpcaster<TEvent>
+    where TOldEvent : notnull
+    where TEvent : notnull
+{
+    public override string EventTypeName => GetEventTypeName<TOldEvent>();
+
+    public override object Upcast(IUpcastPayload payload)
+    {
+        return Upcast(payload.As<TOldEvent>());
+    }
+
+    public override async ValueTask<object> UpcastAsync(IUpcastPayload payload, CancellationToken token)
+    {
+        return Upcast(await payload.AsAsync<TOldEvent>(token).ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Map the deserialized old event to the new event type.
+    /// </summary>
+    protected abstract TEvent Upcast(TOldEvent oldEvent);
+}
+
+/// <summary>
+/// Async-only typed upcaster, for transformations that genuinely need to await. Only usable in a
+/// store's asynchronous read path; the synchronous path throws <see cref="UpcastingException"/>.
+/// Prefer <see cref="EventUpcaster{TOldEvent,TEvent}"/> — an async transformation runs per stored
+/// event and invites N+1 behavior.
+/// </summary>
+/// <typeparam name="TOldEvent">The old CLR event type.</typeparam>
+/// <typeparam name="TEvent">The new CLR event type.</typeparam>
+public abstract class AsyncOnlyEventUpcaster<TOldEvent, TEvent> : EventUpcaster<TEvent>
+    where TOldEvent : notnull
+    where TEvent : notnull
+{
+    public override string EventTypeName => GetEventTypeName<TOldEvent>();
+
+    public override object Upcast(IUpcastPayload payload)
+    {
+        throw new UpcastingException(
+            $"Cannot use AsyncOnlyEventUpcaster of type {GetType().FullNameInCode()} in the synchronous API.");
+    }
+
+    public override async ValueTask<object> UpcastAsync(IUpcastPayload payload, CancellationToken token)
+    {
+        return await UpcastAsync(await payload.AsAsync<TOldEvent>(token).ConfigureAwait(false), token)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Map the deserialized old event to the new event type, asynchronously.
+    /// </summary>
+    protected abstract Task<TEvent> UpcastAsync(TOldEvent oldEvent, CancellationToken token);
+}

--- a/src/JasperFx.Events/Upcasting/IUpcastPayload.cs
+++ b/src/JasperFx.Events/Upcasting/IUpcastPayload.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+
+namespace JasperFx.Events.Upcasting;
+
+/// <summary>
+/// The store-side seam of the shared upcasting contract: one stored event payload, about to be
+/// deserialized, presented to an upcast transformation without exposing how the store actually
+/// reads it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Originated in Marten, where the equivalent surface was the
+/// <c>(ISerializer, DbDataReader, index)</c> triple threaded through
+/// <c>Marten.Services.Json.Transformations.JsonTransformation</c>. That triple is PostgreSQL- and
+/// Marten-serializer-shaped, so the promoted contract abstracts it to "a payload that can hand you
+/// either a deserialized old CLR type or the raw JSON": each store implements this once as a thin
+/// adapter over its own reader and serializer, at the same point in its hydration path where the
+/// event-type name has been resolved and the payload is about to become an object.
+/// </para>
+/// <para>
+/// An implementation is expected to be a short-lived, per-row adapter. Nothing here is cached or
+/// reused; a transformation calls exactly one accessor exactly once per event.
+/// </para>
+/// </remarks>
+public interface IUpcastPayload
+{
+    /// <summary>
+    /// Deserialize the stored payload as <typeparamref name="T"/> through the store's configured
+    /// serializer. This is what a typed <c>TOld → TNew</c> upcast uses to obtain the old CLR type.
+    /// </summary>
+    T As<T>() where T : notnull;
+
+    /// <summary>
+    /// Async counterpart of <see cref="As{T}"/>, for stores whose async read path can stream the
+    /// payload rather than buffer it.
+    /// </summary>
+    ValueTask<T> AsAsync<T>(CancellationToken token) where T : notnull;
+
+    /// <summary>
+    /// The stored payload as a raw <see cref="JsonDocument"/>, for transformations that upcast
+    /// without keeping the old CLR type in the codebase.
+    /// </summary>
+    /// <remarks>
+    /// Available whenever the store persists events as System.Text.Json — always true for Polecat
+    /// and Fisher, true for Marten when its serializer is STJ-based. A store whose configured
+    /// serializer cannot produce a <see cref="JsonDocument"/> must throw
+    /// <see cref="UpcastingException"/> here rather than guessing at an encoding. The caller owns
+    /// disposing the returned document.
+    /// </remarks>
+    JsonDocument AsJsonDocument();
+
+    /// <summary>
+    /// Async counterpart of <see cref="AsJsonDocument"/>.
+    /// </summary>
+    ValueTask<JsonDocument> AsJsonDocumentAsync(CancellationToken token);
+}

--- a/src/JasperFx.Events/Upcasting/SystemTextJson/EventUpcaster.cs
+++ b/src/JasperFx.Events/Upcasting/SystemTextJson/EventUpcaster.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using JasperFx.Core.Reflection;
+
+namespace JasperFx.Events.Upcasting.SystemTextJson;
+
+/// <summary>
+/// Raw System.Text.Json upcaster: transforms the stored payload's <see cref="JsonDocument"/>
+/// directly into <typeparamref name="TEvent"/>, with no old CLR type kept in the codebase. The
+/// stored event type name defaults to <typeparamref name="TEvent"/>'s conventional name — the
+/// "same name, older JSON schema" case; override <see cref="EventUpcaster.EventTypeName"/> for a
+/// rename.
+/// </summary>
+/// <remarks>
+/// The namespace and type names deliberately mirror Marten's
+/// <c>Marten.Services.Json.Transformations.SystemTextJson</c>, so migrating an existing Marten
+/// upcaster is a using-directive change. Requires a store whose serializer is
+/// System.Text.Json-based — always true for Polecat and Fisher; Marten throws
+/// <see cref="UpcastingException"/> from <see cref="IUpcastPayload.AsJsonDocument"/> under a
+/// non-STJ serializer.
+/// </remarks>
+/// <typeparam name="TEvent">The new CLR event type.</typeparam>
+public abstract class EventUpcaster<TEvent> : Upcasting.EventUpcaster<TEvent>
+    where TEvent : notnull
+{
+    public override object Upcast(IUpcastPayload payload)
+    {
+        using var document = payload.AsJsonDocument();
+        return Upcast(document);
+    }
+
+    public override async ValueTask<object> UpcastAsync(IUpcastPayload payload, CancellationToken token)
+    {
+        using var document = await payload.AsJsonDocumentAsync(token).ConfigureAwait(false);
+        return Upcast(document);
+    }
+
+    /// <summary>
+    /// Map the stored JSON to the new event type. The document is disposed by the caller.
+    /// </summary>
+    protected abstract TEvent Upcast(JsonDocument oldEvent);
+}
+
+/// <summary>
+/// Async-only raw System.Text.Json upcaster. Only usable in a store's asynchronous read path; the
+/// synchronous path throws <see cref="UpcastingException"/>. Prefer
+/// <see cref="EventUpcaster{TEvent}"/> — an async transformation runs per stored event and
+/// invites N+1 behavior.
+/// </summary>
+/// <typeparam name="TEvent">The new CLR event type.</typeparam>
+public abstract class AsyncOnlyEventUpcaster<TEvent> : Upcasting.EventUpcaster<TEvent>
+    where TEvent : notnull
+{
+    public override object Upcast(IUpcastPayload payload)
+    {
+        throw new UpcastingException(
+            $"Cannot use AsyncOnlyEventUpcaster of type {GetType().FullNameInCode()} in the synchronous API.");
+    }
+
+    public override async ValueTask<object> UpcastAsync(IUpcastPayload payload, CancellationToken token)
+    {
+        using var document = await payload.AsJsonDocumentAsync(token).ConfigureAwait(false);
+        return await UpcastAsync(document, token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Map the stored JSON to the new event type, asynchronously. The document is disposed by the
+    /// caller.
+    /// </summary>
+    protected abstract Task<TEvent> UpcastAsync(JsonDocument oldEvent, CancellationToken token);
+}

--- a/src/JasperFx.Events/Upcasting/UpcastTransformation.cs
+++ b/src/JasperFx.Events/Upcasting/UpcastTransformation.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using JasperFx.Core.Reflection;
+using static JasperFx.Events.EventTypeExtensions;
+
+namespace JasperFx.Events.Upcasting;
+
+/// <summary>
+/// One registered event payload transformation: for a stored event type name, how the payload
+/// becomes an instance of the new CLR event type, in both the sync and async read paths.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The store-agnostic promotion of Marten's
+/// <c>Marten.Services.Json.Transformations.JsonTransformation</c>: the same sync/async delegate
+/// pair, but over the abstract <see cref="IUpcastPayload"/> instead of
+/// <c>(ISerializer, DbDataReader, index)</c>, and carrying its own <see cref="EventType"/> and
+/// <see cref="EventTypeName"/> so a registry can be keyed without a separate mapping step.
+/// </para>
+/// <para>
+/// Build instances through the static factories (<see cref="For{TOldEvent,TEvent}(Func{TOldEvent,TEvent},string?)"/>
+/// and friends) or from an <see cref="IEventUpcaster"/>; the raw constructor exists for stores and
+/// tests that need full control.
+/// </para>
+/// </remarks>
+public sealed class UpcastTransformation
+{
+    public UpcastTransformation(
+        Type eventType,
+        string eventTypeName,
+        Func<IUpcastPayload, object> upcast,
+        Func<IUpcastPayload, CancellationToken, ValueTask<object>>? upcastAsync = null)
+    {
+        EventType = eventType ?? throw new ArgumentNullException(nameof(eventType));
+        EventTypeName = eventTypeName ?? throw new ArgumentNullException(nameof(eventTypeName));
+        Upcast = upcast ?? throw new ArgumentNullException(nameof(upcast));
+        UpcastAsync = upcastAsync ?? ((payload, _) => new ValueTask<object>(upcast(payload)));
+    }
+
+    /// <summary>
+    /// The new CLR event type this transformation produces. Events read through this
+    /// transformation report this type — projections and aggregations only ever see the new type.
+    /// </summary>
+    public Type EventType { get; }
+
+    /// <summary>
+    /// The stored event type name this transformation claims — the SOURCE name. Once registered,
+    /// this transformation is the authoritative interpretation of that name on read.
+    /// </summary>
+    public string EventTypeName { get; }
+
+    /// <summary>
+    /// The synchronous transformation. Async-only registrations throw
+    /// <see cref="UpcastingException"/> from here.
+    /// </summary>
+    public Func<IUpcastPayload, object> Upcast { get; }
+
+    /// <summary>
+    /// The asynchronous transformation. Defaults to wrapping <see cref="Upcast"/> when no async
+    /// variant was supplied.
+    /// </summary>
+    public Func<IUpcastPayload, CancellationToken, ValueTask<object>> UpcastAsync { get; }
+
+    /// <summary>
+    /// Typed sync upcast: deserialize the payload as <typeparamref name="TOldEvent"/> through the
+    /// store's serializer, then map it to <typeparamref name="TEvent"/>.
+    /// </summary>
+    /// <param name="upcast">The old-to-new mapping function.</param>
+    /// <param name="eventTypeName">
+    /// The stored event type name to claim. Defaults to <typeparamref name="TOldEvent"/>'s
+    /// conventional event type name, which is what makes previously stored rows of the old type
+    /// deserialize through the upcast with no further mapping.
+    /// </param>
+    public static UpcastTransformation For<TOldEvent, TEvent>(
+        Func<TOldEvent, TEvent> upcast,
+        string? eventTypeName = null)
+        where TOldEvent : notnull
+        where TEvent : notnull
+    {
+        ArgumentNullException.ThrowIfNull(upcast);
+
+        return new UpcastTransformation(
+            typeof(TEvent),
+            eventTypeName ?? GetEventTypeName<TOldEvent>(),
+            payload => upcast(payload.As<TOldEvent>()),
+            async (payload, token) =>
+                upcast(await payload.AsAsync<TOldEvent>(token).ConfigureAwait(false)));
+    }
+
+    /// <summary>
+    /// Typed async-only upcast. The synchronous read path throws <see cref="UpcastingException"/>;
+    /// prefer the sync form unless the transformation genuinely needs to await.
+    /// </summary>
+    public static UpcastTransformation For<TOldEvent, TEvent>(
+        Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync,
+        string? eventTypeName = null)
+        where TOldEvent : notnull
+        where TEvent : notnull
+    {
+        ArgumentNullException.ThrowIfNull(upcastAsync);
+
+        return new UpcastTransformation(
+            typeof(TEvent),
+            eventTypeName ?? GetEventTypeName<TOldEvent>(),
+            _ => throw new UpcastingException(
+                $"Cannot use the upcast of event '{typeof(TOldEvent).FullNameInCode()}' to '{typeof(TEvent).FullNameInCode()}' in the synchronous API. It was registered as async only."),
+            async (payload, token) =>
+                await upcastAsync(await payload.AsAsync<TOldEvent>(token).ConfigureAwait(false), token)
+                    .ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Raw System.Text.Json sync upcast: transform the stored payload's
+    /// <see cref="JsonDocument"/> directly, with no old CLR type kept in the codebase.
+    /// </summary>
+    /// <param name="upcast">The JSON-to-new-type mapping function.</param>
+    /// <param name="eventTypeName">
+    /// The stored event type name to claim. Defaults to <typeparamref name="TEvent"/>'s
+    /// conventional event type name — the "same name, older JSON schema" case.
+    /// </param>
+    public static UpcastTransformation FromJson<TEvent>(
+        Func<JsonDocument, TEvent> upcast,
+        string? eventTypeName = null)
+        where TEvent : notnull
+    {
+        ArgumentNullException.ThrowIfNull(upcast);
+
+        return new UpcastTransformation(
+            typeof(TEvent),
+            eventTypeName ?? GetEventTypeName<TEvent>(),
+            payload =>
+            {
+                using var document = payload.AsJsonDocument();
+                return upcast(document);
+            },
+            async (payload, token) =>
+            {
+                using var document = await payload.AsJsonDocumentAsync(token).ConfigureAwait(false);
+                return upcast(document);
+            });
+    }
+
+    /// <summary>
+    /// Raw System.Text.Json async-only upcast. The synchronous read path throws
+    /// <see cref="UpcastingException"/>.
+    /// </summary>
+    public static UpcastTransformation FromJson<TEvent>(
+        Func<JsonDocument, CancellationToken, Task<TEvent>> upcastAsync,
+        string? eventTypeName = null)
+        where TEvent : notnull
+    {
+        ArgumentNullException.ThrowIfNull(upcastAsync);
+
+        return new UpcastTransformation(
+            typeof(TEvent),
+            eventTypeName ?? GetEventTypeName<TEvent>(),
+            _ => throw new UpcastingException(
+                $"Cannot use the JSON transformation to event '{typeof(TEvent).FullNameInCode()}' in the synchronous API. It was registered as async only."),
+            async (payload, token) =>
+            {
+                using var document = await payload.AsJsonDocumentAsync(token).ConfigureAwait(false);
+                return await upcastAsync(document, token).ConfigureAwait(false);
+            });
+    }
+
+    /// <summary>
+    /// Wrap a class-based <see cref="IEventUpcaster"/> as a transformation.
+    /// </summary>
+    public static UpcastTransformation For(IEventUpcaster upcaster)
+    {
+        ArgumentNullException.ThrowIfNull(upcaster);
+
+        return new UpcastTransformation(
+            upcaster.EventType,
+            upcaster.EventTypeName,
+            upcaster.Upcast,
+            upcaster.UpcastAsync);
+    }
+}

--- a/src/JasperFx.Events/Upcasting/UpcastingException.cs
+++ b/src/JasperFx.Events/Upcasting/UpcastingException.cs
@@ -1,0 +1,23 @@
+namespace JasperFx.Events.Upcasting;
+
+/// <summary>
+/// Thrown when an upcast transformation is misused — most commonly calling an async-only
+/// transformation from a store's synchronous read path, or asking for a raw
+/// <see cref="System.Text.Json.JsonDocument"/> from a store whose serializer is not
+/// System.Text.Json-based.
+/// </summary>
+/// <remarks>
+/// A shared exception type rather than each store's own (Marten threw <c>MartenException</c> here)
+/// so that the compliance suites — and application code written against more than one store — can
+/// assert the failure portably.
+/// </remarks>
+public class UpcastingException : Exception
+{
+    public UpcastingException(string message) : base(message)
+    {
+    }
+
+    public UpcastingException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/JasperFx.Events/Upcasting/UpcastingRegistry.cs
+++ b/src/JasperFx.Events/Upcasting/UpcastingRegistry.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using ImTools;
+
+namespace JasperFx.Events.Upcasting;
+
+/// <summary>
+/// The shared registration and resolution surface for event upcasting, exposed by every store as
+/// <see cref="EventRegistry.Upcasters"/>. Registration happens at configuration time through the
+/// fluent <c>Upcast</c> overloads (kept deliberately close to Marten's
+/// <c>IEventStoreOptions.Upcast</c> family); at read time a store resolves a stored event type
+/// name through <see cref="TryFindTransformation"/> inside its own hydration path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What a store owes this registry on its read path.</b> Wherever the store turns a stored row
+/// into an <see cref="IEvent"/> — stream reads, aggregation, <c>FetchForWriting</c>, the async
+/// daemon, subscriptions; every path that deserializes an event — it must first consult
+/// <see cref="TryFindTransformation"/> with the stored event type name. On a hit, the payload is
+/// produced by the transformation (over the store's <see cref="IUpcastPayload"/> adapter) instead
+/// of default deserialization, and the resulting envelope reports the transformation's
+/// <see cref="UpcastTransformation.EventType"/>.
+/// </para>
+/// <para>
+/// <b>The authority rule (marten#4680).</b> A registered transformation is the authoritative
+/// interpretation of its source event type name. Stores that persist a stored-CLR-type hint
+/// alongside the event type name (Marten's <c>mt_dotnet_type</c>) must NOT let that hint override
+/// a registered upcast: when the old CLR type is appended typed into the same store, its rows
+/// still read back through the upcaster. Any alternate-mapping swap keyed on the stored CLR type
+/// name applies only to names with no registered transformation.
+/// </para>
+/// <para>
+/// Registration is last-wins per event type name, matching Marten: re-registering a name replaces
+/// the earlier transformation.
+/// </para>
+/// </remarks>
+public class UpcastingRegistry
+{
+    private ImHashMap<string, UpcastTransformation> _byName = ImHashMap<string, UpcastTransformation>.Empty;
+    private readonly List<UpcastTransformation> _all = new();
+
+    /// <summary>
+    /// True if at least one transformation has been registered. Lets a store keep its unmodified
+    /// hydration path when upcasting is unused.
+    /// </summary>
+    public bool HasAny => _all.Count != 0;
+
+    /// <summary>
+    /// Every registered transformation, in registration order (including ones later replaced by a
+    /// re-registration of the same name). Stores use this to pre-register the target event types.
+    /// </summary>
+    public IReadOnlyList<UpcastTransformation> AllTransformations => _all;
+
+    /// <summary>
+    /// Resolve the transformation registered for a stored event type name, if any. This is the
+    /// call a store makes on its read path before default deserialization.
+    /// </summary>
+    public bool TryFindTransformation(string eventTypeName,
+        [NotNullWhen(true)] out UpcastTransformation? transformation)
+    {
+        return _byName.TryFind(eventTypeName, out transformation);
+    }
+
+    /// <summary>
+    /// True if the given stored event type name has a registered transformation — i.e. the name is
+    /// an upcast SOURCE whose interpretation is authoritative on read (marten#4680).
+    /// </summary>
+    public bool IsUpcastSource(string eventTypeName) => _byName.TryFind(eventTypeName, out _);
+
+    /// <summary>
+    /// The low-level registration every fluent overload funnels into.
+    /// </summary>
+    public UpcastingRegistry Register(UpcastTransformation transformation)
+    {
+        ArgumentNullException.ThrowIfNull(transformation);
+
+        _all.Add(transformation);
+        _byName = _byName.AddOrUpdate(transformation.EventTypeName, transformation);
+        return this;
+    }
+
+    /// <summary>
+    /// Typed upcast from the old CLR event type to the new one. The stored event type name is
+    /// <typeparamref name="TOldEvent"/>'s conventional name.
+    /// </summary>
+    public UpcastingRegistry Upcast<TOldEvent, TEvent>(Func<TOldEvent, TEvent> upcast)
+        where TOldEvent : notnull
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.For(upcast));
+    }
+
+    /// <summary>
+    /// Typed upcast from the old CLR event type to the new one, claiming an explicit stored event
+    /// type name.
+    /// </summary>
+    public UpcastingRegistry Upcast<TOldEvent, TEvent>(string eventTypeName, Func<TOldEvent, TEvent> upcast)
+        where TOldEvent : notnull
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.For(upcast, eventTypeName));
+    }
+
+    /// <summary>
+    /// Async-only typed upcast. Only usable in a store's asynchronous read path; the synchronous
+    /// path throws <see cref="UpcastingException"/>.
+    /// </summary>
+    public UpcastingRegistry Upcast<TOldEvent, TEvent>(Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync)
+        where TOldEvent : notnull
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.For(upcastAsync));
+    }
+
+    /// <summary>
+    /// Async-only typed upcast claiming an explicit stored event type name.
+    /// </summary>
+    public UpcastingRegistry Upcast<TOldEvent, TEvent>(string eventTypeName,
+        Func<TOldEvent, CancellationToken, Task<TEvent>> upcastAsync)
+        where TOldEvent : notnull
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.For(upcastAsync, eventTypeName));
+    }
+
+    /// <summary>
+    /// Raw System.Text.Json upcast for the stored event type name matching
+    /// <typeparamref name="TEvent"/>'s conventional name — the "same name, older JSON schema" case.
+    /// </summary>
+    public UpcastingRegistry Upcast<TEvent>(Func<JsonDocument, TEvent> upcast)
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.FromJson(upcast));
+    }
+
+    /// <summary>
+    /// Raw System.Text.Json upcast claiming an explicit stored event type name.
+    /// </summary>
+    public UpcastingRegistry Upcast<TEvent>(string eventTypeName, Func<JsonDocument, TEvent> upcast)
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.FromJson(upcast, eventTypeName));
+    }
+
+    /// <summary>
+    /// Async-only raw System.Text.Json upcast. Only usable in a store's asynchronous read path.
+    /// </summary>
+    public UpcastingRegistry AsyncOnlyUpcast<TEvent>(Func<JsonDocument, CancellationToken, Task<TEvent>> upcastAsync)
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.FromJson(upcastAsync));
+    }
+
+    /// <summary>
+    /// Async-only raw System.Text.Json upcast claiming an explicit stored event type name.
+    /// </summary>
+    public UpcastingRegistry AsyncOnlyUpcast<TEvent>(string eventTypeName,
+        Func<JsonDocument, CancellationToken, Task<TEvent>> upcastAsync)
+        where TEvent : notnull
+    {
+        return Register(UpcastTransformation.FromJson(upcastAsync, eventTypeName));
+    }
+
+    /// <summary>
+    /// Register one or more class-based upcasters.
+    /// </summary>
+    public UpcastingRegistry Upcast(params IEventUpcaster[] upcasters)
+    {
+        foreach (var upcaster in upcasters)
+        {
+            Register(UpcastTransformation.For(upcaster));
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Register a class-based upcaster by type.
+    /// </summary>
+    public UpcastingRegistry Upcast<TUpcaster>() where TUpcaster : IEventUpcaster, new()
+    {
+        return Register(UpcastTransformation.For(new TUpcaster()));
+    }
+}


### PR DESCRIPTION
Closes #752. Stoat plan `event-compliance-wave-13`, node `upcasting-contract`. **Do not merge without maintainer review** — this is the wave's design task, and the PR body doubles as the design doc.

## Why

Marten is the only Critter Stack store with event upcasting (`Marten.Services.Json.Transformations` + the `IEventStoreOptions.Upcast` overload family). Polecat and Fisher have none. Rather than each store inventing its own surface, this promotes a store-agnostic contract into `JasperFx.Events` and pins the behavior with a compliance suite, so the two SQL stores implement once against a shared definition and Marten adapts what it has.

## The contract (`JasperFx.Events.Upcasting`)

### The one real portability problem, and the seam that absorbs it

Everything in Marten's design ports cleanly except the transformation signature, which is `(ISerializer, DbDataReader, int index)` — PostgreSQL- and Marten-serializer-shaped. The shared contract replaces that triple with **`IUpcastPayload`**: a short-lived, per-row adapter each store implements over its own reader and serializer, at the exact point in its hydration path where the event type name has been resolved and the payload is about to become an object.

```csharp
public interface IUpcastPayload
{
    T As<T>() where T : notnull;                                  // typed path: old CLR type via the store's serializer
    ValueTask<T> AsAsync<T>(CancellationToken token) where T : notnull;
    JsonDocument AsJsonDocument();                                // raw path: no old CLR type needed
    ValueTask<JsonDocument> AsJsonDocumentAsync(CancellationToken token);
}
```

`AsJsonDocument` throws `UpcastingException` on a store whose serializer is not STJ-based (always available on Polecat/Fisher; Marten only under `SystemTextJsonSerializer`, matching its current STJ-upcaster guard).

### The carrier

**`UpcastTransformation`** is the promoted `JsonTransformation`: the sync/async delegate pair over `IUpcastPayload`, now also carrying its own `EventType` (the NEW CLR type) and `EventTypeName` (the SOURCE stored name) so the registry needs no separate mapping step. Static factories cover every registration shape — `For<TOld,TNew>(Func<TOld,TNew>)`, the async-only `Func<TOld, CancellationToken, Task<TNew>>` form, and `FromJson<TNew>(...)` sync/async raw forms. Name defaulting matches Marten exactly: typed forms default to `GetEventTypeName<TOldEvent>()`, raw-JSON forms to `GetEventTypeName<TEvent>()` (the "same name, older schema" case).

### Class-based upcasters, kept Marten-shaped for migration

`IEventUpcaster` plus bases `EventUpcaster`, `EventUpcaster<TEvent>`, `EventUpcaster<TOldEvent, TEvent>`, `AsyncOnlyEventUpcaster<TOldEvent, TEvent>`, and — in `JasperFx.Events.Upcasting.SystemTextJson`, deliberately mirroring Marten's namespace trick — the raw-JSON `EventUpcaster<TEvent>` / `AsyncOnlyEventUpcaster<TEvent>`. Migrating an existing Marten upcaster class is a using-directive change plus renaming `FromDbDataReader` overrides to `Upcast(IUpcastPayload)` (or nothing, for subclasses of the typed bases, which never touched the reader).

Misuse throws the shared `UpcastingException` instead of `MartenException`, so failure assertions are portable.

### Registration and resolution: `EventRegistry.Upcasters`

`UpcastingRegistry` hangs off the shared `EventRegistry` (Marten's `EventGraph`, and the other stores' event options, already derive from it, so every store inherits the surface). Fluent `Upcast(...)` overloads stay as close to `IEventStoreOptions.Upcast` as portability allows; resolution is `TryFindTransformation(eventTypeName, out ...)` / `IsUpcastSource(name)`, `HasAny` short-circuits untouched stores, and registration is last-wins per name (matching Marten).

### Semantics pinned, including marten#4680

A registered transformation is the **authoritative interpretation of its source event type name**. Stores that persist a stored-CLR-type hint next to the name (Marten's `mt_dotnet_type`) must not let that hint override a registered upcast — a typed append of the old CLR type into the same store still reads back through the upcaster. Marten already fixed this on master (`EventMapping.IsUpcastTarget` guarding the alt-mapping swap in `EventDocumentStorage.Resolve`); the rule is now written on the shared registry and asserted by the suite, so Polecat and Fisher cannot re-introduce the bug independently.

## What each store must implement

1. **`IUpcastPayload`** — one small adapter over its reader + serializer.
2. **Read-path consult** — everywhere a stored row becomes an `IEvent` (stream reads, aggregation, `FetchForWriting`, daemon, subscriptions), check `Events.Upcasters.TryFindTransformation(storedName)` before default deserialization; on a hit, produce the payload through the transformation and report its `EventType` on the envelope. Sync read paths call `Upcast`, async paths `UpcastAsync`.
3. **The authority rule** — any stored-CLR-type alt-mapping applies only to names with no registered transformation.
4. **Target-type pre-registration** — walk `Upcasters.AllTransformations` at store build time to register each `EventType`.
5. **Compliance** — implement `IComplianceStoreRegistrar.Upcast(UpcastTransformation)`, enroll `UpcastingCompliance`, flip `SupportsUpcasting`.

**What Marten must adapt:** forward its existing `IEventStoreOptions.Upcast` overloads into `Events.Upcasters` (they keep working verbatim — the overload family is mirrored), implement `IUpcastPayload` over `(ISerializer, DbDataReader, index)`, replace the `EventMapping`-held `JsonTransformation` with a registry consult (or populate the mapping from the registry), and derive `IsUpcastTarget` from `Upcasters.IsUpcastSource`. Its store-specific `IEventUpcaster` shapes can retype onto the shared bases with obsolete shims for the old signatures.

## The compliance suite

`UpcastingCompliance` is doubly opt-in, because it is written ahead of any implementation: the registrar member has the usual throwing default, and the suite is gated on **`SupportsUpcasting`, the one capability flag defaulting to `false`** — the suite skips configuration as well as facts while the gate is closed, so an enrolled-but-unimplemented store stays green and the throwing default is never reached. Same declare-then-implement ordering as `SupportsFlatTableProjections`.

Most facts run **two-phase against one schema**: a "legacy" store configuration (old event types, no upcasts) writes the rows, then the migrated configuration (upcasts, no old CLR types) reads them back — the honest reproduction of a real schema migration. Facts:

- typed upcast: old-named rows deserialize as the new type on `FetchStreamAsync`
- raw-JSON transformation with the old CLR type absent from the migrated configuration
- async-only upcast on the async read path
- upcasting under live aggregation (`AggregateStreamAsync` over an aggregate with no old-type `Apply`)
- upcasting under `FetchForWriting`, including appending new-schema events onto the upcast stream
- upcasting under async daemon projections
- the single-store marten#4680 fact: a typed append of the old CLR type does not shadow the upcaster

No store is enrolled in this PR. Seam changes to `IComplianceStoreRegistrar` / `ComplianceStoreConfig` / the fixture are purely additive.

## Tests

- `EventTests` (new `Upcasting/upcasting_contract_tests.cs`): 21 facts over a stub payload — name defaulting, sync/async routing (asserting which accessor ran), async-only throwing, raw-JSON forms, class-based bases, registry resolution/last-wins/`IsUpcastSource`, `EventRegistry.Upcasters`.
- Full `EventTests`: 1025 passed. `EventStoreTests`: 141 passed. `JasperFx.Events` + `JasperFx.Events.ComplianceTests` build clean (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)