### PR TITLE
Let a tag filter be ANDed with the rest of an EventQuery (jasperfx#801)

### DIFF
--- a/src/EventTests/CommandLine/EventQueryInputTests.cs
+++ b/src/EventTests/CommandLine/EventQueryInputTests.cs
@@ -64,7 +64,12 @@ public class EventQueryInputTests
         query.PageNumber.ShouldBe(3);
         query.PageSize.ShouldBe(25);
 
-        query.SpecifiedFilters.ShouldBe(EventQueryFilters.All & ~EventQueryFilters.EventTypeName);
+        // Everything but the single-name spelling (the CLI always builds the list form) and the
+        // lossy TagValues spelling — the command's --tags flag builds the rich TagConditions form,
+        // and the two are mutually exclusive (jasperfx#801).
+        query.SpecifiedFilters.ShouldBe(
+            EventQueryFilters.All & ~EventQueryFilters.EventTypeName & ~EventQueryFilters.TagValues);
+        query.TagValues.ShouldBeEmpty();
     }
 
     [Fact]

--- a/src/EventTests/EventQueryTests.cs
+++ b/src/EventTests/EventQueryTests.cs
@@ -49,12 +49,20 @@ public class EventQueryTests
 
         var spec = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")));
         new EventQuery { TagConditions = spec }.SpecifiedFilters.ShouldBe(EventQueryFilters.TagConditions);
+
+        new EventQuery { TagValues = { ["manifest"] = "m-1" } }
+            .SpecifiedFilters.ShouldBe(EventQueryFilters.TagValues);
     }
 
+    /// <summary>
+    /// Every filter at once, in each of its two tag spellings. There is deliberately no single query
+    /// that specifies <see cref="EventQueryFilters.All"/>: the two tag members are exclusive
+    /// (jasperfx#801), so <c>All</c> is what a store declares, not what one query can carry.
+    /// </summary>
     [Fact]
-    public void a_fully_loaded_query_specifies_all()
+    public void a_fully_loaded_query_specifies_all_but_one_tag_spelling()
     {
-        var query = new EventQuery
+        EventQuery loaded() => new()
         {
             EventTypeName = "a",
             EventTypeNames = ["b"],
@@ -66,14 +74,78 @@ public class EventQueryTests
             TimestampFrom = DateTimeOffset.UtcNow.AddDays(-1),
             TimestampTo = DateTimeOffset.UtcNow,
             SequenceFloor = 1,
-            SequenceCeiling = 100,
-            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")))
+            SequenceCeiling = 100
         };
 
-        query.SpecifiedFilters.ShouldBe(EventQueryFilters.All);
+        var rich = loaded();
+        rich.TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")));
+        rich.SpecifiedFilters.ShouldBe(EventQueryFilters.All & ~EventQueryFilters.TagValues);
 
-        // A fully implemented store declares All and takes anything.
-        Should.NotThrow(() => query.AssertFiltersAreSupported(EventQueryFilters.All));
+        var lossy = loaded();
+        lossy.TagValues["manifest"] = "m-1";
+        lossy.SpecifiedFilters.ShouldBe(EventQueryFilters.All & ~EventQueryFilters.TagConditions);
+
+        // A fully implemented store declares All and takes either.
+        Should.NotThrow(() => rich.AssertFiltersAreSupported(EventQueryFilters.All));
+        Should.NotThrow(() => lossy.AssertFiltersAreSupported(EventQueryFilters.All));
+    }
+
+    [Fact]
+    public void an_empty_tag_values_dictionary_is_no_filter()
+    {
+        // Same reason as the empty EventTypeNames list: the default instance must not read as a
+        // supplied filter, or every existing caller would trip the guard rail on a store that has
+        // not implemented jasperfx#801 yet.
+        new EventQuery().SpecifiedFilters.ShouldBe(EventQueryFilters.None);
+        new EventQuery { TagValues = new Dictionary<string, string>() }
+            .SpecifiedFilters.ShouldBe(EventQueryFilters.None);
+    }
+
+    [Fact]
+    public void the_two_tag_spellings_cannot_be_combined()
+    {
+        var query = new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1"))),
+            TagValues = { ["manifest"] = "m-1" }
+        };
+
+        var ex = Should.Throw<ArgumentException>(() => query.AssertIsWellFormed());
+        ex.Message.ShouldContain("EventQuery.TagConditions");
+        ex.Message.ShouldContain("EventQuery.TagValues");
+
+        // And the guard rail every implementation already calls carries the same refusal, so a store
+        // does not have to remember a second assertion. It refuses ahead of the support check —
+        // "you cannot ask for both" beats "I do not support one of them".
+        Should.Throw<ArgumentException>(() => query.AssertFiltersAreSupported(EventQueryFilters.All));
+        Should.Throw<ArgumentException>(() => query.AssertFiltersAreSupported(EventQueryFilters.Baseline));
+    }
+
+    [Fact]
+    public void either_tag_spelling_alone_is_well_formed()
+    {
+        Should.NotThrow(() => new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new QueryManifest("m-1")))
+        }.AssertIsWellFormed());
+
+        Should.NotThrow(() => new EventQuery { TagValues = { ["manifest"] = "m-1" } }.AssertIsWellFormed());
+        Should.NotThrow(() => new EventQuery().AssertIsWellFormed());
+    }
+
+    [Fact]
+    public void a_store_without_the_lossy_tag_form_refuses_it_by_name()
+    {
+        var query = new EventQuery { StreamId = "s", TagValues = { ["manifest"] = "m-1" } };
+
+        // The jasperfx#801 member joined EventQueryFilters.All, so a store that has not implemented
+        // it must subtract it from its declaration — and then refuse the filter by name rather than
+        // returning events that ignore it.
+        var ex = Should.Throw<NotSupportedException>(
+            () => query.AssertFiltersAreSupported(EventQueryFilters.All & ~EventQueryFilters.TagValues));
+
+        ex.Message.ShouldContain("EventQuery.TagValues");
+        ex.Message.ShouldNotContain("EventQuery.StreamId");
     }
 
     [Fact]
