### PR TITLE
gh-778: a single stream projection applies to Archived, and the async path archives too

### DIFF
--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -69,6 +69,49 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
         _streamActionSource = StreamAction.CreateAggregateIdentitySource<TId>();
     }
 
+    /// <summary>
+    /// A single stream projection always applies to <see cref="Archived" />, whether or not the
+    /// aggregate declares anything for it — jasperfx#778.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The gate outside the one jasperfx#780 closed</b>, and on a store where it bites, closing that
+    /// one alone changes nothing. <c>Archived</c> carries no state, so an aggregate has no reason to
+    /// declare an <c>Apply</c> for it — which leaves it out of <c>AllEventTypes</c>, so
+    /// <c>AppliesTo</c> answers false, <c>ApplyInline</c>'s opening
+    /// <c>streams.Where(AppliesTo(...))</c> screens the whole stream out before reading anything, and
+    /// the async shard's own event filter never delivers the event into a slice at all.
+    /// </para>
+    /// <para>
+    /// Verified on Fisher, whose <c>StreamArchivingCompliance</c> still failed both archived-event
+    /// facts against jasperfx#780 alone and passes both with this.
+    /// </para>
+    /// <para>
+    /// Only the single stream scope, because only it archives: <c>maybeArchiveStream</c> returns
+    /// immediately for any other scope, so widening a multi stream projection's event types would hand
+    /// its shard events it has nothing to do with.
+    /// </para>
+    /// <para>
+    /// Widening what the projection <em>sees</em> is not widening what it <em>archives</em>. Ownership
+    /// is still the marten#4093 rule — a snapshot present before or after the slice — so a sibling
+    /// projection in a composite that does not own the stream now sees the event and still declines.
+    /// </para>
+    /// <para>
+    /// ⚠️ <b>An empty set is left empty</b>, and skipping that guard is a real regression rather than a
+    /// tidiness point: <c>AppliesTo</c> reads an empty <c>AllEventTypes</c> as "applies to everything",
+    /// which is how a catch-all <c>Evolve(IEvent)</c> projection declares itself. Adding
+    /// <c>Archived</c> unconditionally turns that "everything" into "exactly one type", and such a
+    /// projection then sees nothing at all — seven of
+    /// <c>SelfAggregatingEvolveCompliance</c>'s facts, caught by the first cut of this override.
+    /// </para>
+    /// </remarks>
+    protected override Type[] determineEventTypes()
+    {
+        var types = base.determineEventTypes();
+
+        return types.Length == 0 ? types : [.. types, typeof(Archived)];
+    }
+
     // ForceSingleTenancy is the wolverine#2053 / marten#4085 fix: on a single-tenanted store, events whose
     // tenant_id values disagree must still fold into one aggregate. Marten used to be the only store that
     // set it, by overriding this method -- so a consumer deriving from THIS type, and both other stores

--- a/src/JasperFx.Events/Daemon/AggregationRunner.cs
+++ b/src/JasperFx.Events/Daemon/AggregationRunner.cs
@@ -399,6 +399,14 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
 
         if (action == ActionType.Nothing)
         {
+            // ⚠️ jasperfx#778, the async half of what jasperfx#780 closed inline. Archival is decided
+            // by the slice's events and by ownership, never by whether the aggregate changed —
+            // Archived carries no state, so an aggregate has no reason to declare an Apply for it and
+            // a slice carrying it alone leaves the action at Nothing, which used to return here and
+            // never archive. Ownership is the pre-loaded snapshot alone, since Nothing means no new
+            // one was produced.
+            maybeArchiveUnchangedStream(storage, slice);
+
             return;
         }
 
@@ -486,6 +494,45 @@ public class AggregationRunner<TDoc, TId, TOperations, TQuerySession> : IGrouped
             _caches = _caches.AddOrUpdate(tenantId, cache);
 
             return cache;
