### PR TITLE
Compliance suite: a store registers a reachable IProjectionCoordinator

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -31,6 +31,13 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     private Action<ComplianceStoreConfig>? _lastConfiguration;
 
     /// <summary>
+    /// The most recently built store-neutral configuration — what
+    /// <see cref="StartCoordinatorHostAsync(bool)"/> replays into a hosted store so the suite's
+    /// projections are registered there as well as on the fixture's own store.
+    /// </summary>
+    protected ComplianceStoreConfig? CurrentConfig { get; private set; }
+
+    /// <summary>
     /// Cancellation token handed to every store call the suites make. Overridable rather than
     /// hard-coded so a consumer can swap in its own budget.
     /// </summary>
@@ -57,6 +64,7 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
 
         await BuildStoreAsync(config).ConfigureAwait(false);
 
+        CurrentConfig = config;
         _lastConfiguration = configure;
     }
 
@@ -389,6 +397,83 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// </para>
     /// </remarks>
     public virtual bool SupportsUpcasting => false;
+
+
+    /// <summary>
+    /// Build and START an application host whose container registers this store the way the
+    /// product documents it — the product's own <c>AddXxx(...)</c> service registration plus its
+    /// documented async daemon registration — replaying <paramref name="config"/> so the suite's
+    /// projections are registered on the hosted store. Point the hosted store at the same database
+    /// (and the config's schema) as the fixture's own store, so the per-test
+    /// <see cref="CleanEventDataAsync"/> isolation covers it. Disposing the returned wrapper must
+    /// stop the host.
+    /// </summary>
+    /// <param name="config">The suite's store-neutral configuration, to replay onto the hosted store.</param>
+    /// <param name="includeAncillaryStore">
+    /// True only when <see cref="SupportsAncillaryCoordinators"/> is true and the ancillary fact is
+    /// running: additionally register one ancillary store (Marten's <c>AddMartenStore&lt;T&gt;</c>
+    /// and its siblings) with its documented daemon registration, whose coordinator
+    /// <see cref="AncillaryCoordinatorFrom"/> resolves. False for every other fact, and load-bearing
+    /// there: the suite asserts the hosted-service walk finds EXACTLY one coordinator, so the
+    /// default host must register only the primary store.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// The seam jasperfx#732 names. Every other daemon suite drives a daemon the fixture built by
+    /// hand (<see cref="StartDaemonAsync"/>), which can never observe whether the documented DI
+    /// registration produces a reachable <see cref="IProjectionCoordinator"/> — fisher#138 shipped
+    /// exactly that gap, and passed all 37 suites while it did.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default so consumers keep compiling across the bump, but unlike the
+    /// opt-in capability members there is deliberately NO <c>Supports</c> flag and no skip. A store
+    /// that enrolls <see cref="ProjectionCoordinatorCompliance{TFixture,TOperations,TQuerySession}"/>
+    /// without implementing this member fails every fact rather than skipping, because a skippable
+    /// registration check recreates the silent gap the suite exists to close — the third instance
+    /// of the jasperfx#700 / jasperfx#718 pattern, and the reason the suite exists at all.
+    /// </para>
+    /// </remarks>
+    protected virtual Task<IComplianceCoordinatorHost<TOperations>> StartCoordinatorHostAsync(
+        ComplianceStoreConfig config, bool includeAncillaryStore)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement StartCoordinatorHostAsync, so it cannot run the projection coordinator compliance suite (jasperfx#732).");
+
+    /// <summary>
+    /// Start the coordinator host for the suite's current configuration — the one the last
+    /// <see cref="ConfigureAsync"/> built.
+    /// </summary>
+    public Task<IComplianceCoordinatorHost<TOperations>> StartCoordinatorHostAsync(
+        bool includeAncillaryStore = false)
+    {
+        if (CurrentConfig == null)
+        {
+            throw new InvalidOperationException(
+                "ConfigureAsync must run before a coordinator host can be started.");
+        }
+
+        return StartCoordinatorHostAsync(CurrentConfig, includeAncillaryStore);
+    }
+
+    /// <summary>
+    /// True in a store that supports ancillary store registration (Marten's
+    /// <c>AddMartenStore&lt;T&gt;</c> and its siblings) whose hosted daemon registers a
+    /// marker-typed <see cref="IProjectionCoordinator{T}"/>. Gates only the ancillary fact of
+    /// <see cref="ProjectionCoordinatorCompliance{TFixture,TOperations,TQuerySession}"/> — the
+    /// core coordinator facts deliberately have no gate.
+    /// </summary>
+    public virtual bool SupportsAncillaryCoordinators => false;
+
+    /// <summary>
+    /// Resolve the ancillary store's marker-typed coordinator from a host started with
+    /// <c>includeAncillaryStore: true</c> — typically
+    /// <c>services.GetRequiredService&lt;IProjectionCoordinator&lt;TMarker&gt;&gt;()</c> over the
+    /// fixture's own marker type. A fixture member because the marker type cannot be shared: every
+    /// product constrains ancillary markers to its own store interface, so only the fixture can
+    /// name one.
+    /// </summary>
+    public virtual IProjectionCoordinator AncillaryCoordinatorFrom(IServiceProvider services)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement AncillaryCoordinatorFrom, so it cannot run the ancillary coordinator compliance fact.");
 
 
     public virtual ValueTask InitializeAsync() => default;

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -77,6 +77,15 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
 
     protected Task<IProjectionDaemon> StartDaemonAsync() => theFixture.StartDaemonAsync();
 
+    /// <summary>
+    /// Build and start an application host with the store registered the documented way plus its
+    /// documented async daemon registration, for the projection coordinator suite. See
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.StartCoordinatorHostAsync(bool)"/>.
+    /// </summary>
+    protected Task<IComplianceCoordinatorHost<TOperations>> StartCoordinatorHostAsync(
+        bool includeAncillaryStore = false)
+        => theFixture.StartCoordinatorHostAsync(includeAncillaryStore);
+
     protected Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout)
         => theFixture.WaitForNonStaleProjectionDataAsync(timeout);
 