@@ -85,6 +157,7 @@ public class EventQueryTests
 
         EventQueryFilters.TimestampWindow.ShouldBe(EventQueryFilters.TimestampFrom | EventQueryFilters.TimestampTo);
         EventQueryFilters.SequenceWindow.ShouldBe(EventQueryFilters.SequenceFloor | EventQueryFilters.SequenceCeiling);
+        EventQueryFilters.Tags.ShouldBe(EventQueryFilters.TagConditions | EventQueryFilters.TagValues);
     }
 
     [Fact]
@@ -186,5 +259,32 @@ public class EventQueryTests
         condition.EventType.ShouldBe(typeof(ManifestOpened));
         condition.TagType.ShouldBe(typeof(QueryManifest));
         condition.TagValue.ShouldBe(new QueryManifest("m-1"));
+    }
+
+    /// <summary>
+    /// The lossy tag form's whole reason to exist is a caller that holds a name/value pair and no CLR
+    /// type graph — which is a caller on the far side of a wire — so it has to survive the hop.
+    /// </summary>
+    [Fact]
+    public void the_lossy_tag_form_round_trips_through_json()
+    {
+        var original = new EventQuery
+        {
+            EventTypeNames = ["manifest_opened"],
+            SequenceFloor = 10,
+            TagValues = { ["QueryManifest"] = "m-1", ["manifest"] = "m-2" }
+        };
+
+        var query = JsonSerializer.Deserialize<EventQuery>(JsonSerializer.Serialize(original));
+
+        query.ShouldNotBeNull();
+        query.TagValues.Count.ShouldBe(2);
+        query.TagValues["QueryManifest"].ShouldBe("m-1");
+        query.TagValues["manifest"].ShouldBe("m-2");
+        query.TagConditions.ShouldBeNull();
+
+        query.SpecifiedFilters.ShouldBe(original.SpecifiedFilters);
+        query.SpecifiedFilters.ShouldBe(
+            EventQueryFilters.EventTypeNames | EventQueryFilters.SequenceFloor | EventQueryFilters.TagValues);
     }
 }

