### PR TITLE
gh-785: the insert path follows the strictly-greater ruling too

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -639,12 +639,29 @@ neither store's comment referencing the other's. Matching test names over opposi
 is the failure mode this whole library exists to catch.
 
 **The maintainer ruled for strictly-greater**, so this suite pins it and Polecat changes
-(polecat#559). Seven facts: revision `0` is the auto sentinel and always wins, whatever is stored; a
+(polecat#559). Nine facts: revision `0` is the auto sentinel and always wins, whatever is stored; a
 new document lands at `1`; an explicit revision greater than the stored one is accepted and lands at
 *exactly* that value; an explicit revision **equal** to the stored one is refused, as is one below
 it; and an explicit revision may **jump non-contiguously** (3 → 10). That last one is the capability
 an equality rule cannot express, and it is much of why the ruling went this way — it is what lets a
 caller adopt a revision decided somewhere else rather than one the store is counting.
+
+The **insert path follows the same rule**, ruled separately once the update path settled: a brand-new
+document carrying an explicit revision lands at exactly that revision rather than at 1. Marten's
+insert value is `CASE WHEN ? = 0 THEN 1 ELSE ? END` and Fisher's is the same; Polecat hard-codes `1`
+and discards the caller's revision, which is now part of polecat#559 rather than an open question.
+Two facts cover it, and the second is the one that matters: a store ignoring revisions entirely still
+serializes `Version` as an ordinary property and hands the same value back on load, so reading the
+revision off a loaded document passes vacuously. Following the insert with an auto store — which must
+land at 8, not 2 — is what has teeth.
+
+Two neighbouring insert cases are deliberately **unpinned**. An explicit revision of `0` on a new
+document means auto and lands at 1, but that is already the `a_new_document_lands_at_revision_one`
+fact and is not restated. A **negative** revision is left alone because it is undefined rather than
+divergent: no store range-checks one, none tests it, Marten and Fisher would store it verbatim and
+then refuse every later write below it, and Polecat's hard-coded `1` would swallow it. Three
+accidents, not two contracts and a bug — the question there is which behavior to *choose*, and it
+should be ruled before it is pinned.
 
 The observable consequence is worth stating plainly because it is a sharp edge: loading a document at
 revision 5 and storing it back still carrying 5 is a `ConcurrencyException`, not a read-modify-write.

--- a/src/JasperFx.Events.ComplianceTests/Suites/NumericRevisionCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/NumericRevisionCompliance.cs
@@ -39,6 +39,35 @@ namespace JasperFx.Events.ComplianceTests;
 /// imported record. An equality rule can only ever step by one.
 /// </para>
 /// <para>
+/// <b>The insert path follows the same rule</b> (ruled separately on jasperfx#785 after the update
+/// path). An explicit revision on a brand-new document is honoured rather than discarded: the row
+/// lands at exactly that revision, not at 1. Marten spells the insert value
+/// <c>CASE WHEN ? = 0 THEN 1 ELSE ? END</c> and Fisher's <c>NumericRevision.InsertValueSql</c> is
+/// <c>case when ? = 0 then 1 else ? end</c> — identical, and identical to the update assignment in
+/// treating <c>?</c> as the target rather than something to increment past. Polecat hard-codes the
+/// insert to <c>1</c> and is the side that changes (polecat#559).
+/// </para>
+/// <para>
+/// Two neighbouring insert cases are deliberately <em>not</em> pinned, for opposite reasons:
+/// </para>
+/// <para>
+/// An explicit revision of <b>zero</b> on a new document means auto and lands at 1 — but that is
+/// already <see cref="a_new_document_lands_at_revision_one" />, which stores a document whose
+/// <c>Version</c> is the default <c>0</c>. It is the same assertion, so it is not restated here;
+/// verified against both stores' <c>WHEN ? = 0 THEN 1</c> branch rather than assumed from the update
+/// path's use of the same sentinel.
+/// </para>
+/// <para>
+/// A <b>negative</b> revision is left unpinned because it is genuinely undefined rather than
+/// divergent, and pinning it either way would invent a contract. No store guards against one — there
+/// is no range check anywhere in Marten's, Fisher's or Polecat's revision handling — and none has a
+/// test for it. Marten and Fisher would take the <c>ELSE ?</c> branch and store the negative
+/// verbatim, after which the strictly-greater update guard refuses everything below it, so the row
+/// sits at a revision no caller can have meant; Polecat's hard-coded <c>1</c> would swallow it. That
+/// is three accidents, not two contracts and a bug. If a consumer ever needs an answer, the question
+/// is which behavior to <em>choose</em>, and it should be ruled on before it is pinned.
+/// </para>
+/// <para>
 /// <b>No seam members.</b> Every fact here runs through
 /// <see cref="IDocumentWriteOperations.Store{T}" /> and <see cref="IRevisioned.Version" />, which is
 /// the whole of the reachable surface: <c>Store(doc, revision)</c>, <c>UpdateRevision</c> and
@@ -122,6 +151,58 @@ public abstract class NumericRevisionCompliance<TFixture> : DocumentStorageCompl
         await StoreAsync(id, "Acme", 0);
 
         (await StoredRevisionAsync(id)).ShouldBe(1);
+    }
+
+    /// <summary>
+    /// <b>The insert-path ruling.</b> A brand-new document carrying an explicit revision lands at
+    /// exactly that revision. The revision is honoured, not discarded in favour of 1 — the same rule
+    /// the update path follows, one row earlier: an explicit revision is the version the caller is
+    /// asking for, and on an insert there is nothing stored for it to have to exceed.
+    /// </summary>
+    /// <remarks>
+    /// This is a jump on first write, and it is the capability that makes importing a record at the
+    /// revision it already had, or seeding a document at a version decided upstream, expressible at
+    /// all. A store that always starts at 1 forces the caller to insert and then immediately update.
+    /// </remarks>
+    [Fact]
+    public async Task a_new_document_lands_at_an_explicit_revision()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme, imported at seven", 7);
+
+        (await StoredRevisionAsync(id)).ShouldBe(7);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, imported at seven");
+    }
+
+    /// <summary>
+    /// The insert really wrote 7 — the store is counting from it, not merely round-tripping the value
+    /// it was handed.
+    /// </summary>
+    /// <remarks>
+    /// This fact exists because the one above can pass <em>vacuously</em>. A store that ignores
+    /// revisions entirely still serializes <see cref="IRevisioned.Version" /> as an ordinary property
+    /// and hands the same 7 back on load, so reading the revision off a loaded document cannot by
+    /// itself distinguish "stored a revision of 7" from "stored a document with a field set to 7".
+    /// Following the insert with an auto store settles it: only a real stored revision increments to
+    /// 8, and only a real guard refuses the re-store at 7.
+    /// </remarks>
+    [Fact]
+    public async Task an_explicit_insert_revision_becomes_the_stored_revision()
+    {
+        SkipUnlessSupported();
+
+        var id = Guid.NewGuid();
+        await StoreAsync(id, "Acme, imported at seven", 7);
+
+        // The strictly-greater guard now applies from 7, not from 1.
+        await StoreShouldBeRefusedAsync(id, "Acme, stale", 7);
+
+        // And auto counts on from 7 rather than restarting.
+        await StoreAsync(id, "Acme, moved on", 0);
+        (await StoredRevisionAsync(id)).ShouldBe(8);
+        (await StoredCustomerAsync(id)).ShouldBe("Acme, moved on");
     }
 
     /// <summary>


