### PR TITLE
gh-743: let generated code carry its own attributes, and know its language

### DIFF
--- a/docs/codegen/aot.md
+++ b/docs/codegen/aot.md
@@ -142,6 +142,47 @@ If publish fails with IL warnings-as-errors, the build output tells you exactly 
 | `IL3050: …RequiresDynamicCodeAttribute` on `MakeGenericType` / `Activator.CreateInstance` in your own code | You're doing reflection. | Refactor to source-generated code, or to `JasperFx.Core.Reflection.GenericFactoryCache.BuildAs<T>(...)` with a delegate factory. |
 | `Unable to load type 'X' from assembly 'Y' at runtime` | The trimmer dropped a type that was reachable only by reflection. | Annotate the reflective call site with `[DynamicallyAccessedMembers]` on the relevant `Type` parameter, or add a `[DynamicDependency]` to keep the type alive. |
 
+### Rooting pre-generated types
+
+There is a trap in the two-phase model above. Pre-generated types are only ever *reached* reflectively — the host scans the application assembly's exported types and calls `Activator.CreateInstance`. ILC sees no static reference to any of them, so it trims them, and `TypeLoadMode.Static` then degrades into a scan that finds nothing. The failure is quiet: the app boots, the scan comes up empty, and the behavior you pre-generated simply isn't there.
+
+The fix is to root the generated types from the generated code itself, which is the one place that knows every type involved. JasperFx emits that as an **AOT roots companion** — a generated class whose single `static void` method carries a `[ModuleInitializer]` plus one `[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(...))]` per rooted type. A module initializer is an unconditional ILC root, so the whole graph is anchored with no application-side code:
+
+```cs
+// inside an ICodeFile.AssembleTypes(GeneratedAssembly assembly)
+assembly.AddAotRoots("AotRoots", new[]
+{
+    "MyApp.Generated.GeneratedHandlerRegistry",
+    "MyApp.Generated.SomeGeneratedHandler",
+    "MyApp.Messages.CreateOrder"
+});
+```
+
+which emits:
+
+```cs
+// Native AOT rooting companion
+[global::System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")]
+public sealed class AotRoots
+{
+    [global::System.Runtime.CompilerServices.ModuleInitializer]
+    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::MyApp.Generated.GeneratedHandlerRegistry))]
+    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::MyApp.Generated.SomeGeneratedHandler))]
+    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::MyApp.Messages.CreateOrder))]
+    public static void Pin()
+    {
+        // Intentionally empty. The [DynamicDependency] attributes above are the payload...
+    }
+}
+```
+
+Notes:
+
+- Pass sibling *generated* types by name (the `IEnumerable<string>` overload). They do not exist as runtime `Type`s while `codegen write` is running. There are also overloads taking `IEnumerable<Type>` for types that do already exist, and `IEnumerable<AttributeArg>` when you need to mix the two.
+- `[DynamicDependency]` has `AttributeUsage(Constructor | Field | Method)`, so it cannot sit on the class — the method is the only legal home for the block.
+- The companion is **C# only**. The F# compiler does not honor `ModuleInitializerAttribute` (an F# module's `do` bindings initialize lazily and are not an ILC root), so `AddAotRoots` returns `null` and emits nothing when `assembly.TargetLanguage` is `fsharp` rather than emitting rooting that silently does nothing.
+- Deciding *which* types to root is the consuming framework's call — see [jasperfx#743](https://github.com/JasperFx/jasperfx/issues/743) and [wolverine#4287](https://github.com/JasperFx/wolverine/issues/4287).
+
 ### Verification
 
 The published binary should run with no AOT-specific warnings on the console:

--- a/docs/codegen/generated-types.md
+++ b/docs/codegen/generated-types.md
@@ -211,7 +211,7 @@ Argument kinds:
 |---------|------------|------------|
 | `AttributeArg.Type(typeof(T))` | `typeof(global::Ns.T)` | `typeof<Ns.T>` |
 | `AttributeArg.TypeNamed("Ns.T")` | `typeof(global::Ns.T)` | `typeof<Ns.T>` |
-| `AttributeArg.Enum(value)` | `global::Ns.E.Member` (`\|` for combined flags) | `Ns.E.Member` (`\|\|\|`) |
+| `AttributeArg.Enum(value)` | `global::Ns.E.Member`, combined flags joined with the C# bitwise-or | `Ns.E.Member`, combined flags joined with the F# bitwise-or |
 | `AttributeArg.Value(literal)` | `"text"` / `true` / `5L` / `null` | same, with F# numeric literal rules |
 | `AttributeArg.Raw(csharp, fsharp)` | verbatim | verbatim |
 

--- a/docs/codegen/generated-types.md
+++ b/docs/codegen/generated-types.md
@@ -184,6 +184,64 @@ public static string AddCustomMethod()
 
 `AddVoidMethod` and `AddMethodThatReturns<T>` let you define methods that do not come from a base class or interface.
 
