### PR TITLE
gh-785: pin the numeric revision ruling as NumericRevisionCompliance

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/ComplianceDocuments.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceDocuments.cs
@@ -60,3 +60,35 @@ public class ComplianceCoupon
     public string Description { get; set; } = string.Empty;
     public int PercentOff { get; set; }
 }
+
+/// <summary>
+/// A document opting into numeric revisions through <see cref="IRevisioned" /> — the marker every
+/// Critter Stack store already shares (it lives in <c>JasperFx</c>, not in any product), so a store
+/// needs no compliance-specific configuration to recognize it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Separate from <see cref="ComplianceWidget" /> rather than a flag on it, because the marker is not
+/// a property of an instance: implementing <see cref="IRevisioned" /> changes the storage the store
+/// builds for the type, so the concurrency-checked and unchecked cases cannot share a document.
+/// </para>
+/// <para>
+/// <c>Version</c> is the only member the numeric revision contract needs. It carries the expected
+/// revision on the way in and the landed revision on the way out, which is what makes
+/// <see cref="NumericRevisionCompliance{TFixture}" /> writable through
+/// <see cref="Documents.IDocumentWriteOperations.Store{T}" /> alone — <c>UpdateRevision</c> and
+/// <c>TryUpdateRevision</c> are product API and stay off the shared contract (jasperfx#785 §5.3).
+/// </para>
+/// </remarks>
+public class ComplianceLedgerEntry: IRevisioned
+{
+    public Guid Id { get; set; }
+    public string Customer { get; set; } = string.Empty;
+    public int Amount { get; set; }
+
+    /// <summary>
+    /// The revision. Zero means "auto" on the way in; after a commit or a load it carries whatever
+    /// the store has stored.
+    /// </summary>
+    public int Version { get; set; }
+}

--- a/src/JasperFx.Events.ComplianceTests/DocumentStorageComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/DocumentStorageComplianceFixture.cs
@@ -81,6 +81,26 @@ public abstract class DocumentStorageComplianceFixture : IAsyncLifetime
     /// </remarks>
     public abstract Task CleanDocumentDataAsync();
 
+    /// <summary>
+    /// Does this store implement numeric revisions — the <see cref="IRevisioned" /> marker and the
+    /// concurrency guard behind it? Gates <see cref="NumericRevisionCompliance{TFixture}" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A capability flag, not a seam: it is <c>virtual</c> rather than <c>abstract</c>, so the three
+    /// abstract members stay three and every existing fixture keeps compiling untouched. The suite it
+    /// gates reaches the whole behavior through <see cref="IDocumentWriteOperations.Store{T}" /> and
+    /// <see cref="IRevisioned.Version" />, so nothing here reaches past the contract — which is
+    /// exactly the bar the class-level remarks set.
+    /// </para>
+    /// <para>
+    /// Default <b>false</b>, following the established pattern, because numeric revisions are opt-in
+    /// storage behavior rather than part of the eight-operation contract: a store can implement the
+    /// document contract completely and stamp no revisions at all. Flip it after implementing them.
+    /// </para>
+    /// </remarks>
+    public virtual bool SupportsNumericRevisions => false;
+
     public virtual ValueTask InitializeAsync() => default;
 
     public virtual ValueTask DisposeAsync() => default;

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -574,6 +574,7 @@ alongside the event store — `JasperFx.Events.Documents`:
 | The route from a session to its event store | `DocumentSessionEventsCompliance` |
 | The stream actions a session has queued but not committed | `PendingStreamActionsCompliance` |
 | Post-commit session listeners and the change set they receive | `DocumentCommitListenerCompliance` |
+| What an explicit numeric revision means on the update path | `NumericRevisionCompliance` |
 
 Enrollment is deliberately much cheaper than the event side. `DocumentStorageComplianceFixture` has
 **three** abstract members — build a store, hand back an `IDocumentSessionFactory`, wipe the data —
@@ -625,6 +626,35 @@ the enclosing transaction rather than `SaveChangesAsync` is what makes the data 
 unconditionally). The second is unreachable from a suite in any case — enlistment is spelled on each
 product's own `SessionOptions`, which `IDocumentSessionFactory` does not expose — so it belongs in
 each store's own tests.