--- a/src/JasperFx.Events.ComplianceTests/IComplianceCoordinatorHost.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceCoordinatorHost.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// A started application host wrapping a store registered the documented way — the product's
+/// <c>AddXxx(...)</c> service registration plus its documented async daemon registration — handed
+/// to <see cref="ProjectionCoordinatorCompliance{TFixture,TOperations,TQuerySession}"/> by
+/// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.StartCoordinatorHostAsync()"/>.
+/// </summary>
+/// <typeparam name="TOperations">The store's writable session type.</typeparam>
+/// <remarks>
+/// <para>
+/// Deliberately tiny. The suite resolves everything else through <see cref="Services"/> and the
+/// shared interfaces (<c>IProjectionCoordinator</c>, <c>IHostedService</c>,
+/// <c>IProjectionDaemon</c>); the one thing a generic suite cannot pull out of a container
+/// portably is a writable session typed as the fixture's session pair, which is what
+/// <see cref="OpenSession"/> supplies. Every other seam member the suite already has —
+/// <c>SaveChangesAsync</c>, <c>LoadDocumentAsync</c>, <c>EventsFor</c> — takes the session as a
+/// parameter, so it works against a hosted store's session unchanged.
+/// </para>
+/// <para>
+/// <see cref="IAsyncDisposable.DisposeAsync"/> must STOP the host gracefully before disposing it —
+/// Microsoft's <c>IHost.Dispose</c> alone does not call <c>StopAsync</c>, and an abandoned daemon
+/// host leaks agents into the next test.
+/// </para>
+/// </remarks>
+public interface IComplianceCoordinatorHost<out TOperations> : IAsyncDisposable
+{
+    /// <summary>
+    /// The started host's root service provider — the container an application would resolve
+    /// <c>IProjectionCoordinator</c> from.
+    /// </summary>
+    IServiceProvider Services { get; }
+
+    /// <summary>
+    /// Open a writable session against the hosted store — not against the fixture's own store
+    /// instance. Callers dispose it.
+    /// </summary>
+    TOperations OpenSession();
+}

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -253,6 +253,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | `AggregateToAsync` over an event query | `AggregateToLinqOperatorCompliance` |
 | `AggregateToManyAsync` through a registered projection | `AggregateToManyCompliance` |
 | Event upcasting — old stored schemas read as the current types | `UpcastingCompliance` |