### PR DESCRIPTION
Second ruling on jasperfx#785, following the update path settled in #786: **an explicit revision on a brand-new document is honoured, not discarded.** It lands at exactly that revision rather than at 1 — the same rule one row earlier, where there is nothing stored for the revision to have to exceed.

## Verified, not assumed

The insert path was surfaced as an open question in #786 rather than surveyed, so both implementations were re-read:

- **Marten** (`DocumentStorageDescriptorBuilder.BuildCoreColumns`) — `CASE WHEN ? = 0 THEN 1 ELSE ? END`
- **Fisher** (`NumericRevision.InsertValueSql`) — `case when ? = 0 then 1 else ? end`

Identical, and identical to the update assignment in the way that matters: `?` is the target, not something to increment past. Nothing contradicts the ruling's premise.

One thing worth recording — **neither store has a test for it.** Fisher's `insert_starts_a_new_document_at_revision_one` covers only the auto case; Marten's `numeric_revisioning.cs` never inserts at an explicit revision. So these facts are new coverage rather than a port of an existing one, and the behavior they pin was, until now, implemented identically by accident of both following the same shared operation shape rather than by anything holding them to it.

Polecat hard-codes the insert to `1` (`SqlServerDocumentStorageDescriptorBuilder.cs:342-347`) and is the side that changes — now part of the required change in polecat#559 rather than an open question.