+### Static Methods
+
+`AddStaticVoidMethod` emits a `static void` method. Unlike the other `Add*Method` calls it also tolerates an empty `Frames` collection, because a method whose entire payload is its attributes is a legitimate thing to generate — see [Rooting pre-generated types](./aot#rooting-pre-generated-types).
+
+```cs
+var companion = assembly.AddType("AotRoots");
+var pin = companion.AddStaticVoidMethod("Pin");
+```
+
+## Attributes
+
+Every `GeneratedType` and `GeneratedMethod` carries an `Attributes` collection of `GeneratedAttribute`. Attributes are *modeled* rather than smuggled as raw text so each language writer renders them in its own syntax -- `[Foo(...)]` in C#, `[<Foo(...)>]` in F#:
+
+```cs
+type.Attributes.Add(new GeneratedAttribute(typeof(ObsoleteAttribute), AttributeArg.Value("use the new one")));
+
+method.Attributes.Add(new GeneratedAttribute(typeof(DynamicDependencyAttribute),
+    AttributeArg.Enum(DynamicallyAccessedMemberTypes.All),
+    AttributeArg.TypeNamed("MyApp.Generated.SomeGeneratedHandler")));
+```
+
+Argument kinds:
+
+| Factory | Emits (C#) | Emits (F#) |
+|---------|------------|------------|
+| `AttributeArg.Type(typeof(T))` | `typeof(global::Ns.T)` | `typeof<Ns.T>` |
+| `AttributeArg.TypeNamed("Ns.T")` | `typeof(global::Ns.T)` | `typeof<Ns.T>` |
+| `AttributeArg.Enum(value)` | `global::Ns.E.Member` (`\|` for combined flags) | `Ns.E.Member` (`\|\|\|`) |
+| `AttributeArg.Value(literal)` | `"text"` / `true` / `5L` / `null` | same, with F# numeric literal rules |
+| `AttributeArg.Raw(csharp, fsharp)` | verbatim | verbatim |
+
+`AttributeArg.TypeNamed` is the important one for generated code: a *sibling generated type* has no runtime `Type` while `codegen write` is running, so it can only be referenced by name. Rendering is always fully qualified, so attributes never depend on the `using` / `open` statements at the top of the file.
+
+Every generated type is seeded with the `[GeneratedCode("JasperFx", "1.0.0")]` marker through this same mechanism.
+
+::: tip
+`GeneratedType.Header` / `GeneratedMethod.Header` can still smuggle arbitrary text in front of a declaration, but raw C# attribute text in a `Header` silently corrupts `codegen write --language fsharp` output. Prefer `Attributes`.
+:::
+
+## Target Language
+
+`GeneratedAssembly.TargetLanguage` reports which language the assembly is about to be rendered as. `DynamicCodeBuilder` stamps it *before* it calls `ICodeFile.AssembleTypes`, so a code file can vary what it emits by language:
+
+```cs
+public void AssembleTypes(GeneratedAssembly assembly)
+{
+    var handler = assembly.AddType("SomeHandler", typeof(MessageHandler));
+    // ...
+
+    if (assembly.TargetLanguage == CodegenLanguage.csharp)
+    {
+        // C#-only artifact
+    }
+}
+```
+
+It defaults to `CodegenLanguage.csharp`, and the runtime Roslyn path never changes it.
+
 ## Frames Collection
 
 The `Frames` property on `GeneratedMethod` is a `FramesCollection`. You interact with it primarily through:

--- a/src/CodegenTests.FSharpFixture/Generated.fs
+++ b/src/CodegenTests.FSharpFixture/Generated.fs
@@ -8,6 +8,7 @@ open Microsoft.Extensions.DependencyInjection
 open System
 open System.Threading.Tasks
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedGreeter(greetingService: FSharpCodegenTarget.GreetingService) =
     let _greetingService = greetingService
 
@@ -19,6 +20,7 @@ type GeneratedGreeter(greetingService: FSharpCodegenTarget.GreetingService) =
             let result = result_of_CreateGreeting.ToUpper()
             result
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedAsyncGreeter(greetingService: FSharpCodegenTarget.GreetingService) =
     let _greetingService = greetingService
 
@@ -31,6 +33,7 @@ type GeneratedAsyncGreeter(greetingService: FSharpCodegenTarget.GreetingService)
                 return result_of_CreateGreetingAsync
             }
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedDirectAsyncGreeter(greetingService: FSharpCodegenTarget.GreetingService) =
     let _greetingService = greetingService
 
@@ -40,6 +43,7 @@ type GeneratedDirectAsyncGreeter(greetingService: FSharpCodegenTarget.GreetingSe
             let salutation = FSharpCodegenTarget.Salutation(name)
             _greetingService.CreateGreetingAsync(salutation)
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedAccumulator(accumulatorService: FSharpCodegenTarget.AccumulatorService) =
     let _accumulatorService = accumulatorService
 
@@ -49,6 +53,7 @@ type GeneratedAccumulator(accumulatorService: FSharpCodegenTarget.AccumulatorSer
             mutableBox <- _accumulatorService.Advance(mutableBox)
             mutableBox
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedConditionalGreeter(controlFlowService: FSharpCodegenTarget.ControlFlowService) =
     let _controlFlowService = controlFlowService
 
@@ -59,6 +64,7 @@ type GeneratedConditionalGreeter(controlFlowService: FSharpCodegenTarget.Control
             else
                 _controlFlowService.Echo(input)
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedFSharpSagaGuard(sagaService: FSharpCodegenTarget.SagaService) =
     let _sagaService = sagaService
 
@@ -69,6 +75,7 @@ type GeneratedFSharpSagaGuard(sagaService: FSharpCodegenTarget.SagaService) =
             else
                 _sagaService.Echo(saga)
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedToggle(controlFlowService: FSharpCodegenTarget.ControlFlowService) =
     let _controlFlowService = controlFlowService
 
@@ -77,6 +84,7 @@ type GeneratedToggle(controlFlowService: FSharpCodegenTarget.ControlFlowService)
             if flag then
                 _controlFlowService.Record()
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedResourceRunner(controlFlowService: FSharpCodegenTarget.ControlFlowService) =
     let _controlFlowService = controlFlowService
 
@@ -88,6 +96,7 @@ type GeneratedResourceRunner(controlFlowService: FSharpCodegenTarget.ControlFlow
             finally
                 _controlFlowService.End()
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedOrderHandler(confirmationFactory: FSharpCodegenTarget.ConfirmationFactory, orderRepository: FSharpCodegenTarget.IOrderRepository) =
     let _confirmationFactory = confirmationFactory
     let _orderRepository = orderRepository
@@ -102,6 +111,7 @@ type GeneratedOrderHandler(confirmationFactory: FSharpCodegenTarget.Confirmation
                 return orderConfirmation
             }
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedSyncTaskHandler(controlFlowService: FSharpCodegenTarget.ControlFlowService) =
     let _controlFlowService = controlFlowService
 
@@ -110,12 +120,14 @@ type GeneratedSyncTaskHandler(controlFlowService: FSharpCodegenTarget.ControlFlo
             _controlFlowService.Record()
             System.Threading.Tasks.Task.CompletedTask
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedCalculator() =
     inherit FSharpCodegenTarget.CalculatorBase()
     override this.Compute(seed: int) : int =
         let result_of_Bump = this.Bump(seed)
         result_of_Bump
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedThingHandler(thingDescriber: FSharpCodegenTarget.ThingDescriber) =
     let _thingDescriber = thingDescriber
 
@@ -124,6 +136,7 @@ type GeneratedThingHandler(thingDescriber: FSharpCodegenTarget.ThingDescriber) =
             let thing = FSharpCodegenTarget.Thing()
             _thingDescriber.Describe((thing :> FSharpCodegenTarget.IThing))
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedScopedConsumer(serviceScopeFactory: Microsoft.Extensions.DependencyInjection.IServiceScopeFactory) =
     let _serviceScopeFactory = serviceScopeFactory
 
@@ -136,11 +149,13 @@ type GeneratedScopedConsumer(serviceScopeFactory: Microsoft.Extensions.Dependenc
                 do! scopedThing.DoAsync()
             }
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedActivityEmitter() =
     interface FSharpCodegenTarget.IActivityEmitter with
         member this.Emit() : unit =
             if not (isNull System.Diagnostics.Activity.Current) then System.Diagnostics.Activity.Current.AddEvent(System.Diagnostics.ActivityEvent("sample.activity.event")) |> ignore
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedNowHandler(clockService: FSharpCodegenTarget.ClockService) =
     let _clockService = clockService
 
@@ -149,6 +164,7 @@ type GeneratedNowHandler(clockService: FSharpCodegenTarget.ClockService) =
             let now = System.DateTime.UtcNow
             _clockService.Stamp(now)
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedValueTaskHandler(controlFlowService: FSharpCodegenTarget.ControlFlowService) =
     let _controlFlowService = controlFlowService
 
@@ -157,6 +173,7 @@ type GeneratedValueTaskHandler(controlFlowService: FSharpCodegenTarget.ControlFl
             let result_of_Fallback = _controlFlowService.Fallback()
             System.Threading.Tasks.ValueTask<string>(result_of_Fallback)
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedMemberAccessHandler() =
     interface FSharpCodegenTarget.IMemberAccessHandler with
         member this.Read() : int =
@@ -164,6 +181,7 @@ type GeneratedMemberAccessHandler() =
             let value = mutableBox.Value
             value
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedArrayHandler(thingA: FSharpCodegenTarget.Thing, thingB: FSharpCodegenTarget.Thing) =
     let _thingA = thingA
     let _thingB = thingB
@@ -173,6 +191,7 @@ type GeneratedArrayHandler(thingA: FSharpCodegenTarget.Thing, thingB: FSharpCode
             let thingArray = [| _thingA; _thingB |]
             thingArray
 
+[<System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")>]
 type GeneratedLazyHandler(provider: System.IServiceProvider) =
     let _provider = provider
 

--- a/src/CodegenTests/AotRootsCompanionTests.cs
+++ b/src/CodegenTests/AotRootsCompanionTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using Shouldly;
+using Xunit;
+
+namespace CodegenTests;
+
+public class AotRootsCompanionTests
+{
+    [Fact]
+    public void emits_a_module_initializer_rooted_companion()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        assembly.AddType("SomeHandler", typeof(object)).AddVoidMethod("Go").Frames.Add(new CommentFrame("nothing"));
+
+        var companion = assembly.AddAotRoots("AotRoots", new[]
+        {
+            "LamarGenerated.SomeHandler",
+            "MyApp.Messages.CreateOrder"
+        });
+
+        companion.ShouldNotBeNull();
+
+        var code = assembly.GenerateCode();
+
+        code.ShouldContain("[global::System.Runtime.CompilerServices.ModuleInitializer]");
+        code.ShouldContain(
+            "[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::LamarGenerated.SomeHandler))]");
+        code.ShouldContain(
+            "[global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::MyApp.Messages.CreateOrder))]");
+        code.ShouldContain("public static void Pin()");
+        code.ShouldContain("public sealed class AotRoots");
+    }
+
+    [Fact]
+    public void roots_types_that_do_exist_at_codegen_time()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        assembly.AddAotRoots("AotRoots", new[] { typeof(AotRootsCompanionTests) });
+
+        assembly.GenerateCode().ShouldContain("typeof(global::CodegenTests.AotRootsCompanionTests)");
+    }
+
+    [Fact]
+    public void the_companion_is_skipped_for_fsharp()
+    {
+        // The F# compiler does not honor ModuleInitializerAttribute, so a companion emitted into
+        // F# output would read as rooting while doing nothing at all.
+        var assembly = GeneratedAssembly.Empty();
+        assembly.TargetLanguage = CodegenLanguage.fsharp;
+
+        assembly.AddAotRoots("AotRoots", new[] { "Some.Type" }).ShouldBeNull();
+        assembly.GeneratedTypes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void nothing_is_emitted_for_an_empty_root_list()
+    {
+        var assembly = GeneratedAssembly.Empty();
+
+        assembly.AddAotRoots("AotRoots", Array.Empty<string>()).ShouldBeNull();
+        assembly.GeneratedTypes.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_companion_compiles_and_the_module_initializer_actually_runs()
+    {
+        var assembly = new GeneratedAssembly(new GenerationRules("AotRootsCompanion.Compiled"));
+        var rooted = assembly.AddType("RootedType", typeof(IWidgetMaker));
+        rooted.MethodFor(nameof(IWidgetMaker.Make)).Frames.Code("return 11;");
+
+        assembly.AddAotRoots("AotRoots", new[] { "AotRootsCompanion.Compiled.RootedType" }).ShouldNotBeNull();
+
+        assembly.CompileAll();
+
+        // A module initializer runs when the assembly's module is first touched, so reaching this
+        // point at all proves the emitted attributes are valid enough for Roslyn AND for the
+        // runtime's module initializer rules (a bad signature is a TypeLoadException, not a
+        // compile error).
+        var companionType = assembly.GeneratedTypes.Single(x => x.TypeName == "AotRoots").CompiledType!;
+        var pin = companionType.GetMethod(AotRootsCompanionExtensions.PinMethodName);
+
+        pin.ShouldNotBeNull();
+        pin!.IsStatic.ShouldBeTrue();
+        pin.GetCustomAttributes(typeof(System.Runtime.CompilerServices.ModuleInitializerAttribute), false)
+            .ShouldNotBeEmpty();
+        pin.GetCustomAttributes(typeof(System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute), false)
+            .Length.ShouldBe(1);
+
+        ((IWidgetMaker)Activator.CreateInstance(rooted.CompiledType!)!).Make().ShouldBe(11);
+    }
+
+    [Fact]
+    public void a_static_void_method_may_have_an_empty_body()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("Empty");
+        type.AddStaticVoidMethod("DoNothing");
+
+        assembly.GenerateCode().ShouldContain("public static void DoNothing()");
+    }
+
+    [Fact]
+    public void a_static_method_is_emitted_without_a_self_identifier_in_fsharp()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("Empty");
+        type.AddStaticVoidMethod("DoNothing").Attributes.Add(new GeneratedAttribute(typeof(SampleMarkerAttribute)));
+
+        var code = assembly.GenerateFSharpCode();
+
+        code.ShouldContain("[<CodegenTests.SampleMarker>]");
+        code.ShouldContain("static member DoNothing() : unit =");
+        code.ShouldNotContain("this.DoNothing");
+        // F# has no empty body; the unit value stands in for one.
+        code.ShouldContain("()");
+    }
+
+    [Fact]
+    public void an_ordinary_method_still_refuses_an_empty_body()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("Empty");
+        type.AddVoidMethod("DoNothing");
+
+        Should.Throw<ArgumentOutOfRangeException>(() => assembly.GenerateCode());
+    }
+}

--- a/src/CodegenTests/CodegenLanguageTests.cs
+++ b/src/CodegenTests/CodegenLanguageTests.cs
@@ -55,6 +55,28 @@ public class CodegenLanguageTests
         File.ReadAllText(fsFile).ShouldContain("namespace");
     }
 
+    [Fact]
+    public void assemble_types_observes_the_target_language()
+    {
+        // #743: an ICodeFile has to be able to see the language *while it is assembling types* so
+        // it can decline to emit C#-only artifacts (AOT rooting companions) under --language fsharp.
+        var recorder = new LanguageRecordingFile("Greeter");
+        var collection = new SampleCollection(new GenerationRules("Generated"), recorder);
+
+        new DynamicCodeBuilder(new ServiceCollection().BuildServiceProvider(), [collection])
+        {
+            Language = CodegenLanguage.fsharp
+        }.GenerateAllCode();
+
+        recorder.Observed.ShouldBe(CodegenLanguage.fsharp);
+    }
+
+    [Fact]
+    public void a_generated_assembly_defaults_to_csharp()
+    {
+        GeneratedAssembly.Empty().TargetLanguage.ShouldBe(CodegenLanguage.csharp);
+    }
+
     private static DynamicCodeBuilder Build(CodegenLanguage language, GenerationRules? rules = null)
     {
         var collection = new SampleCollection(rules ?? new GenerationRules("Generated"), new SampleFile("Greeter"));
@@ -80,6 +102,33 @@ public class CodegenLanguageTests
         public string FileName { get; } = fileName;
 
         public void AssembleTypes(GeneratedAssembly assembly) => assembly.AddType(FileName + "Type", typeof(object));
+
+        public Task<bool> AttachTypes(GenerationRules rules, System.Reflection.Assembly assembly,
+            IServiceProvider? services, string containingNamespace) => Task.FromResult(false);
+
+        public bool AttachTypesSynchronously(GenerationRules rules, System.Reflection.Assembly assembly,
+            IServiceProvider? services, string containingNamespace) => false;
+
+        public void AssertServiceLocationsAreAllowed(ServiceLocationReport[] reports, IServiceProvider? services) { }
+
+        public bool TryReplaceServiceProvider(out Variable serviceProvider)
+        {
+            serviceProvider = default!;
+            return false;
+        }
+    }
+
+    private sealed class LanguageRecordingFile(string fileName) : ICodeFile
+    {
+        public CodegenLanguage? Observed { get; private set; }
+
+        public string FileName { get; } = fileName;
+
+        public void AssembleTypes(GeneratedAssembly assembly)
+        {
+            Observed = assembly.TargetLanguage;
+            assembly.AddType(FileName + "Type", typeof(object));
+        }
 
         public Task<bool> AttachTypes(GenerationRules rules, System.Reflection.Assembly assembly,
             IServiceProvider? services, string containingNamespace) => Task.FromResult(false);

--- a/src/CodegenTests/GeneratedAttributeTests.cs
+++ b/src/CodegenTests/GeneratedAttributeTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using JasperFx.CodeGeneration;
+using JasperFx.CodeGeneration.Frames;
+using JasperFx.CodeGeneration.Model;
+using Shouldly;
+using Xunit;
+
+namespace CodegenTests;
+
+public class GeneratedAttributeTests
+{
+    [Fact]
+    public void render_an_attribute_with_no_arguments()
+    {
+        var attribute = new GeneratedAttribute(typeof(SampleMarkerAttribute));
+
+        attribute.ToCSharpDeclaration().ShouldBe("[global::CodegenTests.SampleMarker]");
+        attribute.ToFSharpDeclaration().ShouldBe("[<CodegenTests.SampleMarker>]");
+    }
+
+    [Fact]
+    public void the_attribute_suffix_is_trimmed_like_hand_written_code()
+    {
+        AttributeArg.TrimAttributeSuffix("Ns.FooAttribute").ShouldBe("Ns.Foo");
+    }
+
+    [Fact]
+    public void the_attribute_suffix_is_left_alone_when_it_is_the_whole_simple_name()
+    {
+        // "System.Attribute" must not collapse to "System."
+        AttributeArg.TrimAttributeSuffix("System.Attribute").ShouldBe("System.Attribute");
+    }
+
+    [Fact]
+    public void render_a_typeof_argument()
+    {
+        var attribute = new GeneratedAttribute(typeof(SampleValueAttribute), AttributeArg.Type(typeof(string)));
+
+        attribute.ToCSharpDeclaration().ShouldBe("[global::CodegenTests.SampleValue(typeof(string))]");
+        attribute.ToFSharpDeclaration().ShouldBe("[<CodegenTests.SampleValue(typeof<string>)>]");
+    }
+
+    [Fact]
+    public void render_a_typeof_argument_for_a_closed_generic()
+    {
+        AttributeArg.Type(typeof(System.Collections.Generic.List<string>)).ToCSharp()
+            .ShouldBe("typeof(global::System.Collections.Generic.List<string>)");
+    }
+
+    [Fact]
+    public void render_a_type_named_argument_for_a_sibling_generated_type()
+    {
+        // The whole point of TypeNamed: the type does not exist yet, so there is no runtime Type.
+        var arg = AttributeArg.TypeNamed("MyApp.Generated.GeneratedHandlerRegistry");
+
+        arg.ToCSharp().ShouldBe("typeof(global::MyApp.Generated.GeneratedHandlerRegistry)");
+        arg.ToFSharp().ShouldBe("typeof<MyApp.Generated.GeneratedHandlerRegistry>");
+    }
+
+    [Fact]
+    public void render_an_enum_argument()
+    {
+        var arg = AttributeArg.Enum(DynamicallyAccessedMemberTypes.All);
+
+        arg.ToCSharp()
+            .ShouldBe("global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All");
+        arg.ToFSharp().ShouldBe("System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All");
+    }
+
+    [Fact]
+    public void render_combined_flags_with_the_right_operator_per_language()
+    {
+        var arg = AttributeArg.Enum(DynamicallyAccessedMemberTypes.PublicConstructors |
+                                    DynamicallyAccessedMemberTypes.PublicMethods);
+
+        arg.ToCSharp().ShouldContain(" | ");
+        arg.ToCSharp().ShouldContain("PublicConstructors");
+        arg.ToCSharp().ShouldContain("PublicMethods");
+
+        arg.ToFSharp().ShouldContain(" ||| ");
+    }
+
+    [Fact]
+    public void render_literal_values()
+    {
+        AttributeArg.Value("hello").ToCSharp().ShouldBe("\"hello\"");
+        AttributeArg.Value(true).ToCSharp().ShouldBe("true");
+        AttributeArg.Value(null).ToCSharp().ShouldBe("null");
+        AttributeArg.Value(5).ToCSharp().ShouldBe("5");
+        AttributeArg.Value(5L).ToCSharp().ShouldBe("5L");
+    }
+
+    [Fact]
+    public void escape_quotes_and_backslashes_in_string_values()
+    {
+        AttributeArg.Value("say \"hi\"\\").ToCSharp().ShouldBe("\"say \\\"hi\\\"\\\\\"");
+    }
+
+    [Fact]
+    public void a_double_literal_carries_a_decimal_point_in_fsharp()
+    {
+        AttributeArg.Value(2.0).ToCSharp().ShouldBe("2d");
+        AttributeArg.Value(2.0).ToFSharp().ShouldBe("2.0");
+    }
+
+    [Fact]
+    public void value_routes_a_type_to_typeof()
+    {
+        AttributeArg.Value(typeof(string)).ToCSharp().ShouldBe("typeof(string)");
+    }
+
+    [Fact]
+    public void raw_arguments_pass_through()
+    {
+        var arg = AttributeArg.Raw("Name = \"foo\"", "Name = \"bar\"");
+
+        arg.ToCSharp().ShouldBe("Name = \"foo\"");
+        arg.ToFSharp().ShouldBe("Name = \"bar\"");
+    }
+
+    [Fact]
+    public void reject_a_non_attribute_type()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new GeneratedAttribute(typeof(string)));
+    }
+
+    [Fact]
+    public void attribute_assemblies_are_reported_for_the_roslyn_path()
+    {
+        var attribute = new GeneratedAttribute(typeof(SampleValueAttribute), AttributeArg.Type(typeof(Xunit.FactAttribute)));
+
+        attribute.AssemblyReferences().ShouldContain(typeof(Xunit.FactAttribute).Assembly);
+    }
+
+    [Fact]
+    public void generated_types_still_carry_the_generated_code_marker_by_default()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("Marked", typeof(object));
+        type.AddVoidMethod("Go").Frames.Add(new CommentFrame("nothing"));
+
+        // The [GeneratedCode] line is now modeled rather than hardcoded, but the emitted C# is
+        // exactly what it always was.
+        assembly.GenerateCode().ShouldContain("[global::System.CodeDom.Compiler.GeneratedCode(\"JasperFx\", \"1.0.0\")]");
+    }
+
+    [Fact]
+    public void type_level_attributes_are_emitted_in_csharp()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("Attributed", typeof(object));
+        type.Attributes.Add(new GeneratedAttribute(typeof(SampleValueAttribute), AttributeArg.Type(typeof(string))));
+        type.AddVoidMethod("Go").Frames.Add(new CommentFrame("nothing"));
+
+        var code = assembly.GenerateCode();
+
+        code.ShouldContain("[global::CodegenTests.SampleValue(typeof(string))]");
+        code.ShouldContain("public sealed class Attributed");
+    }
+
+    [Fact]
+    public void method_level_attributes_are_emitted_in_csharp()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("MethodAttributed", typeof(object));
+        var method = type.AddVoidMethod("Go");
+        method.Attributes.Add(new GeneratedAttribute(typeof(SampleMarkerAttribute)));
+        method.Frames.Add(new CommentFrame("nothing"));
+
+        assembly.GenerateCode().ShouldContain("[global::CodegenTests.SampleMarker]");
+    }
+
+    [Fact]
+    public void type_level_attributes_are_emitted_in_fsharp()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("Attributed", typeof(object));
+        type.Attributes.Add(new GeneratedAttribute(typeof(SampleValueAttribute), AttributeArg.Type(typeof(string))));
+        type.AddVoidMethod("Go").Frames.Add(new CommentFrame("nothing"));
+
+        var code = assembly.GenerateFSharpCode();
+
+        code.ShouldContain("[<System.CodeDom.Compiler.GeneratedCode(\"JasperFx\", \"1.0.0\")>]");
+        code.ShouldContain("[<CodegenTests.SampleValue(typeof<string>)>]");
+        code.ShouldNotContain("global::");
+    }
+
+    [Fact]
+    public void an_attributed_generated_type_still_compiles_through_roslyn()
+    {
+        var assembly = GeneratedAssembly.Empty();
+        var type = assembly.AddType("CompiledWithAttributes", typeof(IWidgetMaker));
+        type.Attributes.Add(new GeneratedAttribute(typeof(SampleValueAttribute), AttributeArg.Type(typeof(string))));
+
+        var method = type.MethodFor(nameof(IWidgetMaker.Make));
+        method.Attributes.Add(new GeneratedAttribute(typeof(SampleMarkerAttribute)));
+        method.Frames.Code("return 42;");
+
+        assembly.CompileAll();
+
+        var maker = (IWidgetMaker)Activator.CreateInstance(type.CompiledType!)!;
+        maker.Make().ShouldBe(42);
+
+        type.CompiledType!.GetCustomAttributes(typeof(SampleValueAttribute), false).ShouldNotBeEmpty();
+        type.CompiledType!.GetMethod(nameof(IWidgetMaker.Make))!
+            .GetCustomAttributes(typeof(SampleMarkerAttribute), false).ShouldNotBeEmpty();
+    }
+}
+
+public interface IWidgetMaker
+{
+    int Make();
+}
+
+[AttributeUsage(AttributeTargets.All)]
+public class SampleMarkerAttribute : Attribute
+{
+}
+
+[AttributeUsage(AttributeTargets.All)]
+public class SampleValueAttribute : Attribute
+{
+    public SampleValueAttribute(Type type)
+    {
+        Type = type;
+    }
+
+    public Type Type { get; }
+}

