### PR TITLE
event-query --tags carries tag names, not manufactured type descriptors (jasperfx#803)

### DIFF
--- a/src/EventTests/CommandLine/EventQueryInputTests.cs
+++ b/src/EventTests/CommandLine/EventQueryInputTests.cs
@@ -60,16 +60,16 @@ public class EventQueryInputTests
         query.TimestampTo.ShouldBe(new DateTimeOffset(2026, 9, 2, 0, 0, 0, TimeSpan.Zero));
         query.SequenceFloor.ShouldBe(10);
         query.SequenceCeiling.ShouldBe(200);
-        query.TagConditions.ShouldNotBeNull();
+        query.TagValues["ManifestId"].ShouldBe("m-1");
         query.PageNumber.ShouldBe(3);
         query.PageSize.ShouldBe(25);
 
-        // Everything but the single-name spelling (the CLI always builds the list form) and the
-        // lossy TagValues spelling — the command's --tags flag builds the rich TagConditions form,
-        // and the two are mutually exclusive (jasperfx#801).
+        // Everything but the single-name spelling (the CLI always builds the list form) and the rich
+        // TagConditions spelling — the command's --tags flag carries names, so it builds the lossy
+        // TagValues form, and the two tag members are mutually exclusive (jasperfx#801/#803).
         query.SpecifiedFilters.ShouldBe(
-            EventQueryFilters.All & ~EventQueryFilters.EventTypeName & ~EventQueryFilters.TagValues);
-        query.TagValues.ShouldBeEmpty();
+            EventQueryFilters.All & ~EventQueryFilters.EventTypeName & ~EventQueryFilters.TagConditions);
+        query.TagConditions.ShouldBeNull();
     }
 
     [Fact]
@@ -84,34 +84,54 @@ public class EventQueryInputTests
         query.CombinedEventTypeNames().ShouldBe(["cargo_loaded", "cargo_unloaded"]);
     }
 
+    /// <summary>
+    /// jasperfx#803: the flag carries tag NAMES, not type descriptors. The previous shape built an
+    /// <c>EventTagQuerySpec</c> whose TypeDescriptor.FullName was the bare property name, which
+    /// <c>EventTagQuerySpec.ResolverFor</c> — a full-name match — could never resolve for a tag type
+    /// in a namespace, so the flag threw <c>UnknownTagQueryTypeException</c> against every real store.
+    /// </summary>
     [Fact]
-    public void tags_parse_into_or_conditions_with_no_event_type_scope()
+    public void tags_parse_into_the_lossy_name_value_filter()
     {
-        var (spec, error) = EventQueryInput.TryParseTags("{\"StudentId\":\"s-1\",\"CourseId\":\"c-2\"}");
+        var (tags, error) = EventQueryInput.TryParseTags("{\"StudentId\":\"s-1\",\"course\":\"c-2\"}");
 
         error.ShouldBeNull();
-        spec.ShouldNotBeNull();
-        spec.Conditions.Count.ShouldBe(2);
+        tags.ShouldNotBeNull();
+        tags.Count.ShouldBe(2);
 
-        spec.Conditions[0].TagType.FullName.ShouldBe("StudentId");
-        spec.Conditions[0].EventType.ShouldBeNull();
-        spec.Conditions[0].TagValue.GetString().ShouldBe("s-1");
-
-        spec.Conditions[1].TagType.FullName.ShouldBe("CourseId");
-        spec.Conditions[1].TagValue.GetString().ShouldBe("c-2");
+        // Either spelling passes through untouched — the store resolves the name against its own tag
+        // graph, where the graph actually is.
+        tags["StudentId"].ShouldBe("s-1");
+        tags["course"].ShouldBe("c-2");
     }
 
     [Fact]