+
+`NumericRevisionCompliance` (jasperfx#785 §4.2) is opt-in through `SupportsNumericRevisions` (default
+**false**), and it is the one document suite that exists to record a *ruling* rather than to discover
+a shared behavior. The three stores did not agree. Marten and Fisher hold that an explicit revision
+must be **strictly greater** than the stored one — Marten's guard is
+`(? = 0 or {table}.{version} < ?)` with the assignment `CASE WHEN ? = 0 THEN {version} + 1 ELSE ? END`,
+and Fisher's `NumericRevision` is the same pair, with a comment saying it follows Marten on purpose.
+Polecat made the doc-carried revision an **equality** expectation instead
+(`AND (? = 0 OR t.version = ?)`, assigning `ELSE ? + 1`), also on purpose, also documented locally,
+neither store's comment referencing the other's. Matching test names over opposite contracts, which
+is the failure mode this whole library exists to catch.
+
+**The maintainer ruled for strictly-greater**, so this suite pins it and Polecat changes
+(polecat#559). Seven facts: revision `0` is the auto sentinel and always wins, whatever is stored; a
+new document lands at `1`; an explicit revision greater than the stored one is accepted and lands at
+*exactly* that value; an explicit revision **equal** to the stored one is refused, as is one below
+it; and an explicit revision may **jump non-contiguously** (3 → 10). That last one is the capability
+an equality rule cannot express, and it is much of why the ruling went this way — it is what lets a
+caller adopt a revision decided somewhere else rather than one the store is counting.
+
+The observable consequence is worth stating plainly because it is a sharp edge: loading a document at
+revision 5 and storing it back still carrying 5 is a `ConcurrencyException`, not a read-modify-write.
+Callers spell it `doc.Version + 1`. Refusal is asserted as the shared `JasperFx.ConcurrencyException`
+rather than any store's own type, since that base is what a store-agnostic consumer catches.
+
+No seam members, and none were needed: `Store` passes the document's own `IRevisioned.Version` as the
+expected revision, so setting `Version` before storing names the revision. `Store(doc, revision)`,
+`UpdateRevision` and `TryUpdateRevision` stay product API and off the contract. `SupportsNumericRevisions`
+is `virtual`, not `abstract` — the fixture's three abstract members are still three.
 
 `BuildStoreAsync` must honor `config.ValueTypes` as well as `config.DocumentTypes` — every store
 spells that `options.RegisterValueType(type)`. It is what lets `DocumentLoadAndStoreCompliance` hold

--- a/src/JasperFx.Events.ComplianceTests/Suites/NumericRevisionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/NumericRevisionCompliance.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Threading.Tasks;
+using JasperFx.Events.Documents;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// Numeric revision semantics for a document implementing <see cref="IRevisioned" /> — what an
+/// explicit revision <em>means</em> on the update path, settled by the maintainer ruling on
+/// jasperfx#785 §4.2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The ruling: Marten's strictly-greater rule is the contract.</b> An explicit revision is the
+/// version the caller is asking the document to <em>become</em>, and it is accepted only when it is
+/// strictly greater than the revision currently stored. Revision <c>0</c> is the "auto" sentinel and
+/// always wins, whatever is stored. Two of the three stores already work this way and say so in
+/// their own source — Marten's guard is
+/// <c>(? = 0 or {table}.{version} &lt; ?)</c> with the assignment
+/// <c>CASE WHEN ? = 0 THEN {version} + 1 ELSE ? END</c>, and Fisher's <c>NumericRevision</c> is the
+/// same pair, deliberately. Polecat diverged into an <em>equality</em> expectation
+/// (<c>AND (? = 0 OR t.version = ?)</c>, assigning <c>ELSE ? + 1</c>) and is the side that changes.
+/// </para>
+/// <para>
+/// The observable difference is one line of ordinary code: load a document at revision 5, store it
+/// back still carrying 5. Under this ruling that is a <see cref="ConcurrencyException" />, not a
+/// read-modify-write — 5 is not greater than 5, and the caller has to name 6. That is a sharp edge
+/// and it is pinned deliberately rather than smoothed over, because the alternative silently
+/// disagrees with the advice <see cref="ConcurrencyException.ToMessage" /> already ships ("You may
+/// need to explicitly call <c>IDocumentSession.UpdateRevision()</c>"), which is written against the
+/// strictly-greater model.
+/// </para>
+/// <para>
+/// The capability the equality rule cannot express, and much of why the ruling went this way, is the
+/// <b>non-contiguous jump</b>: an explicit revision may skip ahead (3 → 10), which is what lets a
+/// caller adopt a revision decided somewhere else — an upstream version, a stream version, an
+/// imported record. An equality rule can only ever step by one.
+/// </para>
+/// <para>
+/// <b>No seam members.</b> Every fact here runs through
+/// <see cref="IDocumentWriteOperations.Store{T}" /> and <see cref="IRevisioned.Version" />, which is
+/// the whole of the reachable surface: <c>Store(doc, revision)</c>, <c>UpdateRevision</c> and
+/// <c>TryUpdateRevision</c> are product API and stay off the document contract (jasperfx#785 §5.3).
+/// <c>Store</c> is enough because it passes the document's own <c>Version</c> as the expected
+/// revision — the products' own docs put it as "<c>Store()</c> is essentially
+/// <c>UpdateRevision(entity, entity.Version)</c>" — so setting <c>Version</c> before storing names
+/// the revision. Gated on <see cref="DocumentStorageComplianceFixture.SupportsNumericRevisions" />
+/// (default false) because numeric revisions are opt-in storage behavior, not one of the eight
+/// contract operations.
+/// </para>
+/// <para>
+/// The landed revision is read back off a freshly loaded document rather than off the instance that
+/// was stored. Both routes work on the stores surveyed, but only the first is a statement about what
+/// is <em>stored</em>; write-back onto the caller's instance is a separate convenience and pinning it
+/// here would conflate the two.
+/// </para>
+/// </remarks>
+public abstract class NumericRevisionCompliance<TFixture> : DocumentStorageComplianceSuite<TFixture>
+    where TFixture : DocumentStorageComplianceFixture, new()
+{
+    private static readonly Action<DocumentComplianceConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_revisions";
+        config.AddDocumentType<ComplianceLedgerEntry>();
+    };
+
+    protected override Action<DocumentComplianceConfig> Configuration => _configuration;
+
+    private void SkipUnlessSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsNumericRevisions,
+            "This document store does not implement numeric revisions");
+    }
+
+    /// <summary>
+    /// Store one ledger entry at the named revision, committing in its own session. A fresh instance every
+    /// time so a store that writes the landed revision back onto the caller's document cannot leak
+    /// state from one step of a test into the next.
+    /// </summary>
+    private async Task StoreAsync(Guid id, string customer, int version)
+    {
+        await using var session = LightweightSession();
+        session.Store(new ComplianceLedgerEntry { Id = id, Customer = customer, Amount = 100, Version = version });
+        await session.SaveChangesAsync(Cancellation);
+    }
+
+    private async Task<ConcurrencyException> StoreShouldBeRefusedAsync(Guid id, string customer, int version)
+        => await Should.ThrowAsync<ConcurrencyException>(() => StoreAsync(id, customer, version));
+
+    /// <summary>
+    /// The stored revision, read through the marker interface on a freshly loaded document — the only
+    /// route the shared contract offers, and the one that is a statement about storage.
+    /// </summary>
+    private async Task<int> StoredRevisionAsync(Guid id)
+    {
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceLedgerEntry>(id, Cancellation);
+        loaded.ShouldNotBeNull();
+        return loaded.Version;
+    }
+
+    private async Task<string> StoredCustomerAsync(Guid id)
+    {
+        await using var query = QuerySession();
+        var loaded = await query.LoadAsync<ComplianceLedgerEntry>(id, Cancellation);
+        loaded.ShouldNotBeNull();
+        return loaded.Customer;
+    }
+
+    /// <summary>
+    /// The baseline every other fact is measured against: a document arriving with no revision on it
+    /// is an auto insert, and auto starts at one rather than zero.
+    /// </summary>
+    [Fact]
+    public async Task a_new_document_lands_at_revision_one()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+
+        (await StoredRevisionAsync(id)).ShouldBe(1);
+    }
+
+    /// <summary>
+    /// Revision <c>0</c> means auto — increment whatever is stored — and it is the escape hatch from
+    /// the sharp edge below.
+    /// </summary>
+    [Fact]
+    public async Task an_auto_revision_increments_the_stored_value()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+        await StoreAsync(id, "Acme, renamed", 0);
+        await StoreAsync(id, "Acme, renamed twice", 0);
+
+        (await StoredRevisionAsync(id)).ShouldBe(3);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, renamed twice");
+    }
+
+    /// <summary>
+    /// The supported way to move a loaded document forward: name the revision it is going to. Note
+    /// that it lands at exactly the revision named — the explicit branch assigns the caller's value,
+    /// it does not increment past it.
+    /// </summary>
+    [Fact]
+    public async Task an_explicit_revision_greater_than_the_stored_one_is_accepted()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+
+        await StoreAsync(id, "Acme, revised", 2);
+
+        (await StoredRevisionAsync(id)).ShouldBe(2);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, revised");
+    }
+
+    /// <summary>
+    /// <b>The load-bearing fact, and the one the ruling turns on.</b> Re-storing an instance still
+    /// carrying the revision it was loaded at is a concurrency failure, not an increment: the
+    /// supplied revision must be strictly greater, and equal is not greater. The natural
+    /// read-modify-write spelling is therefore <c>doc.Version + 1</c>, never <c>doc.Version</c>.
+    /// </summary>
+    /// <remarks>
+    /// Asserted as the shared <see cref="ConcurrencyException" /> from <c>JasperFx</c> rather than any
+    /// store's own type. Every Critter Stack store already throws this one — a store-specific subclass
+    /// still satisfies it, a store-specific sibling does not, and the difference is precisely what a
+    /// store-agnostic consumer catching the base type would hit.
+    /// </remarks>
+    [Fact]
+    public async Task an_explicit_revision_equal_to_the_stored_one_is_refused()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+        (await StoredRevisionAsync(id)).ShouldBe(1);
+
+        await StoreShouldBeRefusedAsync(id, "Acme, stale", 1);
+
+        // Refused rather than partially applied.
+        (await StoredRevisionAsync(id)).ShouldBe(1);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme");
+    }
+
+    /// <summary>
+    /// The unambiguous stale write — a revision below what is stored — is refused for the same reason
+    /// and by the same guard.
+    /// </summary>
+    [Fact]
+    public async Task an_explicit_revision_below_the_stored_one_is_refused()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+        await StoreAsync(id, "Acme, second", 0);
+        await StoreAsync(id, "Acme, third", 0);
+        (await StoredRevisionAsync(id)).ShouldBe(3);
+
+        await StoreShouldBeRefusedAsync(id, "Acme, way behind", 2);
+
+        (await StoredRevisionAsync(id)).ShouldBe(3);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, third");
+    }
+
+    /// <summary>
+    /// The capability an equality rule cannot express: an explicit revision may skip ahead rather than
+    /// step by one, and the document lands at exactly the revision named. This is a large part of why
+    /// the ruling went to strictly-greater — it is what lets a caller adopt a revision decided
+    /// somewhere else instead of one the store happens to be counting.
+    /// </summary>
+    [Fact]
+    public async Task an_explicit_revision_may_jump_non_contiguously()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+        await StoreAsync(id, "Acme, second", 0);
+        await StoreAsync(id, "Acme, third", 0);
+        (await StoredRevisionAsync(id)).ShouldBe(3);
+
+        await StoreAsync(id, "Acme, imported", 10);
+
+        (await StoredRevisionAsync(id)).ShouldBe(10);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, imported");
+    }
+
+    /// <summary>
+    /// The other half of "auto always wins": the <c>0</c> sentinel is not compared against anything,
+    /// so it succeeds even where the stored revision is far ahead of any revision the caller has seen
+    /// — and it resumes counting from what is stored, not from what the caller last knew.
+    /// </summary>
+    [Fact]
+    public async Task an_auto_revision_wins_even_when_the_stored_revision_is_far_ahead()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme", 0);
+        await StoreAsync(id, "Acme, imported", 10);
+
+        await StoreAsync(id, "Acme, after the jump", 0);
+
+        (await StoredRevisionAsync(id)).ShouldBe(11);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, after the jump");
+    }
+}


