### PR TITLE
Compliance suites for AggregateToAsync / AggregateToManyAsync over event LINQ queries

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
@@ -205,6 +206,48 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
         Action<Protected.IEventDataMasking> configure, CancellationToken token);
 
     /// <summary>
+    /// Fold every event matched by the store's raw-event LINQ query into a single
+    /// <typeparamref name="T"/> — the product's <c>AggregateToAsync&lt;T&gt;</c> operator over
+    /// <c>QueryAllRawEvents()</c> — optionally seeded with <paramref name="initialState"/>.
+    /// Must return null when the query matches no events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A seam member because nothing shared can reach the operator: the LINQ-returning members are
+    /// deliberately off <see cref="IQueryEventStore"/> (they return product-specific queryable
+    /// types), and <c>AggregateToAsync</c> itself is an extension in each product's own namespace.
+    /// The seam is deliberately the narrowest shape every fact needs — one optional predicate over
+    /// the shared <see cref="IEvent"/>, applied in a single <c>Where()</c>, then the product's own
+    /// terminator — for the same reason <see cref="QueryTableAsync"/> is predicate-free: the moment
+    /// this grows ordering or paging it starts pinning one provider's operator set, which the
+    /// library keeps out of scope permanently.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default because the operators are an opt-in capability rather than part of
+    /// the baseline event contract; the affected suites gate on
+    /// <see cref="SupportsAggregateToLinqOperators"/> and skip until a store implements the pair and
+    /// flips the flag.
+    /// </para>
+    /// </remarks>
+    public virtual Task<T?> AggregateEventsToAsync<T>(TQuerySession session,
+        Expression<Func<IEvent, bool>>? filter, T? initialState, CancellationToken token) where T : class
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement AggregateEventsToAsync, so it cannot run the AggregateTo LINQ operator compliance suite.");
+
+    /// <summary>
+    /// Run the events matched by the store's raw-event LINQ query through the multi-stream
+    /// projection registered for <typeparamref name="T"/> and return one aggregate per resulting
+    /// identity — the product's <c>AggregateToManyAsync&lt;T&gt;</c> operator over
+    /// <c>QueryAllRawEvents()</c>. Must throw <see cref="ArgumentException"/> when no registered
+    /// projection produces <typeparamref name="T"/>, even for an empty result set.
+    /// </summary>
+    /// <inheritdoc cref="AggregateEventsToAsync{T}" path="/remarks"/>
+    public virtual Task<IReadOnlyList<T>> AggregateEventsToManyAsync<T>(TQuerySession session,
+        Expression<Func<IEvent, bool>>? filter, CancellationToken token) where T : class
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement AggregateEventsToManyAsync, so it cannot run the aggregate-to-many compliance suite.");
+
+    /// <summary>
     /// False in stores that build live aggregators automatically and reject explicit registration.
     /// </summary>
     public virtual bool SupportsLiveAggregationRegistration => true;
@@ -244,6 +287,21 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// </para>
     /// </remarks>
     public virtual bool SupportsFlatTableProjections => true;