-    public void a_non_string_tag_value_is_passed_through_as_given()
+    public void a_scalar_tag_value_keeps_its_literal_spelling()
     {
-        // The store side deserializes the value against the resolved tag type, so the CLI passes
-        // whatever JSON the operator supplied rather than insisting on strings.
-        var (spec, error) = EventQueryInput.TryParseTags("{\"OrderId\":{\"value\":42}}");
+        // The store matches on the stored tag value's string form, so a number or boolean carries
+        // through as the text the operator wrote rather than being quoted or reformatted.
+        var (tags, error) = EventQueryInput.TryParseTags("{\"OrderId\":42,\"Active\":true}");
 
         error.ShouldBeNull();
-        spec.ShouldNotBeNull();
-        spec.Conditions.Single().TagValue.ValueKind.ShouldBe(JsonValueKind.Object);
-        spec.Conditions.Single().TagValue.GetProperty("value").GetInt32().ShouldBe(42);
+        tags.ShouldNotBeNull();
+        tags["OrderId"].ShouldBe("42");
+        tags["Active"].ShouldBe("true");
+    }
+
+    [Fact]
+    public void a_composite_tag_value_is_refused()
+    {
+        // A tag value is always a strong-typed id over a primitive, so an object or array is a
+        // mangled invocation. Refused rather than stringified: a stringified object matches nothing
+        // and would read back as "no such events".
+        var (tags, error) = EventQueryInput.TryParseTags("{\"OrderId\":{\"value\":42}}");
+
+        tags.ShouldBeNull();
+        error.ShouldNotBeNull();
+        error.ShouldContain("OrderId");
+        error.ShouldContain("object");
+
+        EventQueryInput.TryParseTags("{\"OrderId\":[1,2]}").Error.ShouldNotBeNull();
     }
 
     [Fact]
@@ -119,14 +139,31 @@ public class EventQueryInputTests
     {
         EventQueryInput.TryParseTags(null).ShouldBe((null, null));
         EventQueryInput.TryParseTags("").ShouldBe((null, null));
+
+        new EventQueryInput().BuildQuery().TagValues.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_tags_flag_lands_on_tag_values_not_tag_conditions()
+    {
+        var query = new EventQueryInput { TagsFlag = "{\"manifest\":\"m-1\",\"shipper\":\"acme\"}" }.BuildQuery();
+
+        query.TagConditions.ShouldBeNull();
+        query.TagValues.Count.ShouldBe(2);
+        query.TagValues["manifest"].ShouldBe("m-1");
+        query.TagValues["shipper"].ShouldBe("acme");
+
+        // And the query stays well formed, so the store's guard rail passes it through.
+        Should.NotThrow(() => query.AssertIsWellFormed());
+        query.SpecifiedFilters.ShouldBe(EventQueryFilters.TagValues);
     }
 
     [Fact]
     public void unparseable_tags_json_is_refused()
     {
-        var (spec, error) = EventQueryInput.TryParseTags("{not json");
+        var (tags, error) = EventQueryInput.TryParseTags("{not json");
 
-        spec.ShouldBeNull();
+        tags.ShouldBeNull();
         error.ShouldNotBeNull();
         error.ShouldContain("--tags is not valid JSON");
     }
@@ -134,9 +171,9 @@ public class EventQueryInputTests
     [Fact]
     public void tags_that_are_not_an_object_are_refused()
     {
-        var (spec, error) = EventQueryInput.TryParseTags("[\"StudentId\"]");
+        var (tags, error) = EventQueryInput.TryParseTags("[\"StudentId\"]");
 
-        spec.ShouldBeNull();
+        tags.ShouldBeNull();
         error.ShouldNotBeNull();
         error.ShouldContain("must be a JSON object");
     }
@@ -146,9 +183,9 @@ public class EventQueryInputTests
     {
         // {} filters nothing; running the query unfiltered would be the silently-ignored-filter
         // failure mode the whole jasperfx#737 surface is built to refuse.
-        var (spec, error) = EventQueryInput.TryParseTags("{}");
+        var (tags, error) = EventQueryInput.TryParseTags("{}");
 
-        spec.ShouldBeNull();
+        tags.ShouldBeNull();
         error.ShouldNotBeNull();
         error.ShouldContain("empty JSON object");
     }
@@ -156,9 +193,9 @@ public class EventQueryInputTests
     [Fact]
     public void a_null_tag_value_is_refused()
     {
-        var (spec, error) = EventQueryInput.TryParseTags("{\"StudentId\":null}");
+        var (tags, error) = EventQueryInput.TryParseTags("{\"StudentId\":null}");
 
-        spec.ShouldBeNull();
+        tags.ShouldBeNull();
         error.ShouldNotBeNull();
         error.ShouldContain("StudentId");
     }

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventQueryCompliance.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using JasperFx.Events.CommandLine;
 using JasperFx.Events.Tags;
 using Shouldly;
 using Xunit;
@@ -1458,6 +1459,40 @@ public abstract class EventQueryCompliance<TFixture, TOperations, TQuerySession>
             TagValues = { ["manifest"] = manifest.Value.ToString() },
             PageSize = 1000
         }));
