### PR TITLE
A declared type and the real type it names are one claim, not a disagreement (#798)

### DIFF
--- a/src/EventTests/EventModeling/SourceDisagreementHotspotTests.cs
+++ b/src/EventTests/EventModeling/SourceDisagreementHotspotTests.cs
@@ -232,3 +232,76 @@ public class SourceDisagreementHotspotTests
     public class OrderShipped { }
     public class AuditRecorded { }
 }
+
+/// <summary>
+/// jasperfx#798: a declared type and the real type it names are the same claim, not a disagreement.
+/// </summary>
+/// <remarks>
+/// A declared type does not exist yet, so its FullName is synthesized from the model's single
+/// namespace while the code puts types in whatever namespaces it likes — typically one per domain.
+/// Keying on that guess made <c>CritterCrush.Appointment</c> and
+/// <c>CritterCrush.Appointments.Appointment</c> disagree, and the hotspot then rendered both sides
+/// as "Appointment": a thing disagreeing with itself. Six of six merged slices in the first real
+/// model to reach this code path.
+/// </remarks>
+public class DeclaredTypeEqualityTests
+{
+    private const string Role = "AggregateTypes";
+
+    /// <summary>A declaration: name-only, FullName synthesized, no assembly.</summary>
+    private static TypeDescriptor Declared(string name, string ns) => new(name, $"{ns}.{name}", string.Empty);
+
+    /// <summary>A real type: the namespace the code actually uses, and an assembly.</summary>
+    private static TypeDescriptor Real(string name, string ns) => new(name, $"{ns}.{name}", "CritterCrush");
+
+    private static EventModelSliceDescriptor Slice(EventModelProvenance provenance, params TypeDescriptor[] aggregates)
+        => EventModelSliceDescriptor.Named("ConfirmAppointment") with
+        {
+            Provenance = provenance,
+            AggregateTypes = aggregates,
+        };
+
+    private static IReadOnlyList<HotspotDescriptor> DisagreementsIn(EventModelSliceDescriptor slice)
+        => slice.Hotspots.Where(x => x.Origin == HotspotOrigin.SourceDisagreement).ToList();
+
+    [Fact]
+    public void a_declared_type_matches_the_real_type_of_the_same_name()
+    {
+        var declared = Slice(EventModelProvenance.Declared, Declared("Appointment", "CritterCrush"));
+        var derived = Slice(EventModelProvenance.Derived, Real("Appointment", "CritterCrush.Appointments"));
+
+        var merged = declared.Merge(derived);
+
+        DisagreementsIn(merged).ShouldBeEmpty();
+        merged.AggregateTypes.Select(x => x.Name).ShouldBe(["Appointment"]);
+    }
+
+    [Fact]
+    public void a_declared_type_the_code_does_not_have_still_disagrees()
+    {
+        // The relaxation must not swallow the case the merge exists for: the model says one thing
+        // and the code does another.
+        var declared = Slice(EventModelProvenance.Declared, Declared("Appointment", "CritterCrush"));
+        var derived = Slice(EventModelProvenance.Derived, Real("Booking", "CritterCrush.Appointments"));
+
+        var hotspot = DisagreementsIn(declared.Merge(derived)).ShouldHaveSingleItem();
+
+        hotspot.Role.ShouldBe(Enum.Parse<EventModelRole>(Role));
+        hotspot.WinningClaim!.Value.ShouldBe("Booking");
+        hotspot.LosingClaim!.Value.ShouldBe("Appointment");
+    }
+
+    [Fact]
+    public void two_real_types_of_the_same_name_disagree_and_say_which_is_which()
+    {
+        // Both sides real, so equality stays on FullName — and the message falls back to the full
+        // name, because "claims Appointment; claims Appointment" is useless precisely here.
+        var derived = Slice(EventModelProvenance.Derived, Real("Appointment", "CritterCrush.Appointments"));
+        var observed = Slice(EventModelProvenance.Observed, Real("Appointment", "CritterCrush.Legacy"));
+
+        var hotspot = DisagreementsIn(derived.Merge(observed)).ShouldHaveSingleItem();
+
+        hotspot.WinningClaim!.Value.ShouldBe("CritterCrush.Legacy.Appointment");
+        hotspot.LosingClaim!.Value.ShouldBe("CritterCrush.Appointments.Appointment");
+    }
+}

