### PR TITLE
Compliance suite for DCB HasTag predicates in event LINQ queries

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JasperFx.Events.Daemon;
@@ -185,6 +186,57 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
         string tableName, CancellationToken token);
 
     /// <summary>
+    /// Execute the store's raw-event LINQ query — <c>QueryAllRawEvents()</c> on both products —
+    /// with <paramref name="filter"/> applied in a single <c>Where()</c> call, and return the
+    /// matched events.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A seam member because the LINQ-returning methods are deliberately off
+    /// <see cref="IQueryEventStore"/> — they return product-specific queryable types. The shape is
+    /// the narrowest that works, on the same reasoning as <see cref="QueryTableAsync"/>: one
+    /// predicate over the shared <see cref="IEvent"/>, one <c>Where()</c>, executed. No ordering, no
+    /// paging, no queryable handed back — the moment this grows operators it starts pinning one
+    /// provider's LINQ surface, which the library keeps out of scope permanently. The single-Where
+    /// contract is itself load-bearing for the HasTag suite: its facts assert that a tag predicate
+    /// composes with ordinary event predicates <em>inside one predicate tree</em>, which two chained
+    /// <c>Where()</c> calls would not exercise.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default because HasTag-in-LINQ is an opt-in capability; the suite gates on
+    /// <see cref="SupportsHasTagLinqPredicates"/> and skips until a store implements this pair and
+    /// flips the flag.
+    /// </para>
+    /// </remarks>
+    public virtual Task<IReadOnlyList<IEvent>> QueryRawEventsAsync(TQuerySession session,
+        Expression<Func<IEvent, bool>> filter, CancellationToken token)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement QueryRawEventsAsync, so it cannot run the DCB HasTag LINQ compliance suite.");
+
+    /// <summary>
+    /// Build the store's own <c>HasTag&lt;TTag&gt;(value)</c> marker predicate, for composing into
+    /// the filter handed to <see cref="QueryRawEventsAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The one part of a HasTag query a shared suite cannot write: both products translate the
+    /// marker by matching the method's <em>declaring type</em> in their LINQ parsers, so the
+    /// expression must invoke the product's own extension (Marten's
+    /// <c>Marten.Events.LinqExtensions.HasTag</c>, Polecat's <c>Polecat.Linq</c> equivalent) — a
+    /// lambda written here would carry the wrong <c>MethodInfo</c> and never be recognized. An
+    /// implementation is one line: <c>e =&gt; e.HasTag(value)</c>.
+    /// </para>
+    /// <para>
+    /// Building the expression must not itself validate the tag type: for an unregistered tag the
+    /// products throw <see cref="InvalidOperationException"/> at query translation, which is the
+    /// behavior the suite pins.
+    /// </para>
+    /// </remarks>
+    public virtual Expression<Func<IEvent, bool>> HasTagFilter<TTag>(TTag value) where TTag : notnull
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement HasTagFilter, so it cannot run the DCB HasTag LINQ compliance suite.");
+
+    /// <summary>
     /// Execute a batch data-masking operation against already-stored events.
     /// </summary>
     /// <remarks>
@@ -213,6 +265,19 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// False where the store cannot slice one database by tenant.
     /// </summary>
     public virtual bool SupportsConjoinedEventTenancy => true;
+
+    /// <summary>
+    /// True in a store that has implemented the <c>IEvent.HasTag&lt;TTag&gt;</c> LINQ marker over
+    /// its raw-event query and the <see cref="QueryRawEventsAsync"/> / <see cref="HasTagFilter{TTag}"/>
+    /// seam members that reach it.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to false, unlike the older gates, because the seam members it guards carry throwing
+    /// defaults: a store that enrolls <c>DcbHasTagLinqCompliance</c> before implementing the seam
+    /// should skip cleanly rather than fail on the default. Implement the two members, flip this to
+    /// true.
+    /// </remarks>
+    public virtual bool SupportsHasTagLinqPredicates => false;
 
     /// <summary>
     /// False where the store cannot run the async projection daemon in the test environment.

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -136,6 +136,21 @@ which a last-write-wins aggregate would hide. Two of the three products already 
 named for that class of bug — `Bug_439_composite_member_teardown` and `composite_member_teardown` —
 which is what marks the behaviour as shared rather than product-owned.
 