--- a/src/JasperFx/CodeGeneration/AotRootsCompanion.cs
+++ b/src/JasperFx/CodeGeneration/AotRootsCompanion.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace JasperFx.CodeGeneration;
+
+/// <summary>
+///     Emits the "AOT roots companion" — a generated class whose only content is a
+///     <c>[ModuleInitializer]</c>-marked static method carrying a block of
+///     <c>[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(...))]</c> attributes.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The problem this solves (jasperfx#743, follow-on from wolverine#4287): pre-generated
+///         code is reached at runtime by reflection — an assembly scan plus
+///         <c>Activator.CreateInstance</c> — so ILC has no static reference to it, trims it, and
+///         <c>TypeLoadMode.Static</c> silently degrades to a scan that finds nothing under Native
+///         AOT. Until now the application author had to hand-write the rooting attributes.
+///     </para>
+///     <para>
+///         A module initializer is an unconditional ILC root, so anchoring the block there roots
+///         the whole graph with zero application-side code. Note that
+///         <c>[DynamicDependency]</c> has <c>AttributeUsage(Constructor | Field | Method)</c> and
+///         therefore cannot sit on the class — the method is the only legal home, which is why
+///         the companion is a class *and* a method rather than an attribute block on the registry.
+///     </para>
+/// </remarks>
+public static class AotRootsCompanionExtensions
+{
+    /// <summary>
+    ///     The name of the generated rooting method.
+    /// </summary>
+    public const string PinMethodName = "Pin";
+
+    private const string BodyComment =
+        "Intentionally empty. The [DynamicDependency] attributes above are the payload: they root the generated types for Native AOT, and [ModuleInitializer] guarantees this method is itself an ILC root.";
+
+    /// <summary>
+    ///     Add an AOT rooting companion to this generated assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly being emitted.</param>
+    /// <param name="typeName">Name of the companion class, e.g. <c>"AotRoots"</c>.</param>
+    /// <param name="rootedTypes">
+    ///     One argument per type to root. Use <see cref="AttributeArg.TypeNamed" /> for sibling
+    ///     generated types — they have no runtime <see cref="Type" /> while <c>codegen write</c>
+    ///     is running — and <see cref="AttributeArg.Type" /> for types that already exist.
+    /// </param>
+    /// <returns>
+    ///     The generated companion type, or <c>null</c> when nothing was emitted: either the
+    ///     assembly is being rendered as F# (see the remarks) or <paramref name="rootedTypes" />
+    ///     was empty.
+    /// </returns>
+    /// <remarks>
+    ///     The companion is <b>C# only</b>. The F# compiler does not honor
+    ///     <c>ModuleInitializerAttribute</c> — an F# module's <c>do</c> bindings initialize lazily
+    ///     and are not an ILC root — so emitting one under
+    ///     <c>codegen write --language fsharp</c> would be a silent no-op that reads as working
+    ///     rooting. This method returns <c>null</c> instead.
+    /// </remarks>
+    public static GeneratedType? AddAotRoots(this GeneratedAssembly assembly, string typeName,
+        IEnumerable<AttributeArg> rootedTypes)
+    {
+        if (assembly == null)
+        {
+            throw new ArgumentNullException(nameof(assembly));
+        }
+
+        if (assembly.TargetLanguage != CodegenLanguage.csharp)
+        {
+            return null;
+        }
+
+        var roots = rootedTypes?.ToArray() ?? [];
+        if (roots.Length == 0)
+        {
+            return null;
+        }
+
+        var companion = assembly.AddType(typeName);
+        companion.CommentType(
+            "Native AOT rooting companion (jasperfx#743). Generated code is only ever reached reflectively, so without these roots ILC trims it and TypeLoadMode.Static finds nothing.");
+
+        var method = companion.AddStaticVoidMethod(PinMethodName);
+        method.Frames.Add(new Frames.NoOpFrame(BodyComment));
+
+        method.Attributes.Add(new GeneratedAttribute(typeof(ModuleInitializerAttribute)));
+
+        foreach (var root in roots)
+        {
+            method.Attributes.Add(new GeneratedAttribute(typeof(DynamicDependencyAttribute),
+                AttributeArg.Enum(DynamicallyAccessedMemberTypes.All), root));
+        }
+
+        return companion;
+    }
+
+    /// <summary>
+    ///     Add an AOT rooting companion for types named in code. Use this overload for sibling
+    ///     generated types, which do not exist as runtime <see cref="Type" />s at
+    ///     <c>codegen write</c> time. Names must be fully qualified.
+    /// </summary>
+    public static GeneratedType? AddAotRoots(this GeneratedAssembly assembly, string typeName,
+        IEnumerable<string> rootedTypeNames)
+    {
+        return assembly.AddAotRoots(typeName,
+            (rootedTypeNames ?? []).Select(AttributeArg.TypeNamed));
+    }
+
+    /// <summary>
+    ///     Add an AOT rooting companion for types that already exist at code generation time —
+    ///     handler classes, message types, closed generics, and so on.
+    /// </summary>
+    public static GeneratedType? AddAotRoots(this GeneratedAssembly assembly, string typeName,
+        IEnumerable<Type> rootedTypes)
+    {
+        return assembly.AddAotRoots(typeName, (rootedTypes ?? []).Select(AttributeArg.Type));
+    }
+}