--- a/src/EventTests/Tags/TagTypeRegistrationExtensionsTests.cs
+++ b/src/EventTests/Tags/TagTypeRegistrationExtensionsTests.cs
@@ -1,0 +1,87 @@
+using JasperFx.Events.Tags;
+using Shouldly;
+
+namespace EventTests.Tags;
+
+// Coverage for jasperfx#801's shared tag-name matcher: the one place that decides what a key in
+// EventQuery.TagValues (or the dictionary QueryByTagsAsync overload) refers to. It lives in the
+// abstraction rather than in each store because a remote caller cannot discover which spelling a
+// given engine accepts.
+public class TagTypeRegistrationExtensionsTests
+{
+    private static readonly ITagTypeRegistration[] _registered =
+    [
+        TagTypeRegistration.Create<StudentId>("student"),
+        TagTypeRegistration.Create<CourseId>("course")
+    ];
+
+    [Fact]
+    public void matches_the_clr_simple_name()
+    {
+        _registered.FindByTagName("StudentId")!.TagType.ShouldBe(typeof(StudentId));
+    }
+
+    [Fact]
+    public void matches_the_registered_table_suffix()
+    {
+        _registered.FindByTagName("course")!.TagType.ShouldBe(typeof(CourseId));
+    }
+
+    [Fact]
+    public void matching_is_case_insensitive_in_both_spellings()
+    {
+        _registered.FindByTagName("studentid")!.TagType.ShouldBe(typeof(StudentId));
+        _registered.FindByTagName("COURSE")!.TagType.ShouldBe(typeof(CourseId));
+    }
+
+    [Fact]
+    public void an_unknown_name_finds_nothing()
+    {
+        _registered.FindByTagName("no_such_tag").ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A CLR name is tried across every registration before any suffix is considered, so a tag type
+    /// whose suffix happens to spell another type's name cannot shadow it.
+    /// </summary>
+    [Fact]
+    public void the_clr_name_wins_over_another_types_suffix()
+    {
+        ITagTypeRegistration[] colliding =
+        [
+            // CourseId's suffix is spelled exactly like StudentId's CLR name.
+            TagTypeRegistration.Create<CourseId>("StudentId"),
+            TagTypeRegistration.Create<StudentId>("student")
+        ];
+
+        colliding.FindByTagName("StudentId")!.TagType.ShouldBe(typeof(StudentId));
+        colliding.FindByTagName("student")!.TagType.ShouldBe(typeof(StudentId));
+        colliding.FindByTagName("CourseId")!.TagType.ShouldBe(typeof(CourseId));
+    }
+
+    [Fact]
+    public void require_returns_the_registration_when_the_name_is_known()
+    {
+        _registered.RequireByTagName("student").TagType.ShouldBe(typeof(StudentId));
+    }
+
+    [Fact]
+    public void require_refuses_an_unknown_name_and_lists_what_is_registered()
+    {
+        // Loud rather than empty: "that tag type does not exist here" and "no event carries that
+        // tag" must not read alike to a caller filtering events.
+        var ex = Should.Throw<ArgumentException>(() => _registered.RequireByTagName("no_such_tag", "tags"));
+
+        ex.ParamName.ShouldBe("tags");
+        ex.Message.ShouldContain("no_such_tag");
+        ex.Message.ShouldContain("StudentId");
+        ex.Message.ShouldContain("course");
+    }
+
+    [Fact]
+    public void an_empty_graph_finds_nothing_and_refuses_everything()
+    {
+        Array.Empty<ITagTypeRegistration>().FindByTagName("StudentId").ShouldBeNull();
+        Should.Throw<ArgumentException>(() => Array.Empty<ITagTypeRegistration>().RequireByTagName("StudentId"));
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
@@ -18,9 +18,17 @@ public record CargoInspected(string Inspector);
 public record CargoUnloaded(string Port);
 
 /// <summary>
-/// Strong-typed tag identity for the folded tag-condition filter.
+/// Strong-typed tag identity for the folded tag-condition filter. Guid-valued deliberately: the
+/// lossy <see cref="EventQuery.TagValues"/> form matches on the tag value's <em>string</em> form, and
+/// engines render a Guid in different casing.
 /// </summary>
 public record ManifestId(Guid Value);
+
+/// <summary>
+/// A second, string-valued tag identity, so the AND-across-entries semantics of
+/// <see cref="EventQuery.TagValues"/> can be exercised with two different tag types at once.
+/// </summary>
+public record ShipperCode(string Value);
 
 #endregion
 
@@ -63,8 +71,11 @@ public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
         config.EnableCorrelationTracking = true;
         config.EnableUserNameTracking = true;
 
-        // No aggregate association: the tag is used purely as a query dimension here.
+        // No aggregate association: the tags are used purely as query dimensions here. The table
+        // suffixes are deliberately NOT the CLR type names, because jasperfx#801's lossy tag filter
+        // accepts either spelling and the suite has to be able to tell them apart.
         config.RegisterTagType<ManifestId>("manifest");
+        config.RegisterTagType<ShipperCode>("shipper");
     };
 
     protected override Action<ComplianceStoreConfig> Configuration => _configuration;
@@ -1169,6 +1180,367 @@ public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
         result.Events.Select(x => x.Sequence).ShouldBe(taggedSequences);
     }
 
+    // ---- the lossy name/value tag filter (jasperfx#801) ----
+    //
+    // EventQuery.TagValues is the same input the dictionary QueryByTagsAsync overload takes, made
+    // composable: a caller holding a tag NAME rather than a CLR tag type can now AND it with every
+    // other filter, and keeps paging and TotalCount doing it. The semantics differ from
+    // TagConditions in two ways this section pins down — entries are AND'd rather than OR'd, and
+    // names/values are matched as text — so a store cannot implement one by delegating to the other
+    // without noticing.
+
+    /// <summary>
+    /// Two tagged events and two decoys: one carrying the same tag type at a different value, one
+    /// carrying no tag at all. Both decoys survive a store that drops the filter.
+    /// </summary>
+    private async Task<(ManifestId Matching, ManifestId Other)> seedTaggedManifestsAsync()
+    {
+        var matching = new ManifestId(Guid.NewGuid());
+        var other = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("grain"), matching);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("alice"), matching);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("coal"), other);
+        await appendAsync(Guid.NewGuid(), new CargoUnloaded("Lisbon"));
+
+        return (matching, other);
+    }
+
+    [Fact]
+    public async Task filters_by_a_tag_name_and_value()
+    {
+        var (matching, _) = await seedTaggedManifestsAsync();
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = matching.Value.ToString() }, PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.Count.ShouldBe(2);
+        result.Events.ShouldContain(x => x.Data is CargoLoaded);
+        result.Events.ShouldContain(x => x.Data is CargoInspected);
+    }
+
+    /// <summary>
+    /// Either spelling of the name resolves to the same registered tag type — the CLR simple name or
+    /// the registered table suffix, which this suite deliberately registers as different strings. A
+    /// remote caller cannot discover which spelling an engine prefers, so both must work everywhere;
+    /// see <c>TagTypeRegistrationExtensions.FindByTagName</c>, the shared matcher.
+    /// </summary>
+    [Fact]
+    public async Task a_tag_name_is_either_the_table_suffix_or_the_clr_type_name()
+    {
+        var (matching, _) = await seedTaggedManifestsAsync();
+
+        var bySuffix = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = matching.Value.ToString() }, PageSize = 1000
+        });
+
+        var byTypeName = await queryAsync(new EventQuery
+        {
+            TagValues = { ["ManifestId"] = matching.Value.ToString() }, PageSize = 1000
+        });
+
+        bySuffix.TotalCount.ShouldBe(2);
+        byTypeName.TotalCount.ShouldBe(2);
+        byTypeName.Events.Select(x => x.Sequence).ShouldBe(bySuffix.Events.Select(x => x.Sequence));
+    }
+
+    [Fact]
+    public async Task tag_name_matching_is_case_insensitive()
+    {
+        var (matching, _) = await seedTaggedManifestsAsync();
+
+        foreach (var name in new[] { "MANIFEST", "Manifest", "manifestid", "MANIFESTID" })
+        {
+            var result = await queryAsync(new EventQuery
+            {
+                TagValues = { [name] = matching.Value.ToString() }, PageSize = 1000
+            });
+
+            result.TotalCount.ShouldBe(2, $"the tag name spelling '{name}' should have resolved");
+        }
+    }
+
+    /// <summary>
+    /// The value is matched against the string form of the stored tag value, case-insensitively —
+    /// the contract on <see cref="EventQuery.TagValues"/>. A Guid-valued tag is where it bites: the
+    /// engines render one in different casing, and an operator's copy-pasted id must not depend on
+    /// which store answered.
+    /// </summary>
+    [Fact]
+    public async Task a_tag_value_matches_regardless_of_its_casing()
+    {
+        var (matching, _) = await seedTaggedManifestsAsync();
+
+        var lower = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = matching.Value.ToString().ToLowerInvariant() }, PageSize = 1000
+        });
+
+        var upper = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = matching.Value.ToString().ToUpperInvariant() }, PageSize = 1000
+        });
+
+        lower.TotalCount.ShouldBe(2);
+        upper.TotalCount.ShouldBe(2);
+        upper.Events.Select(x => x.Sequence).ShouldBe(lower.Events.Select(x => x.Sequence));
+    }
+
+    /// <summary>
+    /// Entries are AND'd — the opposite of <see cref="EventQuery.TagConditions"/>, whose conditions
+    /// are OR'd. A store implementing this member by folding it into the rich form without changing
+    /// the combinator answers three here instead of one.
+    /// </summary>
+    [Fact]
+    public async Task multiple_tag_entries_are_combined_with_and()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+        var shipper = new ShipperCode("acme");
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("both"), manifest, shipper);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("manifest-only"), manifest);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoUnloaded("shipper-only"), shipper);
+
+        var result = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = manifest.Value.ToString(), ["shipper"] = shipper.Value },
+            PageSize = 1000
+        });
+
+        // Exactly the event carrying both, once — a tag-table join without a distinct reads the
+        // doubly-tagged row twice.
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("both");
+        result.Events.Select(x => x.Sequence).Distinct().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task tag_values_combine_with_the_other_filters_as_and()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("tagged-early"), manifest);
+        await appendAsync(Guid.NewGuid(), new CargoLoaded("untagged"));
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("tagged-late"), manifest);
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoInspected("wrong-type"), manifest);
+
+        var all = await queryAllAsync();
+        var sequences = all.Events.Select(x => x.Sequence).ToList();
+
+        // The window admits positions 1..3, the type filter keeps the two Loaded events of that
+        // span, and the tag filter drops the untagged one. Each decoy fails exactly one filter.
+        var result = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = manifest.Value.ToString() },
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            SequenceFloor = sequences[1],
+            SequenceCeiling = sequences[3],
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Sequence.ShouldBe(sequences[2]);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("tagged-late");
+    }
+
+    /// <summary>
+    /// The property jasperfx#801 exists to preserve: unlike the unpaged <c>IAsyncEnumerable</c> the
+    /// dictionary tag query returns, this stays on the <see cref="PagedEvents"/> path, so a tag query
+    /// keeps paging and a truthful <see cref="PagedEvents.TotalCount"/>.
+    /// </summary>
+    [Fact]
+    public async Task the_lossy_tag_filter_keeps_paging_and_the_total_count()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        for (var i = 0; i < 5; i++)
+        {
+            await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded($"match-{i}"), manifest);
+
+            // Interleaved untagged noise, so the matching sequences are non-contiguous and a store
+            // paging BEFORE filtering produces short or bleeding pages.
+            await appendAsync(Guid.NewGuid(), new CargoInspected($"noise-{i}"));
+        }
+
+        var unpaged = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = manifest.Value.ToString() }, PageSize = 1000
+        });
+        unpaged.TotalCount.ShouldBe(5);
+
+        var pages = new List<PagedEvents>();
+        for (var pageNumber = 1; pageNumber <= 3; pageNumber++)
+        {
+            pages.Add(await queryAsync(new EventQuery
+            {
+                TagValues = { ["manifest"] = manifest.Value.ToString() },
+                PageNumber = pageNumber,
+                PageSize = 2
+            }));
+        }
+
+        foreach (var page in pages)
+        {
+            // The filtered total, identical on every page — not the page size and not the store size.
+            page.TotalCount.ShouldBe(5);
+            page.Events.ShouldAllBe(x => x.Data is CargoLoaded);
+        }
+
+        pages[0].Events.Count.ShouldBe(2);
+        pages[1].Events.Count.ShouldBe(2);
+        pages[2].Events.Count.ShouldBe(1);
+
+        pages.SelectMany(x => x.Events).Select(x => x.Sequence)
+            .ShouldBe(unpaged.Events.Select(x => x.Sequence));
+    }
+
+    [Fact]
+    public async Task a_tag_value_matching_nothing_is_an_empty_answer_not_an_error()
+    {
+        var (_, _) = await seedTaggedManifestsAsync();
+
+        // A registered tag name at a value nothing carries: a truthful zero, never a throw — the
+        // mirror image of the unregistered-name refusal below.
+        var result = await queryAsync(new EventQuery
+        {
+            TagValues = { ["manifest"] = Guid.NewGuid().ToString() }, PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(0);
+        result.Events.ShouldBeEmpty();
+    }
+
+    /// <summary>
+    /// An unregistered tag name is refused rather than answered empty: "that tag type does not exist
+    /// here" and "no event carries that tag" must not read alike, or a caller with a typo believes
+    /// the store and concludes the events are gone.
+    /// </summary>
+    [Fact]
+    public async Task an_unregistered_tag_name_is_refused()
+    {
+        await seedInterleavedAsync();
+
+        var ex = await Should.ThrowAsync<ArgumentException>(async () => await queryAsync(new EventQuery
+        {
+            TagValues = { ["no_such_tag"] = "whatever" }, PageSize = 1000
+        }));
+
+        ex.Message.ShouldContain("no_such_tag");
+
+        // And it names what IS registered, so the caller can correct the typo from the message.
+        ex.Message.ShouldContain(nameof(ManifestId));
+    }
+
+    /// <summary>
+    /// The two tag spellings are alternatives, not a combination, and supplying both is refused —
+    /// the <see cref="EventQuery.AssertIsWellFormed"/> rule, asserted through the store because it
+    /// only protects a caller if the store's implementation actually runs the guard rail.
+    /// </summary>
+    [Fact]
+    public async Task supplying_both_tag_spellings_is_refused()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+
+        await using var session = OpenSession();
+        await AppendTaggedEventAsync(session, Guid.NewGuid(), new CargoLoaded("grain"), manifest);
+
+        await Should.ThrowAsync<ArgumentException>(async () => await queryAsync(new EventQuery
+        {
+            TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(manifest)),
+            TagValues = { ["manifest"] = manifest.Value.ToString() },
+            PageSize = 1000
+        }));
+    }
+
+    /// <summary>
+    /// The <see cref="a_kitchen_sink_query_isolates_exactly_one_event"/> twin, in the lossy tag
+    /// spelling: every filter the suite's configuration can express, at once, with each decoy failing
+    /// a different single one.
+    /// </summary>
+    [Fact]
+    public async Task a_kitchen_sink_query_with_the_lossy_tag_filter_isolates_exactly_one_event()
+    {
+        var manifest = new ManifestId(Guid.NewGuid());
+        var shipper = new ShipperCode("acme");
+        var streamId = Guid.NewGuid();
+        var correlation = $"sink-{Guid.NewGuid():N}";
+
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        var parent = new Activity("lossy-sink-parent").Start();
+        var child = new Activity("lossy-sink-child").Start();
+
+        string? causation;
+        try
+        {
+            await using var session = OpenSession();
+            causation = CausationIdFor(session);
+            SetCorrelationId(session, correlation);
+            SetUserName(session, "sink-user");
+
+            var target = EventsFor(session).BuildEvent(new CargoLoaded("bullseye"));
+            target.WithTag(manifest, shipper);
+            EventsFor(session).Append(streamId, target);
+
+            // Fails only the event type filter.
+            var wrongType = EventsFor(session).BuildEvent(new CargoInspected("decoy"));
+            wrongType.WithTag(manifest, shipper);
+            EventsFor(session).Append(streamId, wrongType);
+
+            // Fails only the second tag entry — the trap for a store that stops at the first one.
+            var missingShipper = EventsFor(session).BuildEvent(new CargoLoaded("no-shipper"));
+            missingShipper.WithTag(manifest);
+            EventsFor(session).Append(streamId, missingShipper);
+
+            // Fails only the stream filter.
+            var wrongStream = EventsFor(session).BuildEvent(new CargoLoaded("wrong-stream"));
+            wrongStream.WithTag(manifest, shipper);
+            EventsFor(session).Append(Guid.NewGuid(), wrongStream);
+
+            await SaveChangesAsync(session);
+        }
+        finally
+        {
+            child.Stop();
+            parent.Stop();
+        }
+
+        causation.ShouldNotBeNull();
+
+        // Fails the tag, correlation, causation and user filters at once.
+        await appendAsync(streamId, new CargoLoaded("untagged"));
+
+        var all = await queryAllAsync();
+        all.Events.Count.ShouldBe(5);
+
+        var result = await queryAsync(new EventQuery
+        {
+            StreamId = streamId.ToString(),
+            EventTypeName = EventTypeNameFor<CargoLoaded>(),
+            EventTypeNames = [EventTypeNameFor<CargoUnloaded>()],
+            CorrelationId = correlation,
+            CausationId = causation,
+            UserName = "sink-user",
+            TimestampFrom = all.Events[0].Timestamp,
+            TimestampTo = all.Events[^1].Timestamp,
+            SequenceFloor = all.Events[0].Sequence,
+            SequenceCeiling = all.Events[^1].Sequence,
+            // Both spellings of a name in one query, so neither is special-cased.
+            TagValues = { ["manifest"] = manifest.Value.ToString(), ["ShipperCode"] = shipper.Value },
+            PageSize = 1000
+        });
+
+        result.TotalCount.ShouldBe(1);
+        result.Events.Single().Data.ShouldBeOfType<CargoLoaded>().Cargo.ShouldBe("bullseye");
+    }
+
     // ---- filters against data that contains none of it ----
 
     /// <summary>
