### PR TITLE
Compliance: AlwaysEnforceConsistency, ProjectLatest pending events, stream query plans, archive edges (#762)

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -475,6 +475,73 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
         => throw new NotSupportedException(
             $"{GetType().FullName} does not implement AncillaryCoordinatorFrom, so it cannot run the ancillary coordinator compliance fact.");
 
+    /// <summary>
+    /// True in a store that ships the two stream-fetch query plans — a <c>FetchStreamStatePlan</c>
+    /// and a <c>FetchStreamPlan</c> usable both standalone and inside a batched query — and has
+    /// implemented the two seam members that reach them.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to false: the plan types and the <c>QueryByPlan</c> entry points are per-product
+    /// (each store declares its own <c>IQueryPlan&lt;T&gt;</c> / <c>IBatchQueryPlan&lt;T&gt;</c>), so
+    /// a store without them enrolls
+    /// <see cref="StreamQueryPlanCompliance{TFixture,TOperations,TQuerySession}"/> and skips.
+    /// </remarks>
+    public virtual bool SupportsStreamQueryPlans => false;
+
+    /// <summary>
+    /// Run the store's stream-state query plan for <paramref name="streamIdentity"/> — a
+    /// <see cref="Guid"/> or a <see cref="string"/>, matching the store's stream identity.
+    /// </summary>
+    /// <param name="batched">
+    /// When true the plan must be executed through the store's batched query surface rather than
+    /// standalone. Load-bearing rather than convenience: the two paths compose their SQL separately
+    /// on both products, so a plan that is correct standalone and wrong in a batch is the failure
+    /// this suite is looking for.
+    /// </param>
+    /// <remarks>
+    /// The result type is the shared <see cref="StreamState"/>, and the assertions are all about the
+    /// stream — so only the *route* to the plan is per-product, which is why this is a forwarding
+    /// member rather than an abstraction over query plans in general.
+    /// </remarks>
+    public virtual Task<StreamState?> FetchStreamStateByPlanAsync(
+        TQuerySession session, object streamIdentity, bool batched, CancellationToken token)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement FetchStreamStateByPlanAsync, so it cannot run the stream query plan compliance suite.");
+
+    /// <summary>
+    /// Run the store's raw-event stream query plan for <paramref name="streamIdentity"/>.
+    /// </summary>
+    /// <param name="version">
+    /// Inclusive version cap, or zero for no cap — the same meaning the shared
+    /// <c>FetchStreamAsync</c> overloads give it.
+    /// </param>
+    /// <param name="batched">See <see cref="FetchStreamStateByPlanAsync"/>.</param>
+    public virtual Task<IReadOnlyList<IEvent>> FetchStreamByPlanAsync(
+        TQuerySession session, object streamIdentity, long version, bool batched, CancellationToken token)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement FetchStreamByPlanAsync, so it cannot run the stream query plan compliance suite.");
+
+    /// <summary>
+    /// True in a store that has implemented <c>UnArchiveStream</c> — reversing an archive so the
+    /// stream's events are readable and appendable again.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to false because the operation is genuinely not universal: Polecat declares it on
+    /// its own <c>IEventOperations</c> and Marten has no equivalent today, so it is not on the shared
+    /// <see cref="IEventStoreOperations"/> and cannot be. The suite's unarchive facts skip rather
+    /// than fail on a store without it; the archiving facts around them do not.
+    /// </remarks>
+    public virtual bool SupportsUnarchiveStream => false;
+
+    /// <summary>
+    /// Queue an unarchive of the given stream on the session — <paramref name="streamIdentity"/> is
+    /// a <see cref="Guid"/> or a <see cref="string"/>. Like <c>ArchiveStream</c>, this takes effect
+    /// on SaveChanges rather than immediately.
+    /// </summary>
+    public virtual void UnArchiveStream(TOperations session, object streamIdentity)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement UnArchiveStream, so it cannot run the unarchive compliance facts.");
+
 
     public virtual ValueTask InitializeAsync() => default;
 

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -254,6 +254,29 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | `AggregateToManyAsync` through a registered projection | `AggregateToManyCompliance` |
 | Event upcasting — old stored schemas read as the current types | `UpcastingCompliance` |
 | A reachable `IProjectionCoordinator` over the documented registration | `ProjectionCoordinatorCompliance` |
+| `AlwaysEnforceConsistency` — a version check with no events appended | `AlwaysEnforceConsistencyCompliance` |
+| The stream-fetch query plans, standalone and batched | `StreamQueryPlanCompliance` |
+
+### The empty unit of work (jasperfx#762)
+
+`AlwaysEnforceConsistencyCompliance` is a separate suite rather than more facts on
+`FetchForWritingCompliance`, and the reason generalises. Every concurrency assertion in that suite
+appends an event first, and appending is what makes the ordinary version check fire — so a store
+that ignored `IEventStream<T>.AlwaysEnforceConsistency` completely passes all of it. The flag exists
+for the case that suite structurally cannot reach: a decider that reads a stream, decides to emit
+nothing, and still needs to know its read was not stale. A behaviour whose whole point is what
+happens when *nothing* happens needs its own suite, because the natural setup for every neighbouring
+fact destroys it.
+
+`StreamQueryPlanCompliance` and the unarchive facts on `StreamArchivingCompliance` are both opt-in
+through `Supports` flags defaulting false, for the ordinary reason: each store declares its own
+`IQueryPlan<T>` / `IBatchQueryPlan<T>` and its own `QueryByPlan` route (so the plan types cannot be
+shared, only the results), and `UnArchiveStream` is on Polecat's own `IEventOperations` with no
+Marten equivalent, so it is not on `IEventStoreOperations` and cannot be. Note the query plan suite's
+`batched` axis: a plan implements two interfaces with two separate implementations — standalone it
+owns the whole command, batched it contributes a fragment to someone else's — so every fact runs
+twice, and the version cap, the one parameter that has to survive into the batched fragment's own
+SQL, is where the two paths are most likely to drift.
 
 ### Identity-less boundary aggregates (jasperfx#718)
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/AlwaysEnforceConsistencyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AlwaysEnforceConsistencyCompliance.cs
@@ -1,0 +1,337 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region AlwaysEnforceConsistency events and aggregates
+
+public record ManifestOpened(string Destination);
+
+public record ManifestItemAdded(int Count);
+
+public record ManifestSealed;
+
+/// <summary>
+/// Guid-keyed aggregate for the flag. Deliberately minimal — nothing here is about aggregation.
+/// </summary>
+public partial class ComplianceManifest
+{
+    public Guid Id { get; set; }
+    public string Destination { get; set; } = string.Empty;
+    public int Parcels { get; set; }
+    public bool Dispatched { get; set; }
+
+    public static ComplianceManifest Create(ManifestOpened e) => new() { Destination = e.Destination };
+
+    public void Apply(ManifestItemAdded e) => Parcels += e.Count;
+
+    public void Apply(ManifestSealed _) => Dispatched = true;
+}
+
+/// <summary>
+/// The string-keyed twin. Stream identity is a store-level setting, so the string half needs its
+/// own store and therefore its own aggregate type.
+/// </summary>
+public partial class ComplianceManifestByKey
+{
+    public string Id { get; set; } = string.Empty;
+    public string Destination { get; set; } = string.Empty;
+    public int Parcels { get; set; }
+
+    public static ComplianceManifestByKey Create(ManifestOpened e) => new() { Destination = e.Destination };
+
+    public void Apply(ManifestItemAdded e) => Parcels += e.Count;
+}
+
+#endregion
+
+/// <summary>
+/// <see cref="IEventStream{T}.AlwaysEnforceConsistency"/> — assert the stream version at commit time
+/// even when the handler decided not to append anything.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The flag is declared on the shared <see cref="IEventStream{T}"/> and carried on the shared
+/// <see cref="StreamAction"/>, so it is contract rather than product surface, and this suite needs no
+/// seam member of its own.
+/// </para>
+/// <para>
+/// It is a separate suite from
+/// <see cref="FetchForWritingCompliance{TFixture,TOperations,TQuerySession}"/> rather than more facts
+/// bolted onto it, because the interesting half is the case that suite structurally cannot reach: a
+/// unit of work with <em>no events in it</em>. Every concurrency assertion over there appends
+/// something first, and appending is what makes the ordinary version check fire — so a store could
+/// ignore this flag completely and pass all of `FetchForWritingCompliance`. That is exactly the
+/// silent gap the flag exists to close: a decider that reads a stream, decides to emit nothing, and
+/// still needs to know its read was not stale.
+/// </para>
+/// <para>
+/// The failure is asserted as the shared <see cref="ConcurrencyException"/> base rather than a
+/// specific derived type. Marten's own tests name <c>ConcurrencyException</c> and Polecat's name
+/// <c>EventStreamUnexpectedMaxEventIdException</c>, which derives from it; both are correct and
+/// pinning either one would encode a product's choice as the contract.
+/// </para>
+/// </remarks>
+public abstract class AlwaysEnforceConsistencyCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_enforce_consistency";
+        config.Snapshot<ComplianceManifest>(SnapshotLifecycle.Inline);
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _stringConfiguration = config =>
+    {
+        config.SchemaName = "compliance_enforce_consistency_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+        config.Snapshot<ComplianceManifestByKey>(SnapshotLifecycle.Inline);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private async Task<Guid> aManifestAsync(params object[] extra)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        object[] events = [new ManifestOpened("Bree"), .. extra];
+        EventsFor(session).StartStream<ComplianceManifest>(streamId, events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task<string> aManifestByKeyAsync(params object[] extra)
+    {
+        var key = $"shipment/{Guid.NewGuid():N}";
+
+        await using var session = OpenSession();
+        object[] events = [new ManifestOpened("Bree"), .. extra];
+        EventsFor(session).StartStream<ComplianceManifestByKey>(key, events);
+        await SaveChangesAsync(session);
+
+        return key;
+    }
+
+    /// <summary>
+    /// Append to a stream from a session other than the one under test, which is what makes the
+    /// version the suite fetched go stale.
+    /// </summary>
+    private async Task sneakInAnEventAsync(Guid streamId)
+    {
+        await using var other = OpenSession();
+        EventsFor(other).Append(streamId, new ManifestItemAdded(1));
+        await SaveChangesAsync(other);
+    }
+
+    private async Task sneakInAnEventAsync(string streamKey)
+    {
+        await using var other = OpenSession();
+        EventsFor(other).Append(streamKey, new ManifestItemAdded(1));
+        await SaveChangesAsync(other);
+    }
+
+    [Fact]
+    public async Task the_default_is_off()
+    {
+        var streamId = await aManifestAsync();
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceManifest>(streamId, Cancellation);
+
+        stream.AlwaysEnforceConsistency.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task the_default_is_off_for_string_identity()
+    {
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var key = await aManifestByKeyAsync();
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceManifestByKey>(key, Cancellation);
+
+        stream.AlwaysEnforceConsistency.ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// The baseline the flag is measured against: with it off, a stream fetched for writing and then
+    /// left alone commits an empty unit of work silently, however far the stream has moved on.
+    /// </summary>
+    [Fact]
+    public async Task with_the_flag_off_an_empty_unit_of_work_does_not_check_the_version()
+    {
+        var streamId = await aManifestAsync(new ManifestItemAdded(2));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceManifest>(streamId, Cancellation);
+        stream.AlwaysEnforceConsistency.ShouldBeFalse();
+
+        await sneakInAnEventAsync(streamId);
+
+        // No events appended, flag off: nothing to check, nothing to throw.
+        await SaveChangesAsync(session);
+    }
+
+    [Fact]
+    public async Task with_the_flag_on_and_no_drift_an_empty_unit_of_work_still_commits()
+    {
+        var streamId = await aManifestAsync(new ManifestItemAdded(2), new ManifestSealed());
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceManifest>(streamId, Cancellation);
+        stream.AlwaysEnforceConsistency = true;
+
+        // Nobody moved the stream, so the assertion holds and the commit succeeds.
+        await SaveChangesAsync(session);
+
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// The load-bearing fact. Nothing is appended, so only the flag can produce a failure.
+    /// </summary>
+    [Fact]
+    public async Task with_the_flag_on_an_empty_unit_of_work_fails_on_version_drift()
+    {
+        var streamId = await aManifestAsync(new ManifestItemAdded(2));
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            var stream = await EventsFor(session).FetchForWriting<ComplianceManifest>(streamId, Cancellation);
+            stream.AlwaysEnforceConsistency = true;
+
+            await sneakInAnEventAsync(streamId);
+
+            await SaveChangesAsync(session);
+        });
+    }
+
+    [Fact]
+    public async Task with_the_flag_on_and_events_present_the_write_still_lands()
+    {
+        var streamId = await aManifestAsync(new ManifestItemAdded(2));
+
+        await using (var session = OpenSession())
+        {
+            var stream = await EventsFor(session).FetchForWriting<ComplianceManifest>(streamId, Cancellation);
+            stream.AlwaysEnforceConsistency = true;
+            stream.AppendOne(new ManifestItemAdded(3));
+
+            await SaveChangesAsync(session);
+        }
+
+        await using var reader = OpenSession();
+        var shipment = await LoadDocumentAsync<ComplianceManifest>(reader, streamId);
+        shipment.ShouldNotBeNull();
+        shipment.Parcels.ShouldBe(5);
+    }
+
+    /// <summary>
+    /// Turning the flag on must not <em>replace</em> the ordinary version check that appending
+    /// already performs — a store that routed the flag down a separate code path could lose it.
+    /// </summary>
+    [Fact]
+    public async Task with_the_flag_on_and_events_present_the_version_is_still_checked()
+    {
+        var streamId = await aManifestAsync(new ManifestItemAdded(2));
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            var stream = await EventsFor(session).FetchForWriting<ComplianceManifest>(streamId, Cancellation);
+            stream.AlwaysEnforceConsistency = true;
+            stream.AppendOne(new ManifestItemAdded(3));
+
+            await sneakInAnEventAsync(streamId);
+
+            await SaveChangesAsync(session);
+        });
+    }
+
+    /// <summary>
+    /// A stream that was never created sits at version 0, and the handle's expected version is 0 too,
+    /// so the assertion holds — turning the flag on must not turn "does not exist yet" into a
+    /// conflict. Both products pin this, and it is the case a naive "is there a row?" implementation
+    /// of the check gets wrong.
+    /// </summary>
+    [Fact]
+    public async Task with_the_flag_on_a_never_created_stream_commits()
+    {
+        await using var session = OpenSession();
+        var stream = await EventsFor(session)
+            .FetchForWriting<ComplianceManifest>(Guid.NewGuid(), Cancellation);
+
+        stream.Aggregate.ShouldBeNull();
+        stream.AlwaysEnforceConsistency = true;
+
+        await SaveChangesAsync(session);
+    }
+
+    [Fact]
+    public async Task with_the_flag_on_and_no_drift_a_string_identified_stream_commits()
+    {
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var key = await aManifestByKeyAsync(new ManifestItemAdded(2));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session).FetchForWriting<ComplianceManifestByKey>(key, Cancellation);
+        stream.AlwaysEnforceConsistency = true;
+
+        await SaveChangesAsync(session);
+    }
+
+    [Fact]
+    public async Task with_the_flag_on_a_string_identified_stream_fails_on_version_drift()
+    {
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var key = await aManifestByKeyAsync(new ManifestItemAdded(2));
+
+        await ShouldFailWithAsync<ConcurrencyException>(async () =>
+        {
+            await using var session = OpenSession();
+            var stream = await EventsFor(session)
+                .FetchForWriting<ComplianceManifestByKey>(key, Cancellation);
+            stream.AlwaysEnforceConsistency = true;
+
+            await sneakInAnEventAsync(key);
+
+            await SaveChangesAsync(session);
+        });
+    }
+
+    /// <summary>
+    /// The flag lives on the handle, not on the session: a second stream in the same unit of work
+    /// that did not opt in must not be dragged into the assertion.
+    /// </summary>
+    [Fact]
+    public async Task the_flag_is_scoped_to_the_stream_that_set_it()
+    {
+        var enforced = await aManifestAsync(new ManifestItemAdded(2));
+        var relaxed = await aManifestAsync(new ManifestItemAdded(2));
+
+        await using var session = OpenSession();
+
+        var relaxedStream = await EventsFor(session).FetchForWriting<ComplianceManifest>(relaxed, Cancellation);
+        var enforcedStream = await EventsFor(session).FetchForWriting<ComplianceManifest>(enforced, Cancellation);
+        enforcedStream.AlwaysEnforceConsistency = true;
+
+        // Drift on the stream that did NOT opt in.
+        await sneakInAnEventAsync(relaxed);
+
+        relaxedStream.ShouldNotBeNull();
+        await SaveChangesAsync(session);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventDataMaskingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventDataMaskingCompliance.cs
@@ -45,6 +45,17 @@ public class SubjectClosed
     public string Reason { get; set; } = string.Empty;
 }
 
+/// <summary>
+/// Carries <em>two</em> rules registered against this one concrete type — not an interface and its
+/// implementation, the same type twice. See
+/// <c>EventDataMaskingCompliance.every_rule_against_one_concrete_type_runs</c>.
+/// </summary>
+public class SubjectRelocated
+{
+    public string PreviousAddress { get; set; } = string.Empty;
+    public string NewAddress { get; set; } = string.Empty;
+}
+
 #endregion
 
 /// <summary>
@@ -92,6 +103,7 @@ public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySe
         config.AddEventType<SubjectContacted>();
         config.AddEventType<SubjectNoteAdded>();
         config.AddEventType<SubjectClosed>();
+        config.AddEventType<SubjectRelocated>();
 
         // Contravariant: one rule against the interface reaches both implementing event types.
         config.AddMaskingRule<IComplianceSubjectEvent>(x => x.Subject = Masked);
@@ -101,6 +113,10 @@ public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySe
 
         // The replacing form, which is the only one a record with init-only members can use.
         config.AddMaskingRule<SubjectNoteAdded>(x => x with { Note = Masked });
+
+        // Two rules against the SAME concrete type. See every_rule_against_one_concrete_type_runs.
+        config.AddMaskingRule<SubjectRelocated>(x => x.PreviousAddress = Masked);
+        config.AddMaskingRule<SubjectRelocated>(x => x.NewAddress = Masked);
     };
 
     /// <summary>
