### PR TITLE
gh-807: a partial EventModelDescriptor round-trips

### DIFF
--- a/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
+++ b/src/EventTests/EventModeling/EventModelWireRoundTripTests.cs
@@ -231,6 +231,110 @@ public class EventModelWireRoundTripTests
         slice.Elements.Select(e => e.Kind).ShouldBe(new[] { EventModelElementKind.Command });
     }
 
+    // jasperfx#807. Partial descriptors are the intended shape -- Merge folds several sources'
+    // halves together by slice name, and a source is by definition partial. System.Text.Json leaves
+    // any constructor parameter the JSON does not carry at its `default`, which for a non-nullable
+    // IReadOnlyList is null, so the halves below used to deserialize into a descriptor that threw
+    // on the way back OUT, through the computed Elements getter.
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void a_slice_that_omits_the_constructor_collections_round_trips()
+    {
+        // Verbatim from jasperfx#807: the Bobcat half of a Critter Stack model, which knows the
+        // specifications and nothing else.
+        const string partial = """
+            {
+              "name": "BankAccount",
+              "slices": [
+                { "name": "EnrollClient",
+                  "specifications": [ { "identity": "Bank Account Event Sourcing/Enroll a client" } ] }
+              ]
+            }
+            """;
+
+        var model = JsonSerializer.Deserialize<EventModelDescriptor>(partial, Web)!;
+
+        var slice = model.Slices.Single();
+        slice.EmittedEvents.ShouldBeEmpty();
+        slice.ProjectionTypes.ShouldBeEmpty();
+        slice.ReadModelTypes.ShouldBeEmpty();
+        slice.Specifications.Single().Identity.ShouldBe("Bank Account Event Sourcing/Enroll a client");
+        slice.Specifications.Single().ResolvedTypes.ShouldBeEmpty();
+
+        // The failure landed here, not at the parse: Elements is computed on every read and the
+        // serializer reads it.
+        Should.NotThrow(() => JsonSerializer.Serialize(model, Web));
+
+        JsonSerializer.Deserialize<EventModelDescriptor>(JsonSerializer.Serialize(model, Web), Web)!
+            .Slices.Single().Specifications.Single().Identity
+            .ShouldBe("Bank Account Event Sourcing/Enroll a client");
+    }
+
+    [Fact]
+    public void the_two_halves_of_a_model_merge_after_a_round_trip()
+    {
+        // The scenario the bug blocked: each source pushes its half over the wire, and the
+        // consumer merges them by slice name.
+        var host = roundTrip(
+            """
+            { "name": "BankAccount", "slices": [ { "name": "EnrollClient",
+              "commandType": { "name": "EnrollClient", "fullName": "Bank.EnrollClient", "assemblyName": "Bank" },
+              "emittedEvents": [ { "name": "ClientEnrolled", "fullName": "Bank.ClientEnrolled", "assemblyName": "Bank" } ] } ] }
+            """);
+
+        var specs = roundTrip(
+            """
+            { "name": "BankAccount", "slices": [ { "name": "EnrollClient",
+              "specifications": [ { "identity": "Bank Account Event Sourcing/Enroll a client" } ] } ] }
+            """);
+
+        var merged = EventModelDescriptor.Merge("BankAccount", new[] { host, specs });
+
+        var slice = merged.Slices.Single();
+        slice.EmittedEvents.Single().Name.ShouldBe("ClientEnrolled");
+        slice.Specifications.Single().Identity.ShouldBe("Bank Account Event Sourcing/Enroll a client");
+        slice.Elements.Select(x => x.Kind)
+            .ShouldBe(new[] { EventModelElementKind.Command, EventModelElementKind.Event });
+    }
+
+    private static EventModelDescriptor roundTrip(string json)
+    {
+        var descriptor = JsonSerializer.Deserialize<EventModelDescriptor>(json, Web)!;
+        return JsonSerializer.Deserialize<EventModelDescriptor>(JsonSerializer.Serialize(descriptor, Web), Web)!;
+    }
+
+    [Fact]
+    public void a_model_that_omits_slices_round_trips()
+    {
+        var model = JsonSerializer.Deserialize<EventModelDescriptor>("""{"name":"BankAccount"}""", Web)!;
+
+        model.Slices.ShouldBeEmpty();
+        model.Aggregates.ShouldBeEmpty();
+        Should.NotThrow(() => JsonSerializer.Serialize(model, Web));
+        model.WithProvenance(EventModelProvenance.Declared).Slices.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_rest_of_the_family_normalizes_its_constructor_collections_too()
+    {
+        JsonSerializer.Deserialize<AggregateDescriptor>(
+                """{"type":{"name":"Order","fullName":"x.Order","assemblyName":"x"}}""", Web)!
+            .AppliedEvents.ShouldBeEmpty();
+
+        JsonSerializer.Deserialize<SpecificationDescriptor>("""{"identity":"F/S"}""", Web)!
+            .ResolvedTypes.ShouldBeEmpty();
+
+        var handler = JsonSerializer.Deserialize<HandlerRelationshipDescriptor>(
+            """
+            { "handlerType": { "name": "H", "fullName": "x.H", "assemblyName": "x" },
+              "messageType": { "name": "M", "fullName": "x.M", "assemblyName": "x" } }
+            """, Web)!;
+
+        handler.EmittedEvents.ShouldBeEmpty();
+        handler.ToSliceDescriptor().EmittedEvents.ShouldBeEmpty();
+    }
+
     [Fact]
     public void specification_feature_and_scenario_are_derived_and_not_on_the_wire()
     {

--- a/src/JasperFx/Descriptors/EventModeling/AggregateDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/AggregateDescriptor.cs
@@ -58,4 +58,12 @@ public enum AggregateKind
 public sealed record AggregateDescriptor(
     TypeDescriptor Type,
     AggregateKind Kind,
-    IReadOnlyList<TypeDescriptor> AppliedEvents);
+    IReadOnlyList<TypeDescriptor> AppliedEvents)
+{
+    /// <summary>
+    /// Event types the aggregate consumes, in declaration order. Never null: System.Text.Json leaves
+    /// a constructor parameter the JSON does not carry at its <c>default</c>, so a payload that omits
+    /// the member would otherwise hand back a null list from a non-nullable slot (jasperfx#807).
+    /// </summary>
+    public IReadOnlyList<TypeDescriptor> AppliedEvents { get; init; } = AppliedEvents ?? Array.Empty<TypeDescriptor>();
+}

--- a/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/EventModelSliceDescriptor.cs
@@ -49,6 +49,24 @@ public sealed record EventModelSliceDescriptor(
     public static EventModelSliceDescriptor Named(string name)
         => new(name, null, null, null, null, Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>(), Array.Empty<TypeDescriptor>());
 
+    // jasperfx#807. A partial slice is the designed-for shape -- Merge folds several sources' halves
+    // together by Name, and a source is by definition partial -- but System.Text.Json hands `default`
+    // to any constructor parameter the JSON does not carry. So a slice sent without `emittedEvents` /
+    // `projectionTypes` / `readModelTypes` arrived with them NULL despite the non-nullable
+    // declaration, and buildGraph() blew up on the way back OUT, through the computed Elements
+    // getter. The init-only collections below never had the problem: their initializers hold when the
+    // member is absent. Redeclaring these three gives them the same treatment, so the non-nullable
+    // declaration means what it says however the record was built.
+
+    /// <summary>Event types emitted by the slice, in declaration order. Never null.</summary>
+    public IReadOnlyList<TypeDescriptor> EmittedEvents { get; init; } = EmittedEvents ?? Array.Empty<TypeDescriptor>();
+
+    /// <summary>Projection types that consume the slice's events. Never null.</summary>
+    public IReadOnlyList<TypeDescriptor> ProjectionTypes { get; init; } = ProjectionTypes ?? Array.Empty<TypeDescriptor>();
+
+    /// <summary>Read-model types the slice reads from or produces. Never null.</summary>
+    public IReadOnlyList<TypeDescriptor> ReadModelTypes { get; init; } = ReadModelTypes ?? Array.Empty<TypeDescriptor>();
+
     /// <summary>
     /// Which of the four canonical Event Modeling patterns this slice is. Null until a source
     /// derives it.
@@ -568,6 +586,10 @@ public sealed record EventModelDescriptor(
     string Name,
     IReadOnlyList<EventModelSliceDescriptor> Slices)
 {
+    /// <summary>Slices that make up the model, in declaration order. Never null (jasperfx#807).</summary>
+    public IReadOnlyList<EventModelSliceDescriptor> Slices { get; init; }
+        = Slices ?? Array.Empty<EventModelSliceDescriptor>();
+
     /// <summary>
     /// The aggregate elements of the model — one per aggregate-shaped CLR type, with its kind and
     /// applied events. Slices point at these through

--- a/src/JasperFx/Descriptors/EventModeling/HandlerRelationshipDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/HandlerRelationshipDescriptor.cs
@@ -49,6 +49,13 @@ public sealed record HandlerRelationshipDescriptor(
     TypeDescriptor? TargetAggregate)
 {
     /// <summary>
+    /// Event types the handler emits, in declaration order. Never null: System.Text.Json leaves a
+    /// constructor parameter the JSON does not carry at its <c>default</c>, so a payload that omits
+    /// the member would otherwise hand back a null list from a non-nullable slot (jasperfx#807).
+    /// </summary>
+    public IReadOnlyList<TypeDescriptor> EmittedEvents { get; init; } = EmittedEvents ?? Array.Empty<TypeDescriptor>();
+
+    /// <summary>
     /// How the emitting code is triggered. Defaults to <see cref="PublisherKind.Handler"/>
     /// — the historical behavior where the trigger is the incoming <see cref="MessageType"/>.
     /// Non-<c>Handler</c> kinds (HTTP/gRPC endpoints, projection side-effects, scheduled work)

--- a/src/JasperFx/Descriptors/EventModeling/SpecificationDescriptor.cs
+++ b/src/JasperFx/Descriptors/EventModeling/SpecificationDescriptor.cs
@@ -30,6 +30,13 @@ public sealed record SpecificationDescriptor(
     {
     }
 
+    /// <summary>
+    /// CLR types the specification's steps resolved against the compilation, in step order. Never
+    /// null: a JSON payload that omits the member leaves the constructor parameter at its
+    /// <c>default</c>, which for a non-nullable list is null (jasperfx#807).
+    /// </summary>
+    public IReadOnlyList<TypeDescriptor> ResolvedTypes { get; init; } = ResolvedTypes ?? Array.Empty<TypeDescriptor>();
+
     /// <summary>The <c>{Feature}</c> half of <see cref="Identity"/>, or the whole identity when it has no separator.</summary>
     [JsonIgnore]
     public string Feature


### PR DESCRIPTION
Closes #807.

## The bug

`EventModelSliceDescriptor` is a positional record whose constructor takes three **non-nullable** collections. System.Text.Json hands `default` to any constructor parameter the JSON does not carry, so a slice sent without `emittedEvents` / `projectionTypes` / `readModelTypes` arrived with those three **null**. `buildGraph()` enumerates them unguarded and is reached through the computed `Elements` getter, so the failure landed on the way back *out*:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at JasperFx.Events.EventModeling.EventModelSliceDescriptor.buildGraph()
   at JasperFx.Events.EventModeling.EventModelSliceDescriptor.get_Elements()
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.GetMemberAndWriteJson(...)
```

The `init`-only collections were never affected — their initializers hold when the member is absent. Only the constructor parameters.

## The fix

Redeclare the affected positional members as `init` auto-properties whose initializer normalizes the parameter (`?? Array.Empty<>()`), matching what the `init` members already do. That keeps the invariant the non-nullable declaration promises however the record was built, rather than guarding one call site inside `buildGraph()`. The wire shape, the positional constructor and record equality are all unchanged, so this is source- and binary-compatible.

Partial descriptors are the designed-for shape — `Merge` folds several sources' slices together by `Name`, and a *source* is by definition partial. Concretely: Wolverine's `event-model` export runs against the host and carries no `Specifications`; a Bobcat spec assembly carries the `Specifications` and is invisible to the host. Neither half could be sent over the wire before this.

Per the issue's ⚠️, the same shape was audited across the rest of `Descriptors/EventModeling` and fixed in four more places:

| Record | Member |
|---|---|
| `EventModelSliceDescriptor` | `EmittedEvents`, `ProjectionTypes`, `ReadModelTypes` |
| `EventModelDescriptor` | `Slices` |
| `AggregateDescriptor` | `AppliedEvents` |
| `SpecificationDescriptor` | `ResolvedTypes` |
| `HandlerRelationshipDescriptor` | `EmittedEvents` |

`EventModelElement`, `EventModelEdge`, `HotspotDescriptor`, `EventModelClaim`, `ExternalSystemDescriptor` and `PublisherOrigin` carry no collection constructor parameters and needed nothing.

## Tests

Four new tests in `EventModelWireRoundTripTests`, all under `JsonSerializerDefaults.Web` — the options the report reproduced with:

- `a_slice_that_omits_the_constructor_collections_round_trips` — the issue's payload verbatim; deserialize, then **re-serialize**, which is where it threw.
- `the_two_halves_of_a_model_merge_after_a_round_trip` — the scenario the bug blocked: a host half and a spec half each cross the wire, then `Merge` folds them by slice name into one slice with both the emitted event and the specification.
- `a_model_that_omits_slices_round_trips`
- `the_rest_of_the_family_normalizes_its_constructor_collections_too`

All four reproduce the reported `ArgumentNullException` with the source change reverted. EventTests (1075) and CoreTests (599) pass on net9.0 and net10.0.

Unblocks JasperFx/CritterWatch#1212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)