### PR TITLE
Fix three wave-13 compliance facts that cannot pass on any store

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/AggregateToLinqOperatorCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AggregateToLinqOperatorCompliance.cs
@@ -96,8 +96,20 @@ public abstract class AggregateToLinqOperatorCompliance<TFixture, TOperations, T
             e => e.StreamId == stream, initial, Cancellation);
 
         trail.ShouldNotBeNull();
-        trail.Name.ShouldBe("Long Trail");
+
+        // The fold CONTINUES the supplied state rather than restarting from it: 100 + 10.
         trail.Miles.ShouldBe(110);
+
+        // And the creator does not run, which is the other half of the same statement. A supplied
+        // initial state means the aggregate already exists, so ComplianceTrail.Create(TrailStarted)
+        // is skipped and Name is never assigned — TrailStarted contributes nothing but its place in
+        // the sequence.
+        //
+        // This originally asserted Name == "Long Trail" alongside Miles == 110, which no coherent
+        // implementation can satisfy: running the creator produces a NEW instance and discards the
+        // supplied state, so Name and Miles == 110 are mutually exclusive. Caught the first time the
+        // suite was executed against a real store (polecat#556).
+        trail.Name.ShouldBe(string.Empty);
     }
 
     [Fact]

--- a/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
@@ -297,7 +297,12 @@ public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQue
 
         await daemon.StopAllAsync();
 
-        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout,
+        // nameof(ComplianceWatchtower), the DOCUMENT type, not the projection class:
+        // JasperFxAggregationProjectionBase's constructor sets Name = typeof(TDoc).NameInCode(),
+        // overriding ProjectionBase's class-name default, so an aggregation projection is known to
+        // the daemon by the type it produces. Naming the class here threw
+        // ArgumentOutOfRangeException on every store (found enrolling this suite in polecat#556).
+        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtower), _timeout,
             CancellationToken.None);
 
         var after = await eventsForAsync(streamId);
@@ -474,7 +479,12 @@ public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQue
 
         await daemon.StopAllAsync();
 
-        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout,
+        // nameof(ComplianceWatchtower), the DOCUMENT type, not the projection class:
+        // JasperFxAggregationProjectionBase's constructor sets Name = typeof(TDoc).NameInCode(),
+        // overriding ProjectionBase's class-name default, so an aggregation projection is known to
+        // the daemon by the type it produces. Naming the class here threw
+        // ArgumentOutOfRangeException on every store (found enrolling this suite in polecat#556).
+        await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtower), _timeout,
             CancellationToken.None);
 
         _outbox.PublishedMessages.OfType<WatchtowerReported>().Count().ShouldBe(before);

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamArchivingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamArchivingCompliance.cs
@@ -329,7 +329,12 @@ public abstract class StreamArchivingCompliance<TFixture, TOperations, TQuerySes
 
         await using (var session = OpenSession())
         {
-            EventsFor(session).Append(streamId, new Archived("Closed out"));
+            // LedgerEntryPosted alongside the Archived, exactly as the inline fact above and all
+            // four of Marten's local variants do. Not decoration: a projection's AllEventTypes is
+            // derived from its Create/Apply handlers and ComplianceLedger handles no Archived, so a
+            // slice carrying ONLY an Archived fails AppliesTo and is screened out before the
+            // archival hook is ever reached. This fact asserted a path no store can serve.
+            EventsFor(session).Append(streamId, new LedgerEntryPosted(75), new Archived("Closed out"));
             await SaveChangesAsync(session);
         }
 
@@ -360,7 +365,8 @@ public abstract class StreamArchivingCompliance<TFixture, TOperations, TQuerySes
 
         await using (var session = OpenSession())
         {
-            EventsFor(session).Append(key, new Archived("Closed out"));
+            // See the async fact above: an Archived-only slice never reaches the archival hook.
+            EventsFor(session).Append(key, new LedgerEntryPosted(75), new Archived("Closed out"));
             await SaveChangesAsync(session);
         }
 


### PR DESCRIPTION
Closes #781.

Three facts in the wave-13 compliance suites could not pass on **any** store. All surfaced the first time these suites were executed against a real event store — Polecat's adoption in [polecat#556](https://github.com/JasperFx/polecat/issues/556). Until now they were compile-checked and design-reasoned only, because this repo enrols the document suites but no event store.

## 1. `ProjectionSideEffectCompliance` rebuilt by the wrong name

Both rebuild facts named the projection **class**:

```csharp
await daemon.RebuildProjectionAsync(nameof(ComplianceWatchtowerProjection), _timeout, CancellationToken.None);
```

`ProjectionBase` defaults `Name` to `GetType().Name`, but `JasperFxAggregationProjectionBase`'s constructor overrides it with `typeof(TDoc).NameInCode()` — an aggregation projection is known to the daemon by the type it produces. Both facts threw:

```
ArgumentOutOfRangeException : No registered projection matches the name
'ComplianceWatchtowerProjection'. Available names are 'ComplianceWatchtower'
```

Now names the document type, with a comment so the next reader does not "fix" it back.

## 2. `can_aggregate_with_initial_state_asynchronously` asserted an impossible pair

```csharp
trail.Name.ShouldBe("Long Trail");   // only if Create(TrailStarted) ran
trail.Miles.ShouldBe(110);           // only if the supplied state survived
```

`ComplianceTrail.Create` is a creator — it returns a fresh instance. Run it and the supplied state is gone (`Miles` is 10); skip it and `Name` is never assigned. The two cannot both hold.

Folding onto a supplied state means the aggregate already exists, so skipping the creator is the correct semantics, and it is what the store under test did. The fact now keeps `Miles == 110` — the thing it is actually about — and pins `Name == string.Empty` as the documented consequence. That is **stronger** than dropping the assertion: it now fails a store that restarts from the creator as well as one that ignores the initial state.

## 3. `StreamArchivingCompliance`'s async and string facts appended `Archived` alone

A projection's `AllEventTypes` comes from its `Create`/`Apply` handlers, and `ComplianceLedger` declares no `Archived` handler. So a slice carrying **only** an `Archived`:

- fails `AppliesTo` on the inline path and is screened out before `maybeArchiveStream` is reached;
- never survives the daemon's event-type allow list on the async path.

The inline fact immediately above them already appends `LedgerEntryPosted(75)` alongside its `Archived`, and so do **all four** of Marten's local variants (`archiving_events.cs` — `new DEvent(), new Archived("Complete")`, every time). The two ported facts lost that companion event. Restored.

## Not a weakening

None of these relaxes a suite to accommodate an implementation. The first corrects an identifier; the second replaces an unsatisfiable assertion pair with the contractual behaviour, pinned in both directions; the third restores a precondition the facts always needed and that their own sibling and their Marten ancestors carry.

## Validation

Built Polecat's test assembly against this working copy rather than the package, via Polecat's documented `-p:ComplianceSourceDir=...` flow, and ran the full `Polecat.Tests.Compliance` namespace against SQL Server 2025: **507 passed, 0 failed, 3 skipped** (the 3 skips are capability gates a store legitimately declines). All five previously-failing facts pass; no other fact changed state.

Worth noting these fixes did **not** paper over store bugs — the same run also found five genuine Polecat bugs, fixed separately in polecat#556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)