@@ -127,6 +143,7 @@ public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySe
         new SubjectRegistered { Subject = "Hilda Ravenswood", Email = "hilda@example.com" },
         new SubjectContacted { Subject = "Hilda Ravenswood", Channel = "email" },
         new SubjectNoteAdded("caseworker", "Lives at 14 Rookery Lane"),
+        new SubjectRelocated { PreviousAddress = "14 Rookery Lane", NewAddress = "3 Mill Row" },
         new SubjectClosed { Reason = "resolved" }
     ];
 
@@ -173,6 +190,39 @@ public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySe
         // The interface rule and the concrete rule both ran against the same event.
         registered.Subject.ShouldBe(Masked);
         registered.Email.ShouldBe(Masked);
+    }
+
+    /// <summary>
+    /// marten#5199 / polecat#422, in its sharpest form: two rules registered against the <em>same
+    /// concrete type</em>, both of which must run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="rules_compose_rather_than_replace_one_another"/> already pins the bug as it was
+    /// reported — an interface rule and a concrete rule matching one event, where a short-circuiting
+    /// <c>||=</c> over the rule list let the first match stop every later rule from being invoked,
+    /// and the operation still reported success. For a right-to-erasure feature that means protected
+    /// information silently survives a masking pass.
+    /// </para>
+    /// <para>
+    /// This fact closes the neighbouring hole: a store that keyed its rules by event type — a
+    /// dictionary rather than a list — passes the interface/concrete version, because those are two
+    /// different keys, and silently drops one of the two rules here. Same failure, same silence,
+    /// different mistake.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task every_rule_against_one_concrete_type_runs()
+    {
+        var streamId = await aSubjectAsync();
+
+        await theFixture.ApplyEventDataMaskingAsync(x => x.IncludeStream(streamId), Cancellation);
+
+        var events = await eventsForAsync(streamId);
+        var relocated = events.Select(x => x.Data).OfType<SubjectRelocated>().Single();
+
+        relocated.PreviousAddress.ShouldBe(Masked);
+        relocated.NewAddress.ShouldBe(Masked);
     }
 
     [Fact]
