### PR TITLE
Deepen SubscriptionCompliance: rewind, start-position floor, event filters, session writes and the change listener (jasperfx#768)

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -609,6 +609,21 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     /// </remarks>
     public virtual bool SupportsCommitVisibilityProbe => false;
 
+    /// <summary>
+    /// True in a store whose registrar replays <see cref="ComplianceSubscription.IncludedEventTypes"/>
+    /// onto its own subscription registration, so a declared allow list actually reaches the daemon.
+    /// Gates the one event-filter fact of
+    /// <see cref="SubscriptionCompliance{TFixture,TOperations,TQuerySession}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <strong>false</strong> because the filter has to survive a hop no shared code can
+    /// make for it: every product's bare-<c>ISubscription</c> registration wraps the subscription in
+    /// its own <c>SubscriptionBase</c>, and the daemon reads filters from the <em>wrapper</em>, which
+    /// copies none across. Implementing it is one loop inside the registrar's <c>Subscribe</c> —
+    /// replay each type onto the store's own <c>IncludeType</c> — and then this flips.
+    /// </remarks>
+    public virtual bool SupportsSubscriptionEventFilters => false;
+
 
     public virtual ValueTask InitializeAsync() => default;
 

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -87,13 +87,33 @@ public partial class ComplianceSubscription : ISubscription   // your product's 
         IDocumentOperations operations, CancellationToken cancellationToken)
     {
         Record(page.Events);
-        return Task.FromResult<IChangeListener>(NullChangeListener.Instance);
+
+        // The two guarantees SubscriptionCompliance pins beyond delivery: writes through the
+        // supplied session, and the listener the store is supposed to call after the commit.
+        foreach (var note in NotesFor(page)) operations.Store(note);
+
+        return Task.FromResult<IChangeListener>(new Listener(this));
+    }
+
+    private sealed class Listener(ComplianceSubscription subscription) : IChangeListener
+    {
+        public Task AfterCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+            => subscription.RecordCommitAsync();
+
+        public Task BeforeCommitAsync(IDocumentSession session, IChangeSet commit, CancellationToken token)
+            => Task.CompletedTask;
     }
 }
 ```
 
 Your registrar's `Subscribe` should pin the name to `ComplianceSubscription.SubscriptionName`;
 progression is keyed on it and the products disagree on what an unnamed subscription defaults to.
+It should also replay `subscription.IncludedEventTypes` onto whatever its own registration carries
+filters on — every product wraps a bare `ISubscription` in its own `SubscriptionBase`, and it is the
+wrapper the daemon reads filters from, so a list declared on the shared object reaches nothing on its
+own. That one is gated (`SupportsSubscriptionEventFilters`, default false); the store-side note and
+the listener are **not**, because a store that hands out a session it never commits, or drops the
+listener it was handed, passes every delivery fact in the suite.
 
 `RecordingMessageOutbox` — with its companion `RecordingMessageBatch` — is the third, and it is the
 same shape as the second one more time. Every product declares its own `IMessageOutbox` and
@@ -361,7 +381,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | Conjoined (per-tenant) event tenancy | `ConjoinedEventTenancyCompliance` |
 | The cross-stream event query (`QueryEventsAsync`) | `EventQueryCompliance` |
 | The stream-state queryable (`QueryStreamStates`) | `StreamStateQueryCompliance` |
-| Subscriptions | `SubscriptionCompliance` |
+| Subscriptions — delivery, rewind, filters, session writes, the change listener | `SubscriptionCompliance` |
 | Single-tenanted slicing of disagreeing tenant ids | `SingleTenantedEventSlicingCompliance` |
 | Composite projections — staging and member teardown | `CompositeProjectionCompliance` |
 | `AggregateToAsync` over an event query | `AggregateToLinqOperatorCompliance` |
@@ -452,6 +472,48 @@ ancillary marker types cannot be shared: every product constrains them to its ow
 so only the fixture can name one. The default host registers only the primary store, and that is
 load-bearing: the hosted-service walk asserts **exactly one** coordinator, so the ancillary store
 only joins the host the ancillary fact asks for (`includeAncillaryStore: true`).
+
+### Subscriptions beyond delivery (jasperfx#768)
+
+`SubscriptionCompliance` started as six facts about delivery — the right events, in sequence order,
+from every stream, once each — which is the easy half. What a subscription is *for* went unpinned,
+and two of the gaps were the kind that pass in silence.
+
+**Writes through the supplied session are committed with the batch.** The session is handed over
+precisely so a subscription's writes land in the batch's transaction alongside the progression row;
+that is what makes them exactly-once against the store's own database and what makes a subscription
+a peer of a projection rather than a webhook. A store that hands out a session it never commits
+satisfies all six delivery facts. **And the change listener returned by `ProcessEventsAsync` is
+called, after the commit.** A store that drops the return value passes all six as well. Neither is
+gated, for the reason `ProjectionCoordinatorCompliance` gives: a skippable check recreates the
+silence the fact exists to break. Both cost a consumer two lines in its `ComplianceSubscription`
+partial, shown above.
+
+The listener fact carries a probe rather than just a counter, because "it ran" and "it ran after the
+commit" are different claims and only the second is the contract — a listener called from inside the
+batch delegate fires again on every retry of a transaction that had already committed, which is the
+bug Fisher's local copy of this test records. The probe reads over a separate session and is safe,
+unlike the outbox's before-commit probe in `ProjectionSideEffectCompliance`, because the batch's
+transaction is already closed by the time it runs. It also does not wait on non-stale data and then
+assert: the progression row is written inside the batch's transaction, so non-stale is true strictly
+*before* a post-commit listener runs, and waiting on it is a race that fails perhaps one full-suite
+run in several. The listener is its own signal.
+
+Rewind is pinned in both forms — from scratch, and to a sequence floor — and the second is also how
+the suite reaches a **start position floor** at all. A configuration-time floor
+(`SubscribeFromSequence(n)` and its siblings) cannot be asserted portably: the floor is a literal in
+a static configuration delegate while the sequences under test are assigned at run time, so a suite
+could only guess a constant and would end up asserting either "everything arrived" or nothing.
+`RewindSubscriptionAsync` takes the same floor, is on the shared `IProjectionDaemon`, and lets the
+floor be chosen *after* the events exist — which is what turns the exclusion into a claim.
+
+Only the event-type filter fact is gated (`SupportsSubscriptionEventFilters`, default false), and
+for a reason worth stating so it does not read as timidity: the allow list has to survive a hop no
+shared code can make. Every product wraps a bare `ISubscription` in its own `SubscriptionBase`, the
+daemon reads filters from the *wrapper*, and Marten's `SubscriptionWrapper` copies none across — so
+a registrar has to replay `ComplianceSubscription.IncludedEventTypes` onto its own registration
+call, and until it does, the filter reaches nothing and the fact would fail for a wiring reason
+rather than a behavioral one.
 
 ### The document contract (jasperfx#647)
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/SubscriptionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/SubscriptionCompliance.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using JasperFx.Events.Projections;
 using Shouldly;
 using Xunit;
 
@@ -14,6 +16,22 @@ public record BeaconLit(string Name);
 public record BeaconDimmed(int Level);
 
 public record BeaconExtinguished;
+
+/// <summary>
+/// A document the shared subscription writes through the session the daemon hands it — one per
+/// delivered event, keyed by <see cref="IEvent.Id"/>.
+/// </summary>
+/// <remarks>
+/// Keyed on the event id rather than a fresh one on purpose: it makes the write both idempotent
+/// under a rewind and <em>loadable by the suite</em>, which has only <c>LoadAsync</c> to read with —
+/// the suites never reach for a query provider. So the suite reads the stream, takes the event ids
+/// the store assigned, and loads a note for each.
+/// </remarks>
+public class ComplianceSubscriptionNote
+{
+    public Guid Id { get; set; }
+    public long Sequence { get; set; }
+}
 
 /// <summary>
 /// The portable half of the shared compliance subscription: everything about recording what the
@@ -47,6 +65,62 @@ public partial class ComplianceSubscription
     private readonly object _lock = new();
     private readonly List<IEvent> _received = new();
     private int _pageCount;
+    private int _commitCount;
+
+    /// <summary>
+    /// The event types this subscription declared an allow list for. A registrar's
+    /// <c>Subscribe</c> replays these onto whatever the store's own subscription registration uses
+    /// to carry filters.
+    /// </summary>
+    /// <remarks>
+    /// A plain list rather than deriving from the shared <c>EventFilterable</c>, because the
+    /// products' bare-<c>ISubscription</c> registration paths wrap the subscription in their own
+    /// <c>SubscriptionBase</c> and the wrapper — not this object — is what the daemon reads filters
+    /// from. Marten's <c>SubscriptionWrapper</c> copies nothing, so a filter declared here only
+    /// takes effect if the registrar replays it, which is exactly what
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsSubscriptionEventFilters"/>
+    /// gates.
+    /// </remarks>
+    public List<Type> IncludedEventTypes { get; } = new();
+
+    /// <summary>
+    /// Restrict this subscription to an allow list of event types. Must be called before the store
+    /// is built, since filters are part of registration.
+    /// </summary>
+    public void IncludeType<T>() => IncludedEventTypes.Add(typeof(T));
+
+    /// <summary>
+    /// Optional read of the <em>committed</em> state, run from the change listener this
+    /// subscription returns. Set by a suite before the act.
+    /// </summary>
+    /// <remarks>
+    /// The listener contract is not "it ran" but "it ran <em>after</em> the commit", and only a read
+    /// over a separate session can tell those apart. Unlike the outbox's before-commit probe in
+    /// <see cref="ProjectionSideEffectCompliance{TFixture,TOperations,TQuerySession}"/>, this one
+    /// carries no deadlock hazard: by the time it runs, the batch's transaction is already closed.
+    /// </remarks>
+    public Func<Task<bool>>? CommitProbe { get; set; }
+
+    /// <summary>
+    /// How many times the change listener returned by <c>ProcessEventsAsync</c> was called after a
+    /// batch committed. Zero on a store that ignored the return value.
+    /// </summary>
+    public int CommitCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _commitCount;
+            }
+        }
+    }
+
+    /// <summary>
+    /// What <see cref="CommitProbe"/> saw the first time the listener ran. Null when no probe was
+    /// set, or when the listener never ran at all.
+    /// </summary>
+    public bool? VisibleAtCommit { get; private set; }
 
     public IReadOnlyList<IEvent> Received
     {
@@ -80,6 +154,92 @@ public partial class ComplianceSubscription
             _received.AddRange(events);
             _pageCount++;
         }
+    }
+
+    /// <summary>
+    /// The documents this subscription writes through the session the daemon handed it. Called by
+    /// each consumer's partial, which does the <c>operations.Store(note)</c> — the store call itself
+    /// cannot be shared, since the session type is the product's own.
+    /// </summary>
+    /// <remarks>
+    /// One per event, so a suite that knows the event ids knows exactly what should be there. This
+    /// is what makes "writes through the supplied session are committed with the batch" assertable:
+    /// a store that hands out a session it never commits satisfies every delivery fact in this
+    /// suite and loses these silently.
+    /// </remarks>
+    protected static IEnumerable<ComplianceSubscriptionNote> NotesFor(EventRange page)
+        => page.Events.Select(x => new ComplianceSubscriptionNote { Id = x.Id, Sequence = x.Sequence });
+
+    /// <summary>
+    /// Called by the change listener each consumer's partial returns from its
+    /// <c>ProcessEventsAsync</c>, after the batch commits.
+    /// </summary>
+    /// <remarks>
+    /// Public rather than protected because the listener is a separate type implementing the
+    /// product's own change listener interface, not a subclass of this one — a consumer is free to
+    /// declare it nested or beside the partial, and this member has to be reachable either way.
+    /// </remarks>
+    public async Task RecordCommitAsync()
+    {
+        if (CommitProbe != null && VisibleAtCommit == null)
+        {
+            VisibleAtCommit = await CommitProbe().ConfigureAwait(false);
+        }
+
+        lock (_lock)
+        {
+            _commitCount++;
+        }
+    }
+
+    /// <summary>
+    /// Drop everything recorded so far and clear the probe. Called at the start of every fact,
+    /// because one subscription instance serves the whole suite — the configuration delegate is
+    /// what the fixture keys a store rebuild on, so a new instance per test would need a new
+    /// delegate.
+    /// </summary>
+    /// <remarks>
+    /// Clearing the probe matters more than clearing the counters: a probe left behind by an
+    /// earlier fact closes over that fact's fixture, and would run against a disposed store from
+    /// inside a later fact's daemon.
+    /// </remarks>
+    public void Clear()
+    {
+        CommitProbe = null;
+        VisibleAtCommit = null;
+
+        lock (_lock)
+        {
+            _received.Clear();
+            _pageCount = 0;
+            _commitCount = 0;
+        }
+    }
+
+    /// <summary>
+    /// Poll until the change listener has run at least once, or give up.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately <em>not</em> "wait for non-stale data and then assert the listener fired". The
+    /// progression row is written inside the batch's transaction, so non-stale is true the moment
+    /// that commits — strictly before a post-commit listener runs. Waiting on it and then asserting
+    /// is a race that fails perhaps one full-suite run in several; Fisher's local copy of this test
+    /// carries the same note for the same reason. The listener is its own signal.
+    /// </remarks>
+    public async Task WaitForCommitAsync(TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (CommitCount > 0) return;
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            $"Timed out after {timeout} waiting for the subscription's change listener to run; " +
+            $"the subscription received {Received.Count} event(s) across {PageCount} page(s). " +
+            "A store that ignores the listener returned by ProcessEventsAsync fails here.");
     }
 
     /// <summary>
@@ -155,18 +315,49 @@ public abstract class SubscriptionCompliance<TFixture, TOperations, TQuerySessio
     /// </summary>
     private static readonly ComplianceSubscription _subscription = new();
 
-    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    /// <summary>
+    /// A second instance carrying an allow list, because filters are part of registration and the
+    /// suite's other facts must not be filtered.
+    /// </summary>
+    private static readonly ComplianceSubscription _filteredSubscription = buildFilteredSubscription();
+
+    private static ComplianceSubscription buildFilteredSubscription()
+    {
+        var subscription = new ComplianceSubscription();
+        subscription.IncludeType<BeaconDimmed>();
+        return subscription;
+    }
+
+    private static void configureCore(ComplianceStoreConfig config)
     {
         config.SchemaName = "compliance_subscriptions";
 
         config.AddEventType<BeaconLit>();
         config.AddEventType<BeaconDimmed>();
         config.AddEventType<BeaconExtinguished>();
+    }
 
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        configureCore(config);
         config.Subscribe(_subscription);
     };
 
+    private static readonly Action<ComplianceStoreConfig> _filteredConfiguration = config =>
+    {
+        configureCore(config);
+        config.Subscribe(_filteredSubscription);
+    };
+
     protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        _subscription.Clear();
+        _filteredSubscription.Clear();
+    }
 
     private void SkipUnlessDaemonIsSupported()
     {
@@ -291,5 +482,282 @@ public abstract class SubscriptionCompliance<TFixture, TOperations, TQuerySessio
         // page were dropped AND another duplicated.
         received.Select(x => x.Sequence).Distinct().Count().ShouldBe(received.Count);
         received.Count.ShouldBe(3);
+    }
+
+    #region Rewind
+
+    /// <summary>
+    /// A rewound subscription replays the whole store from the beginning.
+    /// </summary>
+    /// <remarks>
+    /// The recording is cleared before the rewind rather than compared against a doubled total,
+    /// because "twice as many events arrived" is also what a redelivery bug looks like — and this
+    /// fact is about the rewind, not about deduplication.
+    /// </remarks>
+    [Fact]
+    public async Task a_rewound_subscription_replays_from_scratch()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Amon Din"), new BeaconDimmed(1),
+            new BeaconDimmed(2), new BeaconExtinguished());
+
+        var daemon = await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 4, _timeout);
+
+        _subscription.Clear();
+
+        await daemon.RewindSubscriptionAsync(ComplianceSubscription.SubscriptionName,
+            CancellationToken.None);
+
+        await _subscription.WaitForStreamEventCountAsync(streamId, 4, _timeout);
+
+        receivedFor(streamId).Count.ShouldBe(4);
+    }
+
+    /// <summary>
+    /// A rewind to a sequence floor replays only what lies past it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is also how the suite pins a <em>start position floor</em> at all. A store's
+    /// configuration-time floor (Marten's <c>SubscribeFromSequence(n)</c> and its siblings) cannot
+    /// be asserted portably, because the floor is a literal baked into a static configuration
+    /// delegate while the sequence numbers under test are assigned at run time — a suite could only
+    /// guess a constant, and would then be testing either "everything arrived" or nothing at all.
+    /// <c>RewindSubscriptionAsync</c> takes the same floor and is on the shared
+    /// <see cref="Daemon.IProjectionDaemon"/>, so the floor can be chosen <em>after</em> the events
+    /// exist, which is what makes the exclusion assertable rather than assumed.
+    /// </para>
+    /// <para>
+    /// The floor is exclusive — a rewind to sequence <c>n</c> replays from <c>n + 1</c> — which is
+    /// the same meaning both products' local tests pin.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_rewind_to_a_sequence_floor_replays_only_past_it()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Eilenach"), new BeaconDimmed(1),
+            new BeaconDimmed(2), new BeaconDimmed(3), new BeaconExtinguished());
+
+        var daemon = await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 5, _timeout);
+
+        var sequences = receivedFor(streamId).Select(x => x.Sequence).OrderBy(x => x).ToArray();
+        var floor = sequences[1];
+        var expected = sequences.Count(x => x > floor);
+
+        // Chosen so the fact cannot pass by delivering nothing.
+        expected.ShouldBe(3);
+
+        _subscription.Clear();
+
+        await daemon.RewindSubscriptionAsync(ComplianceSubscription.SubscriptionName,
+            CancellationToken.None, floor);
+
+        await _subscription.WaitForStreamEventCountAsync(streamId, expected, _timeout);
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        var received = receivedFor(streamId);
+
+        received.Count.ShouldBe(expected);
+        received.ShouldAllBe(x => x.Sequence > floor);
+    }
+
+    #endregion
+
+    #region The transactional guarantee and the change listener
+
+    /// <summary>
+    /// Writes made through the session the daemon supplies are committed with the batch.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The guarantee that distinguishes a subscription from a webhook: the session is handed over
+    /// so its writes land in the batch's transaction alongside the progression row, which is what
+    /// makes them exactly-once against the store's own database. A subscription cannot advance past
+    /// a range whose writes were rolled back.
+    /// </para>
+    /// <para>
+    /// Deliberately ungated, and the reason is the same one <c>ProjectionCoordinatorCompliance</c>
+    /// gives for having no gate: a store that hands out a session it never commits passes every
+    /// other fact in this suite. A skippable check would recreate exactly the silence this fact
+    /// exists to break. What it costs a consumer is two lines in its
+    /// <c>ComplianceSubscription</c> partial — <c>foreach (var note in NotesFor(page))
+    /// operations.Store(note);</c>.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task writes_through_the_supplied_session_are_committed_with_the_batch()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        await ensureNoteStorageAsync();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Nardol"), new BeaconDimmed(4));
+
+        var eventIds = (await eventsForAsync(streamId)).Select(x => x.Id).ToArray();
+        eventIds.Length.ShouldBe(2);
+
+        await StartDaemonAsync();
+        await _subscription.WaitForStreamEventCountAsync(streamId, 2, _timeout);
+
+        // Polled rather than asserted straight after delivery: the subscription records a page
+        // inside ProcessEventsAsync, which runs before the batch it was handed is committed.
+        await waitForNotesAsync(eventIds);
+
+        await using var session = OpenSession();
+
+        foreach (var id in eventIds)
+        {
+            var note = await LoadDocumentAsync<ComplianceSubscriptionNote>(session, id);
+            note.ShouldNotBeNull();
+        }
+    }
+
+    /// <summary>
+    /// The change listener a subscription returns is called, and called after the commit.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two failures in one fact, and the weaker half is the one a store is likely to have. A store
+    /// that drops the return value of <c>ProcessEventsAsync</c> on the floor never calls the
+    /// listener at all and passes every other fact here; that is what
+    /// <see cref="ComplianceSubscription.WaitForCommitAsync"/> times out on.
+    /// </para>
+    /// <para>
+    /// The stronger half is the probe. "After the commit" is not decoration: a listener called from
+    /// inside the batch delegate fires again on every retry of a transaction that had already
+    /// committed, which is the bug Fisher's own copy of this test records. Reading the note over a
+    /// separate session is what tells the two apart, and it is safe here — unlike the outbox's
+    /// before-commit probe — because the batch's transaction is closed by the time the listener
+    /// runs.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task the_listener_returned_by_the_subscription_runs_after_the_commit()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        await ensureNoteStorageAsync();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Erelas"), new BeaconDimmed(5));
+
+        var eventIds = (await eventsForAsync(streamId)).Select(x => x.Id).ToArray();
+        var lastId = eventIds[^1];
+
+        _subscription.CommitProbe = async () =>
+        {
+            await using var probe = OpenSession();
+            return await LoadDocumentAsync<ComplianceSubscriptionNote>(probe, lastId) != null;
+        };
+
+        await StartDaemonAsync();
+        await _subscription.WaitForCommitAsync(_timeout);
+
+        _subscription.CommitCount.ShouldBeGreaterThan(0);
+
+        // What the listener saw is what the batch had already committed, read over a session of
+        // its own so it is the database's answer rather than the batch session's.
+        _subscription.VisibleAtCommit.ShouldBe(true);
+    }
+
+    #endregion
+
+    #region Event type filters
+
+    /// <summary>
+    /// A subscription that declared an allow list is handed only those event types.
+    /// </summary>
+    /// <remarks>
+    /// Gated on
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsSubscriptionEventFilters"/>
+    /// because the filter has to survive a hop the library cannot make for it. Every product's
+    /// bare-<c>ISubscription</c> registration wraps the subscription in its own
+    /// <c>SubscriptionBase</c>, and it is the wrapper the daemon reads filters from — Marten's
+    /// <c>SubscriptionWrapper</c> copies none of them across. So a registrar has to replay
+    /// <see cref="ComplianceSubscription.IncludedEventTypes"/> onto whatever its own registration
+    /// call carries filters on, and a store that has not done so skips rather than fails.
+    /// </remarks>
+    [Fact]
+    public async Task event_type_filters_restrict_what_the_subscription_is_handed()
+    {
+        SkipUnlessDaemonIsSupported();
+
+        Assert.SkipUnless(theFixture.SupportsSubscriptionEventFilters,
+            "This event store does not replay a subscription's event type allow list onto its own registration");
+
+        await theFixture.ConfigureAsync(_filteredConfiguration);
+        await theFixture.CleanEventDataAsync();
+        _filteredSubscription.Clear();
+
+        var streamId = await aBeaconAsync(new BeaconLit("Min-Rimmon"), new BeaconDimmed(1),
+            new BeaconExtinguished(), new BeaconDimmed(2));
+
+        await StartDaemonAsync();
+        await _filteredSubscription.WaitForStreamEventCountAsync(streamId, 2, _timeout);
+
+        // Settle, so "exactly two" is a real claim rather than a snapshot of a shard mid-page.
+        await WaitForNonStaleProjectionDataAsync(_timeout);
+
+        var received = _filteredSubscription.Received.Where(x => x.StreamId == streamId).ToArray();
+
+        received.Length.ShouldBe(2);
+        received.ShouldAllBe(x => x.Data is BeaconDimmed);
+        received.Select(x => ((BeaconDimmed)x.Data).Level).OrderBy(x => x).ShouldBe(new[] { 1, 2 });
+    }
+
+    #endregion
+
+    private async Task<IReadOnlyList<IEvent>> eventsForAsync(Guid streamId)
+    {
+        await using var session = OpenSession();
+        return await EventsFor(session).FetchStreamAsync(streamId, token: Cancellation);
+    }
+
+    /// <summary>
+    /// Make sure the store can persist a <see cref="ComplianceSubscriptionNote"/> before the daemon
+    /// tries to.
+    /// </summary>
+    /// <remarks>
+    /// Not superstition: a store that creates document storage lazily would otherwise meet this
+    /// type for the first time <em>inside</em> a subscription batch, and the resulting failure
+    /// would indict the transactional guarantee rather than the schema. The sentinel carries an id
+    /// no event will ever have, and every assertion here loads by a known event id, so it is
+    /// invisible to the facts.
+    /// </remarks>
+    private async Task ensureNoteStorageAsync()
+    {
+        await using var session = OpenSession();
+        StoreDocument(session, new ComplianceSubscriptionNote { Id = Guid.NewGuid(), Sequence = -1 });
+        await SaveChangesAsync(session);
+    }
+
+    private async Task waitForNotesAsync(IReadOnlyList<Guid> eventIds)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(_timeout);
+        var missing = eventIds.Count;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await using var session = OpenSession();
+
+            missing = 0;
+            foreach (var id in eventIds)
+            {
+                if (await LoadDocumentAsync<ComplianceSubscriptionNote>(session, id) == null) missing++;
+            }
+
+            if (missing == 0) return;
+
+            await Task.Delay(100, Cancellation);
+        }
+
+        throw new TimeoutException(
+            $"Timed out after {_timeout} waiting for the subscription's writes to commit; " +
+            $"{missing} of {eventIds.Count} note(s) never landed. A store that hands the subscription " +
+            "a session it does not commit fails here.");
     }
 }


### PR DESCRIPTION
Closes #768.

`SubscriptionCompliance` was six facts about delivery — the right events, in sequence order, from every stream, once each. That is the easy half. What a subscription is actually *used* for went unpinned, and two of the gaps pass in silence today.

### Five new facts

| Fact | Gate |
|---|---|
| writes through the supplied session are committed with the batch | none |
| the listener returned by `ProcessEventsAsync` runs after the commit | none |
| a rewound subscription replays from scratch | daemon |
| a rewind to a sequence floor replays only past it | daemon |
| event type filters restrict what the subscription is handed | `SupportsSubscriptionEventFilters` |

### The two that matter, and why they are ungated

A store that hands the subscription a session it never commits, or drops the change listener it was handed, **passes all six existing facts**. That is the whole argument for the pair, and the reason neither is gated — the same reasoning `ProjectionCoordinatorCompliance` gives for having no gate: a skippable check recreates exactly the silence the fact exists to break.

The listener fact carries a probe rather than only a counter, because "it ran" and "it ran *after* the commit" are different claims and only the second is the contract — a listener called from inside the batch delegate fires again on every retry of a transaction that had already committed, which is the bug Fisher's local copy of this test records. The probe reads over a separate session and is safe here (the batch's transaction is closed by then), unlike the outbox's before-commit probe in `ProjectionSideEffectCompliance`.

It also waits on the listener rather than on non-stale data. The progression row is written inside the batch's transaction, so non-stale is true strictly *before* a post-commit listener runs; waiting on it and then asserting is a race that fails perhaps one full-suite run in several.

### Start-position floor

Covered through `RewindSubscriptionAsync(name, token, floor)` rather than a configuration-time `SubscribeFromSequence`. The configuration-time form cannot be asserted portably: the floor is a literal baked into a static configuration delegate while the sequence numbers under test are assigned at run time, so a suite could only guess a constant and would end up asserting either "everything arrived" or nothing at all. The rewind overload takes the same floor, is on the shared `IProjectionDaemon`, and lets the floor be chosen *after* the events exist — which is what turns the exclusion into a claim rather than an assumption. The fact asserts an expected count of 3, so it cannot pass by delivering nothing.

### Working with the existing partial

`ComplianceSubscription` is an existing per-consumer partial, so the library took the new work onto its own half: `IncludedEventTypes` / `IncludeType<T>`, `NotesFor(page)`, `RecordCommitAsync()`, `CommitProbe`, `VisibleAtCommit`, `CommitCount`, `Clear()` and `WaitForCommitAsync()`. A consumer's `ProcessEventsAsync` gains two lines plus a small listener class — the README sample is updated.

### Seams

- `EventStoreComplianceFixture.SupportsSubscriptionEventFilters` (**false**). Gated for a wiring reason worth stating: every product wraps a bare `ISubscription` in its own `SubscriptionBase`, the daemon reads filters from the *wrapper*, and Marten's `SubscriptionWrapper` copies none across — so a registrar has to replay `IncludedEventTypes` onto its own registration call, and until it does the filter reaches nothing.
- `ComplianceSubscriptionNote`, keyed by `IEvent.Id` so the suite can load it back with `LoadAsync` alone — the suites never reach for a query provider. The two facts that use it pre-touch its storage first, so a lazily-created document table cannot make a schema problem look like a broken transactional guarantee.

**No store is enrolled by this PR.**

### Validation

- `JasperFx.Events.ComplianceTests` builds clean (net9.0 and net10.0), 0 errors.
- `EventStoreTests`: 141 passed, 0 failed.

CI is not a gate right now (GitHub Actions stalled org-wide); merged after the local build and test run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