+`DcbHasTagLinqCompliance` (jasperfx#755) is opt-in through fixture seam members rather than the
+registrar. It pins the `IEvent.HasTag<TTag>(value)` LINQ marker — a DCB tag predicate composing with
+ordinary event predicates in one `Where()` over the raw-event query — which no shared surface can
+reach twice over: `QueryAllRawEvents()` is deliberately off `IQueryEventStore`, and both products'
+LINQ parsers recognize `HasTag` by the method's *declaring type*, so an expression written in shared
+source would carry the wrong `MethodInfo` and never be recognized. Two seam members with throwing
+defaults close the gap — `HasTagFilter<TTag>` builds the store's own marker predicate (one line:
+`e => e.HasTag(value)`), and `QueryRawEventsAsync` executes exactly one predicate through one
+`Where()` — gated on `SupportsHasTagLinqPredicates` (default **false** — implement the pair, flip
+the flag). The suite ANDs predicates into a single tree itself, so the parser meets `HasTag` as an
+`AndAlso` operand rather than a lone filter. This stays on the DCB-tag side of the general-LINQ
+exclusion below: the suite pins tag predicate semantics (tag matching, AND composition, tenant
+scoping, unregistered-tag throw), never a provider operator set. Marten's hstore-mode fact stayed
+behind as one engine's storage layout.
+
 `SingleTenantedEventSlicingCompliance` (jasperfx#724) is opt-in for a different reason: it needs no
 registrar seam at all, but the precondition it constructs is unusual enough that a store should adopt
 it knowingly. On a single-tenanted store, events whose `tenant_id` values disagree must still fold into
@@ -173,6 +188,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Self-aggregating `EvolveAsync` conventions | `SelfAggregatingEvolveCompliance` |
 | DCB tag queries and consistency | `DcbTagQueryAndConsistencyCompliance` |
 | `AssignTagWhere` | `AssignTagWhereCompliance` |
+| DCB `HasTag` predicates in event LINQ queries | `DcbHasTagLinqCompliance` |
 | Async daemon smoke + rebuild | `AsyncDaemonCompliance` |
 | Aggregate type auto-discovery | `AutoDiscoveredAggregateCompliance` |
 | `EventProjection` registration and enrichment | `EventProjectionRegistrationCompliance`, `EventProjectionEnrichmentCompliance` |

--- a/src/JasperFx.Events.ComplianceTests/Suites/DcbHasTagLinqCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/DcbHasTagLinqCompliance.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The <c>IEvent.HasTag&lt;TTag&gt;(value)</c> LINQ marker — a DCB tag predicate composing into the
+/// same <c>Where()</c> as ordinary event predicates over a raw-event query (marten#4999,
+/// polecat#364). AND-of-tag-predicates plus normal predicates is the pinned scope;
+/// <c>EventTagQuery</c> with <c>QueryByTagsAsync</c> remains the OR/rich escape hatch, and has its
+/// own suite in <see cref="DcbTagQueryAndConsistencyCompliance{TFixture,TOperations,TQuerySession}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the DCB tag surface adjacent to
+/// <see cref="AssignTagWhereCompliance{TFixture,TOperations,TQuerySession}"/>, not general LINQ:
+/// what is pinned is the tag predicate's semantics — matches only the tagged events, ANDs with
+/// event-type/timestamp/tag predicates in one predicate tree, scopes to the session's tenant,
+/// throws for an unregistered tag type — never a query provider's operator set.
+/// </para>
+/// <para>
+/// Opt-in, through two fixture seam members with throwing defaults, gated on
+/// <c>SupportsHasTagLinqPredicates</c>. <c>HasTagFilter</c> exists because the marker cannot be
+/// spelled here at all: both products' LINQ parsers recognize it by the method's <em>declaring
+/// type</em>, so the expression has to invoke the store's own extension.
+/// <c>QueryRawEventsAsync</c> takes exactly one predicate for one <c>Where()</c>, and the
+/// composition facts build their AND trees with <see cref="And"/> so the parser meets
+/// <c>HasTag</c> as an <c>AndAlso</c> operand — the same tree the products' local tests compile —
+/// rather than as a lone predicate ANDed at the SQL level by chained <c>Where()</c> calls.
+/// </para>
+/// <para>
+/// Reuses the <see cref="StudentId"/> / <see cref="CourseId"/> tag types and
+/// <see cref="StudentEnrolled"/> / <see cref="AssignmentSubmitted"/> events from the DCB
+/// consistency suite, and <see cref="UnregisteredTagId"/> from the AssignTagWhere suite.
+/// </para>
+/// </remarks>
+public abstract class DcbHasTagLinqCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_hastag_linq";
+
+        config.AddEventType<StudentEnrolled>();
+        config.AddEventType<AssignmentSubmitted>();
+
+        config.RegisterTagType<StudentId>("student");
+        config.RegisterTagType<CourseId>("course");
+    };
+
+    /// <summary>
+    /// The same tag registration under conjoined tenancy, in its own schema — the event table's
+    /// shape differs under tenancy, so the single-tenant tests keep their own store.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _conjoinedConfiguration = config =>
+    {
+        config.SchemaName = "compliance_hastag_linq_tenants";
+        config.ConjoinedEventTenancy = true;
+
+        config.AddEventType<StudentEnrolled>();
+        config.AddEventType<AssignmentSubmitted>();
+
+        config.RegisterTagType<StudentId>("student");
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsHasTagLinqPredicates,
+            "This event store has not implemented the HasTag LINQ predicate under test");
+    }
+
+    private Task<IReadOnlyList<IEvent>> queryAsync(TOperations session, Expression<Func<IEvent, bool>> filter)
+        => theFixture.QueryRawEventsAsync(session, filter, Cancellation);
+
+    /// <summary>
+    /// Combine two predicates into the single <c>e =&gt; left &amp;&amp; right</c> tree the C#
+    /// compiler would emit for one <c>Where()</c> — which is the shape under test, since the
+    /// products' parsers have to handle <c>HasTag</c> as an operand of <c>AndAlso</c>.
+    /// </summary>
+    private static Expression<Func<IEvent, bool>> And(Expression<Func<IEvent, bool>> left,
+        Expression<Func<IEvent, bool>> right)
+    {
+        var parameter = left.Parameters[0];
+        var rewritten = new ParameterReplacer(right.Parameters[0], parameter).Visit(right.Body)!;
+        return Expression.Lambda<Func<IEvent, bool>>(Expression.AndAlso(left.Body, rewritten), parameter);
+    }
+
+    private sealed class ParameterReplacer: ExpressionVisitor
+    {
+        private readonly ParameterExpression _from;
+        private readonly ParameterExpression _to;
+
+        public ParameterReplacer(ParameterExpression from, ParameterExpression to)
+        {
+            _from = from;
+            _to = to;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+            => node == _from ? _to : base.VisitParameter(node);
+    }
+
+    [Fact]
+    public async Task has_tag_matches_only_events_carrying_that_tag_value()
+    {
+        SkipUnlessSupported();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var bob = new StudentId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Bob", "Math"), bob);
+
+        var events = await queryAsync(session, theFixture.HasTagFilter(alice));
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>().StudentName.ShouldBe("Alice");
+    }
+
+    [Fact]
+    public async Task has_tag_composes_with_a_normal_event_predicate_in_one_where()
+    {
+        SkipUnlessSupported();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+
+        // Two events for Alice, both tagged with her StudentId, but of different event types.
+        await AppendTaggedEventAsync(session, streamId, new StudentEnrolled("Alice", "Math"), alice);
+        await AppendTaggedEventAsync(session, streamId, new AssignmentSubmitted("HW1", 95), alice);
+
+        // "Alice's events, but only the enrollments" — the tag predicate AND a normal event
+        // predicate, in one Where.
+        var enrolledTypeName = EventTypeNameFor<StudentEnrolled>();
+        var events = await queryAsync(session,
+            And(theFixture.HasTagFilter(alice), e => e.EventTypeName == enrolledTypeName));
+
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>();
+    }
+
+    [Fact]
+    public async Task has_tag_composes_with_a_timestamp_predicate()
+    {
+        SkipUnlessSupported();
+
+        var alice = new StudentId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-1);
+
+        var events = await queryAsync(session,
+            And(theFixture.HasTagFilter(alice), e => e.Timestamp > cutoff));
+
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task and_of_two_tag_predicates_requires_both_tags()
+    {
+        SkipUnlessSupported();
+
+        var alice = new StudentId(Guid.NewGuid());
+        var math = new CourseId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        // Event 1 carries BOTH tags; event 2 carries only the student tag.
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice, math);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new StudentEnrolled("Alice", "Science"), alice);
+
+        var events = await queryAsync(session,
+            And(theFixture.HasTagFilter(alice), theFixture.HasTagFilter(math)));
+
+        // Only the event tagged with both survives the AND.
+        events.Count.ShouldBe(1);
+        events.Single().Data.ShouldBeOfType<StudentEnrolled>().CourseName.ShouldBe("Math");
+    }
+
+    [Fact]
+    public async Task has_tag_is_isolated_by_tenant_under_conjoined_tenancy()
+    {
+        SkipUnlessSupported();
+        Assert.SkipUnless(theFixture.SupportsConjoinedEventTenancy,
+            "This event store cannot slice one database by tenant");
+
+        await theFixture.ConfigureAsync(_conjoinedConfiguration);
+
+        var alice = new StudentId(Guid.NewGuid());
+
+        // The SAME tag value is appended in two tenants; HasTag must only match the session's
+        // tenant. The failure mode is silent and asymmetric — a leaking store still answers
+        // correctly for the tenant that owns the data — so the query runs from the tenant that
+        // must NOT see the other's event.
+        await using var redSession = await openForTenantAsync("red");
+        await AppendTaggedEventAsync(redSession, Guid.NewGuid(), new StudentEnrolled("Alice", "Math"), alice);
+
+        await using var blueSession = await openForTenantAsync("blue");
+        await AppendTaggedEventAsync(blueSession, Guid.NewGuid(), new StudentEnrolled("Alice", "Science"), alice);
+
+        var redEvents = await queryAsync(redSession, theFixture.HasTagFilter(alice));
+
+        redEvents.Count.ShouldBe(1);
+        redEvents.Single().Data.ShouldBeOfType<StudentEnrolled>().CourseName.ShouldBe("Math");
+    }
+
+    [Fact]
+    public async Task has_tag_for_an_unregistered_tag_type_throws()
+    {
+        SkipUnlessSupported();
+
+        var unknown = new UnregisteredTagId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+
+        // The throw comes at query translation, not at predicate construction.
+        await ShouldFailWithAsync<InvalidOperationException>(() =>
+            queryAsync(session, theFixture.HasTagFilter(unknown)));
+    }
+
+    /// <summary>
+    /// A session bound to one tenant, through the shared generic store surface — the same route
+    /// <see cref="ConjoinedEventTenancyCompliance{TFixture,TOperations,TQuerySession}"/> uses.
+    /// </summary>
+    private async Task<TOperations> openForTenantAsync(string tenantId)
+    {
+        var store = (IEventStore<TOperations, TQuerySession>)theFixture.EventStore;
+
+        var databases = await theFixture.EventStore.AllDatabases();
+        var database = databases.First();
+
+        return store.OpenSession(database, tenantId);
+    }
+}