@@ -243,11 +293,11 @@ public abstract class EventDataMaskingCompliance<TFixture, TOperations, TQuerySe
 
         var state = await EventsFor(query).FetchStreamStateAsync(streamId, Cancellation);
         state.ShouldNotBeNull();
-        state.Version.ShouldBe(4);
+        state.Version.ShouldBe(5);
 
         var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
-        events.Count.ShouldBe(4);
-        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
+        events.Count.ShouldBe(5);
+        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4, 5 });
     }
 
     [Fact]

--- a/src/JasperFx.Events.ComplianceTests/Suites/FetchLatestCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/FetchLatestCompliance.cs
@@ -195,6 +195,121 @@ public abstract class FetchLatestCompliance<TFixture, TOperations, TQuerySession
         projected.Closed.ShouldBe(fetched.Closed);
     }
 
+    /// <summary>
+    /// The one thing that separates <c>ProjectLatest</c> from <c>FetchLatest</c>: events appended to
+    /// the session but not yet committed are folded in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Note the deliberate contrast with
+    /// <see cref="fetch_latest_after_fetch_for_writing_and_save_is_not_stale"/>, whose remarks record
+    /// that <c>FetchLatest</c> does <em>not</em> promise uncommitted visibility. <c>ProjectLatest</c>
+    /// does, in both products, and that promise is what makes it usable inside a decider that wants
+    /// to see the effect of what it has already decided. Without a fact here, the two entry points
+    /// are indistinguishable from a compliance suite's point of view —
+    /// <see cref="project_latest_agrees_with_fetch_latest"/> is satisfied by a store that simply
+    /// aliases one to the other.
+    /// </para>
+    /// <para>
+    /// Nothing is saved: the assertion runs against a session holding pending events, and the store
+    /// must not have persisted anything to answer it.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task project_latest_includes_events_pending_in_the_session()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream<ComplianceTab>(streamId,
+            new TabOpened("Ada"), new DrinkOrdered(4), new DrinkOrdered(6));
+
+        var tab = await EventsFor(session).ProjectLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Customer.ShouldBe("Ada");
+        tab.Total.ShouldBe(10);
+    }
+
+    [Fact]
+    public async Task project_latest_merges_committed_and_pending_events()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4));
+
+        await using var session = OpenSession();
+        EventsFor(session).Append(streamId, new DrinkOrdered(6), new TabClosed());
+
+        var tab = await EventsFor(session).ProjectLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Total.ShouldBe(10);
+        tab.Closed.ShouldBeTrue();
+
+        // Still pending: the merge is a read-side fold, not an early commit.
+        await using var other = OpenSession();
+        var persisted = await EventsFor(other).FetchStreamStateAsync(streamId, Cancellation);
+        persisted.ShouldNotBeNull();
+        persisted.Version.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// <c>no_pending_events_behaves_like_fetch_latest</c> — the same fact both products carry
+    /// verbatim. The merge must not cost correctness when there is nothing to merge.
+    /// </summary>
+    [Fact]
+    public async Task project_latest_with_no_pending_events_behaves_like_fetch_latest()
+    {
+        var streamId = await aTabAsync(new DrinkOrdered(4), new DrinkOrdered(6));
+
+        await using var session = OpenSession();
+
+        var fromProjectLatest = await EventsFor(session).ProjectLatest<ComplianceTab>(streamId, Cancellation);
+        var fromFetchLatest = await EventsFor(session).FetchLatest<ComplianceTab>(streamId, Cancellation);
+
+        fromProjectLatest.ShouldNotBeNull();
+        fromFetchLatest.ShouldNotBeNull();
+        fromProjectLatest.Customer.ShouldBe(fromFetchLatest.Customer);
+        fromProjectLatest.Total.ShouldBe(fromFetchLatest.Total);
+        fromProjectLatest.Closed.ShouldBe(fromFetchLatest.Closed);
+    }
+
+    [Fact]
+    public async Task project_latest_for_an_unknown_stream_with_nothing_pending_is_null()
+    {
+        await using var session = OpenSession();
+        var tab = await EventsFor(session).ProjectLatest<ComplianceTab>(Guid.NewGuid(), Cancellation);
+
+        tab.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task project_latest_gives_the_same_answer_with_no_snapshot_registered()
+    {
+        // Live: the aggregate is registered nowhere, so pending events have to be folded on top of a
+        // live fold rather than on top of a persisted document. Both products get one of the two
+        // paths right more easily than the other.
+        await theFixture.ConfigureAsync(_liveConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var writer = OpenSession())
+        {
+            EventsFor(writer).StartStream<ComplianceTab>(streamId, new TabOpened("Ada"), new DrinkOrdered(4));
+            await SaveChangesAsync(writer);
+        }
+
+        await using var session = OpenSession();
+        EventsFor(session).Append(streamId, new DrinkOrdered(6), new TabClosed());
+
+        var tab = await EventsFor(session).ProjectLatest<ComplianceTab>(streamId, Cancellation);
+
+        tab.ShouldNotBeNull();
+        tab.Customer.ShouldBe("Ada");
+        tab.Total.ShouldBe(10);
+        tab.Closed.ShouldBeTrue();
+    }
+
     [Fact]
     public async Task fetch_latest_gives_the_same_answer_with_no_snapshot_registered()
     {

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamArchivingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamArchivingCompliance.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using JasperFx.Events.Projections;
 using Shouldly;
 using Xunit;
 
@@ -13,6 +14,38 @@ public record LedgerOpened(string Name);
 public record LedgerEntryPosted(decimal Amount);
 
 public record LedgerClosed;
+
+/// <summary>
+/// Exists so the suite has a snapshot for the store to own. Capturing an <see cref="Archived"/>
+/// event only archives the stream when a single-stream projection <em>owns</em> it — the shared
+/// <c>JasperFxSingleStreamProjectionBase</c> checks for a snapshot before it archives — so a
+/// configuration with no aggregate registered cannot reach the behaviour at all.
+/// </summary>
+public partial class ComplianceLedger
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+
+    public static ComplianceLedger Create(LedgerOpened e) => new() { Name = e.Name };
+
+    public void Apply(LedgerEntryPosted e) => Balance += e.Amount;
+}
+
+/// <summary>
+/// The string-keyed twin of <see cref="ComplianceLedger"/>, for the same reason every other suite
+/// here carries one: stream identity is a store-level setting.
+/// </summary>
+public partial class ComplianceLedgerByKey
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public decimal Balance { get; set; }
+
+    public static ComplianceLedgerByKey Create(LedgerOpened e) => new() { Name = e.Name };
+
+    public void Apply(LedgerEntryPosted e) => Balance += e.Amount;
+}
 
 #endregion
 
