### PR TITLE
Compliance suite for projection RaiseSideEffects — outbox, commit hooks and raised events (jasperfx#763)

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -274,6 +274,23 @@ public sealed class ComplianceStoreConfig
     }
 
     /// <summary>
+    /// The recording message outbox the suite asked the store to publish side effects through,
+    /// when it asked for one.
+    /// </summary>
+    public RecordingMessageOutbox? MessageOutbox { get; private set; }
+
+    /// <summary>
+    /// Install the shared recording message outbox.
+    /// </summary>
+    /// <inheritdoc cref="IComplianceStoreRegistrar.UseMessageOutbox" path="/remarks"/>
+    public ComplianceStoreConfig UseMessageOutbox(RecordingMessageOutbox outbox)
+    {
+        MessageOutbox = outbox;
+        _registrations.Add(registrar => registrar.UseMessageOutbox(outbox));
+        return this;
+    }
+
+    /// <summary>
     /// Register the shared compliance subscription with the store's async daemon.
     /// </summary>
     /// <inheritdoc cref="IComplianceStoreRegistrar.Subscribe" path="/remarks"/>

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -475,6 +475,45 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
         => throw new NotSupportedException(
             $"{GetType().FullName} does not implement AncillaryCoordinatorFrom, so it cannot run the ancillary coordinator compliance fact.");
 
+    /// <summary>
+    /// True in a store that has a message outbox — an <c>Events.MessageOutbox</c> a bus integration
+    /// replaces — and routes a projection's published side effects through it. Gates the outbox
+    /// facts of
+    /// <see cref="ProjectionSideEffectCompliance{TFixture,TOperations,TQuerySession}"/>; the
+    /// raised-event and rebuild-suppression facts need no outbox and are not gated on it.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <strong>false</strong>, the same declare-the-surface-then-implement ordering as
+    /// <see cref="SupportsUpcasting"/>: a store enrolls the suite, implements
+    /// <see cref="IComplianceStoreRegistrar.UseMessageOutbox"/> and the two consumer partials on
+    /// <see cref="RecordingMessageOutbox"/> / <see cref="RecordingMessageBatch"/>, then flips this.
+    /// Gated rather than always-on because the outbox facts also drive store <em>construction</em>
+    /// through the registrar member, so an ungated suite would reach its throwing default rather
+    /// than skipping.
+    /// </remarks>
+    public virtual bool SupportsMessageOutbox => false;
+
+    /// <summary>
+    /// True where the outbox's commit hooks may safely read committed state over a second session
+    /// while the first session's write transaction is still open.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Gates the one fact that proves the commit <em>boundary</em> rather than merely the hook
+    /// order — before-commit inside the transaction, after-commit outside it. It is separate from
+    /// <see cref="SupportsMessageOutbox"/> because the risk is the engine's, not the outbox's: the
+    /// before-commit probe reads a row the open transaction is in the middle of writing, which a
+    /// snapshot/WAL reader answers immediately but a lock-based reader can block on — and a probe
+    /// that blocks until the commit deadlocks against the hook that is holding the commit open.
+    /// </para>
+    /// <para>
+    /// Default <strong>false</strong> for that reason: a store flips it once it knows its readers
+    /// do not block behind an uncommitted write. Skipping costs one fact; guessing wrong hangs the
+    /// suite.
+    /// </para>
+    /// </remarks>
+    public virtual bool SupportsCommitVisibilityProbe => false;
+
 
     public virtual ValueTask InitializeAsync() => default;
 

--- a/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
+++ b/src/JasperFx.Events.ComplianceTests/IComplianceStoreRegistrar.cs
@@ -188,6 +188,32 @@ public interface IComplianceStoreRegistrar
             $"{GetType().FullName} does not implement Upcast, so it cannot run the event upcasting compliance suite.");
 
     /// <summary>
+    /// Install the shared recording message outbox — every store spells it
+    /// <c>Events.MessageOutbox = outbox</c> — so the suites can see what a projection's
+    /// <c>RaiseSideEffects</c> actually published.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Typed as the concrete <see cref="RecordingMessageOutbox"/> for the same reason as
+    /// <see cref="Subscribe"/>: <c>IMessageOutbox</c> is a per-product interface — Marten's
+    /// <c>CreateBatch</c> takes its internal <c>DocumentSessionBase</c>, Polecat's and Fisher's take
+    /// their own <c>IDocumentSession</c> — so there is no shared type to accept here. The library
+    /// owns the recording type and each consumer completes it as a partial implementing its own
+    /// interface, so naming the concrete type is the one spelling that works everywhere.
+    /// </para>
+    /// <para>
+    /// Carries a throwing default for the same reason as <see cref="UseBinarySerializer{TEvent}"/>:
+    /// a store that has no message outbox does not enroll in
+    /// <see cref="ProjectionSideEffectCompliance{TFixture,TOperations,TQuerySession}"/>, never
+    /// reaches this member, and keeps compiling against a newer compliance package. See
+    /// <see href="https://github.com/JasperFx/jasperfx/issues/763" />.
+    /// </para>
+    /// </remarks>
+    void UseMessageOutbox(RecordingMessageOutbox outbox)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement UseMessageOutbox, so it cannot run the projection side effect compliance suite.");
+
+    /// <summary>
     /// Register the shared compliance subscription with the store's async daemon.
     /// </summary>
     /// <remarks>

