### PR TITLE
2.65.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.64.0</JasperFxVersion>
+        <JasperFxVersion>2.65.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>


### PR DESCRIPTION
`main` has carried eight merges since the 2.64.0 bump under the already-published 2.64.0 version number. This releases them as **2.65.0**.

Headline contents:
- **#780** — an `Archived` event appended with no other handled event in the batch left `transformed` null and an early `continue` skipped archival entirely. Found by the first real execution of the wave-13 suites (marten#5343); Marten's own `archiving_events.cs` could not catch it because every one of its tests appends a handled event beside the marker.
- **#772/#774/#775** — the three maintainer rulings pinned: natural-key uniqueness (refusal, with a shared `DuplicateNaturalKeyException`), flat-table increment counting its creating event, and member-valued decrement inserting the negated value.
- **#767/#770/#771** — projection side-effects, subscription depth, and the `ProjectionScenario` harness suites.
- **#776** — codegen attribute emission and target-language awareness (gh-743).

Unblocks marten#5347 and most of the nine red compliance facts on Marten master.

Local runs are the gate per the September policy; org Actions runners are stalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)