@@ -1189,7 +1561,8 @@ public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
             new() { CorrelationId = $"corr-{Guid.NewGuid():N}" },
             new() { CausationId = $"cause-{Guid.NewGuid():N}" },
             new() { UserName = $"user-{Guid.NewGuid():N}" },
-            new() { TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new ManifestId(Guid.NewGuid()))) }
+            new() { TagConditions = EventTagQuerySpec.From(new EventTagQuery().Or(new ManifestId(Guid.NewGuid()))) },
+            new() { TagValues = { ["manifest"] = Guid.NewGuid().ToString() } }
         };
 
         foreach (var query in nonMatching)

--- a/src/JasperFx.Events/EventQuery.cs
+++ b/src/JasperFx.Events/EventQuery.cs
@@ -131,6 +131,46 @@ public class EventQuery
     public EventTagQuerySpec? TagConditions { get; set; }
 
     /// <summary>
+    /// Optional tag filter in the lossy name/value form — the same input
+    /// <c>IEventStore.QueryByTagsAsync(IReadOnlyDictionary&lt;string,string&gt;, …)</c> takes, now
+    /// expressible on the composable query object so it can be AND-combined with the event type,
+    /// window, stream, metadata and tenant filters instead of forcing a caller to choose. Empty
+    /// applies no tag filter. See jasperfx#801.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Semantics.</b> Every entry must match: an event is selected when it carries <em>all</em> of
+    /// the named tags at the given values (AND across entries, unlike <see cref="TagConditions"/>,
+    /// whose conditions are OR'd). That selection is then AND-combined with every other filter, and
+    /// the result stays on the <see cref="PagedEvents"/> path — a tag query keeps paging and
+    /// <see cref="PagedEvents.TotalCount"/>.
+    /// </para>
+    /// <para>
+    /// <b>Names.</b> A key names a registered tag type, matched case-insensitively against either the
+    /// tag type's CLR simple name (<c>"StudentId"</c>) or its registered table suffix
+    /// (<c>"student"</c>) — see <see cref="TagTypeRegistrationExtensions.FindByTagName"/>, which is
+    /// the shared matcher every store is expected to use. A key naming no registered tag type is an
+    /// <see cref="ArgumentException"/>, never an empty answer: "that tag type does not exist here"
+    /// and "no event carries that tag" must not read alike.
+    /// </para>
+    /// <para>
+    /// <b>Values.</b> A value is matched against the <em>string form</em> of the stored tag value,
+    /// ordinal case-insensitively. Case-insensitive because this form's whole purpose is text a
+    /// caller typed or forwarded rather than a CLR value it holds, and the string form of a Guid tag
+    /// is rendered in different casing by different engines — an operator's copy-pasted Guid must not
+    /// depend on which store answered. A caller that holds real CLR tag values should use
+    /// <see cref="TagConditions"/> instead, which compares the typed value.
+    /// </para>
+    /// <para>
+    /// <b>Not combinable with <see cref="TagConditions"/>.</b> The two are alternative spellings of
+    /// one filter — one lossy and AND'd, one rich and OR'd — and supplying both is an
+    /// <see cref="ArgumentException"/> from <see cref="AssertIsWellFormed"/> rather than a silent
+    /// precedence rule.
+    /// </para>
+    /// </remarks>
+    public Dictionary<string, string> TagValues { get; set; } = new();
+
+    /// <summary>
     /// The effective event type name filter: the union of <see cref="EventTypeName"/> and
     /// <see cref="EventTypeNames"/>, distinct, in declaration order with the single name first.
     /// Empty means no event type filter. Implementations should consume this rather than reading
