### PR TITLE
2.66.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <JasperFxVersion>2.65.0</JasperFxVersion>
+        <JasperFxVersion>2.66.0</JasperFxVersion>
         <LangVersion>13</LangVersion>
         <NoWarn>1570;1571;1572;1573;1574;1587;1591;1701;1702;1711;1735;0618</NoWarn>
         <Authors>Jeremy D. Miller;Jaedyn Tonee</Authors>


### PR DESCRIPTION
Five merges have landed since the 2.65.0 bump. Three downstream stores are sitting on red compliance facts waiting for them.

**The one that matters most: #784.** 2.65.0 carried #780, which turned out **not** to be the `Archived` fix — `Archived` is absent from a single-stream projection's `AllEventTypes`, so `AppliesTo` screens the stream out before the `continue` #780 closed is ever reached. Both the Marten adoption (marten#5343) and the Fisher adoption independently root-caused this, and both measured it rather than inferring it. #784 is the actual fix, for the single-stream *and* async paths.

Also included:
- **#786 / #789** — the numeric-revision ruling pinned on both the update and insert paths (strictly-greater; an explicit revision is the target version, not an expectation).
- **#788** — `UpcastingCompliance`'s raw-JSON fact no longer assumes PascalCase, which passed on Marten and failed on Polecat and Fisher.
- **#791** — the compliance suite is variable on exception type, so a store may keep its own exception hierarchy (Marten's `MartenException` convention; adoption of the shared types deferred to Marten 10).

Clears: Marten's remaining archival fact, Fisher's five, and Polecat's set — none of which need any store-side change.

Local runs are the gate per the September policy. `JasperFx.Events` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)