+
+    /// <summary>
+    /// True in a store that has implemented the <c>AggregateToAsync</c> /
+    /// <c>AggregateToManyAsync</c> operators over its raw-event LINQ query and the
+    /// <see cref="AggregateEventsToAsync{T}"/> / <see cref="AggregateEventsToManyAsync{T}"/> seam
+    /// members that reach them.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to false, unlike the older gates, because the seam members it guards carry throwing
+    /// defaults: a store that enrolls
+    /// <c>AggregateToManyCompliance</c> / <c>AggregateToLinqOperatorCompliance</c> before
+    /// implementing the seam should skip cleanly rather than fail on the default. Implement the two
+    /// members, flip this to true.
+    /// </remarks>
+    public virtual bool SupportsAggregateToLinqOperators => false;
 
 
     public virtual ValueTask InitializeAsync() => default;

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceAggregateToManyPlaceholders.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceAggregateToManyPlaceholders.cs
@@ -1,0 +1,36 @@
+// NOT PACKAGED. See ComplianceQuerySessionPlaceholder.cs for why Local/ exists.
+//
+// AggregateToManyCompliance declares its two multi-stream projections at file scope, so they cannot
+// reach the <TOperations, TQuerySession> pair the suite class is generic over -- the same gap
+// ComplianceMultiStreamProjectionBase closes for the multi-stream suite. Two more per-consumer
+// global aliases close it here, closed generics because the multi stream base is generic over both
+// the document and its identity:
+//
+//     global using ComplianceBalanceProjectionBase =
+//         Marten.Events.Projections.MultiStreamProjection<
+//             JasperFx.Events.ComplianceTests.ComplianceBalance, System.Guid>;
+//     global using ComplianceMemberLoyaltyProjectionBase =
+//         Marten.Events.Projections.MultiStreamProjection<
+//             JasperFx.Events.ComplianceTests.ComplianceMemberLoyalty, System.Guid>;
+//
+// As with the department projection, no constructor shim is needed: both products'
+// MultiStreamProjection<TDoc, TId> are parameterless, and everything the projections use --
+// Identity, CustomGrouping, and the shared IJasperFxAggregateGrouper the custom grouper
+// implements -- is declared on JasperFxMultiStreamProjectionBase rather than on either product's
+// subclass.
+
+global using ComplianceBalanceProjectionBase =
+    JasperFx.Events.ComplianceTests.Local.PlaceholderBalanceProjection;
+global using ComplianceMemberLoyaltyProjectionBase =
+    JasperFx.Events.ComplianceTests.Local.PlaceholderMemberLoyaltyProjection;
+
+using System;
+using JasperFx.Events.Aggregation;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+public abstract class PlaceholderBalanceProjection: JasperFxMultiStreamProjectionBase<ComplianceBalance,
+    Guid, IPlaceholderOperations, IPlaceholderQuerySession>;
+
+public abstract class PlaceholderMemberLoyaltyProjection: JasperFxMultiStreamProjectionBase<
+    ComplianceMemberLoyalty, Guid, IPlaceholderOperations, IPlaceholderQuerySession>;

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -146,6 +146,23 @@ normalised them away, because an unmixed store satisfies the assertion for a rea
 do with the behaviour under test. Vacuous green is worse than a skip, since only one of the two is
 visible.
 