### PR DESCRIPTION
Pins the maintainer ruling on jasperfx#785 §4.2 as a shared compliance suite.

## The ruling

The survey behind #785 found **two contracts behind one test name**. On the update path, for an explicit numeric revision (all three stores spell auto-increment as `? = 0`):

- **Marten** — `(? = 0 or {table}.{version} < ?)`, assigning `CASE WHEN ? = 0 THEN {version} + 1 ELSE ? END`. Strictly greater.
- **Fisher** — `(? = 0 or {table}.revision < ?)`, same assignment shape, with a source comment saying it follows Marten on purpose.
- **Polecat** — `AND (? = 0 OR t.version = ?)`, assigning `ELSE ? + 1`. An **equality** expectation, also documented locally as deliberate, neither comment referencing the other's issue.

The maintainer has ruled: **Marten's strictly-greater rule is the contract.** This unblocks the suite §5.3 deferred, and Polecat is the side that changes — filed as JasperFx/polecat#559, not implemented here.

The observable difference is one line of ordinary code: load a document at revision 5 and store it back still carrying 5. Polecat succeeds; Marten and Fisher throw `ConcurrencyException`, because 5 is not greater than 5. Under the ruling, throwing is correct.

## What is pinned — 7 facts

`NumericRevisionCompliance`, in the document-suite family:

