### PR TITLE
Natural key uniqueness: a second claimant is refused (jasperfx#764 ruling)

### DIFF
--- a/src/EventTests/DuplicateNaturalKeyExceptionTests.cs
+++ b/src/EventTests/DuplicateNaturalKeyExceptionTests.cs
@@ -1,0 +1,66 @@
+using JasperFx.Events;
+using Shouldly;
+
+namespace EventTests;
+
+// jasperfx#764: the natural key uniqueness ruling. Fisher's DuplicateNaturalKeyException is lifted
+// beside the jasperfx#751 exceptions with its message adopted verbatim, so Fisher's swap is a
+// type-forward rather than a subclass. The tests below pin the canonical shape a store has to keep
+// expressible.
+public class DuplicateNaturalKeyExceptionTests
+{
+    [Fact]
+    public void carries_the_aggregate_type_and_the_key()
+    {
+        var ex = new DuplicateNaturalKeyException(typeof(Order), "ORD-1234");
+
+        ex.AggregateType.ShouldBe(typeof(Order));
+        ex.Key.ShouldBe("ORD-1234");
+
+        ex.Message.ShouldBe(
+            "The natural key 'ORD-1234' is already mapped to a different stream for aggregate type "
+            + "'Order'. A natural key identifies one stream; if the mapping is meant to move, delete "
+            + "the existing row first.");
+
+        // Fisher's throw site infers the conflict from a write that affected no rows, so it has
+        // neither stream id in hand. Both stay optional.
+        ex.ExistingStreamId.ShouldBeNull();
+        ex.ClaimingStreamId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void carries_both_stream_ids_when_the_throw_site_knew_them()
+    {
+        // The shape a store takes when it probes the lookup before writing rather than reacting to
+        // an empty result — it knows who holds the key and who tried to take it.
+        var existing = Guid.NewGuid();
+        var claiming = Guid.NewGuid();
+
+        var ex = new DuplicateNaturalKeyException(typeof(Order), "ORD-1234", existing, claiming);
+
+        ex.ExistingStreamId.ShouldBe(existing);
+        ex.ClaimingStreamId.ShouldBe(claiming);
+        ex.Key.ShouldBe("ORD-1234");
+    }
+
+    [Fact]
+    public void a_store_subclass_can_keep_its_diverged_message()
+    {
+        var ex = new StoreishDuplicateNaturalKeyException(typeof(Order), "ORD-1234");
+
+        ex.Message.ShouldBe("Natural key ORD-1234 is taken");
+        ex.AggregateType.ShouldBe(typeof(Order));
+        ex.Key.ShouldBe("ORD-1234");
+        ex.ShouldBeAssignableTo<DuplicateNaturalKeyException>();
+    }
+
+    private class StoreishDuplicateNaturalKeyException : DuplicateNaturalKeyException
+    {
+        public StoreishDuplicateNaturalKeyException(Type aggregateType, object key)
+            : base($"Natural key {key} is taken", aggregateType, key, null, null)
+        {
+        }
+    }
+
+    private class Order;
+}

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -215,19 +215,31 @@ store whose rebuild leaves the table untouched, the same failure mode `Aggregate
 counts cache hits to avoid. The products' own versions delete the table with raw SQL and count rows;
 the table name is per-product, so the async registration buys the same guarantee portably.
 
-The cluster contains more genuine disagreement than its matching test names suggest, and four things
-stayed behind. The **miss on `FetchForWriting`** is three products and two contracts — Marten returns
-a null aggregate at version 0, Polecat throws `InvalidOperationException`, Fisher throws
+**Uniqueness of a key across streams was the one open product question, and it is settled**
+(jasperfx#764): a natural key already mapped to a live stream is *refused* to a second claimant.
+Fisher refused; Polecat's `MERGE` repointed the key at the newcomer, which leaves the original stream
+in place but unreachable by the identifier it was created with, and reports nothing. Refusing is the
+contract, `a_second_stream_cannot_claim_a_live_natural_key` pins it, and Polecat carries the
+behavioral change (polecat#549). The exception is the shared
+`JasperFx.Events.DuplicateNaturalKeyException`, lifted from Fisher's copy alongside the jasperfx#751
+exception types with its message adopted verbatim.
+
+That fact asserts two things, and **the second is the one that does the work**: the throw, *and* that
+the original stream's mapping still resolves afterwards. An implementation could throw and still have
+written the row — repoint, then fail the transaction, or write the mapping through a path the failure
+does not roll back — so asserting only the exception would pass on a repointing store. The mapping is
+read back by stream id rather than by nullness, for the same reason.
+
+The cluster still contains more genuine disagreement than its matching test names suggest, and three
+things stayed behind. The **miss on `FetchForWriting`** is three products and two contracts — Marten
+returns a null aggregate at version 0, Polecat throws `InvalidOperationException`, Fisher throws
 `UnknownNaturalKeyException` — so every "does not resolve" assertion in the suite is written against
-`FetchLatest`, the one miss Marten and Polecat spell identically. **Uniqueness of a key across
-streams** is the sharpest divergence: Fisher refuses a second stream claiming a live key while
-Polecat's `MERGE` repoints it at the newcomer, and Fisher's own test comment names the disagreement,
-so pinning either side would make the other's deliberate choice a compliance failure. **Rollback of
-the key row** is real and shared but needs a poisoned unit of work, which no shared surface can
-produce on demand. And the **"live lifecycle" pair** shares a name across Marten and Polecat but not
-a precondition — Marten registers `LiveStreamAggregation<T>()`, Polecat's same-named tests register
-`Inline` with a comment saying the inline registration is what creates the lookup at all — so the
-shared precondition does not exist yet.
+`FetchLatest`, the one miss Marten and Polecat spell identically. **Rollback of the key row** is real
+and shared but needs a poisoned unit of work, which no shared surface can produce on demand. And the
+**"live lifecycle" pair** shares a name across Marten and Polecat but not a precondition — Marten
+registers `LiveStreamAggregation<T>()`, Polecat's same-named tests register `Inline` with a comment
+saying the inline registration is what creates the lookup at all — so the shared precondition does
+not exist yet.
 
 One thing consumers should expect: the source generator emits an assembly-level
 `NaturalKeyAggregateAttribute` for every type carrying a `[NaturalKey]` property, so a store may
@@ -298,7 +310,7 @@ shared interfaces (`IEventStoreOperations`, `IQueryEventStore`, `IEventRegistry`
 | `AggregateToManyAsync` through a registered projection | `AggregateToManyCompliance` |
 | Event upcasting — old stored schemas read as the current types | `UpcastingCompliance` |
 | A reachable `IProjectionCoordinator` over the documented registration | `ProjectionCoordinatorCompliance` |
-| Natural keys — reaching a stream by its business identifier | `NaturalKeyCompliance` |
+| Natural keys — reaching a stream by its business identifier, and its uniqueness across streams | `NaturalKeyCompliance` |
 | `AlwaysEnforceConsistency` — a version check with no events appended | `AlwaysEnforceConsistencyCompliance` |
 | The stream-fetch query plans, standalone and batched | `StreamQueryPlanCompliance` |
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/NaturalKeyCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/NaturalKeyCompliance.cs
@@ -173,13 +173,6 @@ public partial class ComplianceNaturalKeyInvoice
 /// and that is what every "does not resolve" assertion below is written against.
 /// </description></item>
 /// <item><description>
-/// <b>Uniqueness of a key across streams.</b> Fisher refuses a second stream claiming a live key
-/// (<c>DuplicateNaturalKeyException</c>); Polecat's <c>MERGE</c> repoints the key at the newcomer.
-/// Fisher's own test comment names the disagreement explicitly. This is the sharpest divergence in
-/// the cluster and pinning either side would make the other's deliberate choice a compliance
-/// failure, so it stays product-owned pending a decision.
-/// </description></item>
-/// <item><description>
 /// <b>Transactional rollback of the key row</b> (Fisher). The property is real and shared, but
 /// provoking it needs a poisoned unit of work — Fisher's test queues raw SQL that fails the batch —
 /// and no shared surface can fail a transaction on demand.
@@ -201,6 +194,14 @@ public partial class ComplianceNaturalKeyInvoice
 /// <see cref="SnapshotLifecycleCompliance{TFixture,TOperations,TQuerySession}"/>'s job.
 /// </description></item>
 /// </list>
+/// <para>
+/// <b>Uniqueness across streams was the one open question, and it is now settled</b> (jasperfx#764).
+/// Fisher refused a second stream claiming a live key while Polecat's <c>MERGE</c> repointed it at
+/// the newcomer; refusing is the contract, and
+/// <see cref="a_second_stream_cannot_claim_a_live_natural_key" /> pins it — with the shared
+/// <see cref="DuplicateNaturalKeyException" /> and, more importantly, with the original mapping read
+/// back afterwards. Polecat carries the behavioral change (polecat#549).
+/// </para>
 /// <para>
 /// <b>The load-bearing facts are the rebuild pair</b> (marten#4788 / marten#4966 / polecat#259).
 /// The natural key lookup is maintained by the inline append path, which drives off newly-appended
@@ -547,6 +548,72 @@ public abstract class NaturalKeyCompliance<TFixture, TOperations, TQuerySession>
         (await EventsFor(query)
             .FetchLatest<ComplianceNaturalKeyOrder, ComplianceOrderNumber>(original, Cancellation))
             .ShouldBeNull();
+    }
+
+    // ---------- uniqueness ----------
+
+    /// <summary>
+    /// jasperfx#764: a natural key already mapped to a live stream is <em>refused</em> to a second
+    /// claimant, and the original mapping survives the attempt.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This was the one open product question in the cluster, and it is settled: refusing is the
+    /// contract. Fisher refuses with <c>DuplicateNaturalKeyException</c>; Polecat's <c>MERGE</c>
+    /// lookup write repointed the key at the newcomer, which leaves the original stream in place but
+    /// unreachable by the identifier it was created with, and reports nothing. A natural key exists
+    /// to name one stream, so a second claimant is a bug in the caller's key derivation rather than
+    /// an instruction — and of the two failure modes, the silent one is worse. Polecat carries the
+    /// behavioral change (polecat#549).
+    /// </para>
+    /// <para>
+    /// <b>The second half is the half that does the work.</b> Asserting only the throw would pass on
+    /// a store that repoints the row and <em>then</em> fails the transaction, or that writes the new
+    /// mapping through a path the failure does not roll back — the mapping is the thing being
+    /// protected, so it has to be read back. It is checked through <c>FetchLatest</c>, the one miss
+    /// the products spell identically, and by stream id rather than by nullness so a store that
+    /// repointed the key still fails here rather than passing on "something resolves".
+    /// </para>
+    /// <para>
+    /// Distinct from the two neighbouring behaviors that are <em>not</em> duplicates and are pinned
+    /// elsewhere: re-asserting the same mapping on its own stream is idempotent by design, and
+    /// renaming a key retires the superseded one — see
+    /// <see cref="renaming_the_natural_key_retires_the_previous_key" />, which is what frees an
+    /// identifier for a later stream to claim legitimately.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_second_stream_cannot_claim_a_live_natural_key()
+    {
+        SkipUnlessNaturalKeysAreSupported();
+
+        var number = aNumber("ORD-DUP");
+        var originalId = await anOrderAsync(number, new NaturalKeyOrderItemAdded("Widget", 9.99m));
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceNaturalKeyOrder>(Guid.NewGuid(),
+                new NaturalKeyOrderPlaced(number, "Mallory"));
+
+            var ex = await Should.ThrowAsync<DuplicateNaturalKeyException>(() => SaveChangesAsync(session));
+
+            // Unwrapped, not the ComplianceOrderNumber wrapper: NaturalKeyDefinition unwraps before
+            // the lookup is written, so the value in the row — and therefore at the throw site — is
+            // the inner string.
+            ex.Key.ShouldBe(number.Value);
+            ex.AggregateType.ShouldBe(typeof(ComplianceNaturalKeyOrder));
+        }
+
+        // The mapping the refusal exists to protect. A store that throws but has already repointed
+        // the row fails here, which is the whole point of reading it back.
+        await using var query = OpenSession();
+        var order = await EventsFor(query)
+            .FetchLatest<ComplianceNaturalKeyOrder, ComplianceOrderNumber>(number, Cancellation);
+
+        order.ShouldNotBeNull();
+        order.Id.ShouldBe(originalId);
+        order.Customer.ShouldBe("Alice");
+        order.Total.ShouldBe(9.99m);
     }
 
     // ---------- archiving and cleaning ----------

--- a/src/JasperFx.Events/DuplicateNaturalKeyException.cs
+++ b/src/JasperFx.Events/DuplicateNaturalKeyException.cs
@@ -1,0 +1,79 @@
+namespace JasperFx.Events;
+
+/// <summary>
+///     Thrown when a second event stream tries to claim a natural key that is already mapped to a
+///     different live stream.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Refusing is the contract</b> (jasperfx#764). Two stores disagreed: Fisher refuses the
+///         second claimant, while Polecat's <c>MERGE</c>-based lookup write repoints the key at the
+///         newcomer — the original stream is still there and simply becomes unreachable by the
+///         identifier it was created with. A natural key exists to name one stream, so a second
+///         claimant is a bug in the caller's key derivation rather than an instruction, and silently
+///         losing the original mapping is the worse of the two failure modes because nothing reports
+///         it. Refusing is now what <c>NaturalKeyCompliance</c> pins for every store.
+///     </para>
+///     <para>
+///         Re-asserting the <em>same</em> mapping is not this: every event carrying the key rewrites
+///         the row, and that is idempotent by design. Nor is <em>renaming</em> a key on its own
+///         stream, which retires the superseded key and frees that identifier for someone else.
+///     </para>
+///     <para>
+///         Lifted from Fisher's <c>Fisher.Exceptions.DuplicateNaturalKeyException</c> following the
+///         jasperfx#751 pattern, with its message adopted verbatim as the canonical wording. The
+///         <see cref="ExistingStreamId" /> / <see cref="ClaimingStreamId" /> pair is a nullable
+///         superset for a store that detects the existing mapping before writing (and therefore has
+///         both ids in hand) rather than inferring the conflict from a write that affected no rows.
+///         Stores subclass or type-forward to this.
+///     </para>
+/// </remarks>
+public class DuplicateNaturalKeyException : Exception
+{
+    public DuplicateNaturalKeyException(Type aggregateType, object key) : this(aggregateType, key, null, null)
+    {
+    }
+
+    public DuplicateNaturalKeyException(Type aggregateType, object key, object? existingStreamId,
+        object? claimingStreamId)
+        : this(
+            $"The natural key '{key}' is already mapped to a different stream for aggregate type "
+            + $"'{aggregateType.Name}'. A natural key identifies one stream; if the mapping is meant "
+            + "to move, delete the existing row first.", aggregateType, key, existingStreamId, claimingStreamId)
+    {
+    }
+
+    /// <summary>
+    ///     For store subclasses whose message diverges from the canonical one (and whose tests may
+    ///     assert on that message).
+    /// </summary>
+    protected DuplicateNaturalKeyException(string message, Type aggregateType, object key,
+        object? existingStreamId, object? claimingStreamId) : base(message)
+    {
+        AggregateType = aggregateType;
+        Key = key;
+        ExistingStreamId = existingStreamId;
+        ClaimingStreamId = claimingStreamId;
+    }
+
+    /// <summary>
+    ///     The aggregate type whose natural key lookup was being written.
+    /// </summary>
+    public Type AggregateType { get; }
+
+    /// <summary>
+    ///     The natural key value that two streams claimed, already unwrapped from any strong-typed
+    ///     wrapper by <see cref="NaturalKeyDefinition" />.
+    /// </summary>
+    public object Key { get; }
+
+    /// <summary>
+    ///     The stream the key was already mapped to, when the throw site knew it.
+    /// </summary>
+    public object? ExistingStreamId { get; }
+
+    /// <summary>
+    ///     The stream that tried to take the key, when the throw site knew it.
+    /// </summary>
+    public object? ClaimingStreamId { get; }
+}


### PR DESCRIPTION
Settles the one open product question left behind by jasperfx#764 / #765, and pins it.

## The ruling

**A natural key already mapped to a live stream is refused to a second claimant, not repointed at it.** Fisher refused with `DuplicateNaturalKeyException`; Polecat's `MERGE`-based lookup write repointed the key at the newcomer, which leaves the original stream in place but unreachable by the identifier it was created with, and reports nothing. A natural key exists to name one stream, so a second claimant is a bug in the caller's key derivation rather than an instruction — and of the two failure modes, the silent one is worse.

Fisher's behaviour is the contract. Polecat carries the behavioural change in **JasperFx/polecat#549**, filed against `NaturalKeyUpsertOperation.cs:72` (and `:56` for the conjoined branch), where the `WHEN MATCHED THEN UPDATE SET {streamColumn} = source.{streamColumn}` arm does the repointing.

## The shared exception

`DuplicateNaturalKeyException` lifted from `Fisher.Exceptions` into `JasperFx.Events`, following the jasperfx#751 pattern exactly:

- **Fisher's message adopted verbatim** as the canonical wording. Fisher is the only store that throws it today, so there is no drift to reconcile — which also means Fisher's adoption is a type-forward rather than a subclass.
- **Public constructors** replacing Fisher's `internal` one, plus the **protected message-overriding ctor** the pattern calls for. Fisher's tests do not pin the message (they assert `Key` and `AggregateType`), but the ctor is there for the same reason the other six have one.
- **Superset properties**: `AggregateType` and `Key` are Fisher's; nullable `ExistingStreamId` / `ClaimingStreamId` are added for a throw site that probes the lookup *before* writing and therefore has both ids in hand — which Polecat's fix will, since it has to detect the existing mapping rather than infer the conflict from a write that affected no rows. Nullable in the same way `ExistingStreamIdCollisionException.AggregateType` is nullable: the store that does not know does not have to.

### Why the root namespace and not `JasperFx.Events.Aggregation`

Worth checking, because the issue text points at `Aggregation` — but only the `[NaturalKey]` / `[NaturalKeySource]` attributes and `NaturalKeyAggregateAttribute` live there. **`NaturalKeyDefinition` and `NaturalKeyBuilder` are already in the root `JasperFx.Events` namespace** (`src/JasperFx.Events/NaturalKeyDefinition.cs`, `NaturalKeyBuilder.cs`), and so are all nine shared event exceptions. The root is where both neighbourhoods already are, so `JasperFx.Events.DuplicateNaturalKeyException` sits beside the type that produces the key value it carries *and* beside the exceptions it is a sibling of. Putting it in `Aggregation` would separate it from both.

## The compliance fact

`NaturalKeyCompliance.a_second_stream_cannot_claim_a_live_natural_key`, under the existing `SupportsNaturalKeys` gate. It asserts two things, and **the second is the one that does the work**:

1. The second stream's `SaveChangesAsync` throws `DuplicateNaturalKeyException`, carrying the unwrapped key and the aggregate type.
2. The **original stream's mapping still resolves afterwards** — read back through `FetchLatest` and compared **by stream id**, not by nullness.

Asserting only the throw would pass on a store that repoints the row and *then* fails the transaction, or that writes the new mapping through a path the failure does not roll back. The mapping is the thing the refusal exists to protect, so it has to be read back; and comparing by id rather than by "something resolves" is what keeps a repointing store from passing.

The fact is deliberately distinct from its two neighbours, both already pinned: re-asserting the same mapping on its own stream is idempotent by design, and `renaming_the_natural_key_retires_the_previous_key` is what legitimately frees an identifier for a later stream to claim.

Also removes the "stays product-owned pending a decision" note from the suite's class remarks and from the README, replacing both with the ruling; the README's suite-table row now names uniqueness.

## Validation

GitHub Actions is stalled org-wide, so this was validated locally:

- `JasperFx.Events.ComplianceTests` builds clean (0 errors, net9.0 + net10.0), before and after merging `origin/main`.
- `EventStoreTests` — 141 passed, 0 failed.
- New `EventTests/DuplicateNaturalKeyExceptionTests` — 3 passed (canonical message and shape, the both-ids ctor, and a subclass keeping a diverged message).

**Honest scope of that**: `EventStoreTests` enrols only the *document* compliance suites — it has no `SupportsNaturalKeys` fixture at all — so it validates compilation and no-regression, **not** the new fact's runtime behaviour. No store is enrolled in `NaturalKeyCompliance`, so the fact cannot go red on merge either; it is the bar Polecat's and Fisher's eventual enrolment will have to clear.

Closes the follow-up left open by jasperfx#764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