+`AggregateToManyCompliance` and `AggregateToLinqOperatorCompliance` (jasperfx#754) are opt-in
+through fixture seam members rather than the registrar: the `AggregateToAsync` /
+`AggregateToManyAsync` operators ride on each product's raw-event LINQ query
+(`QueryAllRawEvents()`), which is deliberately not part of the shared `IQueryEventStore` contract,
+so `AggregateEventsToAsync` / `AggregateEventsToManyAsync` carry throwing defaults and the suites
+gate on `SupportsAggregateToLinqOperators` (default **false** — implement the pair, flip the flag).
+The seam is one optional predicate over the shared `IEvent` applied in a single `Where()`, then the
+product's own terminator — deliberately no ordering or paging, for the same reason `QueryTableAsync`
+is predicate-free: this must not grow into pinning a query provider's operator set. Enrolling also
+takes two more closed-generic aliases beside `ComplianceMultiStreamProjectionBase`
+(`ComplianceBalanceProjectionBase`, `ComplianceMemberLoyaltyProjectionBase` — see
+`Local/ComplianceAggregateToManyPlaceholders.cs` for the exact spelling), because the many-suite's
+whole point is that the operator drives the *registered projection* — identity routing, a
+session-reading custom grouper, `ShouldDelete` — rather than reimplementing the fold inline, and its
+projections are registered `Async` with the daemon never started so every asserted aggregate can
+only have come from the live fold.
+
 ## Capability gates
 
 Where a store genuinely cannot support a behavior, override the `virtual bool Supports...` flags on
@@ -202,6 +219,8 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Subscriptions | `SubscriptionCompliance` |
 | Single-tenanted slicing of disagreeing tenant ids | `SingleTenantedEventSlicingCompliance` |
 | Composite projections — staging and member teardown | `CompositeProjectionCompliance` |
+| `AggregateToAsync` over an event query | `AggregateToLinqOperatorCompliance` |
+| `AggregateToManyAsync` through a registered projection | `AggregateToManyCompliance` |
 
 ### Identity-less boundary aggregates (jasperfx#718)
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/AggregateToLinqOperatorCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AggregateToLinqOperatorCompliance.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// <c>AggregateToAsync&lt;T&gt;</c> — folding every event matched by an ad hoc event query into a
+/// single aggregate, regardless of stream, optionally starting from supplied state, with the
+/// aggregate's identity stamped from the last matched event's stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The single-aggregate twin of
+/// <see cref="AggregateToManyCompliance{TFixture,TOperations,TQuerySession}"/>, and it shares that
+/// suite's seam and <c>SupportsAggregateToLinqOperators</c> gate. It deliberately folds
+/// <see cref="ComplianceTrail"/> — the same unregistered self-aggregating type the live aggregation
+/// suite uses — so the operator is proven over the store's derived live aggregator, the common
+/// ground both products share, rather than anything registered.
+/// </para>
+/// <para>
+/// The two identity facts are the ones a store is most tempted to get wrong: identity is stamped
+/// from the <em>stream</em> of the matched events (Guid or string per the store's stream identity),
+/// not from anything the fold itself computed.
+/// </para>
+/// </remarks>
+public abstract class AggregateToLinqOperatorCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_aggregate_to";
+
+        config.AddEventType<TrailStarted>();
+        config.AddEventType<MilesWalked>();
+    };
+
+    /// <summary>
+    /// String stream identity, for the key-stamping fact. Uses the string identity suite's
+    /// self-aggregating quest so nothing here needs registration either.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _stringConfiguration = config =>
+    {
+        config.SchemaName = "compliance_aggregate_to_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+
+        config.AddEventType<StringQuestStarted>();
+        config.AddEventType<StringMembersJoined>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAggregateToLinqOperators,
+            "This event store has not implemented the AggregateTo LINQ operators under test");
+    }
+
+    [Fact]
+    public async Task can_aggregate_events_to_aggregate_type_asynchronously()
+    {
+        SkipUnlessSupported();
+
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(stream1, new TrailStarted("Long Trail"), new MilesWalked(10));
+        EventsFor(session).StartStream(stream2, new MilesWalked(5), new MilesWalked(7));
+        await SaveChangesAsync(session);
+
+        // No filter: every event in the store folds into one aggregate, across both streams.
+        var trail = await theFixture.AggregateEventsToAsync<ComplianceTrail>(session, null, null, Cancellation);
+
+        trail.ShouldNotBeNull();
+        trail.Name.ShouldBe("Long Trail");
+        trail.Miles.ShouldBe(22);
+    }
+
+    [Fact]
+    public async Task can_aggregate_with_initial_state_asynchronously()
+    {
+        SkipUnlessSupported();
+
+        var stream = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(stream, new TrailStarted("Long Trail"), new MilesWalked(10));
+        await SaveChangesAsync(session);
+
+        var initial = new ComplianceTrail { Miles = 100 };
+        var trail = await theFixture.AggregateEventsToAsync(session,
+            e => e.StreamId == stream, initial, Cancellation);
+
+        trail.ShouldNotBeNull();
+        trail.Name.ShouldBe("Long Trail");
+        trail.Miles.ShouldBe(110);
+    }
+
+    [Fact]
+    public async Task returns_null_when_the_query_matches_no_events()
+    {
+        SkipUnlessSupported();
+
+        await using var session = OpenSession();
+
+        var nothing = Guid.NewGuid(); // matches no stream
+        var trail = await theFixture.AggregateEventsToAsync<ComplianceTrail>(session,
+            e => e.StreamId == nothing, null, Cancellation);
+
+        trail.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task gets_the_id_set()
+    {
+        SkipUnlessSupported();
+
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(stream1, new TrailStarted("Long Trail"), new MilesWalked(10));
+        EventsFor(session).StartStream(stream2, new TrailStarted("Other"), new MilesWalked(5));
+        await SaveChangesAsync(session);
+
+        var trail = await theFixture.AggregateEventsToAsync<ComplianceTrail>(session,
+            e => e.StreamId == stream1, null, Cancellation);
+
+        trail.ShouldNotBeNull();
+        trail.Id.ShouldBe(stream1);
+    }
+
+    [Fact]
+    public async Task gets_the_key_set()
+    {
+        SkipUnlessSupported();
+
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var key = Guid.NewGuid().ToString();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key,
+            new StringQuestStarted("Save the World"),
+            new StringMembersJoined(1, "Emond's Field", ["Rand", "Matrim"]));
+        EventsFor(session).StartStream(Guid.NewGuid().ToString(),
+            new StringQuestStarted("Other"),
+            new StringMembersJoined(2, "Tar Valon", ["Elayne"]));
+        await SaveChangesAsync(session);
+
+        var quest = await theFixture.AggregateEventsToAsync<SelfAggregatingStringQuest>(session,
+            e => e.StreamKey == key, null, Cancellation);
+
+        quest.ShouldNotBeNull();
+        quest.Id.ShouldBe(key);
+        quest.Name.ShouldBe("Save the World");
+        quest.Members.ShouldBe(new[] { "Rand", "Matrim" });
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/AggregateToManyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AggregateToManyCompliance.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Grouping;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Aggregate-to-many sample types
+
+public record ComplianceMoneyDeposited(Guid AccountId, int Amount);
+
+public record ComplianceAccountFrozen(Guid AccountId);
+
+public class ComplianceBalance
+{
+    public Guid Id { get; set; }
+    public int Amount { get; set; }
+}
+
+/// <summary>
+/// The straightforward multi-stream projection under compliance: identity-routed, with a
+/// <c>ShouldDelete</c> so the suite can prove deleted identities fall out of the result. The base
+/// type arrives through the consumer-supplied <c>ComplianceBalanceProjectionBase</c> global alias,
+/// exactly like <see cref="ComplianceDepartmentProjection"/>'s.
+/// </summary>
+public partial class ComplianceBalanceProjection: ComplianceBalanceProjectionBase
+{
+    public ComplianceBalanceProjection()
+    {
+        Identity<ComplianceMoneyDeposited>(e => e.AccountId);
+        Identity<ComplianceAccountFrozen>(e => e.AccountId);
+    }
+
+    public void Apply(ComplianceMoneyDeposited e, ComplianceBalance b) => b.Amount += e.Amount;
+
+    public bool ShouldDelete(ComplianceAccountFrozen e) => true;
+}
+
+public record ComplianceLoyaltyEarned(Guid CardId, int Points);
+
+/// <summary>
+/// Present-day reference data: which member owns a card. Stored as a plain document, never an
+/// event, so the grouper below has to read it from the live session.
+/// </summary>
+public class ComplianceCardOwner
+{
+    public Guid Id { get; set; } // card id
+    public Guid MemberId { get; set; }
+}
+
+public class ComplianceMemberLoyalty
+{
+    public Guid Id { get; set; }
+    public int Points { get; set; }
+}
+
+/// <summary>
+/// The enrichment-shaped projection: events are keyed by card, the aggregate by member, and only a
+/// database lookup can translate one to the other. Its grouper implements the shared
+/// <see cref="IJasperFxAggregateGrouper{TId,TQuerySession}"/> against the consumer's
+/// <c>ComplianceQuerySession</c> alias, and loads through
+/// <c>LoadAsync</c> — the same session member the enrichment suite already binds.
+/// </summary>
+public partial class ComplianceMemberLoyaltyProjection: ComplianceMemberLoyaltyProjectionBase
+{
+    public ComplianceMemberLoyaltyProjection()
+    {
+        CustomGrouping(new Grouper());
+    }
+
+    public void Apply(ComplianceLoyaltyEarned e, ComplianceMemberLoyalty agg) => agg.Points += e.Points;
+
+    public class Grouper: IJasperFxAggregateGrouper<Guid, ComplianceQuerySession>
+    {
+        public async Task Group(ComplianceQuerySession session, IReadOnlyList<IEvent> events,
+            IEventGrouping<Guid> grouping)
+        {
+            foreach (var e in events.OfType<IEvent<ComplianceLoyaltyEarned>>())
+            {
+                var owner = await session.LoadAsync<ComplianceCardOwner>(e.Data.CardId).ConfigureAwait(false);
+                if (owner != null)
+                {
+                    grouping.AddEvent(owner.MemberId, e);
+                }
+            }
+        }
+    }
+}
+
+#endregion
+
+/// <summary>
+/// <c>AggregateToManyAsync&lt;T&gt;</c> — running an ad hoc event query through the multi-stream
+/// projection registered for <typeparamref name="T"/> and getting one aggregate per resulting
+/// identity, driven by the projection's real slicer/grouper and per-slice build against the live
+/// session (marten#4998, polecat#364).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Worth pinning cross-store because the operator's whole promise is "the same answer the
+/// projection would give": the projection's own identity routing, its custom grouper reading
+/// reference data from the session it was handed, and its <c>ShouldDelete</c> decisions. A store
+/// that reimplemented any of those inline — rather than driving the registered projection — would
+/// return plausible aggregates that quietly diverge from the persisted ones.
+/// </para>
+/// <para>
+/// The projections are registered <see cref="ProjectionLifecycle.Async"/> and the daemon is never
+/// started, which is load-bearing: every aggregate asserted here can only have come from the live
+/// fold, never from a persisted document.
+/// </para>
+/// <para>
+/// Opt-in: everything runs through the
+/// <c>EventStoreComplianceFixture.AggregateEventsToManyAsync</c> seam (the raw-event LINQ query is
+/// deliberately not part of the shared contract), gated on
+/// <c>SupportsAggregateToLinqOperators</c>.
+/// </para>
+/// </remarks>
+public abstract class AggregateToManyCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_aggregate_to_many";
+
+        config.AddEventType<ComplianceMoneyDeposited>();
+        config.AddEventType<ComplianceAccountFrozen>();
+        config.AddEventType<ComplianceLoyaltyEarned>();
+
+        config.AddProjection(new ComplianceBalanceProjection(), ProjectionLifecycle.Async);
+        config.AddProjection(new ComplianceMemberLoyaltyProjection(), ProjectionLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAggregateToLinqOperators,
+            "This event store has not implemented the AggregateTo LINQ operators under test");
+    }
+
+    [Fact]
+    public async Task fans_a_cross_stream_query_out_to_one_aggregate_per_identity()
+    {
+        SkipUnlessSupported();
+
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        var stream1 = Guid.NewGuid();
+        var stream2 = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        // acctA deposited across two streams; acctB in one — the fan-out keys on AccountId, not stream.
+        EventsFor(session).Append(stream1,
+            new ComplianceMoneyDeposited(acctA, 100),
+            new ComplianceMoneyDeposited(acctB, 50));
+        EventsFor(session).Append(stream2, new ComplianceMoneyDeposited(acctA, 25));
+        await SaveChangesAsync(session);
+
+        var aggregates = await theFixture.AggregateEventsToManyAsync<ComplianceBalance>(session,
+            e => e.StreamId == stream1 || e.StreamId == stream2, Cancellation);
+
+        aggregates.Count.ShouldBe(2);
+
+        // Identity is stamped on each aggregate...
+        aggregates.Single(x => x.Id == acctA).Amount.ShouldBe(125);
+        aggregates.Single(x => x.Id == acctB).Amount.ShouldBe(50);
+    }
+
+    [Fact]
+    public async Task excludes_aggregates_that_should_delete()
+    {
+        SkipUnlessSupported();
+
+        var acctA = Guid.NewGuid();
+        var acctB = Guid.NewGuid();
+        var stream = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        EventsFor(session).Append(stream,
+            new ComplianceMoneyDeposited(acctA, 100),
+            new ComplianceMoneyDeposited(acctB, 200),
+            new ComplianceAccountFrozen(acctB));
+        await SaveChangesAsync(session);
+
+        var aggregates = await theFixture.AggregateEventsToManyAsync<ComplianceBalance>(session,
+            e => e.StreamId == stream, Cancellation);
+
+        // acctB is frozen (ShouldDelete) and so is absent; only acctA survives.
+        aggregates.Count.ShouldBe(1);
+        aggregates.Single().Id.ShouldBe(acctA);
+        aggregates.Single().Amount.ShouldBe(100);
+    }
+
+    [Fact]
+    public async Task enrichment_reads_reference_data_from_the_live_session()
+    {
+        SkipUnlessSupported();
+
+        var cardA = Guid.NewGuid();
+        var cardB = Guid.NewGuid();
+        var cardC = Guid.NewGuid();
+        var memberX = Guid.NewGuid();
+        var memberY = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        // Present-day reference data the grouper reads while the fold runs.
+        StoreDocument(session, new ComplianceCardOwner { Id = cardA, MemberId = memberX });
+        StoreDocument(session, new ComplianceCardOwner { Id = cardB, MemberId = memberX });
+        StoreDocument(session, new ComplianceCardOwner { Id = cardC, MemberId = memberY });
+        await SaveChangesAsync(session);
+
+        var stream = Guid.NewGuid();
+        EventsFor(session).Append(stream,
+            new ComplianceLoyaltyEarned(cardA, 10),
+            new ComplianceLoyaltyEarned(cardB, 5),
+            new ComplianceLoyaltyEarned(cardC, 20));
+        await SaveChangesAsync(session);
+
+        var aggregates = await theFixture.AggregateEventsToManyAsync<ComplianceMemberLoyalty>(session,
+            e => e.StreamId == stream, Cancellation);
+
+        // Member-keyed, not card-keyed — only possible because the grouper read ComplianceCardOwner
+        // from the session.
+        aggregates.Count.ShouldBe(2);
+        aggregates.Single(x => x.Id == memberX).Points.ShouldBe(15);
+        aggregates.Single(x => x.Id == memberY).Points.ShouldBe(20);
+    }
+
+    [Fact]
+    public async Task empty_query_returns_empty_list()
+    {
+        SkipUnlessSupported();
+
+        await using var session = OpenSession();
+
+        var nothing = Guid.NewGuid(); // matches no stream
+        var aggregates = await theFixture.AggregateEventsToManyAsync<ComplianceBalance>(session,
+            e => e.StreamId == nothing, Cancellation);
+
+        aggregates.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task throws_when_no_projection_produces_the_aggregate_type()
+    {
+        SkipUnlessSupported();
+
+        await using var session = OpenSession();
+
+        // Even over an empty result set — a missing projection is a programming error, not an
+        // empty answer.
+        await Should.ThrowAsync<ArgumentException>(() =>
+            theFixture.AggregateEventsToManyAsync<ComplianceUnrelatedAggregate>(session, null, Cancellation));
+    }
+}
+
+/// <summary>
+/// No projection produces this type, which is the point of
+/// <c>throws_when_no_projection_produces_the_aggregate_type</c>.
+/// </summary>
+public class ComplianceUnrelatedAggregate
+{
+    public Guid Id { get; set; }
+}


