### PR TITLE
Two compaction consistency gaps: a stale refusal message, and the unpinned inference question (jasperfx#800)

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/Suites/StreamCompactingCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/StreamCompactingCompliance.cs
@@ -66,6 +66,30 @@ public partial class ComplianceStringMeter
     public void Apply(MeterServiced _) => ServiceCount++;
 }
 
+/// <summary>
+/// The same fold again, under a type this suite deliberately never registers as a snapshot — the
+/// aggregate for the jasperfx#800 inference fact. Identical members to <see cref="ComplianceMeter"/>
+/// so a failure is about the registration and nothing else.
+/// </summary>
+public partial class ComplianceUnregisteredMeter
+{
+    public Guid Id { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public int Total { get; set; }
+    public int ReadCount { get; set; }
+    public int ServiceCount { get; set; }
+
+    public static ComplianceUnregisteredMeter Create(MeterInstalled e) => new() { Location = e.Location };
+
+    public void Apply(MeterRead e)
+    {
+        Total += e.Reading;
+        ReadCount++;
+    }
+
+    public void Apply(MeterServiced _) => ServiceCount++;
+}
+
 #endregion
 
 /// <summary>
@@ -94,6 +118,13 @@ public partial class ComplianceStringMeter
 /// version rather than version one. Only one product's own tests pinned this before the suite
 /// existed; the other asserted merely that appending afterwards still worked, which passes
 /// vacuously if the version rewound and then climbed again.
+/// </para>
+/// <para>
+/// <strong>An aggregation projection registered for T is not a precondition</strong> (jasperfx#800).
+/// The typed overload names T outright, and that is the declaration of intent; requiring a
+/// registration on top of it would mean a compaction policy could only ever target an aggregate the
+/// application already snapshots — a constraint invisible until runtime, and a portability gap
+/// between the stores rather than a safety property.
 /// </para>
 /// <para>
 /// Out of scope on purpose: the <c>Timestamp</c> cut-off on the request. Deriving a cut-off that
@@ -495,6 +526,79 @@ public abstract class StreamCompactingCompliance<TFixture, TOperations, TQuerySe
         meter.Location.ShouldBe("Substation A");
         meter.Total.ShouldBe(300);
         meter.ReadCount.ShouldBe(7);
+        meter.ServiceCount.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// <c>CompactStreamAsync&lt;T&gt;</c> folds <typeparamref name="T"/> from its own
+    /// <c>Create</c>/<c>Apply</c> conventions, with no aggregation projection registered for it.
+    /// See jasperfx#800.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The stores disagreed here and the suite pinned neither, so the same policy declaration worked
+    /// on one store and was refused on another — a <em>portability</em> gap, not a performance one,
+    /// and invisible until runtime. This fact settles it in favour of inference.
+    /// </para>
+    /// <para>
+    /// Requiring the registration is defensible as explicitness, but its real consequence is a
+    /// constraint nobody would infer from the API: a compaction policy could only ever target an
+    /// aggregate the application already snapshots. The typed overload names <typeparamref name="T"/>
+    /// outright, which is the same declaration of intent a registration would be, and every store
+    /// already owns machinery that builds an aggregator for a type on demand.
+    /// </para>
+    /// <para>
+    /// Deliberately the whole round trip rather than "the call did not throw": the fold has to be
+    /// real. A store could satisfy a call-succeeds assertion by writing an empty snapshot and
+    /// destroying the stream's history doing it, which is the worst outcome available here.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task compacting_infers_the_fold_for_an_unregistered_aggregate()
+    {
+        var streamId = Guid.NewGuid();
+
+        await using (var session = OpenSession())
+        {
+            EventsFor(session).StartStream<ComplianceUnregisteredMeter>(streamId, theNineEvents());
+            await SaveChangesAsync(session);
+        }
+
+        await using (var session = OpenSession())
+        {
+            await EventsFor(session).CompactStreamAsync<ComplianceUnregisteredMeter>(streamId);
+            await SaveChangesAsync(session);
+        }
+
+        await using var query = OpenSession();
+        var events = await EventsFor(query).FetchStreamAsync(streamId, token: Cancellation);
+
+        events.Count.ShouldBe(1);
+        var compacted = events.Single().Data.ShouldBeOfType<Compacted<ComplianceUnregisteredMeter>>();
+
+        // A real fold, not a placeholder: Location comes only from MeterInstalled and the total is
+        // the sum of all six reads.
+        compacted.Snapshot.ShouldNotBeNull();
+        compacted.Snapshot.Location.ShouldBe("Substation A");
+        compacted.Snapshot.Total.ShouldBe(210);
+        compacted.Snapshot.ReadCount.ShouldBe(6);
+        compacted.Snapshot.ServiceCount.ShouldBe(2);
+
+        // And compacting an unregistered aggregate is held to the same version contract as a
+        // registered one — destructive to rows, never rewinding the stream.
+        var state = await EventsFor(query).FetchStreamStateAsync(streamId, Cancellation);
+        state.ShouldNotBeNull();
+        state.Version.ShouldBe(9);
+        events.Single().Version.ShouldBe(9);
+
+        // The read side is unchanged by any of it, which is the whole point of compacting.
+        var meter = await EventsFor(query)
+            .AggregateStreamAsync<ComplianceUnregisteredMeter>(streamId, token: Cancellation);
+
+        meter.ShouldNotBeNull();
+        meter.Location.ShouldBe("Substation A");
+        meter.Total.ShouldBe(210);
+        meter.ReadCount.ShouldBe(6);
         meter.ServiceCount.ShouldBe(2);
     }
 

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -125,12 +125,17 @@ public interface IEventStore
     /// Compact a stream by aggregating events into a snapshot.
     /// Resolves aggregate type from stream state.
     /// </summary>
+    /// <remarks>
+    /// This untyped overload is the one a caller holding a runtime <see cref="Type"/> needs — a
+    /// monitoring console or a compaction policy driven by configuration rather than by a compile-time
+    /// aggregate. Support is per-overload: a store can implement the typed
+    /// <c>IEventStoreOperations.CompactStreamAsync&lt;T&gt;</c> and still refuse this one, so ask the
+    /// store you are actually calling rather than assuming compacting is one capability. See
+    /// jasperfx#800, polecat#572.
+    /// </remarks>
     Task CompactStreamAsync(Guid streamId, CancellationToken token = default);
 
-    /// <summary>
-    /// Compact a stream by aggregating events into a snapshot.
-    /// Resolves aggregate type from stream state.
-    /// </summary>
+    /// <inheritdoc cref="CompactStreamAsync(Guid, CancellationToken)"/>
     Task CompactStreamAsync(string streamKey, CancellationToken token = default);
 
     /// <summary>

--- a/src/JasperFx.Events/IEventStoreOperations.cs
+++ b/src/JasperFx.Events/IEventStoreOperations.cs
@@ -105,15 +105,25 @@ public interface IEventStoreOperations : IEventOperations, IQueryEventStore
     /// Configure the request. The default compacts at the latest point in the stream.
     /// </param>
     /// <remarks>
+    /// <para>
     /// A default-implemented member rather than an abstract one, so a store that has not implemented
     /// compacting stays source-compatible -- the same treatment the event store explorer surface gets
     /// on <see cref="IEventStore"/>. <see cref="Protected.StreamCompactingRequest{T}"/> already lived
     /// here; only the declaration was duplicated per product (marten#5153).
+    /// </para>
+    /// <para>
+    /// The refusal names the <em>capability</em> rather than a list of stores, because a store list in
+    /// an exception message goes stale in both directions and did: it named Marten and Polecat while
+    /// Fisher implemented compacting and went unmentioned, and while Polecat implemented this typed
+    /// overload but refused the untyped <see cref="IEventStore.CompactStreamAsync(Guid, CancellationToken)"/>
+    /// -- which is the one a caller holding a runtime <see cref="Type"/> actually needs. Support is
+    /// per-overload, so no store name is a safe answer here. See jasperfx#800, polecat#572.
+    /// </para>
     /// </remarks>
     Task CompactStreamAsync<T>(Guid streamId, Action<Protected.StreamCompactingRequest<T>>? configure = null)
         where T : class
         => throw new NotSupportedException(
-            "Stream compacting is not implemented on this event store. Use Marten or Polecat.");
+            "Stream compacting is not implemented on this event store. Use an event store that implements stream compacting.");
 
     /// <summary>
     /// Compact a stream by replacing its earlier events with a single <c>Compacted&lt;T&gt;</c> event
