### PR TITLE
Pin the flat-table increment onto a row that does not exist yet

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/FlatTableProjectionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/FlatTableProjectionCompliance.cs
@@ -16,6 +16,23 @@ public record FlatValuesAdded(int A, int B, int C, int D);
 
 public record FlatValuesSubtracted(int A, int B, int C, int D);
 
+/// <summary>
+/// An increment event that maps <em>every</em> non-key column in the table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It exists so that an increment can land on a row that does not exist yet and actually reach each
+/// map's insert expression. <see cref="FlatValuesAdded"/> cannot do that job: it leaves
+/// <c>member_count</c> unmapped, and at least one store (Marten, marten#4255) deliberately compiles
+/// an event that maps only some of the table's columns into an <em>update-only</em> statement, so
+/// that a first event of that shape cannot insert a half-populated row into columns it knows nothing
+/// about. That is a defensible rule and this suite does not challenge it — it routes around it, so
+/// the insert branch is reachable on every store and the fact is about increment semantics rather
+/// than about partial mappings.
+/// </para>
+/// </remarks>
+public record FlatValuesAccrued(int A, int B, int C, int D, int MemberCount);
+
 public record FlatValuesDeleted;
 
 #endregion
@@ -113,6 +130,22 @@ public partial class ComplianceFlatTableProjection
             map.SetValue("status", "old");
         });
 