### PR DESCRIPTION
Closes #754.

Lifts the `aggregate_to_many_tests.cs` / `aggregateto_linq_operator_tests.cs` facts that Marten master and Polecat carry as literal copies (Polecat's file is annotated `#364 (marten#4998 parity)`) into two shared suites in `JasperFx.Events.ComplianceTests`.

## What's lifted

**`AggregateToManyCompliance`** — all five shared facts, verbatim in intent:
- `fans_a_cross_stream_query_out_to_one_aggregate_per_identity`
- `excludes_aggregates_that_should_delete`
- `enrichment_reads_reference_data_from_the_live_session`
- `empty_query_returns_empty_list`
- `throws_when_no_projection_produces_the_aggregate_type`

The sample types come over with them (`ComplianceBalance` / `ComplianceCardOwner` / `ComplianceMemberLoyalty`, both multi-stream projections, and the nested database-lookup grouper). The grouper now implements the shared `IJasperFxAggregateGrouper<Guid, ComplianceQuerySession>` and reads reference data through `LoadAsync` — the session member the enrichment suite already binds — instead of each product's own `Query<T>()`, which keeps document LINQ out of the suite per the library's charter. Projections stay registered `Async` with the daemon never started, so every asserted aggregate can only have come from the live fold.

**`AggregateToLinqOperatorCompliance`** — the single-fold companion, the union of the two repos' facts:
- `can_aggregate_events_to_aggregate_type_asynchronously`
- `can_aggregate_with_initial_state_asynchronously`
- `returns_null_when_the_query_matches_no_events` (Polecat's addition; Marten's implementation already returns null)
- `gets_the_id_set`
- `gets_the_key_set`

It folds the existing unregistered self-aggregating `ComplianceTrail` and the string identity suite's `SelfAggregatingStringQuest`, so nothing new needs registration and the operator is proven over the derived live aggregator both products share.

## The new seam (per the opt-in pattern)

The operators ride on each product's `QueryAllRawEvents()`, which is deliberately **not** on the shared `IQueryEventStore` contract, so no existing fixture member can reach them. This PR adds the narrowest seam that works, following the established opt-in capability pattern:

- `AggregateEventsToAsync<T>` / `AggregateEventsToManyAsync<T>` on `EventStoreComplianceFixture`, **virtual with throwing defaults** — one optional `Expression<Func<IEvent, bool>>` applied in a single `Where()`, then the product's own terminator. No ordering, no paging, for the same reason `QueryTableAsync` is predicate-free: this must never grow into pinning a query provider's operator set.
- `SupportsAggregateToLinqOperators`, **default false**, so a store that enrolls before implementing the seam skips cleanly instead of failing on the throwing default.
- Two new closed-generic per-consumer aliases (`ComplianceBalanceProjectionBase`, `ComplianceMemberLoyaltyProjectionBase`) via the existing `ComplianceMultiStreamProjectionBase` mechanism, with `Local/` placeholders for the in-repo type-check compile.

## Deliberately not included

- Store enrollment — separate plan nodes adopt the suites in Marten/Polecat and delete the local copies.
- Anything reaching for a shared queryable type: the seam takes a predicate, not an `IQueryable`.

## Validation

- `dotnet build src/JasperFx.Events.ComplianceTests` — clean, no new warnings.
- `dotnet build src/EventStoreTests` + `dotnet test` (net9.0): 141 passed, 0 failed.
- Event suites are compile-checked in-repo by design (no concrete store here); behavioral validation lands with enrollment.

Note for concurrent compliance-wave work: edits to shared files are additive (`EventStoreComplianceFixture.cs` gains two members + one flag; README gains two table rows + one opt-in paragraph).

Stoat plan `event-compliance-wave-13`, node `suite-aggregate-to-many`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