+    }
+
+    /// <summary>
+    /// The <c>event-query --tags</c> flag end to end: what the command builds must be a query this
+    /// store can actually answer. See jasperfx#803.
+    /// </summary>
+    /// <remarks>
+    /// The flag used to build the rich <see cref="EventTagQuerySpec"/> form out of a manufactured
+    /// <c>TypeDescriptor</c> whose <c>FullName</c> was the bare property name, which
+    /// <c>EventTagQuerySpec.ResolverFor</c> — a full-name match — could not resolve for a tag type in
+    /// a namespace. So the flag threw against every real store, and stayed green in the abstraction's
+    /// own tests, which only asserted that a spec had been <em>built</em>. This suite runs the
+    /// command's own output through the store, which is the only place that gap was ever visible.
+    /// </remarks>
+    [Fact]
+    public async Task the_event_query_commands_tags_flag_builds_a_filter_this_store_can_answer()
+    {
+        var (matching, _) = await seedTaggedManifestsAsync();
+
+        var input = new EventQueryInput
+        {
+            // The tag name as an operator would type it: this suite registers ManifestId under the
+            // table suffix "manifest", and the CLR type lives in a namespace.
+            TagsFlag = $$"""{"manifest":"{{matching.Value}}"}""",
+            PageSizeFlag = 1000
+        };
+
+        input.Validate().ShouldBeNull();
+
+        var result = await queryAsync(input.BuildQuery());
+
+        result.TotalCount.ShouldBe(2);
+        result.Events.ShouldContain(x => x.Data is CargoLoaded);
+        result.Events.ShouldContain(x => x.Data is CargoInspected);
     }
 
     /// <summary>

--- a/src/JasperFx.Events/CommandLine/EventQueryInput.cs
+++ b/src/JasperFx.Events/CommandLine/EventQueryInput.cs
@@ -60,7 +60,7 @@ public class EventQueryInput: NetCoreInput
     [FlagAlias("sequence-ceiling", longAliasOnly: true)]
     public long? SequenceCeilingFlag { get; set; }
 
-    [Description("Tag conditions as a JSON object of tag type name to tag value, e.g. '{\"StudentId\":\"s-1\"}'. Conditions are OR'd, then AND-combined with the other filters")]
+    [Description("Tag filter as a JSON object of tag name to tag value, e.g. '{\"StudentId\":\"s-1\"}'. A name is the tag type's name or its registered table suffix; entries are AND'd, then AND-combined with the other filters")]
     [FlagAlias("tags", longAliasOnly: true)]
     public string? TagsFlag { get; set; }
 
@@ -145,9 +145,13 @@ public class EventQueryInput: NetCoreInput
             SequenceFloor = SequenceFloorFlag,
             SequenceCeiling = SequenceCeilingFlag,
             PageNumber = PageFlag,
-            PageSize = PageSizeFlag,
-            TagConditions = TryParseTags(TagsFlag).Spec
+            PageSize = PageSizeFlag
         };
+
+        if (TryParseTags(TagsFlag).Tags is { } tags)
+        {
+            query.TagValues = tags;
+        }
 
         if (EventTypeFlag.IsNotEmpty())
         {
@@ -162,13 +166,27 @@ public class EventQueryInput: NetCoreInput
     }
 
     /// <summary>
-    /// Parse the <c>--tags</c> JSON object into the wire-serializable <see cref="EventTagQuerySpec"/>.
-    /// Each property becomes one tag-only condition (any event type carrying the tag); the property
-    /// name is the tag type as the store's registered tag graph knows it, and the value is passed
-    /// through as-is for the store side to deserialize against the resolved tag type.
+    /// Parse the <c>--tags</c> JSON object into <see cref="EventQuery.TagValues"/> — the lossy
+    /// name/value tag filter (jasperfx#801). Each property is one entry: the name as the store's
+    /// registered tag graph knows it (the tag type's name or its registered table suffix), the value
+    /// rendered as text for the store to match against the stored tag value's string form.
     /// </summary>