--- a/src/JasperFx.Events.ComplianceTests/Local/ComplianceSideEffectProjectionPlaceholder.cs
+++ b/src/JasperFx.Events.ComplianceTests/Local/ComplianceSideEffectProjectionPlaceholder.cs
@@ -1,0 +1,28 @@
+// NOT PACKAGED. See ComplianceQuerySessionPlaceholder.cs for why Local/ exists.
+//
+// ProjectionSideEffectCompliance declares its projection at file scope, so it cannot reach the
+// <TOperations, TQuerySession> pair the suite class is generic over -- the same gap
+// ComplianceStringPartyProjectionBase closes for the string identity suite. One more per-consumer
+// global alias closes it, a closed generic because the single stream base is generic over both the
+// document and its identity:
+//
+//     global using ComplianceWatchtowerProjectionBase =
+//         Marten.Events.Aggregation.SingleStreamProjection<
+//             JasperFx.Events.ComplianceTests.ComplianceWatchtower, System.Guid>;
+//
+// No constructor shim is needed: every product's SingleStreamProjection<TDoc, TId> is parameterless,
+// and RaiseSideEffects -- the whole point of that suite -- is declared on the shared
+// JasperFxAggregationProjectionBase rather than on any product's subclass. Its first parameter is
+// the product's own writable session type, which the shared source names through the existing
+// ComplianceOperations alias.
+
+global using ComplianceWatchtowerProjectionBase =
+    JasperFx.Events.ComplianceTests.Local.PlaceholderWatchtowerProjection;
+
+using System;
+using JasperFx.Events.Aggregation;
+
+namespace JasperFx.Events.ComplianceTests.Local;
+
+public abstract class PlaceholderWatchtowerProjection: JasperFxSingleStreamProjectionBase<ComplianceWatchtower,
+    Guid, IPlaceholderOperations, IPlaceholderQuerySession>;

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -15,7 +15,7 @@ differences between the repos.
 Reference the package from a test project that already has xunit v3 and Shouldly, then supply three
 things.
 
-**1. Five global aliases naming your store's own types.** The shared suites declare aggregates and
+**1. Six global aliases naming your store's own types.** The shared suites declare aggregates and
 projections at file scope, so they cannot reach the `<TOperations, TQuerySession>` pair the suite
 classes are generic over. The source generator resolves these by type name, so aliases are enough:
 
@@ -29,14 +29,17 @@ global using ComplianceStringPartyProjectionBase =
 global using ComplianceMultiStreamProjectionBase =
     Marten.Events.Projections.MultiStreamProjection<
         JasperFx.Events.ComplianceTests.ComplianceDepartment, string>;
