### PR TITLE
gh-796: a single stream projection applies to Compacted<TDoc>, for every store at once

### DIFF
--- a/src/EventTests/Projections/SingleStreamProjectionTests.cs
+++ b/src/EventTests/Projections/SingleStreamProjectionTests.cs
@@ -26,6 +26,67 @@ public class SingleStreamProjectionTests
             explanation);
     }
 
+    // jasperfx#778 put Archived into a single stream projection's event types; jasperfx#796 is the
+    // same defect one type over. Every store composes its async loader's filter from
+    // IncludedEventTypes, so a Compacted<TDoc> missing here is a filtered shard that never sees the
+    // marker -- and the marker is the only thing left of the pre-compaction history, because
+    // CompactStreamAsync deletes the events it folds. The shard then folds post-compaction events
+    // onto a null snapshot and persists an aggregate missing everything before the compaction, with
+    // nothing thrown and nothing logged.
+    [Fact]
+    public void declared_event_types_carry_archived_and_compacted_over_the_aggregate()
+    {
+        var projection = new ConventionalProjection();
+        projection.AssembleAndAssertValidity();
+
+        projection.AllEventTypes.ShouldContain(typeof(Archived));
+        projection.AllEventTypes.ShouldContain(typeof(Compacted<MyAggregate>));
+    }
+
+    // Compacted<T> is closed over the projection's OWN aggregate. Appending an open or a
+    // wrong-aggregate marker would widen the shard's filter to markers it has nothing to do with,
+    // which is the same objection that keeps Archived out of the multi stream scope.
+    [Fact]
+    public void the_compacted_marker_is_closed_over_this_projections_aggregate_only()
+    {
+        var projection = new ConventionalProjection();
+        projection.AssembleAndAssertValidity();
+
+        projection.AllEventTypes.ShouldNotContain(typeof(Compacted<>));
+        projection.AllEventTypes.ShouldNotContain(typeof(Compacted<MyOtherAggregate>));
+    }
+
+    // AssembleAndAssertValidity ends with IncludedEventTypes.Fill(determineEventTypes()), so the
+    // marker this override appends is written back into IncludedEventTypes -- and the next evaluation
+    // concats that list again, past the base's own Distinct(), and appends the marker a second time.
+    // Before jasperfx#796 this shipped: AllEventTypes came back [AEvent, Archived, Archived]. It does
+    // not change what AppliesTo answers, but every store composes its async loader's allow list
+    // straight from these types, so the duplicate reaches the generated SQL as a repeated IN member
+    // and a repeated parameter slot.
+    [Fact]
+    public void the_appended_markers_are_not_duplicated_by_the_assembly_fill()
+    {
+        var projection = new ConventionalProjection();
+
+        // The Fill happens here -- one call is enough to seed IncludedEventTypes with the markers.
+        projection.AssembleAndAssertValidity();
+
+        projection.AllEventTypes.ShouldBe(projection.AllEventTypes.Distinct().ToArray());
+    }
+
+    // The empty-set guard from jasperfx#778, restated for the second marker. AppliesTo reads an
+    // empty AllEventTypes as "applies to everything" -- how a catch-all Evolve(IEvent) projection
+    // declares itself -- so appending either marker unconditionally turns that "everything" into
+    // "exactly two types" and the projection then sees nothing at all.
+    [Fact]
+    public void an_empty_event_type_set_stays_empty()
+    {
+        var projection = new CatchAllEvolveProjection();
+        projection.AssembleAndAssertValidity();
+
+        projection.AllEventTypes.ShouldBeEmpty();
+    }
+
     // Regression for #298: tryUseAssemblyRegisteredEvolver was short-circuiting on
     // HasShouldDeleteMethods() BEFORE checking IGeneratedSyncDetermineAction, even though
     // that interface is exactly what the SG emits for self-aggregating docs with
@@ -262,3 +323,19 @@ public class FakeSingleProjectionStream<TDoc, TId> : JasperFxSingleStreamProject
     }
 }
 
+// A catch-all projection: it declares no event types at all, so AllEventTypes must come back empty
+// and AppliesTo must keep reading that as "applies to everything". Fixture for the empty-set guard.
+public class CatchAllEvolveProjection : SingleStreamProjection<MyAggregate, Guid>
+{
+    public override MyAggregate? Evolve(MyAggregate? snapshot, Guid id, IEvent e)
+    {
+        return snapshot ?? new MyAggregate();
+    }
+}
+
+// Only ever used as a type argument, to prove the appended Compacted<T> is closed over the
+// projection's own aggregate rather than over anything else.
+public class MyOtherAggregate
+{
+    public Guid Id { get; set; }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamCompactingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamCompactingCompliance.cs
@@ -123,6 +123,16 @@ public abstract class StreamCompactingCompliance<TFixture, TOperations, TQuerySe
         config.Snapshot<ComplianceStringMeter>(SnapshotLifecycle.Inline);
     };
 