+        }
+    }
+
+    /// <summary>
+    /// Archive the stream of a slice that produced no aggregate change — jasperfx#778.
+    /// </summary>
+    /// <remarks>
+    /// Split out rather than inlined because the deferred rebuild window (jasperfx#525) cannot simply
+    /// take a <c>recordDeferredWrite(..., ActionType.Nothing, ...)</c> here: the window keys one
+    /// pending write per aggregate id and a later record overwrites the earlier one, so a bare Nothing
+    /// write would discard a <c>Store</c> already buffered for the same id in this window and lose its
+    /// snapshot. The archive intent is merged onto whatever is already pending instead, and only
+    /// becomes a write of its own when there is nothing to merge with.
+    /// </remarks>
+    private void maybeArchiveUnchangedStream(IProjectionStorage<TDoc, TId> storage, EventSlice<TDoc, TId> slice)
+    {
+        // Nothing means no new snapshot was produced, so a pre-loaded one is the only ownership signal
+        // there is — the same rule the delete path above applies. marten#4093.
+        var ownsStream = slice.Snapshot != null;
+
+        if (!wouldArchiveStream(slice, ownsStream))
+        {
+            return;
+        }
+
+        if (!_deferWrites)
+        {
+            storage.ArchiveStream(slice.Id, slice.TenantId);
+
+            return;
+        }
+
+        lock (_bufferLock)
+        {
+            var pending = _flush!.TryGetPending(storage.TenantId, slice.Id, out var existing)
+                ? existing with { ArchiveStream = true }
+                : new PendingWrite(ActionType.Nothing, default, null, true);
+
+            _flush.Record(storage.TenantId, slice.Id, pending);
         }
     }
 


### PR DESCRIPTION
Closes #778. Follow-up to #780, which closed one of three gates.

#780 fixed the inline `continue` that skipped `maybeArchiveStream`. **On Fisher that changed
nothing** — both of `StreamArchivingCompliance`'s archived-event facts still failed against it,
verified by packing `main` to a local feed and running Fisher's suite. Two gates outside the one it
closed were still swallowing the archive.

## 1. The outermost gate: `Archived` was not in a single stream projection's `AllEventTypes`

`Archived` carries no state, so an aggregate has no reason to declare an `Apply` for it.
`AppliesTo` therefore answered false, and `ApplyInline`'s opening
`streams.Where(x => AppliesTo(...))` screened the whole stream out **before reading a thing** — so
the `continue` #780 fixed was never reached. The same omission keeps the event out of the async
shard's own event filter, so the slice never carries it either.

`determineEventTypes` now appends it, for the single stream scope only: `maybeArchiveStream` returns
immediately for any other scope, so widening a multi stream projection's event types would hand its
shard events it has nothing to do with.

⚠️ **An empty set is left empty.** `AppliesTo` reads an empty `AllEventTypes` as "applies to
everything", which is how a catch-all `Evolve(IEvent)` projection declares itself; adding `Archived`
unconditionally turns that "everything" into "exactly one type". The first cut of this override did
exactly that and took out seven of `SelfAggregatingEvolveCompliance`'s facts.

## 2. The async path returned at `action == ActionType.Nothing`

Before its own `maybeArchiveStream`, for the same reason the inline path did. Ownership there is the
pre-loaded snapshot alone, since `Nothing` means no new one was produced.

The deferred rebuild window (#525) cannot take a bare `Nothing` write — it keys one pending write
per aggregate id and a later record overwrites the earlier one, so that would discard a `Store`
already buffered for the same id and lose its snapshot. The archive intent is merged onto whatever
is pending instead.

Ownership is untouched throughout: marten#4093's rule still decides, so a sibling projection in a
composite that does not own the stream now sees the event and still declines.

## Verification

Packed to a local feed and run against Fisher (fisher#184), which is where this was found:

| | main (#780) | this branch |
|---|---|---|
| `StreamArchivingCompliance` | 14/16 | **16/16** |
| `Fisher.Tests`, all of it | 1653/1655 | **1655/1655** |

`EventTests` 1049 and `EventStoreTests` 141 green on both net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)