--- a/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
@@ -292,7 +292,7 @@ public sealed record EventModelSliceDescriptor(
         }
 
         IReadOnlyList<T> mergeList<T>(EventModelRole role, IReadOnlyList<T> mine, IReadOnlyList<T> theirs,
-            Func<T, string> key, Func<T, string> display)
+            Func<T, string> key, Func<T, string> display, Func<T, string>? ifIndistinguishable = null)
         {
             var myRung = ProvenanceFor(role);
             var theirRung = other.ProvenanceFor(role);
@@ -307,15 +307,40 @@ public sealed record EventModelSliceDescriptor(
 
             if (!sameSet(mine, theirs, key))
             {
-                disagree(role, tookTheirs, render(mine, display), render(theirs, display));
+                var mineValue = render(mine, display);
+                var theirsValue = render(theirs, display);
+
+                if (mineValue == theirsValue && ifIndistinguishable is not null)
+                {
+                    mineValue = render(mine, ifIndistinguishable);
+                    theirsValue = render(theirs, ifIndistinguishable);
+                }
+
+                disagree(role, tookTheirs, mineValue, theirsValue);
             }
 
             return tookTheirs ? theirs : mine;
         }
 
+        // Key on FullName only when BOTH sides have a real one. A declared type does not exist
+        // yet, so its FullName is synthesized from the model's single namespace — and the code it
+        // describes puts types in whatever namespaces it likes, typically one per domain. Keying
+        // on a guess made `CritterCrush.Appointment` and `CritterCrush.Appointments.Appointment`
+        // disagree, which is a thing disagreeing with itself (jasperfx#798). An empty
+        // AssemblyName is exactly the marker for "this is a declaration, not a type".
         IReadOnlyList<TypeDescriptor> mergeTypes(EventModelRole role, IReadOnlyList<TypeDescriptor> mine,
             IReadOnlyList<TypeDescriptor> theirs)
-            => mergeList(role, mine, theirs, x => x.FullName, x => x.Name);
+        {
+            var declared = mine.Concat(theirs).Any(x => string.IsNullOrEmpty(x.AssemblyName));
+
+            return mergeList(role, mine, theirs,
+                key: declared ? x => x.Name : x => x.FullName,
+                display: x => x.Name,
+                // Simple names are what a reader wants, right up until both sides render the same
+                // string — "Derived claims Appointment; Declared claims Appointment" says nothing.
+                // That is exactly when the full name is the only thing that distinguishes them.
+                ifIndistinguishable: x => x.FullName);
+        }
 
         var triggerLabel = mergeScalar(EventModelRole.TriggerLabel, TriggerLabel, other.TriggerLabel, x => x);
         var triggerType = mergeScalar(EventModelRole.TriggerType, TriggerType, other.TriggerType, x => x.Name);


### PR DESCRIPTION
Closes #798.

Registering a curated event-model file alongside the model Wolverine derives from the code it describes — the moment the two sources actually merged, every merged slice raised:

```
AggregateTypes: Derived claims Appointment; Declared claims Appointment
```

Both rungs claim the same thing, by the only name a reader can see, and it was reported as a conflict. Six of six merged slices, on the role they all share.

## The equality

`mergeTypes` keyed on `FullName`. A declared type does not exist yet, so its `FullName` is synthesized from the model's single `namespace:`, while the code puts types in whatever namespaces it likes — typically one per domain. `CritterCrush.Appointment` never matches `CritterCrush.Appointments.Appointment`, so a disagreement was minted for every typed role of every slice. It scaled with how well the model was filled in, which is backwards.

An empty `AssemblyName` is already the marker for *"this is a declaration, not a type"*, so when either side carries one, the key is the simple `Name`. A declaration cannot know the namespace the code will end up in — that is the whole reason the field is empty.

## The display, which needed the opposite treatment

Rendering claims by `Name` is right for a reader, right up until both sides render the same string — which is precisely when the disagreement is *real* and interesting: two same-named types in different namespaces. So `Name` stays the default, and the full name is a fallback used only when the two claims would otherwise be indistinguishable. **Existing hotspot messages are unchanged.**

## Tests

Three, pinning the three cases that matter: a declaration matching its real type raises nothing; a declaration the code does not have still disagrees (the relaxation must not swallow what the merge is *for*); and two real same-named types disagree and say which is which.

EventTests 1056/1056. One unrelated flake was seen once in `BlueGreenSideEffectGateTests.fresh_deploy_suppresses_side_effects_to_the_prior_version_mark_then_enables_them`, and did not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)