### PR TITLE
Fix in-flight Count race in BlockIdleWakeupTests

### DIFF
--- a/src/CoreTests/Blocks/BlockIdleWakeupTests.cs
+++ b/src/CoreTests/Blocks/BlockIdleWakeupTests.cs
@@ -10,6 +10,26 @@ namespace CoreTests.Blocks;
 // three of the four failed on net9.0 as well -- only the bounded case was net10-specific.
 public class BlockIdleWakeupTests
 {
+    /// <summary>
+    /// Count deliberately includes the item currently in flight: Post() increments before the write and
+    /// the consumer loop decrements in a finally AFTER the action returns, which is what lets
+    /// WaitForCompletionAsync and Wolverine's back-pressure agent read it as "work not yet finished".
+    ///
+    /// So it cannot be read straight off the back of a TaskCompletionSource that the action itself
+    /// completed -- that continuation runs while the action is still on the stack, one decrement short.
+    /// These tests flaked on exactly that (net10 lost more races than net9). Quiesce the block first:
+    /// WaitForCompletionAsync only returns once every consumer task has finished its current item, so
+    /// the count it leaves behind is the real one. A leaked increment still fails the assertion --
+    /// the drain loop exits on the completed, empty channel rather than spinning until Count hits zero.
+    /// </summary>
+    private static async Task assertFullyDrained<T>(Block<T> block)
+    {
+        await block.WaitForCompletionAsync()
+            .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        block.Count.ShouldBe(0u);
+    }
+
     [Fact]
     public async Task post_after_idle_does_not_process_inline_on_the_publisher()
     {
@@ -45,7 +65,7 @@ public class BlockIdleWakeupTests
 
         await secondDone.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Volatile.Read(ref processed).ShouldBe(2);
-        block.Count.ShouldBe(0u);
+        await assertFullyDrained(block);
     }
 
     [Fact]
@@ -83,7 +103,7 @@ public class BlockIdleWakeupTests
 
         await done.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Volatile.Read(ref processed).ShouldBe(1 + wave);
-        block.Count.ShouldBe(0u);
+        await assertFullyDrained(block);
     }
 
     /// <summary>
@@ -132,7 +152,7 @@ public class BlockIdleWakeupTests
 
         await done.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Volatile.Read(ref processed).ShouldBe(1 + wave);
-        block.Count.ShouldBe(0u);
+        await assertFullyDrained(block);
     }
 
     /// <summary>

--- a/src/JasperFx/Blocks/Block.cs
+++ b/src/JasperFx/Blocks/Block.cs
@@ -323,6 +323,15 @@ public class Block<T> : BlockBase<T>
         }
     }
 
+    /// <summary>
+    /// The number of items posted to this block whose processing has not yet finished — both the ones
+    /// still buffered in the channel AND the ones currently in flight inside the action. The increment
+    /// happens in Post/PostAsync before the write and the decrement in the consumer loop's finally,
+    /// after the action returns, so a caller that observes this from within the action (or from a
+    /// continuation the action itself scheduled) still sees that item counted. That is the point:
+    /// consumers read this as "work not yet finished", and dropping the in-flight item would let
+    /// <see cref="WaitForCompletionAsync"/> report a block as drained while an action was still running.
+    /// </summary>
     public override uint Count => _count;
 
     public override ValueTask DisposeAsync()


### PR DESCRIPTION
Closes the CI flake in `CoreTests.Blocks.BlockIdleWakeupTests` on net10.0 (seen in run 34344944379, where net9.0 passed on the same commit).

## It's a test bug, not a product bug

`Block<T>.Count` **includes the item currently in flight**, and that is deliberate:

- `Post`/`PostAsync` increment before the channel write ([Block.cs:269](https://github.com/JasperFx/jasperfx/blob/main/src/JasperFx/Blocks/Block.cs#L269)); the consumer loop decrements in a `finally` only *after* `await _action(...)` returns ([Block.cs:206-209](https://github.com/JasperFx/jasperfx/blob/main/src/JasperFx/Blocks/Block.cs#L206-L209)).
- `WaitForCompletionAsync` short-circuits on `_count == 0`, and `BlockSet.Count` is documented as "buffered **or in flight** … work not yet finished" — Wolverine's back-pressure agent reads it that way.
- If `Count` excluded the in-flight item, a block could report itself drained while an action was still running.

The three failing assertions read `Count` straight off a `TaskCompletionSource` that the *action itself* completed, so the assertion ran while that action was still on the stack — one decrement short of zero. Nothing about `Block<T>` is wrong here.

## The fix

Wait for the block to quiesce before reading `Count`, via a small `assertFullyDrained` helper. Not a sleep: `WaitForCompletionAsync` returns only once every consumer task has finished its current item. The assertion keeps its teeth against a leaked increment — the drain loop exits on the completed, empty channel rather than spinning until `Count` hits zero, so a leak still fails.

All three sibling tests with the same pattern are fixed, including both cases of the `[Theory]`. `post_does_not_absorb_the_latency_of_a_slow_action` never asserted on `Count` and is untouched.

Also records the `Count` contract on `Block<T>.Count` itself — it was only written down over on `BlockSet`.

## Verification

Reproduced locally first, to be sure of the diagnosis: reverting to the original assertions and running the class 60x on net10.0 with the CPU saturated gave **1 failure in 60** — in the sibling `a_burst_posted_after_idle_never_executes_on_the_publisher` rather than the originally reported test, confirming all three shared the defect.

After the fix, under the same load:

| | net9.0 | net10.0 |
|---|---|---|
| `BlockIdleWakeupTests` x60 | 0 failed | 0 failed |
| Full CoreTests (600) | 599 passed, 1 skipped | 599 passed, 1 skipped |

`./build.sh test-core` is green. The separately-known-flaky `RetryBlockTests.disregard_after_too_many_failures` and `RecentlyUsedCacheTests.request_item_resets` did not fail in any of these runs and are a different root cause — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)