### PR DESCRIPTION
Closes #755.

Lifts the `dcb_tag_linq_where_tests.cs` facts that Marten master (`src/EventSourcingTests/Dcb/`) and Polecat (`src/Polecat.Tests/Events/`, annotated `#364 (marten#4999 parity)`) carry under the same class name into a shared `DcbHasTagLinqCompliance` suite — the DCB tag surface adjacent to the existing `AssignTagWhereCompliance` / `DcbTagQueryAndConsistencyCompliance`.

## What's lifted

- `has_tag_matches_only_events_carrying_that_tag_value`
- `has_tag_composes_with_a_normal_event_predicate_in_one_where` (using the `EventTypeName ==` spelling both repos can translate; Marten's local file used its own `EventTypesAre` extension, which Polecat doesn't have)
- `has_tag_composes_with_a_timestamp_predicate`
- `and_of_two_tag_predicates_requires_both_tags`
- `has_tag_for_an_unregistered_tag_type_throws` (asserted via `ShouldFailWithAsync<InvalidOperationException>` since the throw comes at query translation)
- `has_tag_is_isolated_by_tenant_under_conjoined_tenancy` — Polecat's portable tenancy fact, additionally gated on `SupportsConjoinedEventTenancy`, opening tenant sessions through the same shared `IEventStore<TOperations,TQuerySession>.OpenSession(database, tenantId)` route `ConjoinedEventTenancyCompliance` uses.