+    /// <summary>
+    /// The async half needs its own store: the projection has to be <see cref="SnapshotLifecycle.Async"/>
+    /// so a shard, and therefore the shard's event filter, is in the picture at all — jasperfx#796.
+    /// </summary>
+    private static readonly Action<ComplianceStoreConfig> _asyncConfiguration = config =>
+    {
+        config.SchemaName = "compliance_compacting_async";
+        config.Snapshot<ComplianceMeter>(SnapshotLifecycle.Async);
+    };
+
     protected override Action<ComplianceStoreConfig> Configuration => _configuration;
 
     /// <summary>
@@ -415,6 +425,77 @@ public abstract class StreamCompactingCompliance<TFixture, TOperations, TQuerySe
             .AggregateStreamAsync<ComplianceStringMeter>(streamKey, token: Cancellation);
         meter.ShouldNotBeNull();
         meter.Total.ShouldBe(210);
+    }
+
+    /// <summary>
+    /// An async shard whose projection declares an event list must still see <c>Compacted&lt;T&gt;</c>,
+    /// or it folds a stream that has been compacted from nothing — jasperfx#796.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the edge that three implementations got wrong independently, and the reason it needs a
+    /// fact rather than a per-store test: every store composes its async loader's allow list from the
+    /// projection's <c>IncludedEventTypes</c>, and <c>Compacted&lt;T&gt;</c> was not in it. Marten
+    /// patched around the gap locally; Polecat (polecat#557) and Fisher (fisher#203) did not.
+    /// </para>
+    /// <para>
+    /// The marker is not an extra event beside the history — <c>CompactStreamAsync</c> <em>deletes</em>
+    /// the events it folds, so the marker is the only thing left of them. A shard that filters it out
+    /// catches up over a compacted stream from a null snapshot, folds only what was appended after the
+    /// compaction, and persists that. Nothing throws and nothing is logged, which is why the assertion
+    /// here is on the projected totals rather than on an exception.
+    /// </para>
+    /// <para>
+    /// The trailing <c>MeterRead(90)</c> matters: without it the filtered shard sees an empty slice and
+    /// writes no document at all, which a "document is missing" assertion would catch for the wrong
+    /// reason. With it, the broken shard produces a <em>plausible</em> document built from the one event
+    /// it was handed, and only the totals tell the two apart.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task an_async_shard_folds_a_compacted_stream_from_the_marker()
+    {
+        Assert.SkipUnless(theFixture.SupportsAsyncDaemon,
+            "This event store does not support the async projection daemon under test");
+
+        await theFixture.ConfigureAsync(_asyncConfiguration);
+
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceMeter>(streamId, theNineEvents());
+            await SaveChangesAsync(session);
+        }
+
+        // Compact BEFORE the daemon ever runs, so the shard's only route to the first nine events is
+        // the marker itself.
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).Append(streamId, new MeterRead(90));
+            await SaveChangesAsync(session);
+        }
+
+        await StartDaemonAsync();
+        await WaitForNonStaleProjectionDataAsync(TimeSpan.FromSeconds(60));
+
+        await using var query = OpenSession();
+        var meter = await LoadDocumentAsync<ComplianceMeter>(query, streamId);
+
+        meter.ShouldNotBeNull();
+
+        // Location comes only from MeterInstalled, which the compaction deleted -- it survives solely
+        // in the marker's snapshot.
+        meter.Location.ShouldBe("Substation A");
+        meter.Total.ShouldBe(300);
+        meter.ReadCount.ShouldBe(7);
+        meter.ServiceCount.ShouldBe(2);
     }
 
     /// <summary>

--- a/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
+++ b/src/JasperFx.Events/Aggregation/JasperFxSingleStreamProjectionBase.cs
@@ -70,8 +70,9 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
     }
 
     /// <summary>
-    /// A single stream projection always applies to <see cref="Archived" />, whether or not the
-    /// aggregate declares anything for it — jasperfx#778.
+    /// A single stream projection always applies to <see cref="Archived" /> and to
+    /// <see cref="Compacted{T}" /> over its own aggregate, whether or not the aggregate declares
+    /// anything for either — jasperfx#778 and jasperfx#796.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -104,12 +105,41 @@ public abstract class JasperFxSingleStreamProjectionBase<TDoc, TId, TOperations,
     /// projection then sees nothing at all — seven of
     /// <c>SelfAggregatingEvolveCompliance</c>'s facts, caught by the first cut of this override.
     /// </para>
