### PR TITLE
Archive on a lone Archived event, plus two compliance-suite fixes (found by marten#5343)

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/AggregateToLinqOperatorCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AggregateToLinqOperatorCompliance.cs
@@ -80,6 +80,26 @@ public abstract class AggregateToLinqOperatorCompliance<TFixture, TOperations, T
         trail.Miles.ShouldBe(22);
     }
 
+    /// <summary>
+    /// Supplied state is folded ONTO, not replaced: the seeded miles survive and the stream's events
+    /// accumulate on top of them.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="ComplianceTrail.Name"/> assertion this fact used to carry was removed in
+    /// marten#5343, the first run of this suite against a real event store, because it could not be
+    /// satisfied by any coherent implementation. <see cref="ComplianceTrail"/> handles
+    /// <see cref="TrailStarted"/> with a <c>Create</c> and no <c>Apply</c>, so over supplied state
+    /// there are only two possible behaviours, and the two assertions demanded one each: skip the
+    /// creator (the usual rule -- the aggregate already exists) and Name stays empty while Miles
+    /// reaches 110; or run the creator and its <c>new()</c> REPLACES the seed, so Name is set but
+    /// Miles is 10, not 110. Asserting both pinned a merge of creator output into supplied state that
+    /// no store does and that the shared contract has never specified.
+    ///
+    /// What the fact is actually for -- that the seed is honoured rather than discarded -- is what
+    /// the miles assertion proves, and it proves it on its own: 110 is only reachable from the seeded
+    /// 100. A separate fact covers identity stamping, and <c>ComplianceTrail.Name</c> is covered
+    /// where a creator legitimately runs, in the unseeded fact above.
+    /// </remarks>
     [Fact]
     public async Task can_aggregate_with_initial_state_asynchronously()
     {
@@ -96,7 +116,8 @@ public abstract class AggregateToLinqOperatorCompliance<TFixture, TOperations, T
             e => e.StreamId == stream, initial, Cancellation);
 
         trail.ShouldNotBeNull();
-        trail.Name.ShouldBe("Long Trail");
+
+        // 110 rather than 10: the seeded state was folded onto, not thrown away.
         trail.Miles.ShouldBe(110);
     }
 

--- a/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
@@ -54,6 +54,28 @@ public partial class ComplianceWatchtower
 /// </remarks>
 public partial class ComplianceWatchtowerProjection: ComplianceWatchtowerProjectionBase
 {
+    /// <summary>
+    /// The name the daemon knows this projection by, pinned explicitly rather than left to whatever
+    /// each store's default naming convention produces.
+    /// </summary>
+    /// <remarks>
+    /// Found by marten#5343, the first run of this suite against a real event store. The two rebuild
+    /// facts below asked the daemon for <c>nameof(ComplianceWatchtowerProjection)</c>, which silently
+    /// assumes every store derives a projection's registered name from the PROJECTION type. Marten
+    /// derives it from the aggregated DOCUMENT type instead, so both facts died on "No registered
+    /// projection matches the name 'ComplianceWatchtowerProjection'. Available names are
+    /// 'ComplianceWatchtower'". Neither convention is wrong, which is precisely why a shared suite
+    /// must not depend on either: naming the projection here makes it the same on every store, and
+    /// the deliberately distinct value keeps it from colliding with a default either convention
+    /// would produce.
+    /// </remarks>
+    public const string ProjectionName = "ComplianceWatchtowerSideEffects";
+
+    public ComplianceWatchtowerProjection()
+    {
+        Name = ProjectionName;
+    }
+
     public static ComplianceWatchtower Create(IEvent<WatchtowerManned> @event) =>
         new() { Id = @event.StreamId, Name = @event.Data.Name };
 
@@ -297,7 +319,7 @@ public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQue
 
         await daemon.StopAllAsync();
 
-        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout,
+        await daemon.RebuildProjectionAsync(ComplianceWatchtowerProjection.ProjectionName, _timeout,
             CancellationToken.None);
 
         var after = await eventsForAsync(streamId);
@@ -474,7 +496,7 @@ public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQue
 
         await daemon.StopAllAsync();
 
-        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout,
+        await daemon.RebuildProjectionAsync(ComplianceWatchtowerProjection.ProjectionName, _timeout,
             CancellationToken.None);
 
         _outbox.PublishedMessages.OfType<WatchtowerReported>().Count().ShouldBe(before);

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -160,21 +160,30 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
                 // Moved out of the application to avoid it getting double called
                 (_, transformed) = tryApplyMetadata(stream.Events, transformed, id, storage);
                 
-                if (transformed == null && action != ActionType.Delete && action != ActionType.HardDelete) continue;
+                // Ownership is signalled by a pre-loaded snapshot OR a materialized one from the
+                // slice. In a composite projection with multiple single-stream children, sibling
+                // projections that do not own this stream skip the archive. See marten#4093.
+                var ownsStream = snapshot != null || transformed != null;
 
-                storage.ApplyInline(transformed, action, id, stream.TenantId);
-
-                // Gate archival on whether this projection owns the stream. Ownership
-                // is signalled by a pre-loaded snapshot OR a materialized one from the
-                // slice. In a composite projection with multiple single-stream children,
-                // sibling projections that do not own this stream skip the archive.
-                // See issue JasperFx/marten#4093.
-                maybeArchiveStream(storage, stream, id, ownsStream: snapshot != null || transformed != null);
-
-                if (session.EnableSideEffectsOnInlineProjections)
+                if (transformed != null || action == ActionType.Delete || action == ActionType.HardDelete)
                 {
-                    await processSideEffectMessages(session, id, stream, transformed).ConfigureAwait(false);
+                    storage.ApplyInline(transformed, action, id, stream.TenantId);
+
+                    if (session.EnableSideEffectsOnInlineProjections)
+                    {
+                        await processSideEffectMessages(session, id, stream, transformed).ConfigureAwait(false);
+                    }
                 }
+
+                // Deliberately NOT inside the block above, and this is the whole of marten#5343's
+                // archiving finding: an Archived event appended on its own -- with no other event the
+                // aggregate handles in the same batch -- leaves transformed null, so the early
+                // `continue` this replaces skipped archival entirely and the stream stayed live.
+                // Ownership does not depend on the aggregate having CHANGED; a pre-loaded snapshot
+                // establishes it on its own, which is what the `snapshot != null` disjunct above was
+                // always for. Under the old shape that disjunct was unreachable -- dead code
+                // documenting the intent the `continue` defeated.
+                maybeArchiveStream(storage, stream, id, ownsStream: ownsStream);
             }
         }
     }