--- a/src/JasperFx/CodeGeneration/DynamicCodeBuilder.cs
+++ b/src/JasperFx/CodeGeneration/DynamicCodeBuilder.cs
@@ -135,6 +135,10 @@ public class DynamicCodeBuilder
                 foreach (var file in collection.BuildFiles())
                 {
                     var generatedAssembly = collection.StartAssembly(collection.Rules);
+
+                    // #743: the target language has to be visible to AssembleTypes so an ICodeFile
+                    // can decline to emit C#-only artifacts (AOT rooting companions) under --language fsharp.
+                    generatedAssembly.TargetLanguage = Language;
                     file.AssembleTypes(generatedAssembly);
 
                     // #2991: apply any per-file service-provider override (e.g. HTTP's
@@ -187,6 +191,7 @@ public class DynamicCodeBuilder
         foreach (var file in collection.BuildFiles())
         {
             var generatedAssembly = collection.StartAssembly(collection.Rules);
+            generatedAssembly.TargetLanguage = Language;
             try
             {
                 file.AssembleTypes(generatedAssembly);
@@ -230,6 +235,7 @@ public class DynamicCodeBuilder
             foreach (var file in collection.BuildFiles())
             {
                 var generatedAssembly = collection.StartAssembly(collection.Rules);
+                generatedAssembly.TargetLanguage = Language;
                 file.AssembleTypes(generatedAssembly);
 
                 // #2991: see WriteGeneratedCode.

--- a/src/JasperFx/CodeGeneration/Frames/NoOpFrame.cs
+++ b/src/JasperFx/CodeGeneration/Frames/NoOpFrame.cs
@@ -1,0 +1,47 @@
+using JasperFx.CodeGeneration.Model;
+using JasperFx.Core;
+
+namespace JasperFx.CodeGeneration.Frames;
+
+/// <summary>
+///     A frame that generates no behavior. Its reason to exist is a generated method whose *only*
+///     payload is its attributes — the AOT rooting companion emitted by
+///     <see cref="AotRootsCompanionExtensions.AddAotRoots(GeneratedAssembly, string, IEnumerable{AttributeArg})" />
+///     being the motivating case. C# tolerates a truly empty block; F# does not, so the F# emit
+///     writes the unit value.
+/// </summary>
+public class NoOpFrame : SyncFrame
+{
+    public NoOpFrame(string? comment = null)
+    {
+        Comment = comment;
+    }
+
+    /// <summary>
+    ///     Optional single line comment explaining why the body is empty.
+    /// </summary>
+    public string? Comment { get; }
+
+    public override void GenerateCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (Comment.IsNotEmpty())
+        {
+            writer.WriteComment(Comment!);
+        }
+
+        Next?.GenerateCode(method, writer);
+    }
+
+    public override void GenerateFSharpCode(GeneratedMethod method, ISourceWriter writer)
+    {
+        if (Comment.IsNotEmpty())
+        {
+            writer.WriteComment(Comment!);
+        }
+
+        // F# has no empty body; `()` is the unit value that stands in for one.
+        writer.WriteLine("()");
+
+        Next?.GenerateFSharpCode(method, writer);
+    }
+}

--- a/src/JasperFx/CodeGeneration/GeneratedAssembly.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedAssembly.cs
@@ -33,6 +33,19 @@ public class GeneratedAssembly
     public Assembly? Assembly { get; private set; }
 
     /// <summary>
+    ///     The language this assembly is about to be rendered as. Stamped by
+    ///     <see cref="DynamicCodeBuilder" /> *before* it calls <see cref="ICodeFile.AssembleTypes" />,
+    ///     so an <see cref="ICodeFile" /> can vary what it emits by language — the motivating case
+    ///     being AOT rooting companions, which are meaningful in C# only. Defaults to
+    ///     <see cref="CodegenLanguage.csharp" />; the runtime Roslyn path never changes it.
+    /// </summary>
+    /// <remarks>
+    ///     This is per-emission-run state, which is why it lives here rather than on the
+    ///     long-lived <see cref="GenerationRules" />. See jasperfx#743.
+    /// </remarks>
+    public CodegenLanguage TargetLanguage { get; set; } = CodegenLanguage.csharp;
+
+    /// <summary>
     ///     Optional code fragment to write at the beginning of this
     ///     code file
     /// </summary>
@@ -52,6 +65,22 @@ public class GeneratedAssembly
     public void ReferenceAssembly(Assembly assembly)
     {
         _assemblies.Fill(assembly);
+    }
+
+    /// <summary>
+    ///     Add a standalone generated type with no base class and no implemented interfaces.
+    /// </summary>
+    public GeneratedType AddType(string typeName)
+    {
+        if (Assembly != null)
+        {
+            throw new InvalidOperationException("This generated assembly has already been compiled");
+        }
+
+        var generatedType = new GeneratedType(this, typeName) { ParentAssembly = this };
+        _generatedTypes.Add(generatedType);
+
+        return generatedType;
     }
 
     public GeneratedType AddType(

--- a/src/JasperFx/CodeGeneration/GeneratedAttribute.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedAttribute.cs
@@ -1,0 +1,423 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using JasperFx.Core;
+using JasperFx.Core.Reflection;
+
+namespace JasperFx.CodeGeneration;
+
+/// <summary>
+///     A single argument passed to a <see cref="GeneratedAttribute" />. Arguments are a small,
+///     closed model rather than raw text so that every language writer can render them in its own
+///     syntax — <c>typeof(T)</c> in C#, <c>typeof&lt;T&gt;</c> in F#, <c>|</c> vs <c>|||</c> for
+///     combined enum flags, and so on.
+/// </summary>
+/// <remarks>
+///     Rendering is always fully qualified (and <c>global::</c>-prefixed in C#), so an attribute
+///     never depends on the <c>using</c> / <c>open</c> statements at the top of the generated file.
+/// </remarks>
+public abstract class AttributeArg
+{
+    private const string Suffix = "Attribute";
+
+    /// <summary>
+    ///     A <c>typeof()</c> argument for a type that exists at code generation time.
+    /// </summary>
+    public static AttributeArg Type(System.Type type)
+    {
+        return new TypeArg(type ?? throw new ArgumentNullException(nameof(type)));
+    }
+
+    /// <summary>
+    ///     A <c>typeof()</c> argument naming a type by its (fully qualified) name in code rather
+    ///     than by a runtime <see cref="System.Type" />. This is the form to use for a *sibling
+    ///     generated type* — a type that only exists in the file being emitted and therefore has
+    ///     no runtime <see cref="System.Type" /> while <c>codegen write</c> is running.
+    /// </summary>
+    /// <param name="typeName">
+    ///     The type name exactly as it should appear inside <c>typeof(...)</c>. Fully qualify it;
+    ///     no <c>using</c> / <c>open</c> bookkeeping is done on your behalf.
+    /// </param>
+    public static AttributeArg TypeNamed(string typeName)
+    {
+        if (typeName.IsEmpty())
+        {
+            throw new ArgumentOutOfRangeException(nameof(typeName), "The type name cannot be empty");
+        }
+
+        return new TypeNamedArg(typeName);
+    }
+
+    /// <summary>
+    ///     An enum member argument, e.g. <c>DynamicallyAccessedMemberTypes.All</c>. Combined
+    ///     <c>[Flags]</c> values are rendered with the language's bitwise-or operator.
+    /// </summary>
+    public static AttributeArg Enum(System.Enum value)
+    {
+        return new EnumArg(value ?? throw new ArgumentNullException(nameof(value)));
+    }
+
+    /// <summary>
+    ///     A literal argument — string, bool, char, numeric, enum, <see cref="System.Type" />, or
+    ///     <c>null</c>.
+    /// </summary>
+    public static AttributeArg Value(object? value)
+    {
+        return value switch
+        {
+            AttributeArg arg => arg,
+            System.Type type => new TypeArg(type),
+            System.Enum e => new EnumArg(e),
+            _ => new ValueArg(value)
+        };
+    }
+
+    /// <summary>
+    ///     An escape hatch for anything the model above cannot express (named arguments, arrays,
+    ///     <c>nameof</c>, …). The text is emitted verbatim.
+    /// </summary>
+    /// <param name="code">The C# text.</param>
+    /// <param name="fsharpCode">The F# text. Defaults to <paramref name="code" />.</param>
+    public static AttributeArg Raw(string code, string? fsharpCode = null)
+    {
+        return new RawArg(code, fsharpCode);
+    }
+
+    /// <summary>
+    ///     Render this argument as it should appear inside a C# attribute usage.
+    /// </summary>
+    public abstract string ToCSharp();
+
+    /// <summary>
+    ///     Render this argument as it should appear inside an F# attribute usage.
+    /// </summary>
+    public abstract string ToFSharp();
+
+    /// <summary>
+    ///     Assemblies that must be referenced for the emitted argument to compile. Only matters on
+    ///     the runtime Roslyn path; the <c>codegen write</c> path never compiles in-process.
+    /// </summary>
+    public virtual IEnumerable<Assembly> AssemblyReferences()
+    {
+        yield break;
+    }
+
+    public override string ToString()
+    {
+        return ToCSharp();
+    }
+
+    /// <summary>
+    ///     Prefix a name with <c>global::</c> when it is namespace-qualified. Aliased primitives
+    ///     (<c>int</c>, <c>string</c>, …) and already-prefixed names are left alone, because
+    ///     <c>global::int</c> does not compile.
+    /// </summary>
+    internal static string QualifyForCSharp(string name)
+    {
+        if (!name.Contains('.') || name.StartsWith("global::", StringComparison.Ordinal))
+        {
+            return name;
+        }
+
+        return "global::" + name;
+    }
+
+    /// <summary>
+    ///     Strip the conventional <c>Attribute</c> suffix from an attribute type's name in code,
+    ///     matching how attributes are written by hand. <c>System.Attribute</c> itself and any
+    ///     type whose simple name *is* "Attribute" are left alone.
+    /// </summary>
+    internal static string TrimAttributeSuffix(string nameInCode)
+    {
+        if (nameInCode.Length <= Suffix.Length || !nameInCode.EndsWith(Suffix, StringComparison.Ordinal))
+        {
+            return nameInCode;
+        }
+
+        // Guard against "System.Attribute" collapsing to "System."
+        if (nameInCode[nameInCode.Length - Suffix.Length - 1] == '.')
+        {
+            return nameInCode;
+        }
+
+        return nameInCode.Substring(0, nameInCode.Length - Suffix.Length);
+    }
+
+    internal static string Quote(string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('"');
+        foreach (var c in value)
+        {
+            switch (c)
+            {
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                default:
+                    builder.Append(c);
+                    break;
+            }
+        }
+
+        builder.Append('"');
+        return builder.ToString();
+    }
+
+    private sealed class TypeArg : AttributeArg
+    {
+        private readonly System.Type _type;
+
+        public TypeArg(System.Type type)
+        {
+            _type = type;
+        }
+
+        public override string ToCSharp()
+        {
+            return $"typeof({QualifyForCSharp(_type.FullNameInCode())})";
+        }
+
+        public override string ToFSharp()
+        {
+            return $"typeof<{_type.FSharpName()}>";
+        }
+
+        public override IEnumerable<Assembly> AssemblyReferences()
+        {
+            yield return _type.Assembly;
+        }
+    }
+
+    private sealed class TypeNamedArg : AttributeArg
+    {
+        private readonly string _typeName;
+
+        public TypeNamedArg(string typeName)
+        {
+            _typeName = typeName;
+        }
+
+        public override string ToCSharp()
+        {
+            return $"typeof({QualifyForCSharp(_typeName)})";
+        }
+
+        public override string ToFSharp()
+        {
+            return $"typeof<{_typeName}>";
+        }
+    }
+
+    private sealed class EnumArg : AttributeArg
+    {
+        private readonly System.Enum _value;
+
+        public EnumArg(System.Enum value)
+        {
+            _value = value;
+        }
+
+        public override string ToCSharp()
+        {
+            return render(QualifyForCSharp(_value.GetType().FullNameInCode()), " | ");
+        }
+
+        public override string ToFSharp()
+        {
+            return render(_value.GetType().FSharpName(), " ||| ");
+        }
+
+        public override IEnumerable<Assembly> AssemblyReferences()
+        {
+            yield return _value.GetType().Assembly;
+        }
+
+        private string render(string typeName, string separator)
+        {
+            // A combined [Flags] value with no single matching member renders as "A, B". Each
+            // member has to be qualified separately and joined with the language's bitwise-or.
+            var members = _value.ToString().Split(',').Select(x => x.Trim()).Where(x => x.IsNotEmpty()).ToArray();
+
+            if (members.Length == 0 || members.Any(x => !char.IsLetter(x[0]) && x[0] != '_'))
+            {
+                // Not a named member (an undefined numeric value) — cast the raw number instead.
+                var numeric = Convert.ToInt64(_value, CultureInfo.InvariantCulture)
+                    .ToString(CultureInfo.InvariantCulture);
+                return $"({typeName}){numeric}";
+            }
+
+            return members.Select(x => $"{typeName}.{x}").Join(separator);
+        }
+    }
+
+    private sealed class ValueArg : AttributeArg
+    {
+        private readonly object? _value;
+
+        public ValueArg(object? value)
+        {
+            _value = value;
+        }
+
+        public override string ToCSharp()
+        {
+            return _value switch
+            {
+                null => "null",
+                string s => Quote(s),
+                bool b => b ? "true" : "false",
+                char c => $"'{c}'",
+                float f => f.ToString("R", CultureInfo.InvariantCulture) + "f",
+                double d => d.ToString("R", CultureInfo.InvariantCulture) + "d",
+                decimal m => m.ToString(CultureInfo.InvariantCulture) + "m",
+                long l => l.ToString(CultureInfo.InvariantCulture) + "L",
+                ulong ul => ul.ToString(CultureInfo.InvariantCulture) + "UL",
+                uint ui => ui.ToString(CultureInfo.InvariantCulture) + "u",
+                IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+                _ => _value.ToString() ?? "null"
+            };
+        }
+
+        public override string ToFSharp()
+        {
+            return _value switch
+            {
+                null => "null",
+                string s => Quote(s),
+                bool b => b ? "true" : "false",
+                char c => $"'{c}'",
+                float f => withDecimalPoint(f.ToString("R", CultureInfo.InvariantCulture)) + "f",
+                double d => withDecimalPoint(d.ToString("R", CultureInfo.InvariantCulture)),
+                decimal m => m.ToString(CultureInfo.InvariantCulture) + "m",
+                long l => l.ToString(CultureInfo.InvariantCulture) + "L",
+                ulong ul => ul.ToString(CultureInfo.InvariantCulture) + "UL",
+                uint ui => ui.ToString(CultureInfo.InvariantCulture) + "u",
+                IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+                _ => _value.ToString() ?? "null"
+            };
+        }
+
+        // F# has no "d" suffix; a floating point literal is distinguished by its decimal point.
+        private static string withDecimalPoint(string text)
+        {
+            return text.Contains('.') || text.Contains('E') || text.Contains('e') ? text : text + ".0";
+        }
+    }
+
+    private sealed class RawArg : AttributeArg
+    {
+        private readonly string _code;
+        private readonly string _fsharpCode;
+
+        public RawArg(string code, string? fsharpCode)
+        {
+            _code = code;
+            _fsharpCode = fsharpCode ?? code;
+        }
+
+        public override string ToCSharp()
+        {
+            return _code;
+        }
+
+        public override string ToFSharp()
+        {
+            return _fsharpCode;
+        }
+    }
+}
+
+/// <summary>
+///     A modeled attribute usage to be emitted on a generated type or generated method. Each
+///     language writer renders the same declaration in its own syntax — <c>[Foo(...)]</c> in C#,
+///     <c>[&lt;Foo(...)&gt;]</c> in F# — so an attribute added by an <see cref="ICodeFile" /> is
+///     correct whichever language <c>codegen write</c> was asked for.
+/// </summary>
+/// <remarks>
+///     This exists because the only previous way to put an attribute in front of a generated
+///     declaration was to smuggle raw C# text through <see cref="GeneratedType.Header" /> /
+///     <see cref="GeneratedMethod.Header" />, which silently corrupts F# output. <c>Header</c>
+///     remains as an escape hatch. See jasperfx#743.
+/// </remarks>
+public class GeneratedAttribute
+{
+    public GeneratedAttribute(Type attributeType, params AttributeArg[] arguments)
+    {
+        if (attributeType == null)
+        {
+            throw new ArgumentNullException(nameof(attributeType));
+        }
+
+        if (!attributeType.CanBeCastTo<Attribute>())
+        {
+            throw new ArgumentOutOfRangeException(nameof(attributeType),
+                $"{attributeType.FullNameInCode()} is not an Attribute type");
+        }
+
+        AttributeType = attributeType;
+        Arguments = new List<AttributeArg>(arguments);
+    }
+
+    public Type AttributeType { get; }
+
+    public IList<AttributeArg> Arguments { get; }
+
+    /// <summary>
+    ///     The full C# attribute usage, brackets included.
+    /// </summary>
+    public string ToCSharpDeclaration()
+    {
+        var name = AttributeArg.QualifyForCSharp(AttributeArg.TrimAttributeSuffix(AttributeType.FullNameInCode()));
+        return Arguments.Count == 0
+            ? $"[{name}]"
+            : $"[{name}({Arguments.Select(x => x.ToCSharp()).Join(", ")})]";
+    }
+
+    /// <summary>
+    ///     The full F# attribute usage, brackets included.
+    /// </summary>
+    public string ToFSharpDeclaration()
+    {
+        var name = AttributeArg.TrimAttributeSuffix(AttributeType.FSharpName());
+        return Arguments.Count == 0
+            ? $"[<{name}>]"
+            : $"[<{name}({Arguments.Select(x => x.ToFSharp()).Join(", ")})>]";
+    }
+
+    /// <summary>
+    ///     Write this attribute in the syntax of the supplied language.
+    /// </summary>
+    public void Write(ISourceWriter writer, CodegenLanguage language)
+    {
+        // WriteLine rather than Write: Write() substitutes '`' for '"', which would corrupt a
+        // generic type name (List`1) appearing inside a raw or named-type argument.
+        writer.WriteLine(language == CodegenLanguage.fsharp ? ToFSharpDeclaration() : ToCSharpDeclaration());
+    }
+
+    public IEnumerable<Assembly> AssemblyReferences()
+    {
+        yield return AttributeType.Assembly;
+
+        foreach (var argument in Arguments)
+        foreach (var assembly in argument.AssemblyReferences())
+            yield return assembly;
+    }
+
+    public override string ToString()
+    {
+        return ToCSharpDeclaration();
+    }
+}

--- a/src/JasperFx/CodeGeneration/GeneratedMethod.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedMethod.cs
@@ -91,6 +91,25 @@ public class GeneratedMethod : IGeneratedMethod
     public ICodeFragment? Header { get; set; }
 
     /// <summary>
+    ///     Attributes emitted immediately in front of this method's declaration, rendered in the
+    ///     syntax of whichever language is being generated. See jasperfx#743.
+    /// </summary>
+    public IList<GeneratedAttribute> Attributes { get; } = new List<GeneratedAttribute>();
+
+    /// <summary>
+    ///     Emit this method as <c>static</c>. Mutually exclusive with <see cref="Overrides" />.
+    /// </summary>
+    public bool IsStatic { get; set; }
+
+    /// <summary>
+    ///     Permit an empty <see cref="Frames" /> collection. Normally an empty method body is a
+    ///     configuration mistake and <see cref="ArrangeFrames" /> throws; a method whose only
+    ///     payload is its <see cref="Attributes" /> is the exception. Set by
+    ///     <see cref="GeneratedType.AddStaticVoidMethod" />.
+    /// </summary>
+    public bool AllowEmptyBody { get; set; }
+
+    /// <summary>
     ///     The name of the method being generated
     /// </summary>
     public string MethodName { get; }
@@ -169,11 +188,17 @@ public class GeneratedMethod : IGeneratedMethod
 
         Header?.Write(writer);
 
+        foreach (var attribute in Attributes) attribute.Write(writer, CodegenLanguage.csharp);
+
         var returnValue = determineReturnExpression();
 
         if (Overrides)
         {
             returnValue = "override " + returnValue;
+        }
+        else if (IsStatic)
+        {
+            returnValue = "static " + returnValue;
         }
 
         var arguments = Arguments.Select(x => x.Declaration).Join(", ");
@@ -205,6 +230,8 @@ public class GeneratedMethod : IGeneratedMethod
 
         Header?.Write(writer);
 
+        foreach (var attribute in Attributes) attribute.Write(writer, CodegenLanguage.fsharp);
+
         // Propagate IsReferenced from DerivedVariables to Arguments that share the same Usage name.
         // Handles the case where a method argument (e.g. `context: MessageContext`) is exposed under
         // an interface alias in DerivedVariables (e.g. `ContextVariable("context", IMessageContext)`):
@@ -222,13 +249,15 @@ public class GeneratedMethod : IGeneratedMethod
 
         var arguments = Arguments.Select(x => $"{(x.IsReferenced ? x.Usage : "_" + x.Usage)}: {x.VariableType.FSharpName()}").Join(", ");
         var returnType = ReturnType.FSharpName();
-        var keyword = Overrides ? "override" : "member";
+        var keyword = Overrides ? "override" : IsStatic ? "static member" : "member";
 
         // A named `this` self identifier is required so emitted frames can call inherited instance
         // members (e.g. a base class's `WriteJsonAsync`/`ReadJsonAsync`) — F# has no implicit `this`,
         // and `member _.` would discard the instance. F# does not warn on an unused member self
         // identifier (unlike an unused `let` binding), so this is safe. See jasperfx#393.
-        writer.Write($"BLOCK:{keyword} this.{MethodName}({arguments}) : {returnType} =");
+        // A static member has no instance to name, so it takes no self identifier at all.
+        var selfIdentifier = IsStatic && !Overrides ? "" : "this.";
+        writer.Write($"BLOCK:{keyword} {selfIdentifier}{MethodName}({arguments}) : {returnType} =");
 
         if (AsyncMode == AsyncMode.AsyncTask)
         {
@@ -284,7 +313,14 @@ public class GeneratedMethod : IGeneratedMethod
     {
         if (!Frames.Any())
         {
-            throw new ArgumentOutOfRangeException(nameof(Frames), "Cannot be an empty list");
+            if (!AllowEmptyBody)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Frames), "Cannot be an empty list");
+            }
+
+            // The arranger still has to run (it computes the async mode and builds the frame
+            // chain), so stand a do-nothing frame up rather than special casing _top.
+            Frames.Add(new NoOpFrame());
         }
 
         services?.StartNewMethod();

--- a/src/JasperFx/CodeGeneration/GeneratedType.cs
+++ b/src/JasperFx/CodeGeneration/GeneratedType.cs
@@ -50,6 +50,22 @@ public class GeneratedType : IVariableSource, IGeneratedType
     /// </summary>
     public ICodeFragment? Footer { get; set; }
 
+    /// <summary>
+    ///     Attributes emitted immediately in front of this type's declaration, rendered in the
+    ///     syntax of whichever language is being generated. Seeded with the
+    ///     <c>[GeneratedCode("JasperFx", "1.0.0")]</c> marker that every generated type carries.
+    /// </summary>
+    /// <remarks>
+    ///     Prefer this over smuggling raw attribute text through <see cref="Header" />: a C#
+    ///     attribute in a <c>Header</c> corrupts <c>codegen write --language fsharp</c> output.
+    ///     See jasperfx#743.
+    /// </remarks>
+    public IList<GeneratedAttribute> Attributes { get; } = new List<GeneratedAttribute>
+    {
+        new(typeof(System.CodeDom.Compiler.GeneratedCodeAttribute), AttributeArg.Value("JasperFx"),
+            AttributeArg.Value("1.0.0"))
+    };
+
     public string Namespace { get; internal set; }
 
     public Type? BaseType { get; private set; }
@@ -189,6 +205,26 @@ public class GeneratedType : IVariableSource, IGeneratedType
         return method;
     }
 
+    /// <summary>
+    ///     Add a <c>static void</c> method to this type. Unlike <see cref="AddVoidMethod" />, the
+    ///     method is allowed to have an empty body — the motivating case is a method whose only
+    ///     payload is its <see cref="GeneratedMethod.Attributes" />, such as the
+    ///     <c>[ModuleInitializer]</c> AOT rooting companion from jasperfx#743.
+    /// </summary>
+    public GeneratedMethod AddStaticVoidMethod(string name, params Argument[] args)
+    {
+        var method = new GeneratedMethod(name, typeof(void), args)
+        {
+            ParentType = this,
+            IsStatic = true,
+            AllowEmptyBody = true
+        };
+
+        AddMethod(method);
+
+        return method;
+    }
+
     public GeneratedMethod AddMethodThatReturns<TReturn>(string name, params Argument[] args)
     {
         var method = new GeneratedMethod(name, typeof(TReturn), args) { ParentType = this };
@@ -236,6 +272,8 @@ public class GeneratedType : IVariableSource, IGeneratedType
         var ctorArgs = AllInjectedFields
             .Select(x => $"{x.CtorArg}: {x.ArgType.FSharpName()}")
             .Join(", ");
+
+        writeAttributes(writer, CodegenLanguage.fsharp);
 
         writer.Write($"BLOCK:type {TypeName}({ctorArgs}) =");
 
@@ -326,7 +364,7 @@ public class GeneratedType : IVariableSource, IGeneratedType
     private void writeDeclaration(ISourceWriter writer)
     {
         var implemented = implements().ToArray();
-        writer.WriteLine("[global::System.CodeDom.Compiler.GeneratedCode(\"JasperFx\", \"1.0.0\")]");
+        writeAttributes(writer, CodegenLanguage.csharp);
         if (implemented.Any())
         {
             writer.Write(
@@ -336,6 +374,11 @@ public class GeneratedType : IVariableSource, IGeneratedType
         {
             writer.Write($"BLOCK:public sealed class {TypeName}");
         }
+    }
+
+    private void writeAttributes(ISourceWriter writer, CodegenLanguage language)
+    {
+        foreach (var attribute in Attributes) attribute.Write(writer, language);
     }
 
     private IEnumerable<Type> implements()
@@ -386,6 +429,13 @@ public class GeneratedType : IVariableSource, IGeneratedType
         }
 
         foreach (var @interface in _interfaces) yield return @interface.Assembly;
+
+        // An attribute's own assembly (and any assembly named by its arguments) has to be
+        // referenced for the runtime Roslyn path to compile an attributed generated type.
+        foreach (var assembly in Attributes.SelectMany(x => x.AssemblyReferences())) yield return assembly;
+
+        foreach (var assembly in _methods.SelectMany(m => m.Attributes).SelectMany(x => x.AssemblyReferences()))
+            yield return assembly;
     }
 
     public T CreateInstance<T>(params object[] arguments)


### PR DESCRIPTION
Closes #743.

## The problem

Pre-generated code is only ever *reached* reflectively — an assembly scan plus `Activator.CreateInstance` — so ILC has no static reference to it, trims it, and `TypeLoadMode.Static` quietly degrades into a scan that finds nothing under Native AOT. Today the app author hand-writes the rooting attributes (verified working in JasperFx/wolverine#4287).

The generated file is the one place that knows every type involved, but it had no way to say so. The only way to put an attribute in front of a generated declaration was to smuggle raw C# text through `Header`, which silently corrupts `codegen write --language fsharp` output.

## What's here

Four primitives. **No change to `ICodeFile` / `ICodeFileCollection` / `ICodeFragment` / `ISourceWriter`** — every addition is a property with a default on a concrete `Generated*` class, so Wolverine, Marten, Grpc and every test fixture compile unchanged.

**J1 — attribute emission is a modeled concept.** `GeneratedAttribute` (attribute `Type` + a typed argument model) with an `Attributes` list on both `GeneratedType` and `GeneratedMethod`. Each language writer renders the same declaration in its own syntax: `[Foo(...)]` / `[<Foo(...)>]`, `typeof(T)` / `typeof<T>`, `|` / `|||` for combined flags. Rendering is always fully qualified (`global::`-prefixed in C#), so there is no using/open bookkeeping.

`AttributeArg.TypeNamed(string)` is the one that matters for generated code: a *sibling generated type* has no runtime `Type` while `codegen write` is running, so it can only be referenced by name. Also `Type`, `Enum`, `Value`, and a `Raw` escape hatch, per the maintainer ruling on open question 3.

The hardcoded `[GeneratedCode]` line in `GeneratedType.writeDeclaration` folds into the same mechanism. **C# output is byte-identical** (`end_to_end_compilation` guards it); F# output gains `[<GeneratedCode>]` per ruling 1, so `Generated.fs` is regenerated in this PR. `AssemblyReferences()` now also yields attribute and argument assemblies so the runtime Roslyn path still compiles attributed types.

**J2 — language awareness.** `GeneratedAssembly.TargetLanguage`, stamped by `DynamicCodeBuilder` right after each of its three `StartAssembly` calls and *before* `AssembleTypes`, so a code file can see the language while it is assembling types. Per-emission-run state, which is why it is here and not on the long-lived `GenerationRules`. Named `TargetLanguage` per ruling 5.

**J3 — static methods.** `GeneratedMethod.IsStatic`, `GeneratedType.AddStaticVoidMethod`, and a `NoOpFrame` so a method whose only payload is its attributes may have an empty body. `ArrangeFrames` still throws on an empty `Frames` list for every other method. F# renders `static member Foo()` with no self identifier and `()` for the empty body.

**J4 — the companion helper.** `assembly.AddAotRoots(typeName, roots)` emits a class whose single static method carries `[ModuleInitializer]` and one `[DynamicDependency(All, typeof(...))]` per rooted type — a module initializer is an unconditional ILC root, so the graph is anchored with zero app-side code. It lives in JasperFx per ruling 2. Overloads take names (sibling generated types), `Type`s, or raw `AttributeArg`s.

Two corrections to the issue text, both confirmed against the framework:

- `[DynamicDependency]` is `AttributeUsage(Constructor | Field | Method)` — it is **not** valid on a class, so the block cannot go "on the registry class". The method is its only legal home, which merges the issue's two bullets into one artifact.
- The companion is **C#-only**. The F# compiler does not honor `ModuleInitializerAttribute` (a module's `do` bindings initialize lazily and are not an ILC root), so `AddAotRoots` returns `null` and emits nothing under `--language fsharp` rather than emitting rooting that silently does nothing.

## Emitted output

```cs
// Native AOT rooting companion (jasperfx#743). ...
[global::System.CodeDom.Compiler.GeneratedCode("JasperFx", "1.0.0")]
public sealed class AotRoots
{
    [global::System.Runtime.CompilerServices.ModuleInitializer]
    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::MyApp.Generated.GeneratedHandlerRegistry))]
    [global::System.Diagnostics.CodeAnalysis.DynamicDependency(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::MyApp.Messages.CreateOrder))]
    public static void Pin()
    {
        // Intentionally empty. The [DynamicDependency] attributes above are the payload...
    }
}
```

## Tests

`GeneratedAttributeTests` and `AotRootsCompanionTests` (24 new assertions across both languages), plus two additions to `CodegenLanguageTests`. The strongest one runs the emitted companion through **real Roslyn** (`CompileAll`) and then asserts the compiled `Pin` is static, carries `[ModuleInitializer]` and the `[DynamicDependency]` block, and that the module loaded at all — a bad module-initializer signature is a `TypeLoadException` at runtime, not a compile error, so reaching the assertions proves the shape is accepted by both the compiler and the runtime.

Locally green: `test-core`, `test-codegen` (467), `test-codegen-fsharp`, `test-command-line`, `test-events`, `test-event-store`, `smoke-test-commands`, `smoke-test-aot`.

## Deliberately left out

The scoping comment's J4 also suggested a `JasperFx.AotSmoke` proof that a companion-rooted type survives an actual `PublishAot` + `StaticTypeLoader` round trip. That is not in this PR: it needs a new pre-generated-code harness in the smoke app plus an ILC publish job (a native toolchain and a couple of minutes of CI), and the issue is scoped to "pure codegen surface" per ruling 6. The Roslyn compile test above covers everything short of the ILC run. Worth a follow-up issue if you want the end-to-end gate.

Docs: a "Rooting pre-generated types" section in `docs/codegen/aot.md`, and Attributes / Target Language / Static Methods sections in `docs/codegen/generated-types.md`.

Wolverine needs exactly `AttributeDeclaration`-with-`TypeNamed` (here as `GeneratedAttribute`), `GeneratedMethod.Attributes` + `IsStatic`, `GeneratedAssembly.TargetLanguage`, and the companion helper — all four ship here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)