### PR TITLE
Make the compliance suite variable on exception type

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/ComplianceExceptionKind.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceExceptionKind.cs
@@ -1,0 +1,66 @@
+namespace JasperFx.Events.ComplianceTests;
+
+/// <summary>
+/// The event store failure categories a shared suite asserts by <em>behaviour</em>, naming the
+/// category rather than a concrete exception type. Resolved to a type per store through
+/// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.ExceptionTypeFor"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each member corresponds to one of the six event store exceptions lifted into
+/// <c>JasperFx.Events</c>, which is what the fixture returns by default. The indirection exists
+/// because a store may legitimately own its exception hierarchy and therefore cannot subclass the
+/// lifted type.
+/// </para>
+/// <para>
+/// Marten is the concrete example: it enforces a convention test —
+/// <c>all_exceptions_should_derive_from_MartenException</c> — that every exception Marten throws
+/// derives from <c>MartenException</c>. C# has single inheritance, so a Marten type cannot derive
+/// from both <c>MartenException</c> and the lifted JasperFx type. Marten therefore keeps its own
+/// six declarations in <c>Marten.Exceptions</c> and names them from its fixture. That is a
+/// legitimate store design, not a compliance gap, so the suite asserts the behaviour and lets the
+/// store name the type.
+/// </para>
+/// <para>
+/// This is <em>not</em> a licence to loosen an assertion to "something threw". The suite still
+/// requires the nominated type; only the naming of it moved to the fixture.
+/// </para>
+/// </remarks>
+public enum ComplianceExceptionKind
+{
+    /// <summary>
+    /// An event row names an event type the store cannot resolve.
+    /// Defaults to <see cref="UnknownEventTypeException"/>.
+    /// </summary>
+    UnknownEventType,
+
+    /// <summary>
+    /// An operation addressed a stream that does not exist.
+    /// Defaults to <see cref="NonExistentStreamException"/>.
+    /// </summary>
+    NonExistentStream,
+
+    /// <summary>
+    /// A stream was started with an identity that is already taken.
+    /// Defaults to <see cref="ExistingStreamIdCollisionException"/>.
+    /// </summary>
+    ExistingStreamIdCollision,
+
+    /// <summary>
+    /// An event's body could not be deserialized, though its type resolved.
+    /// Defaults to <see cref="EventDeserializationFailureException"/>.
+    /// </summary>
+    EventDeserializationFailure,
+
+    /// <summary>
+    /// An exclusive lock on a stream could not be taken.
+    /// Defaults to <see cref="StreamLockedException"/>.
+    /// </summary>
+    StreamLocked,
+
+    /// <summary>
+    /// The default tenant was used in a store configured to forbid it.
+    /// Defaults to <see cref="DefaultTenantUsageDisabledException"/>.
+    /// </summary>
+    DefaultTenantUsageDisabled
+}

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -676,6 +676,53 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
             $"{GetType().FullName} does not implement CreateProjectionScenario, so it cannot run the projection scenario compliance suite.");
 
 
