### PR TITLE
gh-787: UpcastingCompliance's raw-JSON fact must not assume a property casing

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/UpcastingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/UpcastingCompliance.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using JasperFx.Events.Projections;
@@ -119,8 +121,8 @@ public abstract class UpcastingCompliance<TFixture, TOperations, TQuerySession>
             {
                 var root = document.RootElement;
                 return new UpcastDiscountApplied(
-                    root.GetProperty("CartId").GetGuid(),
-                    root.GetProperty("Percent").GetInt32() / 100.0);
+                    Property(root, "CartId").GetGuid(),
+                    Property(root, "Percent").GetInt32() / 100.0);
             },
             _couponEventTypeName));
 
@@ -131,6 +133,42 @@ public abstract class UpcastingCompliance<TFixture, TOperations, TQuerySession>
     };
 
     protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// Read one property of a stored event body <b>case-insensitively</b>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ⚠️ <see cref="JsonElement.GetProperty(string)"/> is case-sensitive, and property casing is a
+    /// store-serializer decision rather than anything this contract fixes: Marten's default
+    /// <c>PropertyNamingPolicy</c> is null (so <c>"CartId"</c>) while Polecat's and Fisher's is
+    /// <see cref="JsonNamingPolicy.CamelCase"/> (so <c>"cartId"</c>). Reading the stored JSON is the
+    /// whole point of the raw-JSON registration shape — it is what lets an application upcast
+    /// without keeping the old CLR type in the codebase — so the transformation genuinely sees
+    /// whatever that store's serializer wrote. See jasperfx#787.
+    /// </para>
+    /// <para>
+    /// Deliberately not solved by pinning a <c>PropertyNamingPolicy</c> on the fixture's serializer:
+    /// that would make this fact a test of the fixture's configuration rather than of upcasting, and
+    /// it would stop reproducing the thing an application actually meets. The typed registration
+    /// shapes get the same tolerance for free, from <c>PropertyNameCaseInsensitive</c> on each
+    /// store's own deserializer.
+    /// </para>
+    /// </remarks>
+    private static JsonElement Property(JsonElement root, string name)
+    {
+        foreach (var property in root.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value;
+            }
+        }
+
+        throw new KeyNotFoundException(
+            $"The stored event body has no property named '{name}' in any casing. Present: "
+            + string.Join(", ", root.EnumerateObject().Select(x => x.Name)));
+    }
 
     private static readonly TimeSpan _timeout = TimeSpan.FromSeconds(60);
 


### PR DESCRIPTION
Closes #787.

Found by Fisher implementing the shared upcasting contract (fisher#185) — **the first time this
suite has run against any store**, since its gate ships closed.

`a_raw_json_transformation_upcasts_without_the_old_clr_type` reached the stored body with
`JsonElement.GetProperty("CartId")`, which is case-sensitive. Property casing is a store-serializer
decision rather than anything this contract fixes:

| Store | Default `PropertyNamingPolicy` | Stored as |
|---|---|---|
| Marten | `null` | `"CartId"` |
| Polecat | `CamelCase` | `"cartId"` |
| Fisher | `CamelCase` | `"cartId"` |

So it passed on Marten and threw `KeyNotFoundException` on the other two — and on Fisher it took two
more facts down with it, since `upcasting_applies_in_live_aggregation` and
`upcasting_applies_in_async_daemon_projections` both append a coupon event. The daemon one surfaces
sixty seconds later as a shard that recorded no progress, which is a long way from the cause.

## Why the fixture's serializer is the wrong place to fix it

Reading the **stored** JSON is the entire point of the raw-JSON registration shape — it is what lets
an application upcast without keeping the old CLR type in the codebase — so the transformation
genuinely sees whatever that store's serializer wrote. Pinning a `PropertyNamingPolicy` on the
fixture would make the fact a test of the fixture's configuration instead of a test of upcasting,
and would stop it reproducing what an application actually meets.

A case-insensitive lookup is the narrow answer, and it is the same tolerance the *typed*
registration shapes already get for free from `PropertyNameCaseInsensitive` on each store's own
deserializer. The helper's failure message lists the properties that are present, so the next
mismatch says what it found rather than only what it wanted.

## Verification

Packed to a local feed and run against Fisher, which is where this was found:

| | main | this branch |
|---|---|---|
| `upcasting_compliance` | 4/7 | **7/7** |
| `Fisher.Tests`, all of it | — | **1713 green** |

`EventTests` 1049 green on both TFMs. One pre-existing intermittent seen along the way and
unrelated to this change (it touches only the compliance suite's source):
`BlueGreenSideEffectGateTests.fresh_deploy_suppresses_side_effects_to_the_prior_version_mark_then_enables_them`
failed once on net10.0 and passed on every rerun — noted so a first sighting elsewhere is
recognised rather than investigated from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)