### PR TITLE
gh-810: give the explorer reads a database dimension

### DIFF
--- a/src/EventTests/DatabaseScopedExplorerReadDefaultsTests.cs
+++ b/src/EventTests/DatabaseScopedExplorerReadDefaultsTests.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using JasperFx.Events;
+using JasperFx.Events.Daemon;
+using JasperFx.Events.Descriptors;
+using JasperFx.Events.Projections;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace EventTests;
+
+/// <summary>
+/// jasperfx#810 — the explorer reads were scoped by tenant only, so on a store with more than one
+/// database a store-global read answers from whichever database the default session resolved and looks
+/// exactly like a complete answer. The database-scoped overloads add the missing dimension. These pin the
+/// two halves of their default: on a single-database store the database argument is necessarily the
+/// store's one database, so the read delegates; on a multi-database store the default refuses instead of
+/// quietly answering from one of them.
+/// </summary>
+public class DatabaseScopedExplorerReadDefaultsTests
+{
+    // Overrides only the TENANT-scoped explorer reads, recording the tenant it was handed. That is what
+    // lets these tests prove the database overload delegates with the tenant intact, rather than merely
+    // failing to throw. The database-scoped overloads are the defaults under test.
+    private sealed class ExplorerEventStore(DatabaseCardinality cardinality) : IEventStore
+    {
+        public List<string> Calls { get; } = [];
+
+        public DatabaseCardinality DatabaseCardinality => cardinality;
+
+        public Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(int count, string? tenantId,
+            CancellationToken ct)
+        {
+            Calls.Add($"GetRecentStreamsAsync({count}, {tenantId ?? "null"})");
+            return Task.FromResult<IReadOnlyList<StreamSummary>>([]);
+        }
+
+        public async IAsyncEnumerable<EventRecord> ReadStreamAsync(string streamId, string? tenantId,
+            CancellationToken ct)
+        {
+            Calls.Add($"ReadStreamAsync({streamId}, {tenantId ?? "null"})");
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task<StreamMetadata?> GetStreamMetadataAsync(string streamId, string? tenantId, CancellationToken ct)
+        {
+            Calls.Add($"GetStreamMetadataAsync({streamId}, {tenantId ?? "null"})");
+            return Task.FromResult<StreamMetadata?>(null);
+        }
+
+        public async IAsyncEnumerable<EventRecord> QueryByTagsAsync(IReadOnlyDictionary<string, string> tags,
+            string? tenantId, CancellationToken ct)
+        {
+            Calls.Add($"QueryByTagsAsync({tags.Count} tags, {tenantId ?? "null"})");
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public Task<IReadOnlyList<ProjectionStatus>> GetProjectionStatusesAsync(string? tenantId, CancellationToken ct)
+        {
+            Calls.Add($"GetProjectionStatusesAsync({tenantId ?? "null"})");
+            return Task.FromResult<IReadOnlyList<ProjectionStatus>>([]);
+        }
+
+        public Task<EventStoreUsage?> TryCreateUsage(CancellationToken token) => throw new NotImplementedException();
+        public Uri Subject => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(
+            string? tenantIdOrDatabaseIdentifier = null, ILogger? logger = null)
+            => throw new NotImplementedException();
+
+        public ValueTask<IProjectionDaemon> BuildProjectionDaemonAsync(DatabaseId id)
+            => throw new NotImplementedException();
+
+        public Meter Meter => throw new NotImplementedException();
+        public ActivitySource ActivitySource => throw new NotImplementedException();
+        public string MetricsPrefix => throw new NotImplementedException();
+        public bool HasMultipleTenants => throw new NotImplementedException();
+        public EventStoreIdentity Identity => throw new NotImplementedException();
+        public IReadOnlyEventStore OpenReadOnlyEventStore() => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(Guid streamId, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task CompactStreamAsync(string streamKey, CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    // Only the Identifier matters: the refusal has to name the database that could not be read, or an
+    // operator staring at 512 shard databases learns nothing from it.
+    private sealed class NamedEventDatabase(string identifier) : IEventDatabase
+    {
+        public string Identifier => identifier;
+        public Uri DatabaseUri => throw new NotImplementedException();
+        public ShardStateTracker Tracker => throw new NotImplementedException();
+        public string StorageIdentifier => throw new NotImplementedException();
+
+        public Task StoreDeadLetterEventAsync(object storage, DeadLetterEvent deadLetterEvent, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task EnsureStorageExistsAsync(Type storageType, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task WaitForNonStaleProjectionDataAsync(TimeSpan timeout) => throw new NotImplementedException();
+
+        public Task<long> ProjectionProgressFor(ShardName name, CancellationToken token = default)
+            => throw new NotImplementedException();
+
+        public Task<long?> FindEventStoreFloorAtTimeAsync(DateTimeOffset timestamp, CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<long> FetchHighestEventSequenceNumber(CancellationToken token)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyList<ShardState>> AllProjectionProgress(CancellationToken token = default)
+            => throw new NotImplementedException();
+    }
+
+    private readonly IEventDatabase theDatabase = new NamedEventDatabase("shard_017");
+    private readonly Dictionary<string, string> theTags = new() { ["account"] = "abc" };
+
+    private readonly ExplorerEventStore theRecorder = new(DatabaseCardinality.Single);
+
+    // The database overloads are default interface members, so they are only reachable through the
+    // interface — not off the concrete type. That is exactly how CritterWatch consumes them.
+    private IEventStore theStore => theRecorder;
+
+    #region single database delegates, tenant intact
+
+    [Fact]
+    public async Task get_recent_streams_on_a_single_database_store_delegates()
+    {
+        await theStore.GetRecentStreamsAsync(theDatabase, 5, "tenant-a", CancellationToken.None);
+        theRecorder.Calls.ShouldBe(["GetRecentStreamsAsync(5, tenant-a)"]);
+    }
+
+    [Fact]
+    public async Task read_stream_on_a_single_database_store_delegates()
+    {
+        await foreach (var _ in theStore.ReadStreamAsync(theDatabase, "stream-1", "tenant-a", CancellationToken.None))
+        {
+        }
+
+        theRecorder.Calls.ShouldBe(["ReadStreamAsync(stream-1, tenant-a)"]);
+    }
+
+    [Fact]
+    public async Task get_stream_metadata_on_a_single_database_store_delegates()
+    {
+        await theStore.GetStreamMetadataAsync(theDatabase, "stream-1", null, CancellationToken.None);
+        theRecorder.Calls.ShouldBe(["GetStreamMetadataAsync(stream-1, null)"]);
+    }
+
+    [Fact]
+    public async Task query_by_tags_on_a_single_database_store_delegates()
+    {
+        await foreach (var _ in theStore.QueryByTagsAsync(theDatabase, theTags, "tenant-a", CancellationToken.None))
+        {
+        }
+
+        theRecorder.Calls.ShouldBe(["QueryByTagsAsync(1 tags, tenant-a)"]);
+    }
+
+    [Fact]
+    public async Task projection_statuses_on_a_single_database_store_delegates()
+    {
+        await theStore.GetProjectionStatusesAsync(theDatabase, "tenant-a", CancellationToken.None);
+        theRecorder.Calls.ShouldBe(["GetProjectionStatusesAsync(tenant-a)"]);
+    }
+
+    #endregion
+
+    #region multiple databases refuse
+
+    [Theory]
+    [InlineData(DatabaseCardinality.StaticMultiple)]
+    [InlineData(DatabaseCardinality.DynamicMultiple)]
+    public async Task get_recent_streams_on_a_multi_database_store_refuses(DatabaseCardinality cardinality)
+    {
+        var recorder = new ExplorerEventStore(cardinality);
+        IEventStore store = recorder;
+
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => store.GetRecentStreamsAsync(theDatabase, 5, null, CancellationToken.None));
+
+        // Naming the database is the whole point: the alternative behavior — quietly answering from one of
+        // them — is indistinguishable from a complete answer, which is what jasperfx#810 is about.
+        ex.Message.ShouldContain("shard_017");
+        ex.Message.ShouldContain(cardinality.ToString());
+        recorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void read_stream_on_a_multi_database_store_refuses()
+    {
+        // Expression-bodied rather than an async iterator, like the tenant overloads: a caller that never
+        // enumerates still gets told the database scope was ignored.
+        var recorder = new ExplorerEventStore(DatabaseCardinality.StaticMultiple);
+        IEventStore store = recorder;
+
+        Should.Throw<NotSupportedException>(
+            () => store.ReadStreamAsync(theDatabase, "stream-1", null, CancellationToken.None));
+        recorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task get_stream_metadata_on_a_multi_database_store_refuses()
+    {
+        var recorder = new ExplorerEventStore(DatabaseCardinality.DynamicMultiple);
+        IEventStore store = recorder;
+
+        await Should.ThrowAsync<NotSupportedException>(
+            () => store.GetStreamMetadataAsync(theDatabase, "stream-1", null, CancellationToken.None));
+        recorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void query_by_tags_on_a_multi_database_store_refuses()
+    {
+        var recorder = new ExplorerEventStore(DatabaseCardinality.StaticMultiple);
+        IEventStore store = recorder;
+
+        Should.Throw<NotSupportedException>(
+            () => store.QueryByTagsAsync(theDatabase, theTags, null, CancellationToken.None));
+        recorder.Calls.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task projection_statuses_on_a_multi_database_store_refuses()
+    {
+        var recorder = new ExplorerEventStore(DatabaseCardinality.DynamicMultiple);
+        IEventStore store = recorder;
+
+        await Should.ThrowAsync<NotSupportedException>(
+            () => store.GetProjectionStatusesAsync(theDatabase, null, CancellationToken.None));
+        recorder.Calls.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    [Fact]
+    public void a_null_database_is_rejected_rather_than_silently_meaning_store_global()
+    {
+        // The single-database delegation would otherwise turn a null database into a store-global read,
+        // which is precisely the ambiguity these overloads exist to remove.
+        Should.Throw<ArgumentNullException>(
+            () => theStore.GetRecentStreamsAsync(null!, 5, null, CancellationToken.None));
+        Should.Throw<ArgumentNullException>(
+            () => theStore.ReadStreamAsync(null!, "stream-1", null, CancellationToken.None));
+        Should.Throw<ArgumentNullException>(
+            () => theStore.GetStreamMetadataAsync(null!, "stream-1", null, CancellationToken.None));
+        Should.Throw<ArgumentNullException>(
+            () => theStore.QueryByTagsAsync(null!, theTags, null, CancellationToken.None));
+        Should.Throw<ArgumentNullException>(
+            () => theStore.GetProjectionStatusesAsync(null!, null, CancellationToken.None));
+
+        theRecorder.Calls.ShouldBeEmpty();
+    }
+}

--- a/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/EventStoreExplorerCompliance.cs
@@ -216,6 +216,106 @@ public abstract class EventStoreExplorerCompliance<TFixture, TOperations, TQuery
         metadata.ShouldBeNull();
     }
 
+    // ---- the database dimension (jasperfx#810) ----
+    //
+    // The explorer reads were scoped by tenant only. On a store with more than one database that makes a
+    // store-global read a silent partial answer: it comes back from whichever database the default session
+    // resolved, with nothing in the result saying so. The database-scoped overloads are how a tool
+    // enumerates AllDatabases() and attributes each answer to the database it came from.
+    //
+    // This fixture is single-database, so what is pinned here is the half that a single-database store can
+    // pin: the database overload agrees with the store-global read rather than being a differently-behaved
+    // second path. The multi-database arms (database-per-tenant, and sharded tenancy where several tenants
+    // share a database) belong with a multi-database fixture and are tracked per store.
+
+    private async Task<IEventDatabase?> theOnlyDatabaseAsync()
+    {
+        var databases = await EventStore.AllDatabases();
+        return databases.Count == 1 ? databases[0] : null;
+    }
+
+    [Fact]
+    public async Task recent_streams_scoped_to_the_database_agree_with_the_store_global_read()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        var database = await theOnlyDatabaseAsync();
+        if (database == null)
+        {
+            Assert.Skip("This store does not report exactly one database through AllDatabases().");
+        }
+
+        var streamId = await aVoyageAsync(new PortVisited("Plymouth"));
+
+        var streams = await EventStore.GetRecentStreamsAsync(database, 10, null, Cancellation);
+
+        streams.Select(x => x.StreamId).ShouldContain(streamId.ToString());
+    }
+
+    [Fact]
+    public async Task stream_metadata_scoped_to_the_database_agrees_with_the_store_global_read()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        var database = await theOnlyDatabaseAsync();
+        if (database == null)
+        {
+            Assert.Skip("This store does not report exactly one database through AllDatabases().");
+        }
+
+        var streamId = await aVoyageAsync(new PortVisited("Plymouth"), new PortVisited("Bahia"));
+
+        var metadata = await EventStore.GetStreamMetadataAsync(database, streamId.ToString(), null, Cancellation);
+
+        metadata.ShouldNotBeNull();
+        metadata.StreamId.ShouldBe(streamId.ToString());
+        metadata.Version.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task stream_events_scoped_to_the_database_agree_with_the_store_global_read()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        var database = await theOnlyDatabaseAsync();
+        if (database == null)
+        {
+            Assert.Skip("This store does not report exactly one database through AllDatabases().");
+        }
+
+        var streamId = await aVoyageAsync(new PortVisited("Plymouth"));
+
+        var versions = new List<long>();
+        await foreach (var e in EventStore.ReadStreamAsync(database, streamId.ToString(), null, Cancellation))
+        {
+            versions.Add(e.StreamVersion);
+        }
+
+        versions.ShouldBe([1L, 2L]);
+    }
+
+    [Fact]
+    public async Task a_null_database_is_rejected_by_the_database_scoped_reads()
+    {
+        if (!SupportsExplorer)
+        {
+            Assert.Skip("This store does not implement the event store explorer surface.");
+        }
+
+        // Null would otherwise read as "store-global", which is the ambiguity these overloads remove.
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => EventStore.GetRecentStreamsAsync(null!, 10, null, Cancellation));
+    }
+
     [Fact]
     public async Task usage_describes_the_registered_event_types()
     {

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -166,6 +166,28 @@ public interface IEventStore
                 "Per-tenant GetRecentStreamsAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
 
     /// <summary>
+    /// Return the most recently updated streams from a single <paramref name="database" />, optionally
+    /// scoped to one tenant within it. This is the database dimension the tenant-only overloads do not
+    /// have: on a store whose <see cref="DatabaseCardinality" /> is not <see cref="DatabaseCardinality.Single" />,
+    /// a store-global read answers from whichever database the store's default session resolves, and the
+    /// result is indistinguishable from a complete answer. A tool enumerates <see cref="AllDatabases" />
+    /// and calls this per database, attributing each answer to the database it came from. See jasperfx#810,
+    /// CritterWatch#1231.
+    /// </summary>
+    /// <param name="database">The database to read from. Never null.</param>
+    /// <param name="count">Maximum number of streams to return from this database.</param>
+    /// <param name="tenantId">Tenant partition to scope the listing to within that database. Null means database-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(IEventDatabase database, int count, string? tenantId,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return DatabaseCardinality == DatabaseCardinality.Single
+            ? GetRecentStreamsAsync(count, tenantId, ct)
+            : throw databaseScopedExplorerReadNotSupported(nameof(GetRecentStreamsAsync), database);
+    }
+
+    /// <summary>
     /// Stream the events of a single stream from oldest to newest. Powers
     /// the explorer's stream-detail timeline. The default implementation
     /// throws <see cref="NotImplementedException"/>.
@@ -195,6 +217,25 @@ public interface IEventStore
                 "Per-tenant ReadStreamAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
 
     /// <summary>
+    /// Stream the events of a single stream from one <paramref name="database" />, optionally scoped to one
+    /// tenant within it. The database dimension matters more here than for a listing: on a multi-database
+    /// store the same stream id can exist in several databases, so a store-global read answers from whichever
+    /// one the default session resolves and says nothing about the rest. See jasperfx#810.
+    /// </summary>
+    /// <param name="database">The database to read the stream from. Never null.</param>
+    /// <param name="streamId">String form of the stream identifier.</param>
+    /// <param name="tenantId">Tenant partition to read the stream from within that database. Null means database-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    IAsyncEnumerable<EventRecord> ReadStreamAsync(IEventDatabase database, string streamId, string? tenantId,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return DatabaseCardinality == DatabaseCardinality.Single
+            ? ReadStreamAsync(streamId, tenantId, ct)
+            : throw databaseScopedExplorerReadNotSupported(nameof(ReadStreamAsync), database);
+    }
+
+    /// <summary>
     /// Return full diagnostic metadata for a single stream — version,
     /// timestamps, snapshot info, archive flag, tags. The default
     /// implementation throws <see cref="NotImplementedException"/>.
@@ -221,6 +262,26 @@ public interface IEventStore
             ? GetStreamMetadataAsync(streamId, ct)
             : throw new NotSupportedException(
                 "Per-tenant GetStreamMetadataAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
+
+    /// <summary>
+    /// Return full diagnostic metadata for a single stream from one <paramref name="database" />, optionally
+    /// scoped to one tenant within it. A null answer means "no such stream in THIS database" rather than
+    /// "no such stream", which is the distinction a store-global read cannot make on a multi-database store.
+    /// See jasperfx#810.
+    /// </summary>
+    /// <param name="database">The database to resolve the stream in. Never null.</param>
+    /// <param name="streamId">String form of the stream identifier.</param>
+    /// <param name="tenantId">Tenant partition to resolve the stream in within that database. Null means database-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Stream metadata, or <see langword="null"/> when no stream exists with that id in that database.</returns>
+    Task<StreamMetadata?> GetStreamMetadataAsync(IEventDatabase database, string streamId, string? tenantId,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return DatabaseCardinality == DatabaseCardinality.Single
+            ? GetStreamMetadataAsync(streamId, tenantId, ct)
+            : throw databaseScopedExplorerReadNotSupported(nameof(GetStreamMetadataAsync), database);
+    }
 
     /// <summary>
     /// Stream events that match all of the supplied DCB tag values.
@@ -252,6 +313,25 @@ public interface IEventStore
             ? QueryByTagsAsync(tags, ct)
             : throw new NotSupportedException(
                 "Per-tenant QueryByTagsAsync is not implemented on this IEventStore. Use an event store that implements multi-tenancy.");
+
+    /// <summary>
+    /// Stream events matching all of the supplied DCB tag values from one <paramref name="database" />,
+    /// optionally scoped to one tenant within it. Tag values are not unique across databases, so on a
+    /// multi-database store a store-global query answers from one database and shows no sign of it.
+    /// See jasperfx#810.
+    /// </summary>
+    /// <param name="database">The database to query. Never null.</param>
+    /// <param name="tags">Tag-name -> tag-value pairs to match.</param>
+    /// <param name="tenantId">Tenant partition to scope the query to within that database. Null means database-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    IAsyncEnumerable<EventRecord> QueryByTagsAsync(IEventDatabase database,
+        IReadOnlyDictionary<string, string> tags, string? tenantId, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return DatabaseCardinality == DatabaseCardinality.Single
+            ? QueryByTagsAsync(tags, tenantId, ct)
+            : throw databaseScopedExplorerReadNotSupported(nameof(QueryByTagsAsync), database);
+    }
 
     /// <summary>
     /// Rehydrate a DCB-projected entity by tag set, returning the
@@ -323,6 +403,38 @@ public interface IEventStore
             ? GetProjectionStatusesAsync(ct)
             : throw new NotSupportedException(
                 "Per-tenant GetProjectionStatusesAsync is not implemented on this IEventStore. Use an event store that implements per-tenant partitioning.");
+
+    /// <summary>
+    /// Return a snapshot of every projection's status on one <paramref name="database" />, optionally scoped
+    /// to one tenant within it. Progression rows are per database, so on a multi-database store the
+    /// store-global snapshot describes one database's rows and reads as the whole store's. This is the same
+    /// database dimension as the explorer reads (jasperfx#810), and the counterpart to the per-cell lag that
+    /// <see cref="IEventDatabase.FetchProjectionLagAsync(IReadOnlyList{ShardName},CancellationToken)" />
+    /// already reports one database at a time.
+    /// </summary>
+    /// <param name="database">The database whose projection statuses to report. Never null.</param>
+    /// <param name="tenantId">Tenant partition to scope statuses to within that database. Null means database-global.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<ProjectionStatus>> GetProjectionStatusesAsync(IEventDatabase database, string? tenantId,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        return DatabaseCardinality == DatabaseCardinality.Single
+            ? GetProjectionStatusesAsync(tenantId, ct)
+            : throw databaseScopedExplorerReadNotSupported(nameof(GetProjectionStatusesAsync), database);
+    }
+
+    /// <summary>
+    /// The refusal every database-scoped explorer read shares. Named rather than inlined so the message
+    /// stays identical across the family, and so a store that implements some of them and not others
+    /// produces a diagnosable answer rather than a silently partial one.
+    /// </summary>
+    private NotSupportedException databaseScopedExplorerReadNotSupported(string member, IEventDatabase database)
+        => new(
+            $"Database-scoped {member} is not implemented on this IEventStore, whose DatabaseCardinality is " +
+            $"{DatabaseCardinality}. Only a store with exactly one database can answer it from the store-global " +
+            $"overload, so '{database.Identifier}' cannot be read without a real implementation. Use an event store " +
+            "version that implements the database-scoped explorer reads (jasperfx#810).");
 
     /// <summary>
     /// Replay a projection over a fixed in-memory event list, returning


### PR DESCRIPTION
Addresses the abstraction half of #810. Refs CritterWatch#1231, jasperfx#502, jasperfx#503.

## The gap

The explorer reads on `IEventStore` — `GetRecentStreamsAsync`, `ReadStreamAsync`, `GetStreamMetadataAsync`, `QueryByTagsAsync` — are scoped by **tenant only**. On a store whose `DatabaseCardinality` is not `Single`, a store-global read answers from whichever database the store's default session resolved, and nothing in the result says so: it looks exactly like a complete answer. A production console over 512 shard databases lists recent streams from one of them, and no caller can say "list database X" because nothing on the surface takes one.

CritterWatch already fans out across every *store* and attributes rows per store; it cannot fan out across a store's *databases*.

## The change

Database-scoped overloads alongside the tenant-scoped ones, shaped like the `IEventDatabase` overloads `FetchProjectionLagAsync` and `DeleteProjectionProgressAsync` already use:

```csharp
Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(IEventDatabase database, int count, string? tenantId, CancellationToken ct);
IAsyncEnumerable<EventRecord>      ReadStreamAsync(IEventDatabase database, string streamId, string? tenantId, CancellationToken ct);
Task<StreamMetadata?>              GetStreamMetadataAsync(IEventDatabase database, string streamId, string? tenantId, CancellationToken ct);
IAsyncEnumerable<EventRecord>      QueryByTagsAsync(IEventDatabase database, IReadOnlyDictionary<string, string> tags, string? tenantId, CancellationToken ct);
Task<IReadOnlyList<ProjectionStatus>> GetProjectionStatusesAsync(IEventDatabase database, string? tenantId, CancellationToken ct);
```

A tool enumerates `AllDatabases()` and calls these per database, attributing each answer to the database it came from. `GetProjectionStatusesAsync` is included per the issue's sibling audit — progression rows are per database too.

The defaults:

- **Single-database store → delegate.** The argument is necessarily the store's one database, so Fisher and single-database Marten/Polecat are correct with no implementation work.
- **Multi-database store → refuse**, naming the database and the cardinality, rather than answering from whichever database it happened to open. The refusal is shared across the family so a half-implemented store is diagnosable rather than silently partial.
- **Null database → `ArgumentNullException`.** Null would otherwise read as "store-global", which is the ambiguity these overloads exist to remove.

## What this PR deliberately does not do

Items 2, 3 and the multi-database compliance arms from the issue are store-side and cannot be expressed here — a store overrides these members outright, so no default in JasperFx can enforce them, and the compliance fixture is single-database.

- **Decide the tenant predicate by tenancy style, not cardinality.** Marten skips the `tenant_id` filter whenever the store spans several databases, on the premise that every stream in a tenant's database belongs to that tenant. That holds for database-per-tenant; it does not hold for `ShardedTenancy`, where many tenants share each database.
- **A store-global read on a multi-database store must fan out or throw**, never silently answer from one database.
- **Compliance arms** for database-per-tenant and for sharded tenancy (two tenants co-located, same stream id in both).

Downstream issues filed: JasperFx/marten#5383, JasperFx/polecat#584, JasperFx/fisher#240.

## Tests

- `EventTests/DatabaseScopedExplorerReadDefaultsTests.cs` — for each of the five members: a single-database store delegates with the tenant intact; a `StaticMultiple`/`DynamicMultiple` store refuses with the database named and nothing reached; a null database is rejected.
- `EventStoreExplorerCompliance` — four cross-store tests that the database-scoped read agrees with the store-global read on a single-database fixture, plus the null-database rejection. Skipped when the store does not report exactly one database through `AllDatabases()`.

`EventTests` (1093) and `EventStoreTests` (141) pass locally. The compliance additions have not been run against a live Marten/Polecat/Fisher here; on a single-database fixture they reduce to the existing store-global read paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