+    /// <summary>
+    /// The exception type this store throws for a given failure category. Defaults to the matching
+    /// exception lifted into <c>JasperFx.Events</c>, so a store that adopted the lifted types — by
+    /// throwing them or by subclassing them — needs no override at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Virtual with a total default rather than abstract, deliberately: an abstract member would
+    /// break every consuming store on the next package bump for the sake of a seam most of them do
+    /// not need. Polecat and Fisher subclass the lifted types, so the default answers correctly for
+    /// both.
+    /// </para>
+    /// <para>
+    /// The seam exists because a store may legitimately own its exception hierarchy and therefore
+    /// be unable to subclass a lifted type. Marten is the concrete case: its
+    /// <c>all_exceptions_should_derive_from_MartenException</c> convention test requires every
+    /// exception Marten throws to derive from <c>MartenException</c>, and C# has single
+    /// inheritance, so a Marten type cannot derive from both that base and the lifted JasperFx
+    /// type. Marten keeps its own six declarations in <c>Marten.Exceptions</c> and names them here.
+    /// That is a store design decision the compliance library has no business overruling.
+    /// </para>
+    /// <para>
+    /// Note what this does <strong>not</strong> loosen. The suites still demand an exception of the
+    /// nominated type — the store picks the name, not whether the assertion has teeth. Nor does it
+    /// touch the categories that are genuinely shared already: <c>JasperFx.ConcurrencyException</c>
+    /// and <see cref="EventStreamUnexpectedMaxEventIdException"/> live in JasperFx, every store
+    /// throws them directly, and the suites keep asserting those types outright.
+    /// </para>
+    /// <para>
+    /// Resist the urge to "tidy" a <see cref="ComplianceExceptionKind"/> assertion back to a hard
+    /// type. Doing so silently re-imposes a shared hierarchy on stores that have declined it, and
+    /// the failure lands on the store rather than here.
+    /// </para>
+    /// </remarks>
+    public virtual Type ExceptionTypeFor(ComplianceExceptionKind kind) =>
+        kind switch
+        {
+            ComplianceExceptionKind.UnknownEventType => typeof(UnknownEventTypeException),
+            ComplianceExceptionKind.NonExistentStream => typeof(NonExistentStreamException),
+            ComplianceExceptionKind.ExistingStreamIdCollision => typeof(ExistingStreamIdCollisionException),
+            ComplianceExceptionKind.EventDeserializationFailure => typeof(EventDeserializationFailureException),
+            ComplianceExceptionKind.StreamLocked => typeof(StreamLockedException),
+            ComplianceExceptionKind.DefaultTenantUsageDisabled => typeof(DefaultTenantUsageDisabledException),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind,
+                $"{GetType().FullName} was asked for an unknown compliance exception category.")
+        };
+
     public virtual ValueTask InitializeAsync() => default;
 
     public virtual ValueTask DisposeAsync() => default;

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceSuite.cs
@@ -107,23 +107,55 @@ public abstract class EventStoreComplianceSuite<TFixture, TOperations, TQuerySes
     /// in parallel and aggregates. The failure semantics are identical, so the suites assert the
     /// semantics and let the exception shape vary.
     /// </remarks>
-    protected static async Task ShouldFailWithAsync<TException>(Func<Task> action) where TException : Exception
+    protected static Task ShouldFailWithAsync<TException>(Func<Task> action) where TException : Exception
+        => ShouldFailWithAsync(typeof(TException), action);
+
+    /// <summary>
+    /// Assert that an operation fails with the exception type this store nominates for
+    /// <paramref name="kind"/>, whether thrown directly or wrapped in an
+    /// <see cref="AggregateException"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Used where the failure <em>category</em> is shared across every store but the exception
+    /// <em>type</em> is not. The six event store exceptions lifted into <c>JasperFx.Events</c> are
+    /// the default answer, so a store that adopted them names nothing; a store that owns its own
+    /// hierarchy overrides
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.ExceptionTypeFor"/>.
+    /// </para>
+    /// <para>
+    /// Marten is the concrete reason this is variable: its
+    /// <c>all_exceptions_should_derive_from_MartenException</c> convention test forces every Marten
+    /// exception onto <c>MartenException</c>, and single inheritance means a Marten type cannot
+    /// also derive from the lifted JasperFx type. Owning your exception hierarchy is a legitimate
+    /// store decision, so the suite asserts the behaviour and lets the store name the type.
+    /// </para>
+    /// <para>
+    /// This is not a weakening. An exception of the nominated type is still required — "something
+    /// threw" would not pass. Do not replace a <see cref="ComplianceExceptionKind"/> assertion with
+    /// a hard type; that re-imposes a shared hierarchy on stores that have declined it.
+    /// </para>
+    /// </remarks>
+    protected Task ShouldFailWithAsync(ComplianceExceptionKind kind, Func<Task> action)
+        => ShouldFailWithAsync(theFixture.ExceptionTypeFor(kind), action);
+
+    private static async Task ShouldFailWithAsync(Type expectedType, Func<Task> action)
     {
         var exception = await Should.ThrowAsync<Exception>(action).ConfigureAwait(false);
 
-        if (exception is TException)
+        if (expectedType.IsInstanceOfType(exception))
         {
             return;
         }
 
         if (exception is AggregateException aggregate &&
-            aggregate.Flatten().InnerExceptions.Any(x => x is TException))
+            aggregate.Flatten().InnerExceptions.Any(expectedType.IsInstanceOfType))
         {
             return;
         }
 
         throw new ShouldAssertException(
-            $"Expected {typeof(TException).Name}, directly or aggregated, but got {exception.GetType().FullName}: {exception.Message}");
+            $"Expected {expectedType.Name}, directly or aggregated, but got {exception.GetType().FullName}: {exception.Message}");
     }
 
     /// <summary>