@@ -44,6 +77,34 @@ public abstract class StreamArchivingCompliance<TFixture, TOperations, TQuerySes
         config.AddEventType<LedgerEntryPosted>();
         config.AddEventType<LedgerClosed>();
     };
+
+    /// <summary>
+    /// Same schema, plus an inline snapshot, so a single-stream projection owns the stream and can
+    /// react to an <see cref="Archived"/> event.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _inlineSnapshotConfiguration = config =>
+    {
+        config.SchemaName = "compliance_archiving_snapshot";
+        config.AddEventType<LedgerClosed>();
+        config.Snapshot<ComplianceLedger>(SnapshotLifecycle.Inline);
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _asyncSnapshotConfiguration = config =>
+    {
+        config.SchemaName = "compliance_archiving_snapshot_async";
+        config.AddEventType<LedgerClosed>();
+        config.Snapshot<ComplianceLedger>(SnapshotLifecycle.Async);
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _stringSnapshotConfiguration = config =>
+    {
+        config.SchemaName = "compliance_archiving_snapshot_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+        config.AddEventType<LedgerClosed>();
+        config.Snapshot<ComplianceLedgerByKey>(SnapshotLifecycle.Inline);
+    };
+
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
 
     protected override Action<ComplianceStoreConfig> Configuration => _configuration;
 
@@ -175,5 +236,276 @@ public abstract class StreamArchivingCompliance<TFixture, TOperations, TQuerySes
         state.ShouldNotBeNull();
         state.Version.ShouldBe(3);
         state.IsArchived.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Archiving is not a soft delete you can keep writing through. Whatever the store's exact
+    /// exception type, the append must not land.
+    /// </summary>
+    /// <remarks>
+    /// The exception type is deliberately unpinned. Marten throws its own
+    /// <c>InvalidStreamOperationException</c> with a message naming the stream, Polecat throws its
+    /// own type whose message merely contains "archived", and neither is on the shared surface —
+    /// so the contract asserted here is the one both agree on: the commit fails, and the stream is
+    /// exactly as it was.
+    /// </remarks>
+    [Fact]
+    public async Task appending_to_an_archived_stream_is_rejected()
+    {
+        var streamId = await aLedgerAsync();
+        await archiveAsync(streamId);
+
+        await Should.ThrowAsync<Exception>(async () =>
+        {
+            await using var session = OpenSession();
+            EventsFor(session).Append(streamId, new LedgerEntryPosted(10));
+            await SaveChangesAsync(session);
+        });
+
+        await using var reader = OpenSession();
+        var state = await EventsFor(reader).FetchStreamStateAsync(streamId, Cancellation);
+
+        // Rejected, not partially applied.
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(3);
+        state.IsArchived.ShouldBeTrue();
+    }
+
+    // ---------- Archiving through an Archived event ----------
+
+    /// <summary>
+    /// A stream archives itself when a single-stream projection that owns it processes an
+    /// <see cref="Archived"/> event. That routing lives in JasperFx's own
+    /// <c>JasperFxSingleStreamProjectionBase</c>, so it is shared code — but every store wires its
+    /// own projection storage under it, and Marten carries four local variants of this test for
+    /// exactly that reason.
+    /// </summary>
+    [Fact]
+    public async Task capturing_an_archived_event_through_an_inline_snapshot_archives_the_stream()
+    {
+        await theFixture.ConfigureAsync(_inlineSnapshotConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceLedger>(streamId,
+                new LedgerOpened("Petty Cash"), new LedgerEntryPosted(25));
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new LedgerEntryPosted(75), new Archived("Closed out"));
+            await SaveChangesAsync(session);
+        }
+
+        await using var reader = OpenSession();
+        var state = await EventsFor(reader).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeTrue();
+        state.Version.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task capturing_an_archived_event_through_an_async_snapshot_archives_the_stream()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        await theFixture.ConfigureAsync(_asyncSnapshotConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceLedger>(streamId,
+                new LedgerOpened("Petty Cash"), new LedgerEntryPosted(25));
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new Archived("Closed out"));
+            await SaveChangesAsync(session);
+        }
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        await using var reader = OpenSession();
+        var state = await EventsFor(reader).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task capturing_an_archived_event_archives_a_string_identified_stream()
+    {
+        await theFixture.ConfigureAsync(_stringSnapshotConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var key = $"ledger/{Guid.NewGuid():N}";
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceLedgerByKey>(key,
+                new LedgerOpened("Petty Cash"), new LedgerEntryPosted(25));
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(key, new Archived("Closed out"));
+            await SaveChangesAsync(session);
+        }
+
+        await using var reader = OpenSession();
+        var state = await EventsFor(reader).FetchStreamStateAsync(key, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// The negative half, and the one that keeps the three facts above from being satisfied by a
+    /// store that archives every stream it snapshots: without the <see cref="Archived"/> event, the
+    /// same projection over the same events leaves the stream live.
+    /// </summary>
+    [Fact]
+    public async Task a_snapshotted_stream_without_an_archived_event_stays_live()
+    {
+        await theFixture.ConfigureAsync(_inlineSnapshotConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceLedger>(streamId,
+                new LedgerOpened("Petty Cash"), new LedgerEntryPosted(25));
+            await SaveChangesAsync(session);
+        }
+
+        await using var reader = OpenSession();
+        var state = await EventsFor(reader).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeFalse();
+    }
+
+    // ---------- Unarchiving ----------
+
+    private void assertUnarchiveSupported() => Assert.SkipUnless(theFixture.SupportsUnarchiveStream,
+        "This event store does not implement UnArchiveStream");
+
+    private async Task unarchiveAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        theFixture.UnArchiveStream(session, streamId);
+        await SaveChangesAsync(session);
+    }
+
+    [Fact]
+    public async Task unarchiving_clears_is_archived_on_the_stream_state()
+    {
+        assertUnarchiveSupported();
+
+        var streamId = await aLedgerAsync();
+        await archiveAsync(streamId);
+        await unarchiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeFalse();
+        state.Version.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// The flag has to come off the <em>events</em>, not just the stream row. A store that flipped
+    /// only the stream would pass the state assertion above and still read back an empty stream.
+    /// </summary>
+    [Fact]
+    public async Task unarchiving_restores_the_events_to_an_ordinary_stream_read()
+    {
+        assertUnarchiveSupported();
+
+        var streamId = await aLedgerAsync();
+        await archiveAsync(streamId);
+        await unarchiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var events = await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(3);
+        events.ShouldAllBe(x => !x.IsArchived);
+    }
+
+    [Fact]
+    public async Task unarchiving_makes_the_stream_appendable_again()
+    {
+        assertUnarchiveSupported();
+
+        var streamId = await aLedgerAsync();
+        await archiveAsync(streamId);
+        await unarchiveAsync(streamId);
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new LedgerEntryPosted(10));
+            await SaveChangesAsync(session);
+        }
+
+        await using var reader = OpenSession();
+        var state = await EventsFor(reader).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(4);
+        state.IsArchived.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task unarchiving_a_stream_that_was_never_archived_is_not_an_error()
+    {
+        assertUnarchiveSupported();
+
+        var streamId = await aLedgerAsync();
+        await unarchiveAsync(streamId);
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+
+        state.ShouldNotBeNull();
+        state.IsArchived.ShouldBeFalse();
+        state.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task unarchiving_one_stream_leaves_its_neighbours_archived()
+    {
+        assertUnarchiveSupported();
+
+        var restored = await aLedgerAsync();
+        var stillArchived = await aLedgerAsync();
+
+        await archiveAsync(restored);
+        await archiveAsync(stillArchived);
+        await unarchiveAsync(restored);
+
+        await using var session = OpenSession();
+
+        var restoredState = await EventsFor(session).FetchStreamStateAsync(restored, Cancellation);
+        restoredState.ShouldNotBeNull();
+        restoredState.IsArchived.ShouldBeFalse();
+
+        var archivedState = await EventsFor(session).FetchStreamStateAsync(stillArchived, Cancellation);
+        archivedState.ShouldNotBeNull();
+        archivedState.IsArchived.ShouldBeTrue();
     }
 }

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamQueryPlanCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamQueryPlanCompliance.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Stream query plan events
+
+public record ExpeditionStarted(string Name);
+
+public record ExplorerJoined(string Explorer);
+
+#endregion
+
+/// <summary>
+/// The two stream-fetch query plans — a stream <em>state</em> plan and a raw <em>event</em> plan —
+/// executed standalone and inside a batched query.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both products ship a file literally named <c>fetching_stream_query_plans.cs</c> asserting the
+/// same six behaviours, which is what marks this as shared rather than product-owned. The plan types
+/// themselves are not shared and cannot be: each store declares its own <c>IQueryPlan&lt;T&gt;</c>
+/// and <c>IBatchQueryPlan&lt;T&gt;</c>, and a plan is bound to the store's own reader. So the suite
+/// costs two seam members — <c>FetchStreamStateByPlanAsync</c> and <c>FetchStreamByPlanAsync</c> —
+/// and asserts against the shared <see cref="StreamState"/> and <see cref="IEvent"/> results.
+/// </para>
+/// <para>
+/// The <c>batched</c> axis is the point of the suite rather than thoroughness for its own sake. A
+/// plan implements two interfaces with two separate implementations: standalone it owns the whole
+/// command, batched it contributes a fragment to someone else's. Every behaviour is therefore
+/// asserted twice, and the version cap — the one parameter that has to survive into the batched
+/// fragment's own SQL — is the one most likely to drift between the two.
+/// </para>
+/// <para>
+/// Deliberately out of scope: proving that several plans genuinely share <em>one</em> round trip.
+/// Both products' local tests batch the two plans alongside a document load and assert all three
+/// answer, but round-trip counting is not observable through any shared surface, and the fixture
+/// member here takes one plan at a time on purpose — a seam that accepted a plan list would be
+/// re-implementing each store's batch API rather than reaching it. What is portable is that a plan
+/// executed <em>through</em> the batched path answers identically to the standalone one, and that is
+/// what every fact below asserts twice.
+/// </para>
+/// </remarks>
+public abstract class StreamQueryPlanCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_stream_plans";
+        config.AddEventType<ExpeditionStarted>();
+        config.AddEventType<ExplorerJoined>();
+    };
+
+    private static readonly Action<ComplianceStoreConfig> _stringConfiguration = config =>
+    {
+        config.SchemaName = "compliance_stream_plans_string";
+        config.StreamIdentity = StreamIdentity.AsString;
+        config.AddEventType<ExpeditionStarted>();
+        config.AddEventType<ExplorerJoined>();
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void assertSupported() => Assert.SkipUnless(theFixture.SupportsStreamQueryPlans,
+        "This event store does not ship the stream fetch query plans");
+
+    private async Task<Guid> anExpeditionAsync()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId,
+            new ExpeditionStarted("Erebor"),
+            new ExplorerJoined("Bilbo"),
+            new ExplorerJoined("Thorin"));
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    private async Task<string> anExpeditionByKeyAsync()
+    {
+        var key = $"expedition/{Guid.NewGuid():N}";
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(key,
+            new ExpeditionStarted("Erebor"),
+            new ExplorerJoined("Bilbo"),
+            new ExplorerJoined("Thorin"));
+        await SaveChangesAsync(session);
+
+        return key;
+    }
+
+    private Task<StreamState?> stateByPlanAsync(TQuerySession session, object identity, bool batched)
+        => theFixture.FetchStreamStateByPlanAsync(session, identity, batched, Cancellation);
+
+    private Task<IReadOnlyList<IEvent>> eventsByPlanAsync(
+        TQuerySession session, object identity, bool batched, long version = 0)
+        => theFixture.FetchStreamByPlanAsync(session, identity, version, batched, Cancellation);
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task the_stream_state_plan_returns_the_stream_state(bool batched)
+    {
+        assertSupported();
+
+        var streamId = await anExpeditionAsync();
+
+        await using var session = OpenSession();
+        var state = await stateByPlanAsync(session, streamId, batched);
+
+        state.ShouldNotBeNull();
+        state.Id.ShouldBe(streamId);
+        state.Version.ShouldBe(3);
+        state.IsArchived.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task the_stream_state_plan_is_null_for_a_stream_that_does_not_exist(bool batched)
+    {
+        assertSupported();
+
+        await using var session = OpenSession();
+        var state = await stateByPlanAsync(session, Guid.NewGuid(), batched);
+
+        state.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task the_stream_plan_returns_the_events_in_version_order(bool batched)
+    {
+        assertSupported();
+
+        var streamId = await anExpeditionAsync();
+
+        await using var session = OpenSession();
+        var events = await eventsByPlanAsync(session, streamId, batched);
+
+        events.Count.ShouldBe(3);
+        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3 });
+        events[0].Data.ShouldBeOfType<ExpeditionStarted>().Name.ShouldBe("Erebor");
+        events.ShouldAllBe(x => x.StreamId == streamId);
+    }
+
+    /// <summary>
+    /// The parameter most likely to survive standalone and be dropped in the batched fragment, since
+    /// the batched item composes its own SQL.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task the_stream_plan_honours_the_version_cap(bool batched)
+    {
+        assertSupported();
+
+        var streamId = await anExpeditionAsync();
+
+        await using var session = OpenSession();
+        var events = await eventsByPlanAsync(session, streamId, batched, version: 2);
+
+        events.Count.ShouldBe(2);
+        events[^1].Version.ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task the_stream_plan_is_empty_for_a_stream_that_does_not_exist(bool batched)
+    {
+        assertSupported();
+
+        await using var session = OpenSession();
+        var events = await eventsByPlanAsync(session, Guid.NewGuid(), batched);
+
+        events.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task the_plans_work_against_string_stream_identity(bool batched)
+    {
+        assertSupported();
+
+        await theFixture.ConfigureAsync(_stringConfiguration);
+
+        var key = await anExpeditionByKeyAsync();
+
+        await using var session = OpenSession();
+
+        var state = await stateByPlanAsync(session, key, batched);
+        state.ShouldNotBeNull();
+        state.Key.ShouldBe(key);
+        state.Version.ShouldBe(3);
+
+        var events = await eventsByPlanAsync(session, key, batched);
+        events.Count.ShouldBe(3);
+        events.ShouldAllBe(x => x.StreamKey == key);
+    }
+
+    /// <summary>
+    /// The plans read; they must not write. Running one inside a session with queued, uncommitted
+    /// work leaves that work queued.
+    /// </summary>
+    [Fact]
+    public async Task running_a_plan_does_not_commit_pending_session_work()
+    {
+        assertSupported();
+
+        var streamId = await anExpeditionAsync();
+
+        await using var session = OpenSession();
+        EventsFor(session).Append(streamId, new ExplorerJoined("Balin"));
+
+        var state = await stateByPlanAsync(session, streamId, batched: false);
+
+        // The plan reads what is persisted, and the pending append is still pending.
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(3);
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StrongTypedIdentityCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StrongTypedIdentityCompliance.cs
@@ -125,6 +125,20 @@ public abstract class StrongTypedIdentityCompliance<TFixture, TOperations, TQuer
     };
 
     /// <summary>
+    /// The Guid-backed aggregate registered as a live aggregation — no persisted document at all.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _liveConfiguration = config =>
+    {
+        config.SchemaName = "compliance_strong_typed_live";
+
+        config.AddEventType<PaymentRaised>();
+        config.AddEventType<PaymentSettled>();
+
+        config.RegisterValueType<CompliancePaymentId>();
+        config.LiveAggregation<CompliancePayment>();
+    };
+
+    /// <summary>
     /// The string-backed aggregate. Stream identity is a store-level setting, so the string-keyed
     /// half cannot share a store with the Guid-keyed half.
     /// </summary>
@@ -284,6 +298,74 @@ public abstract class StrongTypedIdentityCompliance<TFixture, TOperations, TQuer
         payment.ShouldNotBeNull();
         payment.Id.Value.ShouldBe(streamId);
         payment.Outstanding.ShouldBe(50m);
+    }
+
+    /// <summary>
+    /// The lifecycle matrix both products still carry locally — Marten's
+    /// <c>use_fetch_for_writing(ProjectionLifecycle)</c> theory in
+    /// <c>using_guid_based_strong_typed_id_for_aggregate_identity.cs</c>, and its string-based twin.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The facts above already cover <c>FetchForWriting</c> under an inline snapshot and
+    /// <c>FetchLatest</c> under an async one, but never the same call across all three registrations
+    /// of the same aggregate — and that is where strong-typed identity actually breaks. The three
+    /// lifecycles reach the id through three different code paths: live folds and never touches
+    /// document identity, inline resolves the id to write a snapshot in the same transaction, and
+    /// async resolves it inside the daemon's own storage. A store can get any one of the three right
+    /// on its own.
+    /// </para>
+    /// <para>
+    /// Note that the answer asserted is identical in all three cases, which is the actual contract:
+    /// the lifecycle changes when the document is written, never what <c>FetchForWriting</c> hands
+    /// back.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(ProjectionLifecycle.Live)]
+    [InlineData(ProjectionLifecycle.Inline)]
+    [InlineData(ProjectionLifecycle.Async)]
+    public async Task fetch_for_writing_by_strong_typed_id_under_every_lifecycle(ProjectionLifecycle lifecycle)
+    {
+        if (lifecycle == ProjectionLifecycle.Live)
+        {
+            Assert.SkipUnless(theFixture.SupportsLiveAggregationRegistration,
+                "This event store builds live aggregators automatically and rejects explicit registration");
+        }
+
+        if (lifecycle == ProjectionLifecycle.Async)
+        {
+            Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+                "This event store does not support the async projection daemon under test");
+        }
+
+        await theFixture.ConfigureAsync(lifecycle switch
+        {
+            ProjectionLifecycle.Live => _liveConfiguration,
+            ProjectionLifecycle.Async => _asyncConfiguration,
+            _ => _configuration
+        });
+
+        var streamId = await aPaymentAsync(new PaymentRaised(100m), new PaymentSettled(40m));
+
+        await using var session = OpenSession();
+        var stream = await EventsFor(session)
+            .FetchForWriting<CompliancePayment>(streamId, Cancellation);
+
+        stream.Aggregate.ShouldNotBeNull();
+        stream.Aggregate.Id.Value.ShouldBe(streamId);
+        stream.Aggregate.Outstanding.ShouldBe(60m);
+        stream.StartingVersion.ShouldBe(2);
+
+        stream.AppendOne(new PaymentSettled(60m));
+        await SaveChangesAsync(session);
+
+        await using var reader = OpenSession();
+        var payment = await EventsFor(reader)
+            .AggregateStreamAsync<CompliancePayment>(streamId, token: Cancellation);
+        payment.ShouldNotBeNull();
+        payment.Id.Value.ShouldBe(streamId);
+        payment.Settled.ShouldBeTrue();
     }
 
     // ---------- String-backed ----------


### PR DESCRIPTION
Closes #762. Stoat node `suite-easy-batch` of plan `event-compliance-wave-13`.

Five store-agnostic behaviours both SQL stores test locally and no shared suite pinned, plus one delta on an existing suite. No store is enrolled.

### New: `AlwaysEnforceConsistencyCompliance` (12 facts)

`IEventStream<T>.AlwaysEnforceConsistency` is declared on the shared interface and carried on the shared `StreamAction`, so the suite needs no seam of its own.

It is a *separate* suite rather than more facts on `FetchForWritingCompliance`, and the reason is the interesting part: every concurrency assertion over there appends an event first, and appending is what makes the ordinary version check fire — so a store could ignore this flag completely and pass all of it. The flag exists for the case that suite structurally cannot reach, a decider that reads a stream, decides to emit nothing, and still needs to know its read was not stale. A behaviour whose whole point is what happens when *nothing* happens needs its own suite, because the natural setup for every neighbouring fact destroys it.

Covers: default off (Guid and string identity); flag off + empty unit of work does not check; flag on + no drift commits; flag on + drift throws; flag on with events still commits and still checks; a never-created stream at expected version 0 commits rather than throwing; the flag is scoped to the handle that set it. The failure is asserted as the shared `ConcurrencyException` base — Marten's tests name that, Polecat's name `EventStreamUnexpectedMaxEventIdException` which derives from it, and pinning either would encode a product's choice as the contract.

### New: `StreamQueryPlanCompliance` (11 facts, opt-in)

`fetching_stream_query_plans.cs` exists under that exact filename in both repos with the same behaviours. The plan types cannot be shared — each store declares its own `IQueryPlan<T>` / `IBatchQueryPlan<T>` — so this costs `SupportsStreamQueryPlans` (default false) plus two throwing-default seam members returning the shared `StreamState` / `IEvent`.

Every fact runs standalone **and** batched. That axis is the suite rather than thoroughness for its own sake: a plan implements two interfaces with two separate implementations, and the version cap — the one parameter that has to survive into the batched fragment's own SQL — is where they drift. Proving that several plans share *one* round trip is explicitly out of scope and the class comment says why.

### `FetchLatestCompliance`: the pending-event merge

Five facts. Pending-event visibility is the only thing separating `ProjectLatest` from `FetchLatest`, and without it the existing `project_latest_agrees_with_fetch_latest` is satisfied by a store that aliases one to the other. Includes `no_pending_events_behaves_like_fetch_latest`, which both products carry verbatim, and the live-lifecycle variant where pending events fold on top of a live fold rather than a persisted document.

Note the deliberate contrast with `fetch_latest_after_fetch_for_writing_and_save_is_not_stale`, whose remarks record that `FetchLatest` does *not* promise uncommitted visibility. `ProjectLatest` does; the new facts say so and assert that the merge did not quietly commit.

### `StreamArchivingCompliance`: unarchive and the archive edges

- Appending to an archived stream is rejected and the stream is left exactly as it was. The exception type is deliberately unpinned — Marten throws `InvalidStreamOperationException`, Polecat its own type, neither is on the shared surface.
- Capturing an `Archived` event through a projection archives the stream: inline, async, and string identity, plus the negative that keeps the three honest (a snapshotted stream without an `Archived` event stays live). The routing lives in JasperFx's own `JasperFxSingleStreamProjectionBase`, but every store wires its own projection storage under it — which is why Marten carries four local variants. Marten's `[Theory] (bool usePartitioning)` axis is storage layout and stays behind.
- Five unarchive facts behind `SupportsUnarchiveStream` (default false) — the operation is on Polecat's own `IEventOperations` with no Marten equivalent, so it is not on `IEventStoreOperations` and cannot be. Note `unarchiving_restores_the_events_to_an_ordinary_stream_read`: the flag has to come off the *events*, not just the stream row, and a store that flipped only the row passes the state assertion and still reads back an empty stream.

### `EventDataMaskingCompliance`: `every_rule_against_one_concrete_type_runs`

marten#5199 / polecat#422 as *reported* is already pinned by `rules_compose_rather_than_replace_one_another` (wave 6) — an interface rule and a concrete rule matching one event, where `||=` over the rule list let the first match silence the rest while the operation still reported success. This adds the neighbouring hole: two rules against the same concrete type. A store keying its rules by event type — a dictionary rather than a list — passes the reported version, because those are two different keys, and silently drops one of the two here. Same failure, same silence, different mistake.

### `StrongTypedIdentityCompliance`: the lifecycle matrix

The `[Theory]`-over-`ProjectionLifecycle` both products still carry locally. The suite already covered `FetchForWriting` under an inline snapshot and `FetchLatest` under an async one, but never the same call across all three registrations of the same aggregate — and the three lifecycles reach the id through three different code paths (live never touches document identity, inline resolves it to write in the same transaction, async resolves it inside the daemon's storage). A store can get any one right on its own.

### Seams added

All additive on `EventStoreComplianceFixture`, all with throwing defaults and `Supports` flags defaulting false:

- `SupportsStreamQueryPlans`, `FetchStreamStateByPlanAsync`, `FetchStreamByPlanAsync`
- `SupportsUnarchiveStream`, `UnArchiveStream`

### Validation

`dotnet build src/JasperFx.Events.ComplianceTests` clean; `dotnet test src/EventStoreTests -f net9.0` — 141 passed, 0 failed. Note that only the *document* suites are executed in this repo, so the new event suites are compile-checked here and behaviourally validated when a store enrolls them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)