+        // Every non-key column the table has, on purpose — see FlatValuesAccrued. Mapping the whole
+        // row is what keeps this event's insert branch reachable on every store, which is the only
+        // way a suite can pin what an increment does to a row that is not there yet.
+        Project<FlatValuesAccrued>(map =>
+        {
+            map.Increment(x => x.A);
+            map.Increment(x => x.B);
+            map.Increment(x => x.C);
+            map.Increment(x => x.D);
+            map.Increment(x => x.MemberCount);
+
+            map.Increment("revision");
+
+            map.SetValue("status", "accrued");
+        });
+
         Project<FlatValuesSubtracted>(map =>
         {
             map.Decrement(x => x.A);
@@ -143,6 +176,24 @@ public partial class ComplianceFlatTableProjection
 /// once — is exactly what two independent implementations get wrong in different ways.
 /// </para>
 /// <para>
+/// The increment-onto-a-missing-row edge is the one that went unpinned longest, and it is worth
+/// saying exactly how much of it is claimed here. Every fact but one starts by mapping a row into
+/// existence, so the increment maps' <em>insert</em> expressions were unreachable and three stores
+/// disagreed on them unnoticed: Marten counted the creating event as zero where Polecat, Fisher and
+/// the lifted <c>Weasel.Storage.Flattened</c> DSL all counted it as one. One is the ruling
+/// (marten#5341, fixed in marten#5342) and
+/// <c>an_increment_on_a_row_that_does_not_exist_yet_counts_the_creating_event</c> holds it there.
+/// </para>
+/// <para>
+/// Two neighbouring insert expressions are deliberately <em>not</em> asserted, because the stores do
+/// not agree and no ruling has been made. A by-column <c>Decrement(name)</c> inserts <c>0</c>
+/// everywhere, so a first event that is a decrement leaves the column at zero rather than at minus
+/// one — which reads as asymmetric now that increment counts its creating event, but changing it is
+/// a behavioural decision this suite has no standing to force (jasperfx#773). And a member-valued
+/// <c>Decrement(x =&gt; x.A)</c> inserts the negated value on one store and the value as given on the
+/// other three. Pinning either here would manufacture a contract rather than record one.
+/// </para>
+/// <para>
 /// Table *shape* is asserted only through the columns that come back with a row. The generated DDL,
 /// the upsert mechanism, index layout and identifier quoting are all storage layout and stay in
 /// each product's own tests.
@@ -159,6 +210,7 @@ public abstract class FlatTableProjectionCompliance<TFixture, TOperations, TQuer
 
         config.AddEventType<FlatValuesSet>();
         config.AddEventType<FlatValuesAdded>();
+        config.AddEventType<FlatValuesAccrued>();
         config.AddEventType<FlatValuesSubtracted>();
         config.AddEventType<FlatValuesDeleted>();
 
@@ -175,6 +227,7 @@ public abstract class FlatTableProjectionCompliance<TFixture, TOperations, TQuer
 
         config.AddEventType<FlatValuesSet>();
         config.AddEventType<FlatValuesAdded>();
+        config.AddEventType<FlatValuesAccrued>();
         config.AddEventType<FlatValuesSubtracted>();
         config.AddEventType<FlatValuesDeleted>();
 
@@ -336,6 +389,55 @@ public abstract class FlatTableProjectionCompliance<TFixture, TOperations, TQuer
 
         // Set to 1, incremented once, decremented once.
         intValue(row, "revision").ShouldBe(1);
+    }
+
+    /// <summary>
+    /// An increment is the first thing the table ever hears about this row.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every other fact in this suite opens with a <see cref="FlatValuesSet"/>, which creates the row
+    /// through <c>SetValue</c> and <c>Map</c>, so the increment maps only ever exercise their
+    /// <em>update</em> expressions. This one never sets anything, so each map has to answer the
+    /// question it was avoiding: what does this column start at when there is no row to add to?
+    /// </para>
+    /// <para>
+    /// The two halves are separate claims. A member-valued increment inserts the event's own value,
+    /// because a first sighting has nothing to add to and the bound parameter is the whole answer;
+    /// all four implementations of the DSL spell that identically. The by-column
+    /// <c>Increment("revision")</c> has no parameter to fall back on, and that is where the
+    /// disagreement was: it inserts <c>1</c>, counting the event that created the row, so N events
+    /// read N rather than N-1 (marten#5341 / marten#5342).
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task an_increment_on_a_row_that_does_not_exist_yet_counts_the_creating_event()
+    {
+        SkipUnlessFlatTablesAreSupported();
+
+        var streamId = Guid.NewGuid();
+
+        // Deliberately no FlatValuesSet first: this is the whole point of the fact.
+        await appendAsync(streamId, new FlatValuesAccrued(3, 4, 5, 6, 7));
+
+        var row = await rowAsync(streamId);
+        row.ShouldNotBeNull(
+            "An increment against a row that does not exist yet should insert it, not silently do nothing");
+
+        // A member-valued increment's insert expression is the bound parameter, so the row starts at
+        // the event's own values rather than at zero-plus-them.
+        intValue(row, "a").ShouldBe(3);
+        intValue(row, "b").ShouldBe(4);
+        intValue(row, "c").ShouldBe(5);
+        intValue(row, "d").ShouldBe(6);
+        intValue(row, "member_count").ShouldBe(7);
+
+        // SetValue writes its configured literal on the insert branch as much as on the update one.
+        row["status"].ShouldBe("accrued");
+
+        // The one that drifted: the creating event counts, so a single increment reads 1, not 0.
+        intValue(row, "revision").ShouldBe(1,
+            "Increment(column) should count the event that created the row (marten#5341)");
     }
 
     [Fact]


### PR DESCRIPTION
## The gap

`FlatTableProjectionCompliance`'s remarks have always named *"an increment landing on a row that does not exist yet"* as one of the edges worth pinning across stores. No fact exercised it. Every fact in the suite opens by appending a `FlatValuesSet`, which creates the row through `SetValue`/`Map`, so the increment maps only ever reached their **update** expressions and their **insert** expressions were dead code as far as this suite was concerned.

That is why three stores disagreed unnoticed: Marten's `IncrementMap.ToInsertExpression` returned `0` where Polecat, Fisher and the lifted `Weasel.Storage.Flattened` DSL all return `1`. `1` is the ruling (marten#5341) and Marten's one-line fix is marten#5342. This adds the fact so it cannot drift again.

## Why the fact needed a new event type

The obvious shape — append only a `FlatValuesAdded` to a fresh stream — does not work, and the reason is worth stating because it is a real cross-store difference rather than an inconvenience.

`FlatValuesAdded` maps `a`, `b`, `c`, `d`, `revision` and `status`, but the table also has `member_count`, which only `FlatValuesSet` writes. Marten treats an event that maps only *some* of the table's non-key columns as a **partial mapping** and compiles it into an `UPDATE`-only function, precisely so a first event of that shape cannot insert a half-populated row into columns it knows nothing about (marten#4255, and its own `partial_event_on_new_stream_is_a_safe_noop` test). Polecat, Fisher and Weasel have no partial-mapping concept at all and always emit the insert branch.

So the literal version of this fact would have asserted `row.ShouldNotBeNull()` and failed on Marten — for a defensible documented rule that has nothing to do with increment semantics, and that no one has ruled on. Rather than challenge marten#4255 sideways through a compliance suite, this routes around it: a new `FlatValuesAccrued(A, B, C, D, MemberCount)` increments **every** non-key column, so its insert branch is reachable on all four implementations and the fact is about the thing it claims to be about.

## What the new fact asserts

`an_increment_on_a_row_that_does_not_exist_yet_counts_the_creating_event` appends one `FlatValuesAccrued(3, 4, 5, 6, 7)` to a fresh stream with no prior `Set`, then asserts:

- **the row exists** — an increment against a missing row inserts it rather than silently doing nothing;
- **`a`/`b`/`c`/`d`/`member_count` read `3`/`4`/`5`/`6`/`7`** — a member-valued increment's insert expression is the bound parameter, so a first sighting starts at the event's own value. Verified against all four sources, which agree exactly: Marten `MemberMap.ToInsertExpression` (`ColumnMapType.Increment` → the argument name), Polecat and Fisher `IncrementMemberMap.InsertExpression`, and `Weasel.Storage.Flattened.IncrementMemberMap`;
- **`status` reads `"accrued"`** — `SetValue` writes its literal on the insert branch too;
- **`revision` reads `1`** — the one that drifted. `Increment("revision")` has no parameter to fall back on, and it counts the event that created the row, so N events read N rather than N-1.

## The decrement asymmetry — reported, not decided

Writing this surfaced two neighbouring insert expressions that are now arguably inconsistent. **Nothing here changes behaviour and the suite asserts neither**; filed as **jasperfx#773** for a ruling, with the reasoning written into the suite's remarks so the gap reads as a decision rather than an oversight.

1. **`Decrement(column)` inserts `0` on all four**, so a first event that is a decrement leaves the column at `0` rather than `-1` — the same off-by-one marten#5341 rejected for increment. Fisher's `DecrementMap` still carries a "Symmetric with IncrementMap" comment that stopped being true when increment moved to `1`. The counter-argument is real, though: a count that goes negative on its first sighting is usually a data error, and `0` is the safer floor. That is a legitimate ruling, just not a stated one.
2. **Member-valued `Decrement(x => x.A)` genuinely disagrees, 1 vs 3**: Marten inserts `-@param`, Polecat/Fisher/Weasel insert `@param`. `Weasel.Storage.Flattened` already records this in an XML comment and preserved the majority rather than reconciling it silently.

My call: worth a ruling, not worth guessing at. Pinning either answer from a compliance suite would manufacture a contract instead of recording one.

## Validation

`src/JasperFx.Events.ComplianceTests` builds clean (0 errors; only pre-existing warnings), and `src/EventStoreTests` is green at **141/141**.

**Be clear about what that does and does not prove.** `EventStoreTests` enrolls the in-memory reference implementation for the *document* suites only — it does not enroll `FlatTableProjectionCompliance`. So this validates that the suite still compiles and that nothing regressed; the new fact's runtime behaviour will first execute when a store runs the suite. Marten with marten#5342 is expected to be the first.

Additive throughout: one new event record, one new `Project<>` block, one `AddEventType` in each of the two store configurations, one new fact, and expanded remarks. No existing fact, mapping or column changed. No store enrolled. The suite README's table names suites rather than facts, so it needed no row change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
