### PR TITLE
2.64.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.63.2</JasperFxVersion>
+        <JasperFxVersion>2.64.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>


### PR DESCRIPTION
Version bump for the wave-13 release: upcasting contract (#752), AggregateToMany/HasTag/coordinator-registration suites (#754, #755, #732), lifted event exceptions (#751) and CompositeProjectionSource (#750).

Local runs are the gate per the September policy; Actions is stalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)