+global using ComplianceWatchtowerProjectionBase =
+    Marten.Events.Aggregation.SingleStreamProjection<
+        JasperFx.Events.ComplianceTests.ComplianceWatchtower, System.Guid>;
 ```
 
 `ComplianceQuerySession` binds the `EvolveAsync(IEvent, …)` convention on the self-aggregating
 fixtures; the next two bind the EventProjection suites to your product's own projection base and
-writable session. The last two are *closed* generics, because the single stream and multi stream
-projection bases are generic over both the document and its identity — they bind the string-identity
-and multi-stream suites' custom projections to your product's `SingleStreamProjection<TDoc, TId>`
-and `MultiStreamProjection<TDoc, TId>`.
+writable session. The last three are *closed* generics, because the single stream and multi stream
+projection bases are generic over both the document and its identity — they bind the string-identity,
+multi-stream and side-effect suites' custom projections to your product's
+`SingleStreamProjection<TDoc, TId>` and `MultiStreamProjection<TDoc, TId>`.
 
 **2. A concrete fixture** closing `EventStoreComplianceFixture<TOperations, TQuerySession>` over your
 store's session pair. Everything portable in the suites runs through the shared JasperFx surfaces
@@ -44,7 +47,7 @@ store's session pair. Everything portable in the suites runs through the shared 
 no shared interface declares — store construction from a `ComplianceStoreConfig`, session
 acquisition, `SaveChangesAsync`, document load-back, batched DCB queries, and teardown.
 
-**3. Two partial classes**, for the two suites whose shared type cannot be reached by an alias.
+**3. Three partial classes**, for the suites whose shared type cannot be reached by an alias.
 
 `FlatTableProjectionCompliance` is the first: every product's flat-table projection base takes
 constructor arguments describing where the table lives, and those signatures genuinely differ, so no
@@ -91,6 +94,33 @@ public partial class ComplianceSubscription : ISubscription   // your product's 
 
 Your registrar's `Subscribe` should pin the name to `ComplianceSubscription.SubscriptionName`;
 progression is keyed on it and the products disagree on what an unnamed subscription defaults to.
+
+`RecordingMessageOutbox` — with its companion `RecordingMessageBatch` — is the third, and it is the
+same shape as the second one more time. Every product declares its own `IMessageOutbox` and
+`IMessageBatch`, and here even the *members* differ: Marten's `IMessageBatch : IMessageSink,
+IChangeListener` takes `(IDocumentSession, IChangeSet, CancellationToken)` on both commit hooks,
+while Polecat's and Fisher's take a bare `CancellationToken`. The library owns the recording, the
+ordering, the commit probe and the shared `IMessageSink` half; a consumer supplies four one-line
+members. Only `ProjectionSideEffectCompliance` needs these, so a store that has no message outbox
+simply leaves `SupportsMessageOutbox` false and never writes them.
+
+```csharp
+namespace JasperFx.Events.ComplianceTests;
+
+public partial class RecordingMessageOutbox : IMessageOutbox   // your product's IMessageOutbox
+{
+    public ValueTask<IMessageBatch> CreateBatch(DocumentSessionBase session) => new(NewBatch());
+}
+
+public partial class RecordingMessageBatch : IMessageBatch     // your product's IMessageBatch
+{
+    public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+        => RecordBeforeCommitAsync();
+
+    public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+        => RecordAfterCommitAsync();
+}
+```
 
 Then enroll each suite with an empty subclass:
 
@@ -193,6 +223,46 @@ the one single-store fact pins the marten#4680 authority rule — a typed append
 type, whose stored dotnet-type hint would otherwise swap the mapping back, must still read through
 the upcaster.
 
+`ProjectionSideEffectCompliance` (jasperfx#763) covers `RaiseSideEffects`, which is genuinely shared
+— declared on `JasperFxAggregationProjectionBase`, drained by the shared single- and multi-stream
+bases into `IProjectionBatch.PublishMessageAsync` and `EventSlice.BuildOperations` — while the half
+underneath it is not. Building the append operations and handing out a message batch is each store's
+own, and that half has shipped **stubbed empty** twice (fisher#61, polecat#420), dropping every
+raised event with no error and no log. A projection whose side effects go nowhere passes every other
+suite here, which is the whole argument for this one.
+
+Its cost is the highest of any suite in the library, and each piece is forced. One more closed
+generic alias beside `ComplianceStringPartyProjectionBase` (`ComplianceWatchtowerProjectionBase` —
+see `Local/ComplianceSideEffectProjectionPlaceholder.cs` for the exact spelling), because the
+suite's projection has to *override* `RaiseSideEffects` and so must derive from the product's own
+`SingleStreamProjection<TDoc, TId>`. And **two more per-consumer partials**,
+`RecordingMessageOutbox` and `RecordingMessageBatch`, for the same reason as `ComplianceSubscription`:
+`IMessageOutbox` and `IMessageBatch` are per-product types whose members genuinely differ — Marten
+declares `IMessageBatch : IMessageSink, IChangeListener`, so its hooks take
+`(IDocumentSession, IChangeSet, CancellationToken)`, while Polecat's and Fisher's take a bare
+`CancellationToken`. The library owns the recording, the ordering and the probe; a consumer writes
+four one-line members. The `IMessageSink` half — `PublishAsync<T>(T, string)` — is shared and stays
+in the library.
+
+The load-bearing shape is the same as `AggregateWriteCacheCompliance`'s: the suite supplies the
+outbox so it can assert a **nonzero publish count**. "The document came out right" and "nothing
+threw" are both vacuously true of a store that discarded the side effects, and the rebuild fact is
+where that matters most — "no messages were published during the rebuild" is trivially satisfied by
+a store that published none at all, so the pre-rebuild count is required to be positive first.
+Likewise the suppression fact asserts on the *stream*, not the aggregate: a rebuild that re-raised
+would append the audit event again on every rebuild, and the projected document is idempotent under
+that and looks identical either way.
+
+Two seams, both gated, both default false. `SupportsMessageOutbox` gates the outbox facts, and it is
+a gate rather than a plain non-enrollment because installing the outbox drives store *construction*
+through `IComplianceStoreRegistrar.UseMessageOutbox` — so the suite keeps the outbox out of its
+standard configuration and reconfigures only after the gate passes, and the raised-event facts run
+either way. `SupportsCommitVisibilityProbe` gates the single fact that proves the commit *boundary*
+rather than the hook order, because that fact deliberately reads a row an open transaction is
+writing: a snapshot reader answers, a lock-based one blocks, and a probe that blocks until the
+commit deadlocks against the hook holding the commit open. Hook order alone does not prove the
+boundary — the two would fire in that order even if both ran before the commit.
+
 ## Capability gates
 
 Where a store genuinely cannot support a behavior, override the `virtual bool Supports...` flags on
@@ -253,6 +323,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | `AggregateToAsync` over an event query | `AggregateToLinqOperatorCompliance` |
 | `AggregateToManyAsync` through a registered projection | `AggregateToManyCompliance` |
 | Event upcasting — old stored schemas read as the current types | `UpcastingCompliance` |
+| Projection `RaiseSideEffects` — raised events and published messages | `ProjectionSideEffectCompliance` |
 | A reachable `IProjectionCoordinator` over the documented registration | `ProjectionCoordinatorCompliance` |
 
 ### Identity-less boundary aggregates (jasperfx#718)

--- a/src/JasperFx.Events.ComplianceTests/RecordingMessageOutbox.cs
+++ b/src/JasperFx.Events.ComplianceTests/RecordingMessageOutbox.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The message outbox a store publishes projection side effects through, recording what it was
+/// asked to do, for <see cref="ProjectionSideEffectCompliance{TFixture,TOperations,TQuerySession}" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Same shape and same purpose as <see cref="RecordingAggregateWriteCache" />: the suite supplies
+/// the collaborator so it can assert a <em>nonzero</em> publish count. Every behavioral fact about
+/// side effects is vacuously true of a store that dropped them on the floor — which is not a
+/// hypothetical, since two of the three products shipped the raise seam stubbed empty and lost
+/// every raised event with no error and no log (fisher#61, polecat#420).
+/// </para>
+/// <para>
+/// This is the third shared type in the library that cannot be reached by an alias alone, after
+/// <c>ComplianceFlatTableProjection</c> and <see cref="ComplianceSubscription" />, and for the same
+/// reason as the second: <c>IMessageOutbox</c> and <c>IMessageBatch</c> are per-product types whose
+/// members genuinely differ. Marten declares <c>IMessageBatch : IMessageSink, IChangeListener</c>,
+/// so its commit hooks take <c>(IDocumentSession, IChangeSet, CancellationToken)</c>, while Polecat
+/// and Fisher declare their own two-member interface taking a bare <c>CancellationToken</c>. The
+/// library owns the recording, the ordering and the probe; a consumer supplies only the interface
+/// implementation:
+/// </para>
+/// <code>
+/// public partial class RecordingMessageOutbox : IMessageOutbox
+/// {
+///     public ValueTask&lt;IMessageBatch&gt; CreateBatch(DocumentSessionBase session)
+///         =&gt; new(NewBatch());
+/// }
+///
+/// public partial class RecordingMessageBatch : IMessageBatch
+/// {
+///     public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+///         =&gt; RecordBeforeCommitAsync();
+///
+///     public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+///         =&gt; RecordAfterCommitAsync();
+/// }
+/// </code>
+/// <para>
+/// Recording is under a lock because the daemon raises side effects for the slices in one batch
+/// concurrently. Marten's own <c>RecordingMessageOutbox</c> carries a comment saying exactly that,
+/// added after an unguarded <c>List.Add</c> silently dropped batches and presented as flakiness
+/// (marten#5065) — so the shared copy is synchronized from the start.
+/// </para>
+/// </remarks>
+public partial class RecordingMessageOutbox
+{
+    private readonly object _locker = new();
+    private readonly List<RecordingMessageBatch> _batches = new();
+
+    /// <summary>
+    /// Optional read of the <em>committed</em> state, run at each commit hook so a suite can tell
+    /// which side of the commit that hook is on. Set by the suite before the act, and handed to
+    /// every batch this outbox creates from then on.
+    /// </summary>
+    /// <remarks>
+    /// Recording the hook order alone does not prove the boundary — the two would fire in that
+    /// order even if both ran before the commit, or both after. What distinguishes them is what the
+    /// rest of the database can see at the moment each runs, which is exactly what an outbox's two
+    /// delivery guarantees rest on.
+    /// </remarks>
+    public Func<Task<bool>>? Probe { get; set; }
+
+    /// <summary>
+    /// Every batch the store has asked for, in order.
+    /// </summary>
+    public IReadOnlyList<RecordingMessageBatch> Batches
+    {
+        get { lock (_locker) { return _batches.ToArray(); } }
+    }
+
+    /// <summary>
+    /// How many times the store asked for a batch. Zero is a real assertion: a unit of work that
+    /// publishes nothing must not reach the outbox at all.
+    /// </summary>
+    public int BatchCount
+    {
+        get { lock (_locker) { return _batches.Count; } }
+    }
+
+    /// <summary>
+    /// Every message published through every batch. The load-bearing count — a store that ignored
+    /// <c>RaiseSideEffects</c> entirely leaves this empty while passing every other fact.
+    /// </summary>
+    public IReadOnlyList<object> PublishedMessages
+        => Batches.SelectMany(x => x.Published).ToArray();
+
+    /// <summary>
+    /// Batches that fired at least one commit hook, which is not the same set as
+    /// <see cref="Batches" />: a unit of work that failed before the commit boundary produces a
+    /// batch that never reaches either hook.
+    /// </summary>
+    public IReadOnlyList<RecordingMessageBatch> CommittedBatches
+        => Batches.Where(x => x.Hooks.Count > 0).ToArray();
+
+    /// <summary>
+    /// Create and record a batch. Called from each consumer's own <c>CreateBatch</c>.
+    /// </summary>
+    protected RecordingMessageBatch NewBatch()
+    {
+        var batch = new RecordingMessageBatch(Probe);
+
+        lock (_locker)
+        {
+            _batches.Add(batch);
+        }
+
+        return batch;
+    }
+
+    /// <summary>
+    /// Drop every batch and clear the probe. Called between arrange and act so a fact asserts on
+    /// the round it is actually testing — the outbox instance is shared across the suite's tests,
+    /// because the configuration delegate is what the fixture keys a store rebuild on.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_locker)
+        {
+            _batches.Clear();
+        }
+
+        Probe = null;
+    }
+}
+
+/// <summary>
+/// One outbox batch — the messages published through it and the order its commit hooks fired in.
+/// </summary>
+/// <inheritdoc cref="RecordingMessageOutbox" path="/remarks"/>
+public partial class RecordingMessageBatch
+{
+    private readonly object _locker = new();
+    private readonly List<object> _published = new();
+    private readonly List<string> _hooks = new();
+    private readonly Func<Task<bool>>? _probe;
+
+    internal RecordingMessageBatch(Func<Task<bool>>? probe) => _probe = probe;
+
+    /// <summary>
+    /// Messages published through this batch, in order.
+    /// </summary>
+    public IReadOnlyList<object> Published
+    {
+        get { lock (_locker) { return _published.ToArray(); } }
+    }
+
+    /// <summary>
+    /// The hooks that fired, in the order they fired — <c>"before"</c> then <c>"after"</c>.
+    /// </summary>
+    public IReadOnlyList<string> Hooks
+    {
+        get { lock (_locker) { return _hooks.ToArray(); } }
+    }
+
+    /// <summary>
+    /// What <see cref="RecordingMessageOutbox.Probe" /> saw when the before-commit hook ran. Null
+    /// when no probe was set, or when the hook never fired.
+    /// </summary>
+    public bool? VisibleAtBeforeCommit { get; private set; }
+
+    /// <summary>
+    /// What <see cref="RecordingMessageOutbox.Probe" /> saw when the after-commit hook ran.
+    /// </summary>
+    public bool? VisibleAtAfterCommit { get; private set; }
+
+    /// <summary>
+    /// The <c>IMessageSink</c> half of the contract, which is genuinely shared
+    /// (<see cref="IMessageSink" /> lives in <c>JasperFx.Events</c>), so the library implements it
+    /// rather than pushing it onto the consumer's partial. The metadata overload is left to the
+    /// interface's own default, which forwards here.
+    /// </summary>
+    public ValueTask PublishAsync<T>(T message, string tenantId)
+    {
+        lock (_locker)
+        {
+            _published.Add(message!);
+        }
+
+        return new ValueTask();
+    }
+
+    /// <summary>
+    /// Called by each consumer's partial from its own before-commit hook.
+    /// </summary>
+    protected async Task RecordBeforeCommitAsync()
+    {
+        if (_probe != null)
+        {
+            VisibleAtBeforeCommit = await _probe().ConfigureAwait(false);
+        }
+
+        lock (_locker)
+        {
+            _hooks.Add("before");
+        }
+    }
+
+    /// <summary>
+    /// Called by each consumer's partial from its own after-commit hook.
+    /// </summary>
+    protected async Task RecordAfterCommitAsync()
+    {
+        if (_probe != null)
+        {
+            VisibleAtAfterCommit = await _probe().ConfigureAwait(false);
+        }
+
+        lock (_locker)
+        {
+            _hooks.Add("after");
+        }
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
@@ -1,0 +1,504 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Events.Projections;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Side effect events, aggregate and projection
+
+public record WatchtowerManned(string Name);
+
+public record WatchtowerRelieved(string Watcher);
+
+/// <summary>
+/// Raised by the projection back onto the stream it just folded.
+/// </summary>
+public record WatchtowerAudited(string Name);
+
+/// <summary>
+/// Published by the projection through the store's message outbox.
+/// </summary>
+public record WatchtowerReported(string Name);
+
+public partial class ComplianceWatchtower
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Reliefs { get; set; }
+    public bool Audited { get; set; }
+}
+
+/// <summary>
+/// A single stream projection that both appends an event and publishes a message from
+/// <c>RaiseSideEffects</c> — the two things that hook can do.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The base type comes from the consumer-supplied <c>ComplianceWatchtowerProjectionBase</c> global
+/// alias, and the first parameter of <c>RaiseSideEffects</c> from the existing
+/// <c>ComplianceOperations</c> alias, because each product closes
+/// <c>JasperFxSingleStreamProjectionBase</c> over its own session pair and this file cannot reach
+/// the suite's generics.
+/// </para>
+/// <para>
+/// The guard is load-bearing rather than tidiness. A raised event lands in the event store like any
+/// other, takes the next sequence, and is therefore read back by the shard on its next pass — so an
+/// unguarded raise is an append loop that never quiesces and the daemon never reports non-stale.
+/// Both products' local tests carry the same guard for the same reason.
+/// </para>
+/// </remarks>
+public partial class ComplianceWatchtowerProjection: ComplianceWatchtowerProjectionBase
+{
+    public static ComplianceWatchtower Create(IEvent<WatchtowerManned> @event) =>
+        new() { Id = @event.StreamId, Name = @event.Data.Name };
+
+    public void Apply(WatchtowerRelieved _, ComplianceWatchtower tower) => tower.Reliefs++;
+
+    public void Apply(WatchtowerAudited _, ComplianceWatchtower tower) => tower.Audited = true;
+
+    public override ValueTask RaiseSideEffects(ComplianceOperations operations,
+        IEventSlice<ComplianceWatchtower> slice)
+    {
+        if (slice.Snapshot == null)
+        {
+            return new ValueTask();
+        }
+
+        if (slice.Events().Any(x => x.Data is WatchtowerAudited))
+        {
+            return new ValueTask();
+        }
+
+        slice.AppendEvent(new WatchtowerAudited(slice.Snapshot.Name));
+        slice.PublishMessage(new WatchtowerReported(slice.Snapshot.Name));
+
+        return new ValueTask();
+    }
+}
+
+#endregion
+
+/// <summary>
+/// <c>RaiseSideEffects</c> — the projection hook that appends events of its own and publishes
+/// messages, and the store-side plumbing that has to carry both.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hook itself is shared: it is declared on <c>JasperFxAggregationProjectionBase</c>, and the
+/// shared single- and multi-stream bases are what drain <c>slice.PublishedMessages()</c> into the
+/// projection batch and <c>slice.RaisedEvents()</c> into append operations. What is <em>not</em>
+/// shared is the half each store has to supply underneath — building those append operations, and
+/// handing out a message batch — and that half is exactly what has been shipped stubbed empty
+/// twice (fisher#61, polecat#420), in both cases dropping every raised event with no error and no
+/// log. A projection whose side effects silently go nowhere passes every other suite in this
+/// library.
+/// </para>
+/// <para>
+/// Hence the shape of the assertions. <see cref="RecordingMessageOutbox"/> is supplied by the suite
+/// and every message fact asserts a <strong>nonzero</strong> publish count, for the same reason
+/// <c>AggregateWriteCacheCompliance</c> asserts a nonzero hit count: "the projection produced the
+/// right document" and "nothing threw" are both vacuously true of a store that discarded the side
+/// effects. The rebuild fact reads the publish count from before the rebuild and requires it to be
+/// positive <em>first</em>, so "no messages were published during the rebuild" cannot pass by
+/// having published nothing at all.
+/// </para>
+/// <para>
+/// Two configurations rather than one, and deliberately: the outbox facts install the outbox
+/// through <see cref="IComplianceStoreRegistrar.UseMessageOutbox"/>, which carries a throwing
+/// default, so a store that has not implemented it would fail at store <em>construction</em> and
+/// take the raised-event facts down with it. Keeping the outbox out of the suite's standard
+/// configuration means the gate can be checked before the member is ever reached.
+/// </para>
+/// </remarks>
+public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// One outbox instance for the whole suite, because the configuration delegate is what the
+    /// fixture keys a store rebuild on — a new instance per test would need a new delegate. Every
+    /// fact calls <see cref="RecordingMessageOutbox.Reset"/> before acting.
+    /// </summary>
+    private static readonly RecordingMessageOutbox _outbox = new();
+
+    private static void configureCore(ComplianceStoreConfig config)
+    {
+        config.SchemaName = "compliance_side_effects";
+
+        config.AddEventType<WatchtowerManned>();
+        config.AddEventType<WatchtowerRelieved>();
+        config.AddEventType<WatchtowerAudited>();
+
+        // Async with the daemon started only by the facts that want it, so the facts about a plain
+        // session's unit of work cannot be disturbed by a projection running inline.
+        config.AddProjection(new ComplianceWatchtowerProjection(), ProjectionLifecycle.Async);
+    }
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = configureCore;
+
+    private static readonly Action<ComplianceStoreConfig> _outboxConfiguration = config =>
+    {
+        configureCore(config);
+        config.UseMessageOutbox(_outbox);
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    private void SkipUnlessDaemonIsSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+    }
+
+    /// <summary>
+    /// Rebuild the store with the outbox installed, and start from a clean slate. Skips first, so a
+    /// store without an outbox never reaches the registrar's throwing default.
+    /// </summary>
+    private async Task WithOutboxAsync()
+    {
+        Assert.SkipUnless(theFixture.SupportsMessageOutbox,
+            "This event store has no message outbox for projection side effects");
+
+        await theFixture.ConfigureAsync(_outboxConfiguration);
+        await theFixture.CleanEventDataAsync();
+
+        _outbox.Reset();
+    }
+
+    private async Task<Guid> aWatchtowerAsync(params object[] events)
+    {
+        var streamId = Guid.NewGuid();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(streamId,
+            events.Length == 0 ? [new WatchtowerManned("Amon Din")] : events);
+        await SaveChangesAsync(session);
+
+        return streamId;
+    }
+
+    /// <summary>
+    /// Poll until the stream reaches an expected version, which is the only signal that means what
+    /// these tests need.
+    /// </summary>
+    /// <remarks>
+    /// Not <c>WaitForNonStaleProjectionDataAsync</c>: a raised event takes a sequence of its own, so
+    /// the shard goes stale again the instant it writes one. Non-stale can therefore be true after
+    /// the original events were folded and before the raised event exists — which is precisely the
+    /// window every fact here would read in.
+    /// </remarks>
+    private async Task WaitForStreamVersionAsync(Guid streamId, long version)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(_timeout);
+        long actual = 0;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await using var session = OpenSession();
+            var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+            actual = state?.Version ?? 0;
+
+            if (actual >= version) return;
+
+            await Task.Delay(100, Cancellation);
+        }
+
+        throw new TimeoutException(
+            $"Timed out after {_timeout} waiting for stream {streamId} to reach version {version}; it is at {actual}.");
+    }
+
+    private async Task<IReadOnlyList<IEvent>> eventsForAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        return await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+    }
+
+    [Fact]
+    public async Task a_raised_event_is_appended_to_its_stream()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aWatchtowerAsync(new WatchtowerManned("Amon Din"));
+
+        await StartDaemonAsync();
+        await WaitForStreamVersionAsync(streamId, 2);
+
+        var events = await eventsForAsync(streamId);
+
+        // The original, plus the one the projection raised.
+        events.Count.ShouldBe(2);
+        events[1].Data.ShouldBeOfType<WatchtowerAudited>().Name.ShouldBe("Amon Din");
+    }
+
+    /// <summary>
+    /// The raised event is numbered from the stream's real version rather than from the slice's own
+    /// event count.
+    /// </summary>
+    /// <remarks>
+    /// The two answers agree only when the projection has seen every event on the stream, which is
+    /// why this fact appends three rather than one: a store numbering the raised event from the
+    /// slice would write version 2 over an event that already exists, or leave a hole.
+    /// </remarks>
+    [Fact]
+    public async Task a_raised_event_continues_the_streams_version_sequence()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aWatchtowerAsync(new WatchtowerManned("Eilenach"),
+            new WatchtowerRelieved("Beregond"), new WatchtowerRelieved("Bergil"));
+
+        await StartDaemonAsync();
+        await WaitForStreamVersionAsync(streamId, 4);
+
+        var events = await eventsForAsync(streamId);
+
+        events.Select(x => x.Version).ShouldBe(new long[] { 1, 2, 3, 4 });
+        events[3].Data.ShouldBeOfType<WatchtowerAudited>();
+
+        await using var session = OpenSession();
+        var state = await EventsFor(session).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(4);
+    }
+
+    /// <summary>
+    /// A rebuild replays the stream with side effects suppressed.
+    /// </summary>
+    /// <remarks>
+    /// The failure this catches is not cosmetic. A rebuild that raised side effects again would
+    /// append the audit event a second time on every rebuild, so the stream grows without bound and
+    /// each growth feeds the shard more events to replay. Asserting on the stream rather than on the
+    /// aggregate is what makes it visible: the projected document is idempotent under a re-raise and
+    /// looks identical either way.
+    /// </remarks>
+    [Fact]
+    public async Task side_effects_are_suppressed_during_a_rebuild()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aWatchtowerAsync(new WatchtowerManned("Nardol"),
+            new WatchtowerRelieved("Beregond"));
+
+        var daemon = await StartDaemonAsync();
+        await WaitForStreamVersionAsync(streamId, 3);
+
+        // Anti-vacuous: the raise has to have happened at all before "it did not happen again"
+        // means anything.
+        var before = await eventsForAsync(streamId);
+        before.Count(x => x.Data is WatchtowerAudited).ShouldBe(1);
+
+        await daemon.StopAllAsync();
+
+        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout,
+            CancellationToken.None);
+
+        var after = await eventsForAsync(streamId);
+
+        after.Count.ShouldBe(before.Count);
+        after.Count(x => x.Data is WatchtowerAudited).ShouldBe(1);
+
+        // And the rebuild still produced the aggregate it was supposed to.
+        await using var session = OpenSession();
+        var tower = await LoadDocumentAsync<ComplianceWatchtower>(session, streamId);
+        tower.ShouldNotBeNull();
+        tower.Name.ShouldBe("Nardol");
+        tower.Reliefs.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task a_message_published_from_a_projection_reaches_the_outbox()
+    {
+        SkipUnlessDaemonIsSupported();
+        await WithOutboxAsync();
+
+        var streamId = await aWatchtowerAsync(new WatchtowerManned("Erelas"));
+
+        await StartDaemonAsync();
+        await WaitForStreamVersionAsync(streamId, 2);
+
+        await waitForPublishedAsync<WatchtowerReported>();
+
+        var published = _outbox.PublishedMessages.OfType<WatchtowerReported>().ToArray();
+
+        published.Length.ShouldBeGreaterThan(0);
+        published.ShouldContain(x => x.Name == "Erelas");
+    }
+
+    /// <summary>
+    /// The hooks bracket the commit, in order.
+    /// </summary>
+    /// <remarks>
+    /// That ordering is the whole contract: an outbox persisting rows in the before hook gets
+    /// atomicity with the write, and one publishing to a broker in the after hook gets the guarantee
+    /// that the write actually landed. Driven from a plain session rather than the daemon because
+    /// the session's own unit of work is the shorter path to the same boundary and needs no
+    /// polling — <c>SaveChangesAsync</c> does not return until both hooks have run.
+    /// </remarks>
+    [Fact]
+    public async Task both_commit_hooks_fire_in_order()
+    {
+        await WithOutboxAsync();
+
+        await using var session = OpenSession();
+        var sink = await session.GetOrStartMessageSink();
+        await sink.PublishAsync(new WatchtowerReported("Min-Rimmon"), StorageConstants.DefaultTenantId);
+
+        EventsFor(session).StartStream(Guid.NewGuid(), new WatchtowerManned("Min-Rimmon"));
+        await SaveChangesAsync(session);
+
+        _outbox.BatchCount.ShouldBe(1);
+        _outbox.Batches[0].Published.Count.ShouldBe(1);
+        _outbox.Batches[0].Hooks.ShouldBe(new[] { "before", "after" });
+    }
+
+    /// <summary>
+    /// The before hook really is inside the transaction and the after hook really is outside it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Hook order alone does not prove this — the two would fire in that order even if both ran
+    /// before the commit, or both after. What separates them is what the rest of the database can
+    /// see at the moment each runs, so the probe reads the committed events over a session of its
+    /// own: invisible in the before hook, visible in the after hook.
+    /// </para>
+    /// <para>
+    /// Gated on <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsCommitVisibilityProbe"/>
+    /// because the before-commit read is the one place in this library where a suite deliberately
+    /// reads a row an open transaction is writing. A snapshot reader answers immediately; a
+    /// lock-based one blocks, and a probe that blocks until the commit deadlocks against the hook
+    /// holding the commit open.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task the_before_hook_runs_inside_the_transaction_and_the_after_hook_outside_it()
+    {
+        await WithOutboxAsync();
+
+        Assert.SkipUnless(theFixture.SupportsCommitVisibilityProbe,
+            "This event store cannot read committed state while its own write transaction is open");
+
+        var streamId = Guid.NewGuid();
+
+        _outbox.Probe = async () =>
+        {
+            await using var probe = OpenSession();
+            var state = await EventsFor(probe).FetchStreamStateAsync(streamId, Cancellation);
+            return state != null;
+        };
+
+        await using var session = OpenSession();
+        var sink = await session.GetOrStartMessageSink();
+        await sink.PublishAsync(new WatchtowerReported("Calenhad"), StorageConstants.DefaultTenantId);
+
+        EventsFor(session).StartStream(streamId, new WatchtowerManned("Calenhad"));
+        await SaveChangesAsync(session);
+
+        _outbox.Batches[0].VisibleAtBeforeCommit.ShouldBe(false);
+        _outbox.Batches[0].VisibleAtAfterCommit.ShouldBe(true);
+    }
+
+    /// <summary>
+    /// A unit of work that fails publishes nothing.
+    /// </summary>
+    /// <remarks>
+    /// A stream id collision is caught by the append itself, well before either hook — so neither
+    /// runs, and the messages the session buffered go nowhere. Asserted as "no hook fired" rather
+    /// than "the after hook did not fire", because the weaker claim would pass even if the failure
+    /// had never reached the hook boundary at all.
+    /// </remarks>
+    [Fact]
+    public async Task a_unit_of_work_that_fails_publishes_nothing()
+    {
+        await WithOutboxAsync();
+
+        var streamId = await aWatchtowerAsync(new WatchtowerManned("Halifirien"));
+
+        _outbox.Reset();
+
+        await using var session = OpenSession();
+        var sink = await session.GetOrStartMessageSink();
+        await sink.PublishAsync(new WatchtowerReported("never sent"), StorageConstants.DefaultTenantId);
+
+        // Same id, so the append itself fails.
+        EventsFor(session).StartStream(streamId, new WatchtowerManned("Halifirien again"));
+
+        await ShouldFailWithAsync<ExistingStreamIdCollisionException>(() => SaveChangesAsync(session));
+
+        _outbox.CommittedBatches.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task a_session_that_never_publishes_never_asks_the_outbox_for_a_batch()
+    {
+        await WithOutboxAsync();
+
+        await using var session = OpenSession();
+        EventsFor(session).StartStream(Guid.NewGuid(), new WatchtowerManned("Amon Anwar"));
+        await SaveChangesAsync(session);
+
+        _outbox.BatchCount.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// A rebuild publishes nothing, and the count it is compared against is required to be positive
+    /// first.
+    /// </summary>
+    /// <remarks>
+    /// The sibling of <see cref="side_effects_are_suppressed_during_a_rebuild"/> on the message
+    /// side, and the one that most needs the anti-vacuous guard: "no messages were published during
+    /// the rebuild" is trivially satisfied by a store that never published any message at all.
+    /// </remarks>
+    [Fact]
+    public async Task no_messages_are_published_during_a_rebuild()
+    {
+        SkipUnlessDaemonIsSupported();
+        await WithOutboxAsync();
+
+        var streamId = await aWatchtowerAsync(new WatchtowerManned("Halifirien"),
+            new WatchtowerRelieved("Beregond"));
+
+        var daemon = await StartDaemonAsync();
+        await WaitForStreamVersionAsync(streamId, 3);
+        await waitForPublishedAsync<WatchtowerReported>();
+
+        var before = _outbox.PublishedMessages.OfType<WatchtowerReported>().Count();
+        before.ShouldBeGreaterThan(0);
+
+        await daemon.StopAllAsync();
+
+        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout,
+            CancellationToken.None);
+
+        _outbox.PublishedMessages.OfType<WatchtowerReported>().Count().ShouldBe(before);
+    }
+
+    /// <summary>
+    /// Poll until at least one message of the given type has reached the outbox.
+    /// </summary>
+    /// <remarks>
+    /// The daemon fires its commit hooks after the batch commits, so the stream version this suite
+    /// otherwise waits on can already be right while the publish is still in flight.
+    /// </remarks>
+    private async Task waitForPublishedAsync<T>()
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(_timeout);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (_outbox.PublishedMessages.OfType<T>().Any()) return;
+            await Task.Delay(100, Cancellation);
+        }
+
+        throw new TimeoutException(
+            $"Timed out after {_timeout} waiting for a {typeof(T).Name} to reach the outbox; " +
+            $"it received {_outbox.PublishedMessages.Count} message(s) across {_outbox.BatchCount} batch(es).");
+    }
+}


### PR DESCRIPTION
Closes #763.

`RaiseSideEffects` is a shared `JasperFx.Events` API — declared on `JasperFxAggregationProjectionBase`, drained by the shared single- and multi-stream bases into `IProjectionBatch.PublishMessageAsync` and `EventSlice.BuildOperations` — and nothing in the compliance library covered it. The half each store supplies underneath (building the append operations, handing out a message batch) has shipped **stubbed empty** twice, dropping every raised event with no error and no log (fisher#61, polecat#420), while passing every other suite in this library.

### `ProjectionSideEffectCompliance` — 9 facts

| Fact | Gate |
|---|---|
| a raised event is appended to its stream | daemon |
| a raised event continues the stream's version sequence | daemon |
| side effects are suppressed during a rebuild | daemon |
| a message published from a projection reaches the outbox | daemon + outbox |
| both commit hooks fire in order | outbox |
| the before hook runs inside the transaction and the after hook outside it | outbox + visibility probe |
| a unit of work that fails publishes nothing | outbox |
| a session that never publishes never asks the outbox for a batch | outbox |
| no messages are published during a rebuild | daemon + outbox |

### Anti-vacuous green

`RecordingMessageOutbox` / `RecordingMessageBatch` follow `RecordingAggregateWriteCache`: the suite supplies the collaborator so it can assert a **nonzero publish count**. "The document came out right" and "nothing threw" are both vacuously true of a store that discarded the side effects. Both rebuild facts take the pre-rebuild count and require it to be positive *before* comparing — "no messages were published during the rebuild" is trivially satisfied by a store that published none at all.

The suppression fact asserts on the **stream**, not the aggregate. A rebuild that re-raised would append the audit event again on every rebuild; the projected document is idempotent under that and looks identical either way.

### Seams — all additive, all defaulting off

- `IComplianceStoreRegistrar.UseMessageOutbox(RecordingMessageOutbox)`, throwing default. Typed to the concrete recording type for the same reason as `Subscribe(ComplianceSubscription)`: `IMessageOutbox` is per-product, so there is no shared type to accept.
- `EventStoreComplianceFixture.SupportsMessageOutbox` (**false**). A gate rather than plain non-enrollment, because installing the outbox drives store *construction* through the registrar member — so the suite keeps the outbox out of its standard configuration and reconfigures only after the gate passes, leaving the raised-event facts running either way.
- `EventStoreComplianceFixture.SupportsCommitVisibilityProbe` (**false**). Gates the one fact that proves the commit *boundary* rather than the hook order, because it deliberately reads a row an open transaction is writing: a snapshot reader answers, a lock-based one blocks, and a probe that blocks until the commit deadlocks against the hook holding the commit open.
- `ComplianceWatchtowerProjectionBase`, one more closed-generic alias — the suite's projection has to *override* `RaiseSideEffects`, so it must derive from the product's own `SingleStreamProjection<TDoc, TId>`.
- `RecordingMessageOutbox` / `RecordingMessageBatch`, two consumer partials. Forced: Marten declares `IMessageBatch : IMessageSink, IChangeListener` with `(IDocumentSession, IChangeSet, CancellationToken)` hooks, while Polecat's and Fisher's take a bare `CancellationToken`. The shared `IMessageSink` half stays in the library; a consumer writes four one-line members.

**No store is enrolled by this PR.**

### Validation

- `JasperFx.Events.ComplianceTests` builds clean (net9.0 and net10.0), 0 errors.
- `EventStoreTests`: 141 passed, 0 failed.

CI is not a gate right now (GitHub Actions stalled org-wide); merged after the local build and test run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