| Fact | Pins |
|---|---|
| `a_new_document_lands_at_revision_one` | the baseline the rest is measured against |
| `an_auto_revision_increments_the_stored_value` | revision `0` is the auto sentinel |
| `an_explicit_revision_greater_than_the_stored_one_is_accepted` | accepted, and lands at **exactly** that value — not value + 1 |
| `an_explicit_revision_equal_to_the_stored_one_is_refused` | the load-bearing one; the case the ruling turns on |
| `an_explicit_revision_below_the_stored_one_is_refused` | the unambiguous stale write |
| `an_explicit_revision_may_jump_non_contiguously` | 3 → 10 — the capability an equality rule cannot express |
| `an_auto_revision_wins_even_when_the_stored_revision_is_far_ahead` | the other half of "auto always wins" |

The two refusal facts also assert the document is left unchanged, so a store that throws *after* writing does not pass.

Refusal is asserted as the shared **`JasperFx.ConcurrencyException`**, never a store-specific type — a store-specific subclass still satisfies it, a sibling does not, and that difference is exactly what a store-agnostic consumer catching the base type would hit.

## No seam members were needed

Every fact runs through `IDocumentWriteOperations.Store` and `IRevisioned.Version`. `Store` passes the document's own `Version` as the expected revision, so setting `Version` before storing *is* how you name a revision through the contract. `Store(doc, revision)`, `UpdateRevision` and `TryUpdateRevision` stay product API and off the contract, per #785 §5.3.