+| A reachable `IProjectionCoordinator` over the documented registration | `ProjectionCoordinatorCompliance` |
 
 ### Identity-less boundary aggregates (jasperfx#718)
 
@@ -275,6 +276,43 @@ runtime scans as `typeof(TDoc).Assembly`. It is deliberately never registered �
 aggregation — since a DCB aggregate is discovered lazily on first use, and registering it eagerly
 would move the failure to store construction, where it would take every other fact in the suite down
 with it.
+
+### A reachable `IProjectionCoordinator` (jasperfx#732)
+
+`ProjectionCoordinatorCompliance` is the one suite that builds a real application host, because what
+it pins cannot be observed any other way: every other daemon suite drives a daemon the fixture
+constructed by hand, which says nothing about whether the store's *documented DI registration*
+produces a coordinator application code can reach. Fisher shipped exactly that gap (fisher#138) —
+`AddAsyncDaemon` registered only an `IHostedService` over an internal class implementing nothing
+else, so `GetRequiredService<IProjectionCoordinator>()` threw and the
+`GetServices<IHostedService>().OfType<IProjectionCoordinator>()` fallback found nothing — and passed
+all 37 suites the whole time. Third instance of the jasperfx#700 / jasperfx#718 pattern, which is
+why it is a suite rather than a third fix.
+
+The seam is one fixture member plus the small `IComplianceCoordinatorHost<TOperations>` wrapper:
+build and **start** a host that registers the store the documented way — the product's `AddXxx(...)`
+plus its documented async daemon registration — replaying the suite's `ComplianceStoreConfig` onto
+the hosted store, over the same database as the fixture's own store. `Services` and `OpenSession()`
+reach the hosted store; `DisposeAsync` stops the host.
+
+The member carries a throwing default so a consumer keeps compiling across the bump, but there is
+deliberately **no `Supports` flag and no skip** for the core facts: a store that enrolls the suite
+without implementing the seam fails every fact rather than skipping, because a skippable
+registration check recreates the silent gap the suite exists to close. Two of the facts carry the
+weight. The same-instance fact is a correctness matter, not tidiness — two registrations of one
+coordinator are two daemons over one database, which for a single-writer store is two writers
+contending for one lock. And the pause/resume fact is the one that would have caught fisher#138's
+real bug: its `StartAsync` only started daemons for databases not already running, so a naive
+`ResumeAsync` restarted nothing — the suite's first append-and-wait round before the pause proves
+the daemon was genuinely running, so a post-resume timeout indicts resume rather than startup.
+
+The one gated fact is the ancillary store's marker-typed `IProjectionCoordinator<T>`, behind
+`SupportsAncillaryCoordinators` (default false), because not every store has ancillary registration
+at all. A store that flips it also implements `AncillaryCoordinatorFrom` — a fixture member because
+ancillary marker types cannot be shared: every product constrains them to its own store interface,
+so only the fixture can name one. The default host registers only the primary store, and that is
+load-bearing: the hosted-service walk asserts **exactly one** coordinator, so the ancillary store
+only joins the host the ancillary fact asks for (`includeAncillaryStore: true`).
 
 ### The document contract (jasperfx#647)
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/ProjectionCoordinatorCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ProjectionCoordinatorCompliance.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+public record WingOpened(string Name);
+
+/// <summary>
+/// A deliberately plain self-aggregating snapshot type for the coordinator suite. The daemon has to
+/// be projecting <em>something</em> for reachability and pause/resume to be observable facts rather
+/// than claims about registration alone.
+/// </summary>
+public partial class WingRoster
+{
+    public Guid Id { get; set; }
+
+    public string Name { get; set; } = "";
+
+    public void Apply(WingOpened e) => Name = e.Name;
+}
+
+/// <summary>
+/// Proves a store registers a REACHABLE <see cref="IProjectionCoordinator"/> over a host built the
+/// documented way — the product's own DI registration plus its documented async daemon
+/// registration — and that both documented routes to it land on one instance (jasperfx#732).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other daemon suite drives a daemon the fixture constructed by hand, which can never
+/// observe whether the documented registration produces a coordinator application code can reach.
+/// fisher#138 shipped exactly that gap: the store registered only an <c>IHostedService</c> over an
+/// internal class implementing nothing else, so <c>GetRequiredService&lt;IProjectionCoordinator&gt;()</c>
+/// threw and the <c>GetServices&lt;IHostedService&gt;().OfType&lt;IProjectionCoordinator&gt;()</c>
+/// fallback found nothing — and the store passed all 37 suites the whole time. This is the third
+/// instance of one pattern (jasperfx#700's unfilled usage slots, jasperfx#718's identity-carrying
+/// DCB aggregates): the store is silently the odd one out, nothing dialect-specific prompts a look,
+/// and the symptom surfaces in a downstream consumer.
+/// </para>
+/// <para>
+/// Which is why this suite deliberately carries NO capability gate. The fixture seam
+/// (<c>StartCoordinatorHostAsync</c>) has a throwing default so consumers keep compiling across the
+/// bump, but a store that enrolls the suite without implementing it fails every fact rather than
+/// skipping — a skippable registration check recreates the silent gap the suite exists to close.
+/// The one gated fact is the ancillary marker-typed coordinator, gated on
+/// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsAncillaryCoordinators"/>
+/// because not every store has ancillary registration at all.
+/// </para>
+/// <para>
+/// The same-instance fact is a correctness matter and not just tidiness: two registrations of one
+/// coordinator are two daemons over one database, which for a single-writer store is two writers
+/// contending for the same lock. And the pause/resume fact is the one that would have caught
+/// fisher#138's real bug — its <c>StartAsync</c> only started daemons for databases not already
+/// running, so a naive <c>ResumeAsync</c> restarted nothing. The first append-and-wait round
+/// before the pause is load-bearing for the same reason: it proves the daemon was genuinely
+/// running, so a post-resume timeout indicts resume rather than startup.
+/// </para>
+/// </remarks>
+public abstract class ProjectionCoordinatorCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_coordinator";
+
+        config.AddEventType<WingOpened>();
+
+        config.Snapshot<WingRoster>(SnapshotLifecycle.Async);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    private async Task<Guid> OpenWingAsync(IComplianceCoordinatorHost<TOperations> host, string name)
+    {
+        var id = Guid.NewGuid();
+
+        await using (var session = host.OpenSession())
+        {
+            EventsFor(session).StartStream<WingRoster>(id, new WingOpened(name));
+            await SaveChangesAsync(session);
+        }
+
+        return id;
+    }
+
+    [Fact]
+    public async Task the_coordinator_resolves_from_the_container()
+    {
+        await using var host = await StartCoordinatorHostAsync();
+
+        host.Services.GetRequiredService<IProjectionCoordinator>().ShouldNotBeNull();
+    }
+
+    /// <summary>
+    /// The documented fallback for a host that resolves hosted services rather than the interface —
+    /// walking <c>GetServices&lt;IHostedService&gt;()</c> and casting — must find the SAME instance
+    /// the container hands out, and exactly one of it. Two instances would be two daemons over one
+    /// database; none is fisher#138. The strict single-item walk is why the default host registers
+    /// only the primary store — an ancillary coordinator would be a second, legitimate item.
+    /// </summary>
+    [Fact]
+    public async Task the_hosted_service_and_the_resolved_coordinator_are_one_instance()
+    {
+        await using var host = await StartCoordinatorHostAsync();
+
+        var resolved = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var walked = host.Services.GetServices<IHostedService>()
+            .OfType<IProjectionCoordinator>()
+            .ShouldHaveSingleItem();
+
+        walked.ShouldBeSameAs(resolved);
+    }
+
+    [Fact]
+    public async Task the_main_database_daemon_is_reachable_and_projecting()
+    {
+        await using var host = await StartCoordinatorHostAsync();
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var id = await OpenWingAsync(host, "East Wing");
+
+        var daemon = coordinator.DaemonForMainDatabase();
+        daemon.ShouldNotBeNull();
+        await daemon.WaitForNonStaleData(_timeout);
+
+        await using var query = host.OpenSession();
+        var roster = await LoadDocumentAsync<WingRoster>(query, id);
+        roster.ShouldNotBeNull();
+        roster.Name.ShouldBe("East Wing");
+    }
+
+    /// <summary>
+    /// Reference identity on purpose: the coordinator's whole job is to HOLD its daemons, which is
+    /// what pause and resume operate on. A coordinator constructing a fresh daemon per call would
+    /// pass a value-equality check while running two daemons over one database.
+    /// </summary>
+    [Fact]
+    public async Task all_daemons_includes_the_main_database_daemon()
+    {
+        await using var host = await StartCoordinatorHostAsync();
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var daemon = coordinator.DaemonForMainDatabase();
+
+        var all = await coordinator.AllDaemonsAsync();
+        all.Any(x => ReferenceEquals(x, daemon)).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// The fact that would have caught fisher#138's real bug: pause must stop agents without
+    /// disposing the daemons, and resume must restart agents on the daemons already held — a
+    /// <c>StartAsync</c> that only starts daemons for databases not already running restarts
+    /// nothing after a pause, and the second wait here times out naming shards that recorded no
+    /// progress.
+    /// </summary>
+    [Fact]
+    public async Task pause_then_resume_leaves_the_daemon_projecting()
+    {
+        await using var host = await StartCoordinatorHostAsync();
+        var coordinator = host.Services.GetRequiredService<IProjectionCoordinator>();
+
+        var before = await OpenWingAsync(host, "Before Pause");
+        await coordinator.DaemonForMainDatabase().WaitForNonStaleData(_timeout);
+
+        await coordinator.PauseAsync();
+        await coordinator.ResumeAsync();
+
+        var after = await OpenWingAsync(host, "After Resume");
+        await coordinator.DaemonForMainDatabase().WaitForNonStaleData(_timeout);
+
+        await using var query = host.OpenSession();
+
+        var resumed = await LoadDocumentAsync<WingRoster>(query, after);
+        resumed.ShouldNotBeNull();
+        resumed.Name.ShouldBe("After Resume");
+
+        var original = await LoadDocumentAsync<WingRoster>(query, before);
+        original.ShouldNotBeNull();
+        original.Name.ShouldBe("Before Pause");
+    }
+
+    /// <summary>
+    /// The one gated fact, because not every store has ancillary store registration. When it does,
+    /// the ancillary coordinator must be its own instance — one non-generic coordinator can only
+    /// mean one store — and must itself be registered as a hosted service exactly once, for the
+    /// same two-daemons reason as the main one.
+    /// </summary>
+    [Fact]
+    public async Task an_ancillary_store_registers_a_marker_typed_coordinator()
+    {
+        Assert.SkipUnless(theFixture.SupportsAncillaryCoordinators,
+            "This event store does not support ancillary store registration with marker-typed coordinators");
+
+        await using var host = await StartCoordinatorHostAsync(includeAncillaryStore: true);
+
+        var main = host.Services.GetRequiredService<IProjectionCoordinator>();
+        var ancillary = theFixture.AncillaryCoordinatorFrom(host.Services);
+
+        ancillary.ShouldNotBeNull();
+        ancillary.ShouldNotBeSameAs(main);
+
+        host.Services.GetServices<IHostedService>()
+            .OfType<IProjectionCoordinator>()
+            .Count(x => ReferenceEquals(x, ancillary))
+            .ShouldBe(1);
+    }
+}


### PR DESCRIPTION
Closes #732

## What this adds

`ProjectionCoordinatorCompliance` — a suite over a real, started application host that registers the store the **documented** way (the product's `AddXxx(...)` plus its documented async daemon registration), pinning the five facts #732 specifies:

1. `IProjectionCoordinator` resolves from the container.
2. The `GetServices<IHostedService>().OfType<IProjectionCoordinator>()` walk finds **exactly one** coordinator, and it is the **same instance** the container hands out — two registrations are two daemons over one database, a correctness matter for a single-writer store, and zero is fisher#138.
3. `DaemonForMainDatabase()` returns a daemon that reaches non-stale after an append (asserted against the persisted projected document).
4. `AllDaemonsAsync()` includes that daemon **by reference** — the coordinator's job is to *hold* its daemons, which is what pause/resume operate on.
5. `PauseAsync()` then `ResumeAsync()` leaves the daemon still projecting — the fact that would have caught fisher#138's real bug (`StartAsync` only started daemons for databases not already running, so a naive `ResumeAsync` restarted nothing). The pre-pause append-and-wait round is load-bearing: it proves the daemon was genuinely running, so a post-resume timeout indicts resume rather than startup.

Plus the optional sixth fact: an ancillary store's marker-typed `IProjectionCoordinator<T>`, gated on `SupportsAncillaryCoordinators` (default false), asserting it is a distinct instance from the main coordinator and itself registered as a hosted service exactly once.

## The seam, and why it is shaped this way

**`EventStoreComplianceFixture.StartCoordinatorHostAsync(ComplianceStoreConfig, bool includeAncillaryStore)`** plus the tiny `IComplianceCoordinatorHost<TOperations>` wrapper (`Services` + `OpenSession()`; `DisposeAsync` stops the host). The base fixture now retains the last-built `ComplianceStoreConfig` (`CurrentConfig`) so the host replays the suite's projections onto the hosted store; every existing session-parameterized seam member (`SaveChangesAsync`, `LoadDocumentAsync`, `EventsFor`) works against a hosted session unchanged.

**Must-implement, not skippable — stated prominently per the issue's framing.** The seam member carries a throwing default so Marten / Polecat / Fisher keep *compiling* across the bump, but unlike the opt-in capability members there is deliberately **no `Supports` flag and no skip** for the core facts: a store that enrolls the suite without implementing the seam **fails every fact** rather than skipping. A skippable registration check would recreate the silent gap this suite exists to close — the third instance of the #700 / #718 pattern. (A hard `abstract` member was the alternative; it buys a compile break but breaks all three consumers on the bump, and it still cannot force *enrollment*, which is the actual opt-in for any suite. Fail-loud-on-enroll keeps consumers compiling and keeps the gap un-skippable, which is the property that matters.)

**Why `includeAncillaryStore` is a parameter rather than a second host member:** the default host must register only the primary store, because fact 2's hosted-service walk is deliberately strict (`ShouldHaveSingleItem`) — an ancillary coordinator would be a second, legitimate item, and filtering it out generically is not portable (a product's marker interface need not implement JasperFx's generic marker; Marten's predates the lift). `AncillaryCoordinatorFrom(IServiceProvider)` is a fixture member because ancillary marker types cannot be shared — every product constrains them to its own store interface, so only the fixture can name one.

Fisher's post-#138 implementation and its `projection_coordinator` coverage are the working reference the facts were shaped against; Marten's jasperfx#430 forward-registration satisfies them as well.

## Files

- `Suites/ProjectionCoordinatorCompliance.cs` — the suite (6 facts) + `WingOpened` / `WingRoster` fixtures, schema `compliance_coordinator`
- `IComplianceCoordinatorHost.cs` — the host wrapper interface
- `EventStoreComplianceFixture.cs` — `CurrentConfig` retention, `StartCoordinatorHostAsync` (throwing default), `SupportsAncillaryCoordinators`, `AncillaryCoordinatorFrom`
- `EventStoreComplianceSuite.cs` — forwarder
- `README.md` — scope-table row + "A reachable `IProjectionCoordinator` (jasperfx#732)" section

Based on main *after* #758 and #759 merged, so the fixture and README edits sit on top of theirs — no overlap left outstanding.

## Validation

Org CI runners are currently stalled, so the local run of the in-repo compliance consumer is the quality gate for this PR:

- `dotnet build src/EventStoreTests/EventStoreTests.csproj` — 0 errors, no warnings from the new/edited files (compiles `JasperFx.Events.ComplianceTests`, including the new suite, on net9.0 and net10.0)
- `DISABLE_TEST_PARALLELIZATION=true dotnet test src/EventStoreTests/EventStoreTests.csproj` — **Passed: 141 / Failed: 0** on net9.0, **Passed: 141 / Failed: 0** on net10.0

(No store is enrolled here by design — the event-store suites execute in the consumers; the source-only package constraints — C# 13, explicit usings, JasperFx.Events + xunit.v3 core/assert + Shouldly only — are observed, with `Microsoft.Extensions.Hosting`/DI reached transitively through `JasperFx` as the daemon types already are.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)