+    /// <para>
+    /// <b><c>Compacted&lt;TDoc&gt;</c> is the same defect one type over, and a worse one</b> —
+    /// jasperfx#796. A dropped <c>Archived</c> loses an archival; a dropped <c>Compacted&lt;TDoc&gt;</c>
+    /// loses the stream's <em>entire pre-compaction history</em>, because <c>CompactStreamAsync</c>
+    /// deletes the events it folds and leaves the marker in their place. The marker is not an extra
+    /// event beside the history — it is the only thing left of it, and
+    /// <see cref="Compacted{T}.MaybeFastForward" /> is what restarts a fold from it. So a filtered
+    /// async shard catching up over a compacted stream from a null snapshot folds only what was
+    /// appended <em>after</em> compaction and persists an aggregate missing everything before it, with
+    /// no exception and no log line, while an unfiltered shard over the identical rows disagrees.
+    /// </para>
+    /// <para>
+    /// Two of the three stores got this wrong independently — polecat#557 and fisher#203 — because
+    /// every store composes its loader filter from <c>IncludedEventTypes</c>, and only Marten patched
+    /// around the gap locally in <c>buildEventLoaderFilters</c>. Appending it here is what makes it
+    /// right for every store at once.
+    /// </para>
+    /// <para>
+    /// <b>The append is deduplicated</b>, which it was not before jasperfx#796.
+    /// <c>AssembleAndAssertValidity</c> ends with <c>IncludedEventTypes.Fill(determineEventTypes())</c>,
+    /// so the marker this override appends is written back into <c>IncludedEventTypes</c> — and the
+    /// next evaluation concats that list again, past the base's own <c>Distinct()</c>, and appends the
+    /// marker a second time. <c>AllEventTypes</c> came back as
+    /// <c>[AEvent, Archived, Archived]</c>. Harmless to <c>AppliesTo</c>, but every store composes its
+    /// async loader's allow list straight from these types, so the duplicate reaches the generated SQL
+    /// as a repeated <c>IN</c> member and a repeated parameter slot.
+    /// </para>
     /// </remarks>
     protected override Type[] determineEventTypes()
     {
         var types = base.determineEventTypes();
 
-        return types.Length == 0 ? types : [.. types, typeof(Archived)];
+        if (types.Length == 0) return types;
+
+        return types.Concat([typeof(Archived), typeof(Compacted<TDoc>)]).Distinct().ToArray();
     }
 
     // ForceSingleTenancy is the wolverine#2053 / marten#4085 fix: on a single-tenanted store, events whose


### PR DESCRIPTION
Follow-up to #784, and the same defect one type over. Closes #796.

#784 established that `Archived` carries no state, so an aggregate has no reason to declare an `Apply` for it, and leaving it out of `determineEventTypes()` kept it out of the async shard's event filter as well as out of `AppliesTo`. `Compacted<TDoc>` was in exactly the same position and was not included.

## Why it is the worse of the two

A dropped `Archived` loses an archival. A dropped `Compacted<TDoc>` loses the stream's **entire pre-compaction history**, because `CompactStreamAsync` *deletes* the events it folds and leaves the marker in their place. The marker is not an extra event beside the history — it is the only thing left of it, and `Compacted<T>.MaybeFastForward` is what restarts a fold from it.

## Why here rather than per store

Every store composes its async loader's allow list from `IncludedEventTypes`. Marten patched around the gap locally in `buildEventLoaderFilters`; Polecat (JasperFx/polecat#557) and Fisher (JasperFx/fisher#203) did not, and got it wrong independently. Both can now drop their local patches.

Same single-stream scope guard and the same empty-set caveat as #784: an empty `AllEventTypes` means "applies to everything", which is how a catch-all `Evolve(IEvent)` projection declares itself, and must stay empty.

## Also: the append was duplicating

`AssembleAndAssertValidity` ends with `IncludedEventTypes.Fill(determineEventTypes())`, so the marker this override appends is written back into `IncludedEventTypes` — and the next evaluation concats that list again, past the base's own `Distinct()`, and appends the marker a second time. `AllEventTypes` came back as `[AEvent, Archived, Archived]`.

It does not change what `AppliesTo` answers, but every store composes its loader's allow list from these types, so the duplicate reached the generated SQL as a repeated `IN` member and a repeated parameter slot. The append is now deduplicated.

## Verification

The failure is silent, so a green suite proves nothing on its own. I packed this branch to a local feed twice — once with the fix, once with the production change alone reverted — and ran Fisher against both.

Without the fix, the new compliance fact fails on Fisher exactly as JasperFx/polecat#567 described:

```
Shouldly.ShouldAssertException : meter.Location
    should be
    but was
```

The document **is** written, so a "document is missing" assertion would not have caught it — only `Location` came back empty. With the fix it passes. **JasperFx/fisher#203 falls out of this, verified rather than assumed.**

The new fact deliberately appends one event *after* the compaction. Without that trailing event a broken shard sees an empty slice and writes no document, which the assertion would catch for the wrong reason; with it, the broken shard writes a *plausible* document and only the totals tell them apart.

## The composite question from the issue

`CompositeProjection` inherits `IncludedEventTypes` from `EventFilterable` and nothing rolls its children's lists up into it, so it stays empty and the composite's shard is unfiltered. The bug cannot occur there today. Worth knowing that it depends on the empty-list-means-no-filter path staying as it is.

## Test results

| Suite | Result |
|---|---|
| EventTests | 1053 green, net9.0 and net10.0 |
| EventStoreTests | 141 green, net9.0 and net10.0 |
| JasperFx.Events.SourceGenerator.Tests | 62 green |
| Fisher.Tests (against the packed build) | 1933 green, net9.0 and net10.0 |
| Polecat.Tests `stream_compacting_compliance` (against the packed build) | 12 green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)