@@ -129,7 +139,7 @@ public interface IEventStoreOperations : IEventOperations, IQueryEventStore
     Task CompactStreamAsync<T>(string streamKey, Action<Protected.StreamCompactingRequest<T>>? configure = null)
         where T : class
         => throw new NotSupportedException(
-            "Stream compacting is not implemented on this event store. Use Marten or Polecat.");
+            "Stream compacting is not implemented on this event store. Use an event store that implements stream compacting.");
 
     /// <summary>
     /// Fetch the projected aggregate T by id with built-in optimistic concurrency checks


### PR DESCRIPTION
Closes #800.

## 1. The refusal named stores instead of the capability

`IEventStoreOperations.CompactStreamAsync<T>`'s default threw:

> Stream compacting is not implemented on this event store. **Use Marten or Polecat.**

Stale in both directions: **Fisher** implements compacting and went unmentioned, and **Polecat** implements this *typed* overload while refusing the *untyped* `IEventStore.CompactStreamAsync` ([polecat#572](https://github.com/JasperFx/polecat/issues/572)) — which is the one a caller holding a runtime `Type` actually needs.

Support is **per-overload**, so no store name is a safe answer. The message now names the capability:

> Stream compacting is not implemented on this event store. Use an event store that implements stream compacting.

The untyped overload on `IEventStore` gains a remark saying the same thing outright — that a store can implement the typed one and refuse this one, so ask the store you are calling rather than assuming compacting is a single capability.

## 2. The stores disagreed on whether a registered projection is required

Same call, same seeded stream, different answer:

| store | `CompactStreamAsync<T>` with no aggregation projection registered for T |
|---|---|
| Marten | refuses — `Unable to find an Aggregation Projection for type X` |
| Fisher | succeeds, with a real fold — correct total, version preserved, watermark stamped |

`StreamCompactingCompliance` pinned neither, so the same policy declaration worked on one store and was refused on another, invisibly until runtime.

**The suite now states inference.** New fact: `compacting_infers_the_fold_for_an_unregistered_aggregate`, over a new `ComplianceUnregisteredMeter` — members identical to `ComplianceMeter` so a failure is about the registration and nothing else — which no configuration in the suite registers as a snapshot.

The reasoning, recorded in the suite's own docs so it does not have to be rediscovered: the typed overload **names T outright**, and that is the same declaration of intent a registration would be. Requiring the registration on top of it is defensible as explicitness, but its real consequence is a constraint nobody would infer from the API — a compaction policy could only ever target an aggregate the application already snapshots. And every store already owns machinery that builds an aggregator for a type on demand.

The fact asserts the **whole round trip**, not that the call didn't throw: one surviving `Compacted<T>`, the folded snapshot's `Location`/`Total`/`ReadCount`/`ServiceCount`, the stream version still 9 with the survivor stamped at 9, and the stream still aggregating to the pre-compaction state. A store could satisfy a call-succeeds assertion by writing an empty snapshot and destroying the stream's history doing it, which is the worst outcome available here.

## Downstream

**Marten will go red on this fact** and needs to adopt inference — `Options.Projections.AggregatorFor<T>()` already builds an aggregator on demand, which is how `RehydrateAtVersionAsync` handles an unregistered type today. I'll file that issue once this merges. Fisher and Polecat already behave this way (Polecat for the typed overload).

CritterWatch's `CompactionRequiresRegisteredProjection` capability flag on `StreamCompactionPolicyParityTests` becomes deletable once Marten lands its side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)