**Left behind on purpose:** Marten's `has_tag_works_in_hstore_storage_mode`. `DcbStorageMode.HStore` is one engine's storage layout, which the library's charter keeps out of scope.

The suite reuses the `StudentId` / `CourseId` tag types and `StudentEnrolled` / `AssignmentSubmitted` events from the DCB consistency suite and `UnregisteredTagId` from the AssignTagWhere suite — no new sample types.

## The new seam (per the opt-in pattern)

Nothing shared can reach this behavior twice over: `QueryAllRawEvents()` is deliberately off the shared `IQueryEventStore` contract, and both products' LINQ parsers recognize `HasTag` by the method's **declaring type**, so an expression written in shared source would carry the wrong `MethodInfo` and never be recognized. Two fixture seam members with throwing defaults close the gap:

- `HasTagFilter<TTag>(value)` — builds the store's own marker predicate; a one-line implementation (`e => e.HasTag(value)`).
- `QueryRawEventsAsync(session, filter, token)` — executes exactly one `Expression<Func<IEvent, bool>>` through one `Where()`. No ordering, no paging, no queryable handed back, on the same "narrowest that works" reasoning as `QueryTableAsync`. The single-Where contract is load-bearing: the suite ANDs predicates into a single `AndAlso` tree itself (small `ExpressionVisitor` combiner), so the parsers meet `HasTag` as an `AndAlso` operand — the composition shape the local tests compiled — rather than as a lone filter ANDed at the SQL level by chained `Where()` calls.
- `SupportsHasTagLinqPredicates`, **default false**, so a store that enrolls before implementing the seam skips cleanly.

This stays on the DCB-tag side of the README's permanent general-LINQ exclusion: the suite pins tag predicate semantics, never a query provider's operator set, and the README paragraph added here says so explicitly. It is also distinct from the new `EventQueryCompliance` (jasperfx#737), which covers the structured `EventQuery` object over the shared contract, not the products' LINQ marker.

## Deliberately not included

Store enrollment — separate plan nodes adopt the suite in Marten/Polecat and delete the local copies.

## Validation

- `dotnet build src/JasperFx.Events.ComplianceTests` — clean, no new warnings.
- `dotnet build src/EventStoreTests` + `dotnet test` (net9.0): 141 passed, 0 failed.
- Event suites are compile-checked in-repo by design; behavioral validation lands with enrollment.

Note for concurrent compliance-wave work: shared-file edits are additive and anchored away from #758's (`EventStoreComplianceFixture.cs` gains two members + one flag; README gains one table row + one opt-in paragraph). Both PRs add the identical `using System.Linq.Expressions;` line, which merges cleanly.

Stoat plan `event-compliance-wave-13`, node `suite-dcb-hastag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