`DocumentStorageComplianceFixture` therefore still has **exactly three abstract members**. The new `SupportsNumericRevisions` gate is `virtual` with a `false` default, not abstract, so every existing fixture compiles untouched.

The landed revision is read back off a freshly loaded document rather than off the stored instance — both work on the stores surveyed, but only the first is a statement about what is *stored*.

## Validation

CI is stalled org-wide, so this was validated locally:

- `src/JasperFx.Events.ComplianceTests` builds clean (0 errors).
- `src/EventStoreTests` — **141 passed, 0 failed, 0 skipped**, unchanged from baseline on both `net9.0` and `net10.0`.

**No store is enrolled**, so these facts execute nowhere yet — including in `EventStoreTests`, which does enrol the in-memory reference store for five of the document suites. That is deliberate, but it means the count above proves the suite *compiles*, not that it *runs*.

So it was checked two ways with a throwaway local enrolment of the in-memory store, since a suite nothing runs is a suite nothing has tested:

- Enrolled as-is (gate default `false`): all 7 **skip**. The gate works.
- Enrolled with `SupportsNumericRevisions => true`: **6 of 7 fail**, because that store has no notion of a revision at all. The facts have teeth.

Worth recording which one passed in that second run: `an_explicit_revision_greater_than_the_stored_one_is_accepted`, because the in-memory store round-trips `Version` verbatim, so setting 2 and reading back 2 succeeds vacuously. It is the one fact in the suite that a store ignoring revisions entirely can pass — the other six are what catch that store, which is the argument for keeping the set at seven rather than trimming.

Both probes were reverted; the diff contains no enrolment.

## Also found while verifying

Two things that were not in the survey and are recorded in polecat#559 rather than acted on here:

- The Polecat change is **two sites, not one** — the single-document MERGE (lines 392–420) and a batched `USING`-source MERGE (lines 508, 519) carrying the same guard/`CASE` pair through `rev0`/`rev1`.
- Polecat's **INSERT** branch hard-codes revision 1 and discards an explicit revision, where Marten and Fisher both honour it. The ruling does not reach the insert path, so the suite deliberately pins only the auto insert and stays silent there.

Refs #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
