### PR TITLE
gh-815: expose the registered shard names non-generically

### DIFF
--- a/src/EventTests/RegisteredShardNamesTests.cs
+++ b/src/EventTests/RegisteredShardNamesTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventTests.Projections;
+using JasperFx;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests;
+
+/// <summary>
+/// jasperfx#815 — <c>AllShards()</c> is declared only on <c>IEventStore&lt;TOperations, TQuerySession&gt;</c>,
+/// so a consumer that ships one assembly against Marten, Polecat and Fisher alike cannot ask what is
+/// registered. <c>RegisteredShardNames()</c> is the non-generic way in. These pin both halves: the generic
+/// interface answers it from its own registry with no change to any store, and a store that implements only
+/// the non-generic interface says so rather than claiming an empty registry.
+/// </summary>
+public class RegisteredShardNamesTests
+{
+    private static AsyncShard<FakeOperations, FakeSession> shard(string projectionName, string? tenantId = null)
+        => new(new AsyncOptions(), ShardRole.Projection,
+            new ShardName(projectionName, ShardName.All, 1, tenantId), null!, new EventFilterable());
+
+    // Implements the GENERIC interface and nothing else — RegisteredShardNames() is deliberately not
+    // written here, because the point of the test is that the generic interface already satisfies it.
+    private sealed class ShardRegistryEventStore(params AsyncShard<FakeOperations, FakeSession>[] shards)
+        : IEventStore<FakeOperations, FakeSession>
+    {
+        public IReadOnlyList<AsyncShard<FakeOperations, FakeSession>> AllShards() => shards;
+
+        public IEventRegistry Registry => throw new NotImplementedException();
+        public Type IdentityTypeForProjectedType(Type aggregateType) => throw new NotImplementedException();
+        public string DefaultDatabaseName => throw new NotImplementedException();
+        public ErrorHandlingOptions ContinuousErrors => throw new NotImplementedException();
+        public ErrorHandlingOptions RebuildErrors => throw new NotImplementedException();
+        public TimeProvider TimeProvider => throw new NotImplementedException();
+        public AutoCreate AutoCreateSchemaObjects => throw new NotImplementedException();
+
+        public Task RewindSubscriptionProgressAsync(IEventDatabase database, string subscriptionName,
+            CancellationToken token, long? sequenceFloor) => throw new NotImplementedException();
+
+        public Task RewindAgentProgressAsync(IEventDatabase database, string shardName, CancellationToken token,
+            long sequenceFloor) => throw new NotImplementedException();
+
+        public Task TeardownExistingProjectionStateAsync(IEventDatabase database, string subscriptionName,
+            CancellationToken token) => throw new NotImplementedException();
+
+        public Task DeleteProjectionProgressAsync(IEventDatabase database, string subscriptionName,
+            CancellationToken token) => throw new NotImplementedException();
+
+        public ValueTask<IProjectionBatch<FakeOperations, FakeSession>> StartProjectionBatchAsync(EventRange range,
+            IEventDatabase database, ShardExecutionMode mode, AsyncOptions projectionOptions,
+            CancellationToken token) => throw new NotImplementedException();
+
+        public IEventLoader BuildEventLoader(IEventDatabase database, ILogger loggerFactory,
+            EventFilterable filtering, AsyncOptions shardOptions) => throw new NotImplementedException();
+
+        public FakeOperations OpenSession(IEventDatabase database) => throw new NotImplementedException();
+
+        public FakeOperations OpenSession(IEventDatabase database, string tenantId)
+            => throw new NotImplementedException();
+
+        public ErrorHandlingOptions ErrorHandlingOptions(ShardExecutionMode mode)
+            => throw new NotImplementedException();
+
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    // Implements ONLY the non-generic interface, so RegisteredShardNames() falls to the base default.
+    private sealed class BareEventStore : IEventStore
+    {
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public DatabaseCardinality DatabaseCardinality => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void the_generic_interface_answers_from_its_own_registry()
+    {
+        // Held as the NON-generic interface on purpose: that is the only handle a store-agnostic
+        // consumer like Wolverine.CritterWatch has, and the whole point of the issue.
+        IEventStore theStore = new ShardRegistryEventStore(
+            shard("WidgetTally"), shard("VoyageLog"), shard("WidgetTally", "tenant-a"));
+
+        theStore.RegisteredShardNames().Select(x => x.Identity)
+            .ShouldBe(["WidgetTally:All", "VoyageLog:All", "WidgetTally:All:tenant-a"]);
+    }
+
+    [Fact]
+    public void a_tenant_qualified_shard_keeps_its_tenant_through_the_non_generic_read()
+    {
+        // FetchProjectionLagAsync correlates on the shard NAME, so a tenant-qualified registration has
+        // to survive the trip through the non-generic surface or the correlation silently loses a cell.
+        IEventStore theStore = new ShardRegistryEventStore(
+            shard("WidgetTally"), shard("VoyageLog"), shard("WidgetTally", "tenant-a"));
+
+        theStore.RegisteredShardNames().ShouldContain(x => x.TenantId == "tenant-a");
+    }
+
+    [Fact]
+    public void an_empty_registry_answers_empty_rather_than_throwing()
+    {
+        IEventStore theStore = new ShardRegistryEventStore();
+
+        theStore.RegisteredShardNames().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void the_non_generic_default_refuses_rather_than_claiming_an_empty_registry()
+    {
+        // Returning [] here would be indistinguishable from "nothing is registered", which is exactly
+        // the answer that latches a readiness probe green during a version bump.
+        IEventStore theStore = new BareEventStore();
+
+        Should.Throw<NotSupportedException>(() => theStore.RegisteredShardNames());
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/AsyncDaemonCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/AsyncDaemonCompliance.cs
@@ -111,4 +111,19 @@ public abstract class AsyncDaemonCompliance<TFixture, TOperations, TQuerySession
         tally.AddedCount.ShouldBe(2);
         tally.RemovedCount.ShouldBe(0);
     }
+
+    [Fact]
+    public void registered_shard_names_are_reachable_from_the_non_generic_store()
+    {
+        // jasperfx#815. Asserted off IEventStore rather than the closed generic on purpose: a consumer
+        // that ships ONE assembly against all three stores (CritterWatch's Wolverine.CritterWatch) can
+        // only hold the non-generic interface, and AllShards() is not on it. This is the "expected" side
+        // of the expected-versus-observed correlation that FetchProjectionLagAsync runs against a single
+        // database's progression rows — without it, a shard registered but never started on some
+        // databases of a multi-database store has nothing to be missing FROM.
+        SkipUnlessDaemonIsSupported();
+
+        EventStore.RegisteredShardNames()
+            .ShouldContain(x => x.Name == nameof(DaemonItemTally));
+    }
 }

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -89,6 +89,29 @@ public interface IEventStore
         => ValueTask.FromResult<IReadOnlyList<IEventDatabase>>([]);
 
     /// <summary>
+    ///     jasperfx#815 — the names of every projection/subscription shard registered with this store,
+    ///     store-agnostically. This is the non-generic counterpart to
+    ///     <see cref="IEventStore{TOperations,TQuerySession}.AllShards" />, which can only be reached by
+    ///     naming a closed generic (<c>IEventStore&lt;IDocumentOperations, IQuerySession&gt;</c> for Marten,
+    ///     the Polecat/Fisher equivalents otherwise) and is therefore unreachable from a consumer that ships
+    ///     one assembly against all three stores — CritterWatch's <c>Wolverine.CritterWatch</c>, for one.
+    ///     It supplies the "expected" side of the expected-versus-observed correlation that
+    ///     <see cref="IEventDatabase.FetchProjectionLagAsync(IReadOnlyList{ShardName},CancellationToken)" />
+    ///     performs against one database's progression rows, which is what distinguishes "registered here,
+    ///     never started here" (<see cref="ProjectionLag.HasProgressionRow" /> false) from "at zero".
+    ///     <para>
+    ///     This is a registry read, not a tenancy-resolving one, so unlike
+    ///     <see cref="GetProjectionStatusesAsync(CancellationToken)" /> it answers on a database-per-tenant
+    ///     store. The generic interface implements it from <c>AllShards()</c>, so every existing store
+    ///     satisfies it with no change; the default here throws rather than returning an empty list, because
+    ///     an empty registry is a meaningful answer that would latch a readiness probe green.
+    ///     </para>
+    /// </summary>
+    IReadOnlyList<ShardName> RegisteredShardNames()
+        => throw new NotSupportedException(
+            "RegisteredShardNames is not implemented on this IEventStore. Use an event store (Marten, Polecat, or Fisher) that registers projection shards.");
+
+    /// <summary>
     ///     Build a standalone, display-only high-water monitor for a single database — just the high-water agent,
     ///     with no projection shards attached, so a monitoring tool can show a live event-store "ceiling" for a
     ///     store whose projections are all Inline/Live and therefore run no async daemon. This is the abstraction
@@ -421,6 +444,14 @@ public interface IEventStore<TOperations, TQuerySession> : IEventStore where TOp
     Task<IReadOnlyList<ProjectionLag>> FetchProjectionLagAsync(IEventDatabase database, ShardName name,
         CancellationToken token = default)
         => database.FetchProjectionLagAsync(registeredShardNames(), name, token);
+
+    /// <summary>
+    ///     jasperfx#815 — satisfies the non-generic <see cref="IEventStore.RegisteredShardNames" /> from the
+    ///     registry every store already exposes here, so a store-agnostic consumer can ask what is registered
+    ///     without naming a closed generic. Implemented on the interface rather than on each store so no
+    ///     store has to change.
+    /// </summary>
+    IReadOnlyList<ShardName> IEventStore.RegisteredShardNames() => registeredShardNames();
 
     private IReadOnlyList<ShardName> registeredShardNames()
         => AllShards().Select(x => x.Name).ToList();


### PR DESCRIPTION
Closes #815.

## The gap

`AllShards()` is declared only on `IEventStore<TOperations, TQuerySession>`, so reaching it means naming a closed generic — `IEventStore<IDocumentOperations, IQuerySession>` for Marten, the Polecat and Fisher equivalents otherwise. A consumer that ships **one** assembly against all three stores cannot ask "what is registered?" at all. That is CritterWatch's `Wolverine.CritterWatch`, whose whole event-store surface is the non-generic `IEventStore` / `IEventDatabase` / `IProjectionDaemon` set.

It is the *expected* half of the expected-versus-observed correlation that `IEventDatabase.FetchProjectionLagAsync` already performs against one database's progression rows — the half that lets `ProjectionLag.HasProgressionRow` distinguish "registered here, never started here" from "at zero". Without it, a shard that was never assigned on some databases of a multi-database store has nothing to be missing *from* (CritterWatch#1234).

`GetProjectionStatusesAsync` is not the alternative: on a database-per-tenant Marten store it throws `NotSupportedException` on both overloads, so on precisely the store shape that has the problem there is no registry to read.

## The change

One member on the non-generic interface:

```csharp
IReadOnlyList<ShardName> RegisteredShardNames();
```

satisfied on `IEventStore<TOperations, TQuerySession>` by the private helper that was already there:

```csharp
IReadOnlyList<ShardName> IEventStore.RegisteredShardNames() => registeredShardNames();
```

Because the generic interface provides the implementation, **no store changes** — Marten, Polecat and Fisher satisfy it as they stand, and the added compliance test passes on all three without a line of downstream work.

The non-generic default throws rather than returning `[]`. An empty registry is a meaningful answer, and handing one back is indistinguishable from "nothing is registered" — which is exactly what latches a readiness probe green during a version bump.

## Tests

- `EventTests/RegisteredShardNamesTests.cs` — the generic interface answers from its own registry when held as the **non-generic** interface (the only handle a store-agnostic consumer has), a tenant-qualified shard keeps its tenant through the trip, an empty registry answers empty, and a store implementing only the non-generic interface refuses.
- `AsyncDaemonCompliance.registered_shard_names_are_reachable_from_the_non_generic_store` — cross-store contract test, asserted off `IEventStore`.

`EventTests` (1085) and `EventStoreTests` (141) pass locally. The compliance addition has not been run against a live Marten/Polecat/Fisher here; it exercises the generic interface's default, which needs no store implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)