## What is pinned — 2 facts (suite goes 7 → 9)

| Fact | Pins |
|---|---|
| `a_new_document_lands_at_an_explicit_revision` | store a new document at 7 → lands at 7, not 1 |
| `an_explicit_insert_revision_becomes_the_stored_revision` | the store is *counting from* 7 — a re-store at 7 is refused, and an auto store lands at **8** |

The second is the one that matters, and it is there for a specific reason found while validating #786. A store that ignores revisions entirely still serializes `IRevisioned.Version` as an ordinary property and hands the same value back on load, so reading the revision off a loaded document **cannot distinguish "stored a revision of 7" from "stored a document with a field set to 7"**. The first fact alone would pass vacuously on exactly the store the suite exists to catch. Following the insert with a refused re-store and an auto increment settles it.

That is confirmed rather than argued: against the in-memory reference store with the gate forced true, the first fact passes and the second fails.

## What is deliberately left unpinned

Both documented in the suite remarks, so a reader does not take them for oversights.

**An explicit revision of `0` on a new document** means auto and lands at 1 — but that is already `a_new_document_lands_at_revision_one`, which stores a document whose `Version` is the default `0`. Same assertion, so it is not restated. Checked against both stores' `WHEN ? = 0 THEN 1` branch rather than inferred from the update path happening to use the same sentinel.

**A negative revision** is left alone because it is **undefined rather than divergent**, and pinning it either way would invent a contract. There is no range check anywhere in Marten's, Fisher's or Polecat's revision handling, and no store tests one. Marten and Fisher would take the `ELSE ?` branch and store the negative verbatim, after which the strictly-greater guard refuses every later write below it and the row sits at a revision no caller can have meant; Polecat's hard-coded `1` would swallow it. That is three accidents, not two contracts and a bug. The question there is which behavior to *choose*, and it should be ruled before it is pinned.

## Validation

CI is stalled org-wide, so local:

- `src/JasperFx.Events.ComplianceTests` builds clean (0 errors).
- `src/EventStoreTests` — **141 passed, 0 failed, 0 skipped**, unchanged from baseline on both `net9.0` and `net10.0`.

No store is enrolled, so as with #786 these facts execute nowhere yet — the count above proves the suite compiles, not that it runs. Checked again with a throwaway local enrolment of the in-memory store, then reverted:

- Gated (default `false`): all 9 skip.
- With `SupportsNumericRevisions => true`: **7 of 9 fail.** The 2 that pass are the two vacuous ones — `an_explicit_revision_greater_than_the_stored_one_is_accepted` and `a_new_document_lands_at_an_explicit_revision` — both of which are round-trip artifacts, and both of which have a companion fact in the suite that catches the same store.

No new seam members; `DocumentStorageComplianceFixture` still has three abstract members and the gate is unchanged.

Refs #785. Merged on top of #788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
