### PR TITLE
gh-811: store-neutral vector contracts in JasperFx.Events

### DIFF
--- a/src/EventTests/Vectors/EmbeddingProviderContractTests.cs
+++ b/src/EventTests/Vectors/EmbeddingProviderContractTests.cs
@@ -1,0 +1,109 @@
+using JasperFx.Events.Vectors;
+using Shouldly;
+
+namespace EventTests.Vectors;
+
+// Compile-pins the store-neutral vector contracts (jasperfx#811) by implementing them, and checks
+// the single-text convenience and the "one vector per input" rule it enforces.
+public class EmbeddingProviderContractTests
+{
+    [Fact]
+    public async Task implementable_and_batch_preserves_order_and_dimensions()
+    {
+        IEmbeddingProvider provider = new FakeProvider(dimensions: 3);
+
+        var vectors = await provider.GenerateEmbeddingsAsync(["alpha", "beta"]);
+
+        vectors.Length.ShouldBe(2);
+        vectors[0].Length.ShouldBe(3);
+        vectors[1].Length.ShouldBe(3);
+        vectors[0].Span[0].ShouldBe("alpha".Length);
+        vectors[1].Span[0].ShouldBe("beta".Length);
+    }
+
+    [Fact]
+    public async Task empty_input_returns_empty_without_calling_the_model()
+    {
+        var provider = new FakeProvider(dimensions: 3);
+
+        var vectors = await provider.GenerateEmbeddingsAsync([]);
+
+        vectors.ShouldBeEmpty();
+        provider.ModelCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task single_text_convenience_delegates_to_the_batch_method()
+    {
+        var provider = new FakeProvider(dimensions: 3);
+
+        var vector = await provider.GenerateEmbeddingAsync("gamma");
+
+        vector.Length.ShouldBe(3);
+        vector.Span[0].ShouldBe("gamma".Length);
+        provider.ModelCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task single_text_convenience_refuses_a_provider_that_breaks_the_one_per_input_rule()
+    {
+        IEmbeddingProvider broken = new BrokenProvider();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => broken.GenerateEmbeddingAsync("x"));
+
+        ex.Message.ShouldContain("returned 2 vectors for a single text");
+    }
+
+    [Fact]
+    public void distance_function_keeps_marten_pgvector_member_names()
+    {
+        // Marten aliases its own enum onto this one by name; a rename here breaks user code there.
+        Enum.GetNames<DistanceFunction>().ShouldBe(["Cosine", "L2", "InnerProduct"]);
+        default(DistanceFunction).ShouldBe(DistanceFunction.Cosine);
+    }
+
+    [Fact]
+    public void vector_match_carries_document_and_double_distance()
+    {
+        var match = new VectorMatch<string>("doc", 0.25);
+
+        match.Document.ShouldBe("doc");
+        match.Distance.ShouldBe(0.25);
+        match.ShouldBe(new VectorMatch<string>("doc", 0.25));
+    }
+
+    // Deterministic stand-in: first element is the text length, the rest zero.
+    private sealed class FakeProvider(int dimensions) : IEmbeddingProvider
+    {
+        public int ModelCalls { get; private set; }
+
+        public int Dimensions { get; } = dimensions;
+
+        public Task<ReadOnlyMemory<float>[]> GenerateEmbeddingsAsync(string[] texts, CancellationToken ct = default)
+        {
+            if (texts.Length == 0)
+            {
+                return Task.FromResult(Array.Empty<ReadOnlyMemory<float>>());
+            }
+
+            ModelCalls++;
+            var result = new ReadOnlyMemory<float>[texts.Length];
+            for (var i = 0; i < texts.Length; i++)
+            {
+                var floats = new float[Dimensions];
+                floats[0] = texts[i].Length;
+                result[i] = floats;
+            }
+
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class BrokenProvider : IEmbeddingProvider
+    {
+        public int Dimensions => 1;
+
+        public Task<ReadOnlyMemory<float>[]> GenerateEmbeddingsAsync(string[] texts, CancellationToken ct = default)
+            => Task.FromResult(new ReadOnlyMemory<float>[] { new float[] { 1f }, new float[] { 2f } });
+    }
+}

--- a/src/JasperFx.Events/Vectors/DistanceFunction.cs
+++ b/src/JasperFx.Events/Vectors/DistanceFunction.cs
@@ -1,0 +1,42 @@
+namespace JasperFx.Events.Vectors;
+
+/// <summary>
+/// The metric a vector search ranks by. Every member is a <em>distance</em>: smaller means closer,
+/// on every store, so a caller can order ascending without knowing which database answered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The member names are Marten.PgVector's, kept verbatim so Marten can alias its own enum onto this
+/// one without renaming anything a user has written. The numeric values are not part of the
+/// contract and are not stable across packages; never persist or compare them.
+/// </para>
+/// <para>
+/// What each member becomes per store is the store's business, but it is pinned here because the
+/// "smaller is closer" promise depends on it:
+/// </para>
+/// <list type="table">
+/// <listheader><term>Member</term><description>Marten (pgvector) / Polecat (SQL Server 2025) / Fisher (SQLite)</description></listheader>
+/// <item><term><see cref="Cosine" /></term><description><c>&lt;=&gt;</c> / <c>VECTOR_DISTANCE('cosine', …)</c> / a registered <c>cosine_distance()</c> function</description></item>
+/// <item><term><see cref="L2" /></term><description><c>&lt;-&gt;</c> / <c>VECTOR_DISTANCE('euclidean', …)</c> / a registered function</description></item>
+/// <item><term><see cref="InnerProduct" /></term><description><c>&lt;#&gt;</c> / <c>VECTOR_DISTANCE('dot', …)</c> / a registered function — all three return the <em>negative</em> inner product, which is what keeps it a distance</description></item>
+/// </list>
+/// </remarks>
+public enum DistanceFunction
+{
+    /// <summary>
+    /// Cosine distance, <c>1 − cos θ</c>, in <c>[0, 2]</c>. The default for text embeddings, whose
+    /// models are trained for cosine similarity and usually return unit vectors.
+    /// </summary>
+    Cosine,
+
+    /// <summary>
+    /// Euclidean (L2) distance. Sensitive to magnitude; appropriate when the embedding model says so.
+    /// </summary>
+    L2,
+
+    /// <summary>
+    /// Negative inner product. Equivalent to cosine for unit vectors and cheaper to compute; only
+    /// meaningful as a ranking when the vectors are normalised.
+    /// </summary>
+    InnerProduct
+}

--- a/src/JasperFx.Events/Vectors/IEmbeddingProvider.cs
+++ b/src/JasperFx.Events/Vectors/IEmbeddingProvider.cs
@@ -1,0 +1,92 @@
+namespace JasperFx.Events.Vectors;
+
+/// <summary>
+/// A user-supplied embedding model: turns text into fixed-dimension float vectors for similarity
+/// search. Implement it with whatever model you run (OpenAI, Ollama, a local ONNX model); the
+/// Critter Stack never names a vendor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The store-agnostic replacement for Marten.PgVector's <c>IEmbeddingProvider</c>, lifted here so
+/// Marten, Polecat and Fisher share one contract. Marten's original returned
+/// <c>Pgvector.Vector[]</c>, which neither of the other two stores can accept: Polecat binds
+/// <c>SqlVector&lt;float&gt;</c> and Fisher writes float32 bytes. Both of those, and
+/// <c>Pgvector.Vector</c> itself, construct directly from <see cref="ReadOnlyMemory{T}" /> of
+/// <see cref="float" />, which is why that is the return element type rather than <c>float[]</c>:
+/// a provider may hand out slices of one pooled buffer, and no store has to copy on the way in.
+/// See <see href="https://github.com/JasperFx/jasperfx/issues/811" />.
+/// </para>
+/// <para>
+/// <strong>Batch by design.</strong> The one method takes an array because embedding models charge
+/// per call, not per text, and every consumer that matters (a projection folding a batch of events,
+/// a session listener with a unit of work) has several texts in hand. A single-text convenience is
+/// <see cref="EmbeddingProviderExtensions.GenerateEmbeddingAsync" />; it is an extension so an
+/// implementer has exactly one method to write.
+/// </para>
+/// <para>
+/// <strong>Where this is called from matters more than what it returns.</strong> A model call is a
+/// network round trip. Called inline from a session's pre-commit hook it holds the store's write
+/// transaction open for that round trip, which on a single-writer file store such as Fisher blocks
+/// every other writer for the duration. The stores' vector projections run it from the async daemon
+/// for that reason, and an inline path is for tests and tiny workloads only.
+/// </para>
+/// </remarks>
+public interface IEmbeddingProvider
+{
+    /// <summary>
+    /// The number of elements in every vector this provider produces.
+    /// </summary>
+    /// <remarks>
+    /// Stores read this once to size the column (<c>vector(768)</c>, <c>VECTOR(768)</c>, a
+    /// 768 × 4 byte BLOB). A provider must return vectors of exactly this length; a store may
+    /// validate and throw rather than write a truncated or padded row.
+    /// </remarks>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Embed one or more texts.
+    /// </summary>
+    /// <param name="texts">The texts to embed, in the order the results must come back.</param>
+    /// <param name="ct">Cancellation for the model call.</param>
+    /// <returns>
+    /// One vector per input, in input order, each of length <see cref="Dimensions" />. The
+    /// returned array must have the same length as <paramref name="texts" />; a store pairs them
+    /// by position and has no other way to match a vector to its text.
+    /// </returns>
+    /// <remarks>
+    /// An empty <paramref name="texts" /> returns an empty array and must not call the model.
+    /// Stores rely on that so a batch in which every text was skipped by content-hash comparison
+    /// costs nothing.
+    /// </remarks>
+    Task<ReadOnlyMemory<float>[]> GenerateEmbeddingsAsync(string[] texts, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Conveniences over <see cref="IEmbeddingProvider" /> so implementers write only the batch method.
+/// </summary>
+public static class EmbeddingProviderExtensions
+{
+    /// <summary>
+    /// Embed a single text.
+    /// </summary>
+    /// <remarks>
+    /// The query-side call: a search takes one string from a user or an agent and needs one vector
+    /// to compare against. Delegates to <see cref="IEmbeddingProvider.GenerateEmbeddingsAsync" />
+    /// with a one-element batch.
+    /// </remarks>
+    public static async Task<ReadOnlyMemory<float>> GenerateEmbeddingAsync(
+        this IEmbeddingProvider provider,
+        string text,
+        CancellationToken ct = default)
+    {
+        var vectors = await provider.GenerateEmbeddingsAsync([text], ct).ConfigureAwait(false);
+        if (vectors.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"{provider.GetType().FullName} returned {vectors.Length} vectors for a single text; " +
+                $"{nameof(IEmbeddingProvider.GenerateEmbeddingsAsync)} must return exactly one vector per input.");
+        }
+
+        return vectors[0];
+    }
+}

--- a/src/JasperFx.Events/Vectors/VectorMatch.cs
+++ b/src/JasperFx.Events/Vectors/VectorMatch.cs
@@ -1,0 +1,28 @@
+namespace JasperFx.Events.Vectors;
+
+/// <summary>
+/// One result of a vector search: the document and how far it was from the query vector.
+/// </summary>
+/// <typeparam name="T">The document type.</typeparam>
+/// <param name="Document">The matched document, materialized exactly as a query would return it.</param>
+/// <param name="Distance">
+/// The distance under the <see cref="DistanceFunction" /> the search ran with. Smaller is closer on
+/// every store and every metric; for <see cref="DistanceFunction.Cosine" /> it is
+/// <c>1 − similarity</c>, so <c>0</c> is identical and <c>1</c> is orthogonal.
+/// </param>
+/// <remarks>
+/// <para>
+/// Exists because a document alone is not enough for two callers the stores have to serve: anything
+/// applying a similarity floor ("nothing below 0.7") and anything fusing this ranking with a full
+/// text ranking. Marten.PgVector's document-level search returned bare documents and only its
+/// projection-table search surfaced a distance; the scored overload on every store returns this
+/// type instead. See <see href="https://github.com/JasperFx/jasperfx/issues/811" />.
+/// </para>
+/// <para>
+/// A <see cref="double" /> even though every store computes in single precision, so a caller can
+/// combine distances arithmetically without a cast at each site. Not the raw <c>float</c> the
+/// database returned: two stores hand it back as <c>float</c>, one as <c>double</c>, and one
+/// declared type beats a per-store difference a consumer would have to know.
+/// </para>
+/// </remarks>
+public sealed record VectorMatch<T>(T Document, double Distance);


### PR DESCRIPTION
Closes #811

Part of the Stoat coordination plan `search-parity-and-stoat-memory` (node `vector-contracts`). This is the Phase 0 step that Fisher, Polecat and Marten vector search all consume.

## What

Adds `JasperFx.Events.Vectors`:

- `IEmbeddingProvider` — batch embedding over `string[]` returning `ReadOnlyMemory<float>[]`, with no vector-library types in the signature. Pgvector's `Vector`, SqlClient's `SqlVector<float>` and a float32 BLOB all construct from `ReadOnlyMemory<float>` without a copy.
- `EmbeddingProviderExtensions.GenerateEmbeddingAsync(text)` — the single-text convenience for the query side; throws if a provider returns anything other than one vector per input.
- `DistanceFunction` — `Cosine` (default), `L2`, `InnerProduct`, keeping Marten.PgVector's member names so Marten can alias onto it. Every member is a distance: smaller is closer on every store.
- `VectorMatch<T>(Document, Distance)` — the scored search result the per-store `VectorSearchWithScoresAsync` overloads return.

## Why here

Marten.PgVector's provider returns `Pgvector.Vector[]`, which Polecat and Fisher cannot take. One search API across the three stores needs one contract, and Stoat's design already requires memory contracts to ride `JasperFx.Events` rather than a store assembly.

## Tests

`EventTests/Vectors/EmbeddingProviderContractTests` compile-pins the contracts through a fake provider and covers input order, dimensions, the empty-batch rule, the single-text convenience, the broken-provider guard, and the enum member names. Full EventTests suite green on net10.0.

Follow-ups in the same plan: `meai-embedding-adapter` (Microsoft.Extensions.AI adapter), then a minor `JasperFx.Events` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