### PR DESCRIPTION
Three findings from **marten#5343** — Marten enrolling the JasperFx 2.64.0 compliance wave, which is the **first time any of these suites has been executed against a real event store**. All three were invisible to this repo, which has no event store to drive the inline projection path with.

## 1. Product bug — `JasperFxSingleStreamProjectionBase.ApplyInline`

An `Archived` event appended to a snapshotted stream **with no other handled event in the same batch** left `transformed` null, so the early `continue` skipped `maybeArchiveStream` entirely and the stream stayed live.

Append `Archived` alongside any event the aggregate handles and it archives correctly — which is exactly why this survived: **all four** of Marten's local archiving tests append a handled event next to the marker, so none of them ever exercised the lone-marker case.

The tell that this is a bug rather than intent is that the existing gate

```csharp
maybeArchiveStream(storage, stream, id, ownsStream: snapshot != null || transformed != null);
```

had a **dead disjunct**: `snapshot != null` was unreachable, because the only way past the `continue` above it was `transformed != null`. That disjunct documents precisely the intent the `continue` defeated — ownership does not depend on the aggregate having *changed*, and a pre-loaded snapshot establishes it on its own.

Reproduced against Marten under **both Guid and string stream identity**, so stream identity is irrelevant here despite the failing fact being the string-keyed one; it is simply the only one of the four archiving facts that appends `Archived` alone.

**The async path is fine.** `AggregationRunner` calls `maybeArchiveStream` unconditionally on both branches, which is why the suite's async archiving fact passed while the inline one did not. No change there.

## 2. Suite fix — `ProjectionSideEffectCompliance` rebuild facts

Both rebuild facts asked the daemon for `nameof(ComplianceWatchtowerProjection)`, which silently assumes every store derives a projection's registered name from the **projection** type. Marten derives it from the aggregated **document** type, so both facts died on:

> No registered projection matches the name 'ComplianceWatchtowerProjection'. Available names are 'ComplianceWatchtower'

Neither convention is wrong, which is exactly why a shared suite must not depend on either one. The projection now pins its own `Name`.

## 3. Suite fix — `AggregateToLinqOperatorCompliance.can_aggregate_with_initial_state_asynchronously`

Its two assertions could not both hold under any coherent implementation. `ComplianceTrail` handles `TrailStarted` with a `Create` and no `Apply`, so over supplied state a store either:

- skips the creator (the usual rule — the aggregate already exists), so `Name` stays empty and `Miles` reaches 110; or
- runs the creator, whose `new()` **replaces** the seed, so `Name` is set and `Miles` is 10.

Asserting `Name == "Long Trail"` **and** `Miles == 110` pinned a merge of creator output into supplied state that no store does and that the shared contract has never specified. The miles assertion alone proves what the fact is actually for — that the seed is folded *onto* rather than discarded — because 110 is only reachable from the seeded 100.

## Testing

`EventTests`: **1049 passed**, 0 failed, on both net9.0 and net10.0.

Regression coverage for (1) is the existing compliance fact `capturing_an_archived_event_archives_a_string_identified_stream`, which fails against the old code and passes against the new. It is deliberately **not** duplicated as a unit test here: this repo cannot construct the inline projection path without an event store — which is the whole reason the compliance library exists, and the reason this bug survived until a store ran it.

No version bump and no package publish in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)