-    /// <returns>The spec, or the operator-facing error. A missing flag is (null, null): no tag filter.</returns>
-    public static (EventTagQuerySpec? Spec, string? Error) TryParseTags(string? json)
+    /// <remarks>
+    /// <para>
+    /// This is the lossy form rather than the rich <see cref="EventTagQuerySpec"/> one, because the
+    /// rich form's tag <em>types</em> can only be resolved against the store's registered graph, and
+    /// the CLI has a name. Building a spec here meant manufacturing a
+    /// <see cref="TypeDescriptor"/> whose <c>FullName</c> was the bare name, which
+    /// <see cref="EventTagQuerySpec.ResolverFor"/> — a full-name match — could never resolve for a
+    /// tag type in a namespace. See jasperfx#803.
+    /// </para>
+    /// <para>
+    /// Entries are therefore AND'd rather than OR'd, which is also what an operator naming two tags
+    /// means, and what the store's own dictionary tag query has always done.
+    /// </para>
+    /// </remarks>
+    /// <returns>The tag entries, or the operator-facing error. A missing flag is (null, null): no tag filter.</returns>
+    public static (Dictionary<string, string>? Tags, string? Error) TryParseTags(string? json)
     {
         if (json.IsEmpty())
         {
@@ -189,33 +207,44 @@ public class EventQueryInput: NetCoreInput
         {
             if (document.RootElement.ValueKind != JsonValueKind.Object)
             {
-                return (null, "--tags must be a JSON object of tag type name to tag value, e.g. '{\"StudentId\":\"s-1\"}'");
+                return (null, "--tags must be a JSON object of tag name to tag value, e.g. '{\"StudentId\":\"s-1\"}'");
             }
 
-            var conditions = new List<EventTagQueryConditionSpec>();
+            var tags = new Dictionary<string, string>();
             foreach (var property in document.RootElement.EnumerateObject())
             {
                 if (property.Value.ValueKind == JsonValueKind.Null)
                 {
-                    return (null, $"--tags value for '{property.Name}' is null; a tag condition needs a value");
+                    return (null, $"--tags value for '{property.Name}' is null; a tag filter needs a value");
                 }
 
-                // Clone: the element must outlive the parsed document.
-                conditions.Add(new EventTagQueryConditionSpec(
-                    EventType: null,
-                    TagType: new TypeDescriptor(property.Name, property.Name, string.Empty),
-                    TagValue: property.Value.Clone()));
+                // A tag value is always a strong-typed id over a primitive -- TagTypeRegistration
+                // requires a simple inner type -- so a composite has no faithful text form and is a
+                // mangled invocation rather than a query. Refused rather than stringified, because
+                // a stringified object would match nothing and read as "no such events".
+                if (property.Value.ValueKind is JsonValueKind.Object or JsonValueKind.Array)
+                {
+                    return (null,
+                        $"--tags value for '{property.Name}' is a JSON {property.Value.ValueKind.ToString().ToLowerInvariant()}; " +
+                        "a tag value is the id itself, written as a string, number or boolean");
+                }
+
+                tags[property.Name] = property.Value.ValueKind == JsonValueKind.String
+                    ? property.Value.GetString()!
+                    // Numbers and booleans keep their literal spelling; the store matches on the
+                    // stored value's string form.
+                    : property.Value.GetRawText();
             }
 
-            if (conditions.Count == 0)
+            if (tags.Count == 0)
             {
                 // An empty object filters nothing, and a tag filter that filters nothing is far more
                 // likely a mangled invocation than an intent — refuse it rather than quietly running
                 // the query unfiltered.
-                return (null, "--tags is an empty JSON object; supply at least one tag condition or omit the flag");
+                return (null, "--tags is an empty JSON object; supply at least one tag filter or omit the flag");
             }
 
-            return (new EventTagQuerySpec(conditions), null);
+            return (tags, null);
         }
     }
 

--- a/src/JasperFx.Events/Tags/EventTagQuerySpec.cs
+++ b/src/JasperFx.Events/Tags/EventTagQuerySpec.cs
@@ -89,11 +89,18 @@ public sealed record EventTagQuerySpec(IReadOnlyList<EventTagQueryConditionSpec>
 
     /// <summary>
     /// Build a <see cref="TypeDescriptor"/>-to-<see cref="Type"/> resolver over a known set of
-    /// types — the store's registered tag types and event types. Matches on full name (falling
-    /// back to simple name when full names are ambiguous only across differing assemblies is not
-    /// a concern for the registered graph). Returns <see langword="null"/> for an unknown type so
-    /// <see cref="Resolve"/> can raise a precise error.
+    /// types — the store's registered tag types and event types. Returns <see langword="null"/> for
+    /// an unknown type so <see cref="Resolve"/> can raise a precise error.
     /// </summary>
+    /// <remarks>
+    /// Matching is on <see cref="TypeDescriptor.FullName"/> and <b>only</b> full name — deliberately
+    /// exact, with no simple-name fallback. Every descriptor this resolver is meant to see was
+    /// produced by <see cref="From"/> from a real <see cref="Type"/>, so it carries a real full name;
+    /// a descriptor that does not is a hand-built one, and guessing at the type it means is how a
+    /// query silently binds to the wrong tag. (An earlier version of this comment claimed a
+    /// simple-name fallback that the code never had, and the <c>event-query --tags</c> flag was built
+    /// against that claim — see jasperfx#803. That flag now carries names rather than descriptors.)
+    /// </remarks>
     /// <param name="knownTypes">The registered tag/event graph types the query may reference.</param>
     public static Func<TypeDescriptor, Type?> ResolverFor(IEnumerable<Type> knownTypes)
     {


### PR DESCRIPTION
Closes #803. Follows #802.

## The defect

`EventQueryInput.TryParseTags` turned each `--tags` JSON property into a wire condition by manufacturing a descriptor from the property name alone:

```csharp
TagType: new TypeDescriptor(property.Name, property.Name, string.Empty)
```

`TypeDescriptor` is `(Name, FullName, AssemblyName)`, so `FullName` became `"StudentId"`. `EventTagQuerySpec.ResolverFor` matches on `FullName` and nothing else, and the registered graph carries real full names (`MyApp.Domain.StudentId`) — so the lookup missed and `Resolve` raised `UnknownTagQueryTypeException`. **`event-query --tags` failed for every tag type not in the global namespace**, at both store-side call sites (Marten `buildTagConditionsFilter`, Fisher `AppendTagConditionsFilter`).

It was wrong twice over. Even had the type resolved, the documented example `'{"StudentId":"s-1"}'` could not have deserialized: `EventTagQuerySpec.From` serializes a tag value under its *runtime* type, so `record StudentId(string Value)` round-trips as `{"Value":"s-1"}`, not `"s-1"`. An operator would have had to type the wrapper's JSON shape.

Both failures are the same mistake — **a name is not a type** — and #802 landed the member that holds a name.

## The fix

`--tags` now builds **`EventQuery.TagValues`**, where the name is resolved against the store's own tag graph (CLR simple name *or* registered table suffix, case-insensitively), which is where the graph actually is. No descriptor is manufactured anywhere.

Two consequences, both deliberate and both improvements:

- **Entries AND rather than OR.** That is what an operator naming two tags means, and what the store's dictionary tag query has always done. The old OR semantics were unreachable in practice, since the flag threw before it could filter anything.
- **A composite JSON value is refused** rather than passed through. A tag value is always a strong-typed id over a primitive (`TagTypeRegistration` requires a simple inner type), so an object or array is a mangled invocation — and a stringified object would match nothing and read back as *"no such events"*. Scalars keep their literal spelling (`42`, `true`), since the store matches on the stored value's string form.

`ResolverFor`'s doc comment claimed a simple-name fallback the code never had — which is what the flag was built against. It now describes the exact full-name match it performs, and says why a fallback would be worse: every descriptor it is meant to see came from `From` over a real `Type`, and guessing at a hand-built one is how a query silently binds to the wrong tag.

## Where the regression test goes

The existing unit tests stayed green over all of this because they only asserted a spec had been **built** (`query.TagConditions.ShouldNotBeNull()`) — never that a store could answer it. So the end-to-end fact goes in the shared suite:

`EventQueryCompliance.the_event_query_commands_tags_flag_builds_a_filter_this_store_can_answer` runs the command's own `BuildQuery()` output through the store, using a tag name spelled as the registered table suffix, against a tag type that lives in a namespace — the exact shape that used to throw. All three stores inherit it.

`EventQueryInputTests` is updated for the new shape: names pass through untouched in either spelling, scalars keep their literal text, composites and nulls and empty objects are refused, and `--tags` lands on `TagValues` with `TagConditions` left null.

No store changes are needed for this one beyond what #801's tracking issues already ask for — the flag now produces a query in the shape those issues are about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)