--- a/src/JasperFx.Events.ComplianceTests/README.md
+++ b/src/JasperFx.Events.ComplianceTests/README.md
@@ -345,6 +345,44 @@ Where a store genuinely cannot support a behavior, override the `virtual bool Su
 the fixture; the affected tests skip rather than fail. Gates are meant to be temporary and tracked —
 a suite failing on your store is usually a product bug, not a test to soften.
 
+## Variable exception types
+
+A handful of facts assert that an operation *fails a particular way*. Where the failure category is
+shared across every store but the exception type is not, the suite names a
+`ComplianceExceptionKind` and the fixture resolves it:
+
+```csharp
+await ShouldFailWithAsync(ComplianceExceptionKind.ExistingStreamIdCollision,
+    () => SaveChangesAsync(session));
+```
+
+`EventStoreComplianceFixture.ExceptionTypeFor(kind)` is **virtual, not abstract**, and defaults to
+the matching exception lifted into `JasperFx.Events` (`UnknownEventTypeException`,
+`NonExistentStreamException`, `ExistingStreamIdCollisionException`,
+`EventDeserializationFailureException`, `StreamLockedException`,
+`DefaultTenantUsageDisabledException`). A store that adopted those — Polecat and Fisher subclass
+them — overrides nothing.
+
+The seam exists because a store may legitimately own its exception hierarchy. Marten is the standing
+example: its `all_exceptions_should_derive_from_MartenException` convention test requires every
+Marten exception to derive from `MartenException`, and C# single inheritance forbids deriving from
+both that base and the lifted type. So Marten keeps its own six in `Marten.Exceptions` and nominates
+them from `MartenComplianceFixture`. That is a store design decision, not a compliance gap.
+
+Two things this does **not** mean:
+
+* It is not a weakening. An exception of the nominated type is still required — "something threw"
+  does not pass, and neither does the wrong type.
+* It does not extend to categories that are genuinely shared already. `JasperFx.ConcurrencyException`
+  and `EventStreamUnexpectedMaxEventIdException` live in JasperFx, every store throws them directly,
+  and `AlwaysEnforceConsistencyCompliance`, `FetchForWritingCompliance`,
+  `AggregateWriteCacheCompliance` and `StringStreamIdentityCompliance` keep asserting those types
+  outright. Do not route them through this seam.
+
+Resist "tidying" a `ComplianceExceptionKind` assertion back to a hard type. Doing so quietly
+re-imposes a shared hierarchy on a store that has declined it, and the failure lands on the store
+rather than here.
+
 ## Local dev loop
 
 Both current consumers accept a `ComplianceSourceDir` property that swaps the published suites for a

--- a/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/ProjectionSideEffectCompliance.cs
@@ -431,10 +431,29 @@ public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQue
     /// A unit of work that fails publishes nothing.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A stream id collision is caught by the append itself, well before either hook — so neither
     /// runs, and the messages the session buffered go nowhere. Asserted as "no hook fired" rather
     /// than "the after hook did not fire", because the weaker claim would pass even if the failure
     /// had never reached the hook boundary at all.
+    /// </para>
+    /// <para>
+    /// The failure is named as <see cref="ComplianceExceptionKind.ExistingStreamIdCollision"/>
+    /// rather than as a fixed exception type. What this fact is about is that a failed unit of work
+    /// publishes nothing; <em>which</em> exception announced the collision is the store's business.
+    /// The lifted <see cref="ExistingStreamIdCollisionException"/> remains the default, so a store
+    /// that adopted the shared types names nothing — but a store may legitimately own its exception
+    /// hierarchy instead. Marten is the standing example: its
+    /// <c>all_exceptions_should_derive_from_MartenException</c> convention test requires every
+    /// Marten exception to derive from <c>MartenException</c>, and single inheritance forbids
+    /// deriving from that base and the lifted type at once, so Marten keeps
+    /// <c>Marten.Exceptions.ExistingStreamIdCollisionException</c> and nominates it from its
+    /// fixture.
+    /// </para>
+    /// <para>
+    /// Do not "tidy" this back to a hard type. The assertion is not loosened by being variable —
+    /// the nominated type is still required, and "something threw" still fails.
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task a_unit_of_work_that_fails_publishes_nothing()
@@ -452,7 +471,8 @@ public abstract class ProjectionSideEffectCompliance<TFixture, TOperations, TQue
         // Same id, so the append itself fails.
         EventsFor(session).StartStream(streamId, new WatchtowerManned("Halifirien again"));
 
-        await ShouldFailWithAsync<ExistingStreamIdCollisionException>(() => SaveChangesAsync(session));
+        await ShouldFailWithAsync(ComplianceExceptionKind.ExistingStreamIdCollision,
+            () => SaveChangesAsync(session));
 
         _outbox.CommittedBatches.ShouldBeEmpty();
     }


### PR DESCRIPTION
## Why

The six event store exceptions lifted into `JasperFx.Events` by #751 are not universally adoptable.
Polecat and Fisher adopted them by subclassing. Marten cannot: its
`all_exceptions_should_derive_from_MartenException` convention test requires every exception Marten
throws to derive from `MartenException`, and C# has single inheritance, so a Marten type cannot
derive from both that base and the lifted type.

Owning your exception hierarchy is a legitimate store design decision, not a compliance gap. So the
suite should assert the **behaviour** and let each store name the type it throws.

Per the ruling on JasperFx/marten#5346: Marten keeps its own six, adoption is deferred to Marten 10,
and the compliance suite is made variable instead.

## The seam

`ComplianceExceptionKind` names the six failure categories.
`EventStoreComplianceFixture.ExceptionTypeFor(kind)` resolves one to a type, and **defaults to the
lifted JasperFx type**, so a store that adopted them — Polecat and Fisher both subclass — overrides
nothing and needs no fixture change on the bump.

**Virtual, not abstract**, deliberately: an abstract member would break all three consuming stores on
the next package bump for the sake of a seam most of them do not need.

`ShouldFailWithAsync` gains a kind-based overload that resolves through the fixture. The assertion is
**not** loosened — an exception of the nominated type is still required; "something threw" does not
pass, and neither does the wrong type.

## Scope

Grepping all six type names across the suites turned up exactly **one** hard-assert:
`ProjectionSideEffectCompliance.a_unit_of_work_that_fails_publishes_nothing`
(`ExistingStreamIdCollisionException`). That is the only call site changed.

Deliberately **not** touched: `JasperFx.ConcurrencyException` and
`EventStreamUnexpectedMaxEventIdException`. Those live in JasperFx, every store throws them directly,
and `AlwaysEnforceConsistencyCompliance`, `FetchForWritingCompliance`, `AggregateWriteCacheCompliance`
and `StringStreamIdentityCompliance` keep asserting them outright. Loosening them would cost coverage
for nothing.

## The remarks are the point

The enum, the fixture member, the suite helper, the fact itself and the README each record *why* the
type is variable, with Marten's convention as the concrete example, and each says plainly that this
is not a weakening and must not be tidied back to a hard type. Without that, the next reader
"simplifies" it and the failure lands on the store rather than here.

## Validation

- `JasperFx.Events.ComplianceTests` builds clean (pre-existing warnings only).
- `EventStoreTests`: 141 passed, 0 failed. In fairness that is weak evidence for *this* change —
  `EventStoreTests` enrols only the document suites (`DocumentStorageComplianceFixture`), so the
  event facts, including the one changed here, do not execute in this repo at all.
- Real validation is on the Marten side (JasperFx/marten#5354), run against this branch via
  `ComplianceSourceDir`: with `MartenComplianceFixture` naming Marten's own six types, the exception
  assertion passes where it previously failed on the type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)