@@ -183,6 +223,7 @@ public class EventQuery
             if (SequenceFloor != null) filters |= EventQueryFilters.SequenceFloor;
             if (SequenceCeiling != null) filters |= EventQueryFilters.SequenceCeiling;
             if (TagConditions != null) filters |= EventQueryFilters.TagConditions;
+            if (TagValues.Count > 0) filters |= EventQueryFilters.TagValues;
 
             return filters;
         }
@@ -201,8 +242,29 @@ public class EventQuery
         (EventQueryFilters.TimestampTo, nameof(TimestampTo)),
         (EventQueryFilters.SequenceFloor, nameof(SequenceFloor)),
         (EventQueryFilters.SequenceCeiling, nameof(SequenceCeiling)),
-        (EventQueryFilters.TagConditions, nameof(TagConditions))
+        (EventQueryFilters.TagConditions, nameof(TagConditions)),
+        (EventQueryFilters.TagValues, nameof(TagValues))
     ];
+
+    /// <summary>
+    /// Assert that this query is internally consistent, independently of what any store supports:
+    /// today, that it does not carry both spellings of the tag filter at once. Called first thing by
+    /// <see cref="AssertFiltersAreSupported"/>, so an implementation that follows the guard-rail
+    /// convention gets it without a second call.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Both <see cref="TagConditions"/> and <see cref="TagValues"/> were supplied.
+    /// </exception>
+    public void AssertIsWellFormed()
+    {
+        if (TagConditions != null && TagValues.Count > 0)
+        {
+            throw new ArgumentException(
+                $"{nameof(EventQuery)}.{nameof(TagConditions)} and {nameof(EventQuery)}.{nameof(TagValues)} are " +
+                "alternative spellings of the tag filter — the rich OR'd condition form and the lossy AND'd " +
+                "name/value form — and cannot be combined. Supply one or the other. See jasperfx#801.");
+        }
+    }
 
     /// <summary>
     /// The jasperfx#737 guard rail, centralized: throw <see cref="NotSupportedException"/> naming
