### PR TITLE
gh-813: Microsoft.Extensions.AI adapter for IEmbeddingProvider

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -100,6 +100,11 @@ jobs:
         run: ./build.sh test-aspire
         shell: bash
 
+      - name: test-microsoft-extensions-ai
+        if: ${{ success() || failure() }}
+        run: ./build.sh test-microsoft-extensions-ai
+        shell: bash
+
       # End-to-end CLI smoke tests, including `codegen preview --language fsharp`: proves the F# flag
       # is wired through the CLI and the F# emit path runs without throwing. It does NOT prove the
       # output compiles -- `preview` only prints, and GeneratorTarget feeds codegen a raw C# CodeFrame

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -40,6 +40,7 @@
         "TestCore",
         "TestEvents",
         "TestEventStore",
+        "TestMicrosoftExtensionsAI",
         "TestSourceGenerators"
       ]
     },

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,6 +78,9 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.7.0" />
+    <!-- JasperFx.Events.MicrosoftExtensionsAI (#813): the abstractions package only, no vendor SDK.
+         Same line Wolverine and CritterWatch pin. -->
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
     <!--
       MTP's collector, replacing coverlet.collector, which is VSTest-only (#581). Note that no build
       target asks for coverage today, so this is capability parity rather than something in use.

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -54,7 +54,7 @@ partial class Build : NukeBuild
                 .EnableNoRestore());
         });
 
-    Target Test => _ => _.DependsOn(TestCore, TestCodegen, TestCodegenFSharp, TestCommandLine, TestEvents, TestEventStore, TestSourceGenerators, TestAspire, SmokeTestAot);
+    Target Test => _ => _.DependsOn(TestCore, TestCodegen, TestCodegenFSharp, TestCommandLine, TestEvents, TestEventStore, TestSourceGenerators, TestAspire, TestMicrosoftExtensionsAI, SmokeTestAot);
     
     Target TestCore => _ => _
         .DependsOn(Compile)
@@ -159,6 +159,19 @@ partial class Build : NukeBuild
         {
             DotNetTest(c => c
                 .SetProjectFile(Solution.src.JasperFx_Aspire_Tests)
+                .SetConfiguration(Configuration)
+                .EnableNoBuild()
+                .EnableNoRestore());
+        });
+
+    // The Microsoft.Extensions.AI adapter for IEmbeddingProvider (#813). Its own project so
+    // Microsoft.Extensions.AI.Abstractions never reaches EventTests.
+    Target TestMicrosoftExtensionsAI => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            DotNetTest(c => c
+                .SetProjectFile(Solution.src.JasperFx_Events_MicrosoftExtensionsAI_Tests)
                 .SetConfiguration(Configuration)
                 .EnableNoBuild()
                 .EnableNoRestore());

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -214,7 +214,8 @@ partial class Build : NukeBuild
                 Solution.JasperFx_Events_ComplianceTests,
                 Solution.src.JasperFx_Events_SourceGenerator,
                 Solution.src.JasperFx_SourceGenerator,
-                Solution.src.JasperFx_Aspire
+                Solution.src.JasperFx_Aspire,
+                Solution.src.JasperFx_Events_MicrosoftExtensionsAI
             };
 
             foreach (var project in projects)

--- a/jasperfx.slnx
+++ b/jasperfx.slnx
@@ -22,6 +22,8 @@
     <Project Path="src/FSharpTypes/FSharpTypes.fsproj" />
     <Project Path="src/JasperFx.Aspire.Tests/JasperFx.Aspire.Tests.csproj" />
     <Project Path="src/JasperFx.Aspire/JasperFx.Aspire.csproj" />