@@ -213,9 +275,15 @@ public class EventQuery
     /// unfiltered results that read as filtered.
     /// </summary>
     /// <param name="supportedFilters">The set of filters the calling implementation honors.</param>
+    /// <exception cref="ArgumentException">The query is not well formed — see <see cref="AssertIsWellFormed"/>.</exception>
     /// <exception cref="NotSupportedException">A filter was supplied that the implementation did not declare.</exception>
     public void AssertFiltersAreSupported(EventQueryFilters supportedFilters)
     {
+        // Well-formedness first: a query carrying both tag spellings is malformed whether or not this
+        // store implements either one, and "you cannot ask for both" is the more useful answer than
+        // "I do not support one of them".
+        AssertIsWellFormed();
+
         var unsupported = SpecifiedFilters & ~supportedFilters;
         if (unsupported == EventQueryFilters.None)
         {
@@ -253,6 +321,7 @@ public enum EventQueryFilters
     SequenceFloor = 1 << 9,
     SequenceCeiling = 1 << 10,
     TagConditions = 1 << 11,
+    TagValues = 1 << 12,
 
     /// <summary>
     /// Both halves of the inclusive timestamp window.
@@ -270,9 +339,23 @@ public enum EventQueryFilters
     Baseline = EventTypeName | StreamId | CorrelationId | CausationId | UserName | TenantId,
 
     /// <summary>
+    /// Both spellings of the tag filter: the rich OR'd <see cref="TagConditions"/> and the lossy
+    /// AND'd <see cref="TagValues"/>. Only one of the two can appear on any single query.
+    /// </summary>
+    Tags = TagConditions | TagValues,
+
+    /// <summary>
     /// Every filter <see cref="EventQuery"/> can carry. What a fully implemented store declares.
     /// </summary>
-    All = Baseline | EventTypeNames | TimestampWindow | SequenceWindow | TagConditions
+    /// <remarks>
+    /// This grows as <see cref="EventQuery"/> grows — <see cref="TagValues"/> joined it in
+    /// jasperfx#801 — so a store that declares <c>All</c> and then upgrades the package silently
+    /// claims support for a filter it has not written yet, which is the failure the guard rail exists
+    /// to prevent. A store adopting a release that widened this enum either implements the new filter
+    /// or subtracts it from its declaration (<c>EventQueryFilters.All &amp; ~EventQueryFilters.TagValues</c>)
+    /// until it does.
+    /// </remarks>
+    All = Baseline | EventTypeNames | TimestampWindow | SequenceWindow | Tags
 }
 
 /// <summary>

--- a/src/JasperFx.Events/Tags/TagTypeRegistrationExtensions.cs
+++ b/src/JasperFx.Events/Tags/TagTypeRegistrationExtensions.cs
@@ -1,0 +1,80 @@
+namespace JasperFx.Events.Tags;
+
+/// <summary>
+/// Resolution of a tag <em>name</em> — the string a caller supplies in the lossy
+/// <see cref="EventQuery.TagValues"/> / <c>QueryByTagsAsync(IReadOnlyDictionary&lt;string,string&gt;)</c>
+/// form — against a store's registered tag graph. See jasperfx#801.
+/// </summary>
+/// <remarks>
+/// Lives here rather than in each store because the name matching <em>is</em> the contract: a caller
+/// holding a store descriptor and a name/value pair has no way to discover which spelling a given
+/// engine accepts, so a store that matched only the CLR name while its sibling matched the table
+/// suffix would make the same query answer differently per store — and the failure would be an
+/// <see cref="ArgumentException"/> at runtime, per store, which is exactly what the shared abstraction
+/// exists to prevent.
+/// </remarks>
+public static class TagTypeRegistrationExtensions
+{
+    /// <summary>
+    /// The registration a tag name refers to, or <see langword="null"/> when the name matches none.
+    /// A name matches case-insensitively against either the tag type's CLR simple name
+    /// (<c>"StudentId"</c>) or its registered table suffix (<c>"student"</c>); the CLR name is tried
+    /// across every registration before the suffix, so a suffix that collides with another tag type's
+    /// name cannot shadow that type.
+    /// </summary>
+    /// <param name="registrations">The store's registered tag types.</param>
+    /// <param name="tagName">The tag name to resolve.</param>
+    public static ITagTypeRegistration? FindByTagName(
+        this IEnumerable<ITagTypeRegistration> registrations, string tagName)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+        ArgumentNullException.ThrowIfNull(tagName);
+
+        // Materialized because both passes walk it, and the caller's source is typically a lazy
+        // Select over the event graph.
+        var all = registrations as IReadOnlyList<ITagTypeRegistration> ?? registrations.ToList();
+
+        foreach (var registration in all)
+        {
+            if (string.Equals(registration.TagType.Name, tagName, StringComparison.OrdinalIgnoreCase))
+            {
+                return registration;
+            }
+        }
+
+        foreach (var registration in all)
+        {
+            if (string.Equals(registration.TableSuffix, tagName, StringComparison.OrdinalIgnoreCase))
+            {
+                return registration;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// <see cref="FindByTagName"/>, refusing an unknown name with an <see cref="ArgumentException"/>
+    /// that lists what <em>is</em> registered. An unknown tag name is an error rather than an empty
+    /// result on purpose: "that tag type does not exist here" and "no event carries that tag" must
+    /// not read alike to a caller filtering events.
+    /// </summary>
+    /// <param name="registrations">The store's registered tag types.</param>
+    /// <param name="tagName">The tag name to resolve.</param>
+    /// <param name="parameterName">Parameter name to attribute the exception to.</param>
+    /// <exception cref="ArgumentException">No registered tag type answers to that name.</exception>
+    public static ITagTypeRegistration RequireByTagName(
+        this IEnumerable<ITagTypeRegistration> registrations, string tagName, string? parameterName = null)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+        ArgumentNullException.ThrowIfNull(tagName);
+
+        var all = registrations as IReadOnlyList<ITagTypeRegistration> ?? registrations.ToList();
+
+        return all.FindByTagName(tagName)
+               ?? throw new ArgumentException(
+                   $"Tag type '{tagName}' is not registered on this event store. Registered tag types: "
+                   + string.Join(", ", all.Select(x => $"{x.TagType.Name} (\"{x.TableSuffix}\")")),
+                   parameterName);
+    }
+}


### PR DESCRIPTION
Closes #801.

## What was wrong

`EventQuery` composes every filter it carries with AND — event type names, timestamp window, sequence window, stream id, tenant — **except tags**. The dictionary form of a tag query existed only on the non-composable `IEventStore.QueryByTagsAsync(IReadOnlyDictionary<string,string>, …)`, so a caller filtered by tags **or** by everything else, never both. Taking the dictionary path also gave up paging and `TotalCount`, because it returns an unpaged `IAsyncEnumerable<EventRecord>`.

The rich `EventTagQuerySpec` form on `EventQuery.TagConditions` is not a substitute: it carries CLR tag *types*, and building one from `{"customerId": "C-42"}` means mapping a name to a type — which is the store's job, service-side. A remote caller holds a store descriptor, not its CLR type graph.

## What this does

Adds **`EventQuery.TagValues`** — `Dictionary<string,string>`, the lossy name/value form — beside `TagConditions`:

- Entries are **AND'd** with each other (an event must carry every named tag at the given value), and the whole selection is AND'd with every other filter.
- The answer stays on the **`PagedEvents`** path, so a tag query keeps paging and `TotalCount` — the property the issue asked to preserve.
- Its own `EventQueryFilters.TagValues` bit, so the jasperfx#737 guard rail refuses it by name on a store that has not implemented it.
- The two tag members are **alternatives, not a combination**: supplying both is an `ArgumentException` from the new `EventQuery.AssertIsWellFormed()`, which `AssertFiltersAreSupported` calls first thing — so a store already following the guard-rail convention gets the refusal without a second call.

## Tag names are contract, not implementation detail

New `TagTypeRegistrationExtensions.FindByTagName` / `RequireByTagName` put the name matching in the abstraction: the tag type's **CLR simple name** (`"StudentId"`) or its **registered table suffix** (`"student"`), case-insensitively, with the CLR name tried across every registration first so a suffix cannot shadow another type's name. An unknown name is refused loudly rather than answered empty — *"that tag type does not exist here"* and *"no event carries that tag"* must not read alike.

This is centralized because Marten and Polecat had already drifted apart on it (Marten: CLR name only, case-sensitive value comparison; Polecat: either spelling, case-insensitive), and the dictionary `QueryByTagsAsync` overload has no compliance coverage at all, which is what let that happen. A caller holding only a descriptor cannot discover which spelling a given engine accepts.

Values are matched against the **string form** of the stored tag value, **ordinal case-insensitively** — this form exists for text a caller typed or forwarded, and the engines render a Guid tag in different casing.

## Compliance

`EventQueryCompliance` gains a section for the new member (and a second, string-valued `ShipperCode` tag type so the AND-across-entries semantics can be exercised with two tag types at once):

- filters by a tag name/value; either spelling of the name; case-insensitive names; case-insensitive values
- multiple entries AND together, and a doubly-tagged event is not duplicated
- composes with event type + sequence window as AND, each decoy failing exactly one filter
- keeps paging and a truthful `TotalCount` across pages, with interleaved noise so a store paging before filtering fails
- a non-matching value is an empty answer, an unregistered name is an `ArgumentException`, and both tag spellings at once is refused
- a kitchen-sink query in the lossy spelling, including a decoy that fails **only** the second tag entry

`every_filter_alone_returns_an_empty_answer_when_nothing_matches` picks up the new member too.

## ⚠️ Note for adopters

`TagValues` joined `EventQueryFilters.All`. A store that declares `All` and then upgrades the package **silently claims support for a filter it has not written** — the exact failure the guard rail exists to prevent. Implement it, or subtract it (`EventQueryFilters.All & ~EventQueryFilters.TagValues`) until you do. Downstream tracking issues are filed against Marten, Polecat and Fisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)