+    <Project Path="src/JasperFx.Events.MicrosoftExtensionsAI.Tests/JasperFx.Events.MicrosoftExtensionsAI.Tests.csproj" />
+    <Project Path="src/JasperFx.Events.MicrosoftExtensionsAI/JasperFx.Events.MicrosoftExtensionsAI.csproj" />
     <Project Path="src/JasperFx.Events.SourceGenerator.Tests/JasperFx.Events.SourceGenerator.Tests.csproj" />
     <Project Path="src/JasperFx.Events.SourceGenerator/JasperFx.Events.SourceGenerator.csproj" />
     <Project Path="src/JasperFx.SourceGenerator.Tests/JasperFx.SourceGenerator.Tests.csproj" />

--- a/src/EventTests/Vectors/EmbeddingProviderContractTests.cs
+++ b/src/EventTests/Vectors/EmbeddingProviderContractTests.cs
@@ -12,7 +12,7 @@ public class EmbeddingProviderContractTests
     {
         IEmbeddingProvider provider = new FakeProvider(dimensions: 3);
 
-        var vectors = await provider.GenerateEmbeddingsAsync(["alpha", "beta"]);
+        var vectors = await provider.GenerateEmbeddingsAsync(["alpha", "beta"], TestContext.Current.CancellationToken);
 
         vectors.Length.ShouldBe(2);
         vectors[0].Length.ShouldBe(3);
@@ -26,7 +26,7 @@ public class EmbeddingProviderContractTests
     {
         var provider = new FakeProvider(dimensions: 3);
 
-        var vectors = await provider.GenerateEmbeddingsAsync([]);
+        var vectors = await provider.GenerateEmbeddingsAsync([], TestContext.Current.CancellationToken);
 
         vectors.ShouldBeEmpty();
         provider.ModelCalls.ShouldBe(0);
@@ -37,7 +37,7 @@ public class EmbeddingProviderContractTests
     {
         var provider = new FakeProvider(dimensions: 3);
 
-        var vector = await provider.GenerateEmbeddingAsync("gamma");
+        var vector = await provider.GenerateEmbeddingAsync("gamma", TestContext.Current.CancellationToken);
 
         vector.Length.ShouldBe(3);
         vector.Span[0].ShouldBe("gamma".Length);

--- a/src/JasperFx.Events.MicrosoftExtensionsAI.Tests/EmbeddingGeneratorProviderTests.cs
+++ b/src/JasperFx.Events.MicrosoftExtensionsAI.Tests/EmbeddingGeneratorProviderTests.cs
@@ -1,0 +1,162 @@
+using JasperFx.Events.MicrosoftExtensionsAI;
+using JasperFx.Events.Vectors;
+using Microsoft.Extensions.AI;
+using Shouldly;
+
+namespace JasperFx.Events.MicrosoftExtensionsAI.Tests;
+
+public class EmbeddingGeneratorProviderTests
+{
+    [Fact]
+    public async Task forwards_a_batch_in_order_and_hands_back_the_vectors()
+    {
+        var generator = new FakeGenerator(dimensions: 3);
+        IEmbeddingProvider provider = generator.AsEmbeddingProvider(dimensions: 3);
+
+        var vectors = await provider.GenerateEmbeddingsAsync(["alpha", "be"], TestContext.Current.CancellationToken);
+
+        vectors.Length.ShouldBe(2);
+        vectors[0].Span[0].ShouldBe(5f);
+        vectors[1].Span[0].ShouldBe(2f);
+        generator.Calls.ShouldBe(1);
+        generator.LastInputs.ShouldBe(["alpha", "be"]);
+    }
+
+    [Fact]
+    public async Task empty_input_returns_empty_without_calling_the_generator()
+    {
+        var generator = new FakeGenerator(dimensions: 3);
+        var provider = generator.AsEmbeddingProvider(dimensions: 3);
+
+        var vectors = await provider.GenerateEmbeddingsAsync([], TestContext.Current.CancellationToken);
+
+        vectors.ShouldBeEmpty();
+        generator.Calls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task options_are_forwarded_verbatim()
+    {
+        var generator = new FakeGenerator(dimensions: 3);
+        var options = new EmbeddingGenerationOptions { ModelId = "custom" };
+        var provider = generator.AsEmbeddingProvider(dimensions: 3, options: options);
+
+        await provider.GenerateEmbeddingsAsync(["x"], TestContext.Current.CancellationToken);
+
+        generator.LastOptions.ShouldBeSameAs(options);
+    }
+
+    [Fact]
+    public void dimensions_come_from_metadata_when_not_supplied()
+    {
+        var generator = new FakeGenerator(dimensions: 3, defaultModelDimensions: 768);
+
+        var provider = generator.AsEmbeddingProvider();
+
+        provider.Dimensions.ShouldBe(768);
+    }
+
+    [Fact]
+    public void explicit_dimensions_win_over_metadata()
+    {
+        var generator = new FakeGenerator(dimensions: 3, defaultModelDimensions: 768);
+
+        generator.AsEmbeddingProvider(dimensions: 3).Dimensions.ShouldBe(3);
+    }
+
+    [Fact]
+    public void requested_dimensions_in_options_are_used_when_nothing_else_says()
+    {
+        var generator = new FakeGenerator(dimensions: 3);
+
+        var provider = generator.AsEmbeddingProvider(options: new EmbeddingGenerationOptions { Dimensions = 3 });
+
+        provider.Dimensions.ShouldBe(3);
+    }
+
+    [Fact]
+    public void refuses_to_construct_when_dimensions_are_unknowable()
+    {
+        var generator = new FakeGenerator(dimensions: 3);
+
+        var ex = Should.Throw<InvalidOperationException>(() => generator.AsEmbeddingProvider());
+
+        ex.Message.ShouldContain("pass dimensions explicitly");
+    }
+
+    [Fact]
+    public async Task refuses_a_generator_that_returns_the_wrong_count()
+    {
+        var generator = new FakeGenerator(dimensions: 3) { ExtraEmbeddings = 1 };
+        var provider = generator.AsEmbeddingProvider(dimensions: 3);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => provider.GenerateEmbeddingsAsync(["a"]));
+
+        ex.Message.ShouldContain("returned 2 embeddings for 1 texts");
+    }
+
+    [Fact]
+    public async Task refuses_a_vector_of_the_wrong_length()
+    {
+        var generator = new FakeGenerator(dimensions: 4);
+        var provider = generator.AsEmbeddingProvider(dimensions: 3);
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => provider.GenerateEmbeddingsAsync(["a"]));
+
+        ex.Message.ShouldContain("length 4 for text 0");
+        ex.Message.ShouldContain("Dimensions = 3");
+    }
+
+    [Fact]
+    public void constructor_validates_its_arguments()
+    {
+        Should.Throw<ArgumentNullException>(() => new EmbeddingGeneratorProvider(null!, 3));
+        Should.Throw<ArgumentOutOfRangeException>(() => new EmbeddingGeneratorProvider(new FakeGenerator(3), 0));
+    }
+
+    // First element of each vector is the text length; the rest are zero.
+    private sealed class FakeGenerator(int dimensions, int? defaultModelDimensions = null)
+        : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        private readonly EmbeddingGeneratorMetadata _metadata =
+            new("fake", defaultModelId: "fake-model", defaultModelDimensions: defaultModelDimensions);
+
+        public int Calls { get; private set; }
+        public string[] LastInputs { get; private set; } = [];
+        public EmbeddingGenerationOptions? LastOptions { get; private set; }
+        public int ExtraEmbeddings { get; init; }
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            LastInputs = values.ToArray();
+            LastOptions = options;
+
+            var embeddings = LastInputs
+                .Select(text =>
+                {
+                    var floats = new float[dimensions];
+                    floats[0] = text.Length;
+                    return new Embedding<float>(floats);
+                })
+                .ToList();
+
+            for (var i = 0; i < ExtraEmbeddings; i++)
+            {
+                embeddings.Add(new Embedding<float>(new float[dimensions]));
+            }
+
+            return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(embeddings));
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(EmbeddingGeneratorMetadata) ? _metadata : null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/JasperFx.Events.MicrosoftExtensionsAI.Tests/JasperFx.Events.MicrosoftExtensionsAI.Tests.csproj
+++ b/src/JasperFx.Events.MicrosoftExtensionsAI.Tests/JasperFx.Events.MicrosoftExtensionsAI.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <!-- xunit v3 test projects are their own MTP executable; see JasperFx.Aspire.Tests. -->
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="Shouldly" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\JasperFx.Events.MicrosoftExtensionsAI\JasperFx.Events.MicrosoftExtensionsAI.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/JasperFx.Events.MicrosoftExtensionsAI/EmbeddingGeneratorProvider.cs
+++ b/src/JasperFx.Events.MicrosoftExtensionsAI/EmbeddingGeneratorProvider.cs
@@ -1,0 +1,150 @@
+using JasperFx.Events.Vectors;
+using Microsoft.Extensions.AI;
+
+namespace JasperFx.Events.MicrosoftExtensionsAI;
+
+/// <summary>
+/// An <see cref="IEmbeddingProvider" /> over a Microsoft.Extensions.AI
+/// <see cref="IEmbeddingGenerator{TInput,TEmbedding}" />, so a model already configured for
+/// OpenAI, Azure OpenAI, Ollama or any other M.E.AI provider drives vector search in Marten, Polecat
+/// and Fisher without a hand-written provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The adapter is deliberately thin: it forwards a batch, then enforces the two rules
+/// <see cref="IEmbeddingProvider" /> makes to the stores before a store sees the result — one
+/// vector per input, in input order, and every vector of length <see cref="Dimensions" />. A
+/// generator that violates either throws here with the model named, rather than a store writing a
+/// truncated row or pairing a vector with the wrong document. See
+/// <see href="https://github.com/JasperFx/jasperfx/issues/813" />.
+/// </para>
+/// <para>
+/// <strong>Dimensions must be known before the first call.</strong> Stores size their column from
+/// <see cref="Dimensions" /> at schema time, before any text has been embedded, so the value cannot
+/// be discovered lazily from the first result. Construct with an explicit count, or through
+/// <see cref="EmbeddingGeneratorExtensions.AsEmbeddingProvider" />, which falls back to the
+/// generator's own <see cref="EmbeddingGeneratorMetadata.DefaultModelDimensions" /> when the
+/// provider publishes one.
+/// </para>
+/// <para>
+/// <see cref="EmbeddingGenerationOptions" /> are passed through verbatim and nothing is synthesised
+/// from <see cref="Dimensions" />: some models accept a requested dimension count and some reject
+/// it, and the person who configured the generator is the one who knows which. If the model should
+/// be asked for a specific size, say so in the options you supply.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingGeneratorProvider : IEmbeddingProvider
+{
+    private readonly IEmbeddingGenerator<string, Embedding<float>> _generator;
+    private readonly EmbeddingGenerationOptions? _options;
+
+    /// <summary>
+    /// Wrap a generator whose vector length is <paramref name="dimensions" />.
+    /// </summary>
+    /// <param name="generator">The Microsoft.Extensions.AI generator to forward to.</param>
+    /// <param name="dimensions">
+    /// The length of every vector the generator returns. Validated against each result.
+    /// </param>
+    /// <param name="options">
+    /// Options forwarded on every call, or <c>null</c> for the generator's defaults.
+    /// </param>
+    public EmbeddingGeneratorProvider(
+        IEmbeddingGenerator<string, Embedding<float>> generator,
+        int dimensions,
+        EmbeddingGenerationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+        ArgumentOutOfRangeException.ThrowIfLessThan(dimensions, 1);
+
+        _generator = generator;
+        _options = options;
+        Dimensions = dimensions;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public async Task<ReadOnlyMemory<float>[]> GenerateEmbeddingsAsync(string[] texts, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(texts);
+
+        if (texts.Length == 0)
+        {
+            return [];
+        }
+
+        var generated = await _generator.GenerateAsync(texts, _options, ct).ConfigureAwait(false);
+
+        if (generated.Count != texts.Length)
+        {
+            throw new InvalidOperationException(
+                $"{describe()} returned {generated.Count} embeddings for {texts.Length} texts. " +
+                $"{nameof(IEmbeddingProvider)} requires exactly one vector per input, in input order.");
+        }
+
+        var vectors = new ReadOnlyMemory<float>[generated.Count];
+        for (var i = 0; i < vectors.Length; i++)
+        {
+            var vector = generated[i].Vector;
+            if (vector.Length != Dimensions)
+            {
+                throw new InvalidOperationException(
+                    $"{describe()} returned a vector of length {vector.Length} for text {i}, but this provider " +
+                    $"was declared with {nameof(Dimensions)} = {Dimensions}. Stores size their vector column from " +
+                    $"{nameof(Dimensions)}, so the two must agree; fix the declared count or the model configuration.");
+            }
+
+            vectors[i] = vector;
+        }
+
+        return vectors;
+    }
+
+    private string describe()
+    {
+        var metadata = _generator.GetService<EmbeddingGeneratorMetadata>();
+        var model = metadata?.DefaultModelId;
+        var name = metadata?.ProviderName ?? _generator.GetType().Name;
+        return model is null ? name : $"{name} ({model})";
+    }
+}
+
+/// <summary>
+/// The one-line way to hand a Microsoft.Extensions.AI generator to a Critter Stack store.
+/// </summary>
+public static class EmbeddingGeneratorExtensions
+{
+    /// <summary>
+    /// Adapt this generator to <see cref="IEmbeddingProvider" />.
+    /// </summary>
+    /// <param name="generator">The generator to adapt.</param>
+    /// <param name="dimensions">
+    /// The vector length, or <c>null</c> to take it from the generator's
+    /// <see cref="EmbeddingGeneratorMetadata.DefaultModelDimensions" />. Supplying it explicitly is
+    /// always allowed and wins over the metadata.
+    /// </param>
+    /// <param name="options">Options forwarded on every call, or <c>null</c> for the defaults.</param>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="dimensions" /> is <c>null</c> and the generator publishes no default
+    /// dimension count. The store needs the number at schema time, so it has to come from somewhere.
+    /// </exception>
+    public static IEmbeddingProvider AsEmbeddingProvider(
+        this IEmbeddingGenerator<string, Embedding<float>> generator,
+        int? dimensions = null,
+        EmbeddingGenerationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+
+        var resolved = dimensions
+                       ?? options?.Dimensions
+                       ?? generator.GetService<EmbeddingGeneratorMetadata>()?.DefaultModelDimensions
+                       ?? throw new InvalidOperationException(
+                           $"{generator.GetType().Name} does not publish a default dimension count in its " +
+                           $"{nameof(EmbeddingGeneratorMetadata)}, so pass dimensions explicitly: " +
+                           $"generator.{nameof(AsEmbeddingProvider)}(dimensions: 1536). Stores size their vector " +
+                           "column from it before the first text is embedded.");
+
+        return new EmbeddingGeneratorProvider(generator, resolved, options);
+    }
+}

--- a/src/JasperFx.Events.MicrosoftExtensionsAI/JasperFx.Events.MicrosoftExtensionsAI.csproj
+++ b/src/JasperFx.Events.MicrosoftExtensionsAI/JasperFx.Events.MicrosoftExtensionsAI.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Description>Adapts a Microsoft.Extensions.AI IEmbeddingGenerator to the Critter Stack's store-neutral IEmbeddingProvider, so an embedding model configured once for OpenAI, Azure OpenAI, Ollama or any other M.E.AI provider drives vector search in Marten, Polecat and Fisher.</Description>
+        <AssemblyName>JasperFx.Events.MicrosoftExtensionsAI</AssemblyName>
+        <PackageId>JasperFx.Events.MicrosoftExtensionsAI</PackageId>
+        <Version>$(JasperFxVersion)</Version>
+        <PackageTags>jasperfx;events;vector;embeddings;microsoft-extensions-ai;critter-stack</PackageTags>
+        <IsAotCompatible>true</IsAotCompatible>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\JasperFx.Events\JasperFx.Events.csproj" />
+        <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="JasperFx.Events.MicrosoftExtensionsAI.Tests" />
+    </ItemGroup>
+</Project>

--- a/src/JasperFx.Events.MicrosoftExtensionsAI/README.md
+++ b/src/JasperFx.Events.MicrosoftExtensionsAI/README.md
@@ -1,0 +1,22 @@
+# JasperFx.Events.MicrosoftExtensionsAI
+
+Adapts a [Microsoft.Extensions.AI](https://learn.microsoft.com/dotnet/ai/microsoft-extensions-ai)
+`IEmbeddingGenerator<string, Embedding<float>>` to the Critter Stack's store-neutral
+`IEmbeddingProvider`, so one embedding model configured for OpenAI, Azure OpenAI, Ollama, ONNX or any
+other M.E.AI provider drives vector search in Marten, Polecat and Fisher.
+
+```csharp
+using JasperFx.Events.MicrosoftExtensionsAI;
+
+IEmbeddingGenerator<string, Embedding<float>> generator = /* from your M.E.AI provider package */;
+
+// Dimensions come from the generator's metadata when it publishes them...
+IEmbeddingProvider provider = generator.AsEmbeddingProvider();
+
+// ...or say them explicitly, which always wins.
+IEmbeddingProvider provider = generator.AsEmbeddingProvider(dimensions: 1536);
+```
+
+The adapter forwards batches and enforces the provider contract before a store sees the result:
+one vector per input, in input order, every vector of the declared length. It takes no vendor SDK,
+only `Microsoft.Extensions.AI.Abstractions`.


### PR DESCRIPTION
Closes #813

Part of the Stoat coordination plan `search-parity-and-stoat-memory` (node `meai-embedding-adapter`). Follows #812, which added the store-neutral contracts.

## What

New satellite package **JasperFx.Events.MicrosoftExtensionsAI**, referencing only `JasperFx.Events` and `Microsoft.Extensions.AI.Abstractions` 10.9.0 (the line Wolverine and CritterWatch already pin). No vendor SDK.

- `EmbeddingGeneratorProvider : IEmbeddingProvider` wraps an M.E.AI `IEmbeddingGenerator<string, Embedding<float>>`, forwards batches with options passed through verbatim, and enforces the provider contract before a store sees a result: one vector per input, in input order, every vector of the declared length. Violations throw with the provider and model named.
- `generator.AsEmbeddingProvider(dimensions?, options?)` resolves `Dimensions` from the explicit argument, then `EmbeddingGenerationOptions.Dimensions`, then the generator's `EmbeddingGeneratorMetadata.DefaultModelDimensions`, and refuses to construct with a message naming the fix when none is available. Stores size their column from `Dimensions` at schema time, so it cannot be discovered lazily.
- Empty input returns empty without calling the generator, as the contract requires.

## Wiring

- Project and test project added to `jasperfx.slnx`; package added to the `NugetPack` list.
- New `test-microsoft-extensions-ai` Nuke target, wired into `Test` and as a CI step, mirroring `test-aspire`. Kept as its own test project so the M.E.AI dependency never reaches `EventTests`.
- Package README for the NuGet page.

Also carries a small fixup to the #812 contract tests (pass `TestContext.Current.CancellationToken`) that clears three xUnit1051 warnings.

## Tests

Ten tests on net9.0 and net10.0 through a fake generator: batch order, empty input, options pass-through, dimension resolution precedence, the unknowable-dimensions refusal, wrong-count and wrong-length guards, constructor validation. `./build.sh test-microsoft-extensions-ai` runs green; the package packs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
