### PR TITLE
gh-810: multi-database arms for the explorer reads

### DIFF
--- a/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
+++ b/src/JasperFx.Events.ComplianceTests/ComplianceStoreConfig.cs
@@ -106,6 +106,42 @@ public sealed class ComplianceStoreConfig
     /// </remarks>
     public bool ConjoinedEventTenancy { get; set; }
 
+    /// <summary>
+    /// Tenant id → logical database name, for the suites that need a store backed by more than one
+    /// database (jasperfx#810). Empty leaves the store single-database, which is every other suite.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two distinct values is database-per-tenant. Two tenants sharing a value, alongside
+    /// <see cref="ConjoinedEventTenancy" />, is sharded tenancy — a pool of databases with many
+    /// tenants co-located in each. Those are genuinely independent axes, which is the whole of
+    /// jasperfx#810's gap 2: Marten decides whether to apply a <c>tenant_id</c> predicate from
+    /// <em>cardinality</em>, on the premise that every stream in a tenant's database belongs to that
+    /// tenant — true for database-per-tenant, false for sharding.
+    /// </para>
+    /// <para>
+    /// Logical names, not connection strings. The fixture owns the physical databases and maps each
+    /// name onto one it creates; nothing in a suite ever reads a name back, because
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.DatabaseForTenantAsync" />
+    /// resolves the <see cref="IEventDatabase" /> a suite actually needs. Distinct names must map to
+    /// distinct databases and equal names to the same one — that is the only thing a suite assumes.
+    /// </para>
+    /// <para>
+    /// A fixture that cannot build a multi-database store declares
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsMultipleDatabases" />
+    /// false and the affected suites skip. A fixture that says it can and then ignores this does not
+    /// skip — the suites fail, because a single-database store passes the isolation facts vacuously.
+    /// </para>
+    /// </remarks>
+    public Dictionary<string, string> TenantDatabases { get; } = new();
+
+    /// <inheritdoc cref="TenantDatabases" />
+    public ComplianceStoreConfig AssignTenantToDatabase(string tenantId, string databaseName)
+    {
+        TenantDatabases[tenantId] = databaseName;
+        return this;
+    }
+
     public List<Type> EventTypes { get; } = new();
 
     public List<(Type Tag, string Suffix, Type? Aggregate)> TagTypes { get; } = new();

--- a/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
+++ b/src/JasperFx.Events.ComplianceTests/EventStoreComplianceFixture.cs
@@ -341,6 +341,52 @@ public abstract class EventStoreComplianceFixture<TOperations, TQuerySession> : 
     public virtual bool SupportsExplorerSurface => true;
 
     /// <summary>
+    /// Can this fixture build a store backed by more than one database, from
+    /// <see cref="ComplianceStoreConfig.TenantDatabases" />? Gates the multi-database explorer arms
+    /// (jasperfx#810).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Default <b>false</b>, unlike most gates here, because this one is about the <em>fixture</em>
+    /// rather than the store: replaying a tenant-to-database map means creating and dropping real
+    /// databases, and a fixture that has never had to do it keeps compiling and skipping rather than
+    /// failing on a bump. Fisher is legitimately false — one file, one database.
+    /// </para>
+    /// <para>
+    /// Saying true is a commitment to both halves: replay
+    /// <see cref="ComplianceStoreConfig.TenantDatabases" />, and implement
+    /// <see cref="DatabaseForTenantAsync" />. A fixture that says true and replays nothing does not
+    /// skip — the isolation facts pass <em>vacuously</em> against a single-database store, which is
+    /// the failure mode the arms exist to catch.
+    /// </para>
+    /// </remarks>
+    public virtual bool SupportsMultipleDatabases => false;
+
+    /// <summary>
+    /// The <see cref="IEventDatabase" /> a tenant's data lives in, per
+    /// <see cref="ComplianceStoreConfig.TenantDatabases" />. Needed because
+    /// <see cref="IEventStore{TOperations,TQuerySession}.OpenSession(IEventDatabase,string)" /> takes
+    /// a database, and nothing store-neutral resolves one from a tenant id.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberately a fixture member and not a suite one. Every store spells this — Marten's
+    /// <c>Tenancy.FindOrCreateDatabase(tenantId)</c> — but on its own tenancy object, and matching
+    /// <see cref="IEventDatabase.Identifier" /> against a logical name from the config would only
+    /// work for a fixture that happened to name its physical databases the same way.
+    /// </para>
+    /// <para>
+    /// Throwing rather than returning the first of <see cref="IEventStore.AllDatabases" />: on a
+    /// multi-database store the wrong database is not a degraded answer but a different one, and a
+    /// fallback here would make the isolation facts assert about whichever database the store
+    /// happened to hand back.
+    /// </para>
+    /// </remarks>
+    public virtual ValueTask<IEventDatabase> DatabaseForTenantAsync(string tenantId)
+        => throw new NotSupportedException(
+            $"{GetType().FullName} does not implement DatabaseForTenantAsync, so it cannot run the multi-database explorer compliance arms (jasperfx#810).");
+
+    /// <summary>
     /// False in a store that has no flat-table event projection — an <c>EventProjection</c> writing
     /// into a plain relational table rather than a document.
     /// </summary>

--- a/src/JasperFx.Events.ComplianceTests/Suites/MultiDatabaseExplorerCompliance.cs
+++ b/src/JasperFx.Events.ComplianceTests/Suites/MultiDatabaseExplorerCompliance.cs
@@ -1,0 +1,565 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JasperFx.Descriptors;
+using Shouldly;
+using Xunit;
+
+namespace JasperFx.Events.ComplianceTests;
+
+#region Multi-database explorer events
+
+public record ManifestFiled(string Port);
+
+public record ManifestAmended(string Note);
+
+#endregion
+
+/// <summary>
+/// The shared machinery for the two multi-database explorer arms (jasperfx#810) — appending into a
+/// named tenant's database, and reading back through each of the three scopings the explorer offers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The explorer reads were scoped by <em>tenant</em> only, which leaves two gaps on a store with more
+/// than one database. The database-scoped overloads shipped in #817; what was still missing was any
+/// arm that runs against a store where there <em>is</em> more than one database, so nothing held
+/// either gap to a definition.
+/// </para>
+/// <para>
+/// Split into two concrete suites rather than one, because the two gaps live on independent axes and
+/// a single configuration cannot express both. Database-per-tenant has no co-located tenants, so it
+/// cannot see a dropped <c>tenant_id</c> predicate; sharded tenancy has co-located tenants, so it
+/// cannot isolate "the wrong database answered" from "the right database answered about the wrong
+/// tenant".
+/// </para>
+/// </remarks>
+public abstract class MultiDatabaseExplorerComplianceBase<TFixture, TOperations, TQuerySession>
+    : EventStoreComplianceSuite<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    /// <summary>
+    /// Deliberately larger than anything a fact appends, so nothing here can pass or fail because of
+    /// where a page boundary fell.
+    /// </summary>
+    protected const int Plenty = 100;
+
+    protected void SkipUnlessSupported()
+    {
+        Assert.SkipUnless(theFixture.SupportsExplorerSurface,
+            "This event store does not implement the event store explorer surface.");
+        Assert.SkipUnless(theFixture.SupportsMultipleDatabases,
+            "This event store fixture cannot build a store backed by more than one database.");
+    }
+
+    protected IEventStore<TOperations, TQuerySession> TheStore
+        => (IEventStore<TOperations, TQuerySession>)theFixture.EventStore;
+
+    protected ValueTask<IEventDatabase> DatabaseForAsync(string tenantId)
+        => theFixture.DatabaseForTenantAsync(tenantId);
+
+    /// <summary>
+    /// Append a stream under one tenant, into that tenant's own database.
+    /// </summary>
+    protected async Task AppendAsync(string tenantId, Guid streamId, params object[] events)
+    {
+        var database = await DatabaseForAsync(tenantId);
+
+        await using var session = TheStore.OpenSession(database, tenantId);
+        EventsFor(session).StartStream(streamId, events);
+        await SaveChangesAsync(session);
+    }
+
+    protected async Task<IReadOnlyList<string>> StreamIdsAsync(
+        Func<Task<IReadOnlyList<StreamSummary>>> read)
+        => (await read()).Select(x => x.StreamId).ToList();
+
+    protected async Task<IReadOnlyList<long>> StreamVersionsAsync(
+        Func<IAsyncEnumerable<EventRecord>> read)
+    {
+        var versions = new List<long>();
+        await foreach (var e in read())
+        {
+            versions.Add(e.StreamVersion);
+        }
+
+        return versions;
+    }
+
+    /// <summary>
+    /// The store reports the databases the configuration asked for, and says so through
+    /// <see cref="IEventStore.DatabaseCardinality" />.
+    /// </summary>
+    /// <remarks>
+    /// A precondition rather than a finding, and it is here so that the isolation facts below cannot
+    /// pass <em>vacuously</em>. A fixture that declared
+    /// <see cref="EventStoreComplianceFixture{TOperations,TQuerySession}.SupportsMultipleDatabases" />
+    /// and then built one database satisfies every "and not the other one's data" assertion by having
+    /// no other one — which is precisely the shape of store these arms exist to stop being tested
+    /// against.
+    /// </remarks>
+    [Fact]
+    public async Task the_store_is_genuinely_backed_by_more_than_one_database()
+    {
+        SkipUnlessSupported();
+
+        var databases = await EventStore.AllDatabases();
+
+        databases.Count.ShouldBeGreaterThanOrEqualTo(2,
+            "The fixture declared SupportsMultipleDatabases but AllDatabases() reports fewer than two, so every isolation fact in this suite would pass vacuously.");
+
+        EventStore.DatabaseCardinality.ShouldNotBe(DatabaseCardinality.Single,
+            "A store backed by several databases reporting DatabaseCardinality.Single sends every database-scoped explorer read down the single-database shortcut.");
+    }
+}
+
+/// <summary>
+/// <b>Gap 1.</b> The explorer reads against a database-per-tenant store: each tenant has a database
+/// of its own, and a store-global read has to say so rather than answering from one of them
+/// (jasperfx#810).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>GetRecentStreamsAsync(count, tenantId: null, ct)</c> means "store-global" in the contract. On a
+/// store whose cardinality is not <see cref="DatabaseCardinality.Single" />, Marten's implementation
+/// opens <c>openExplorerSession()</c> — one session, one database — and the result looks exactly like
+/// a complete answer. CritterWatch#1231 is that in production: a console over <b>512 shard databases
+/// and 2,173 tenants</b> lists recent streams from one database when no tenant is selected, with
+/// nothing in the result saying which.
+/// </para>
+/// <para>
+/// The suite accepts <em>either</em> remedy, because both are defensible and the contract says so:
+/// fan out across <see cref="IEventStore.AllDatabases" /> and merge, or throw pointing at the
+/// database-scoped overload. What it refuses is the third answer — one database's worth of rows,
+/// returned as though it were everything.
+/// </para>
+/// </remarks>
+public abstract class DatabasePerTenantExplorerCompliance<TFixture, TOperations, TQuerySession>
+    : MultiDatabaseExplorerComplianceBase<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private const string TenantA = "acme";
+    private const string TenantB = "globex";
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_db_per_tenant";
+
+        config.AddEventType<ManifestFiled>();
+        config.AddEventType<ManifestAmended>();
+
+        // Database per tenant: distinct names, and deliberately NOT conjoined -- there is no
+        // tenant_id column here, which is what makes this arm blind to gap 2 and why the sharded arm
+        // exists separately.
+        config.AssignTenantToDatabase(TenantA, "compliance_tenant_a");
+        config.AssignTenantToDatabase(TenantB, "compliance_tenant_b");
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// A database-scoped listing answers about that database and no other.
+    /// </summary>
+    /// <remarks>
+    /// Asserted in both directions. A read that returned everything would satisfy the "contains its
+    /// own" half on both databases and be exactly as wrong as one that returned nothing.
+    /// </remarks>
+    [Fact]
+    public async Task a_database_scoped_listing_answers_only_that_database()
+    {
+        SkipUnlessSupported();
+
+        var inA = Guid.NewGuid();
+        var inB = Guid.NewGuid();
+
+        await AppendAsync(TenantA, inA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, inB, new ManifestFiled("Singapore"));
+
+        var databaseA = await DatabaseForAsync(TenantA);
+        var databaseB = await DatabaseForAsync(TenantB);
+
+        var fromA = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(databaseA, Plenty, null, Cancellation));
+
+        fromA.ShouldContain(inA.ToString());
+        fromA.ShouldNotContain(inB.ToString());
+
+        var fromB = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(databaseB, Plenty, null, Cancellation));
+
+        fromB.ShouldContain(inB.ToString());
+        fromB.ShouldNotContain(inA.ToString());
+    }
+
+    /// <summary>
+    /// A database-scoped stream read does not see a same-identified stream in another database.
+    /// </summary>
+    /// <remarks>
+    /// The same stream id in both databases, with different event counts so the two answers cannot be
+    /// confused. On a database-per-tenant store a stream id is unique only within its database, and a
+    /// read that resolved the wrong one returns a plausible, complete-looking, wrong stream.
+    /// </remarks>
+    [Fact]
+    public async Task a_database_scoped_stream_read_does_not_see_another_databases_stream()
+    {
+        SkipUnlessSupported();
+
+        var shared = Guid.NewGuid();
+
+        await AppendAsync(TenantA, shared, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, shared, new ManifestFiled("Singapore"), new ManifestAmended("re-routed"));
+
+        var databaseA = await DatabaseForAsync(TenantA);
+        var databaseB = await DatabaseForAsync(TenantB);
+
+        var fromA = await StreamVersionsAsync(() =>
+            EventStore.ReadStreamAsync(databaseA, shared.ToString(), null, Cancellation));
+        var fromB = await StreamVersionsAsync(() =>
+            EventStore.ReadStreamAsync(databaseB, shared.ToString(), null, Cancellation));
+
+        fromA.ShouldBe([1L]);
+        fromB.ShouldBe([1L, 2L]);
+    }
+
+    /// <summary>
+    /// A database-scoped metadata read reports that database's version of the stream.
+    /// </summary>
+    [Fact]
+    public async Task a_database_scoped_metadata_read_answers_only_that_database()
+    {
+        SkipUnlessSupported();
+
+        var shared = Guid.NewGuid();
+
+        await AppendAsync(TenantA, shared, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, shared, new ManifestFiled("Singapore"), new ManifestAmended("re-routed"));
+
+        var metadataA = await EventStore.GetStreamMetadataAsync(
+            await DatabaseForAsync(TenantA), shared.ToString(), null, Cancellation);
+        var metadataB = await EventStore.GetStreamMetadataAsync(
+            await DatabaseForAsync(TenantB), shared.ToString(), null, Cancellation);
+
+        metadataA.ShouldNotBeNull();
+        metadataB.ShouldNotBeNull();
+
+        metadataA.Version.ShouldBe(1);
+        metadataB.Version.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// <b>The headline fact.</b> A store-global listing on a multi-database store is not a silent
+    /// partial answer: it either covers every database or it refuses.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both remedies are accepted deliberately — the choice between merging and refusing is a product
+    /// decision, and pinning one of them here would be inventing a contract rather than closing a
+    /// gap. What is pinned is that the third answer is not available.
+    /// </para>
+    /// <para>
+    /// The assertion is written as "contains both or threw" rather than counting rows, so a store
+    /// that fans out and applies its own per-database cap still passes.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task a_store_global_listing_is_not_a_silent_partial_answer()
+    {
+        SkipUnlessSupported();
+
+        var inA = Guid.NewGuid();
+        var inB = Guid.NewGuid();
+
+        await AppendAsync(TenantA, inA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, inB, new ManifestFiled("Singapore"));
+
+        IReadOnlyList<string> ids;
+        try
+        {
+            ids = await StreamIdsAsync(() => EventStore.GetRecentStreamsAsync(Plenty, null, Cancellation));
+        }
+        catch (Exception e) when (e is NotSupportedException or InvalidOperationException)
+        {
+            // The refusing remedy. A caller that gets this goes to the database-scoped overload,
+            // which is the outcome the fan-out remedy reaches by a different route.
+            return;
+        }
+
+        ids.ShouldContain(inA.ToString());
+        ids.ShouldContain(inB.ToString(),
+            "A store-global listing returned one database's streams and not the other's. On a store with 512 databases that result is indistinguishable from a complete answer (CritterWatch#1231): either fan out across AllDatabases(), or throw pointing at the database-scoped overload.");
+    }
+
+    /// <summary>
+    /// The same rule for the stream read, where getting it wrong is sharper still: the same stream id
+    /// exists in both databases, so the store-global read does not merely return <em>less</em> than
+    /// everything, it returns one plausible answer out of two.
+    /// </summary>
+    [Fact]
+    public async Task a_store_global_stream_read_is_not_a_silent_partial_answer()
+    {
+        SkipUnlessSupported();
+
+        var shared = Guid.NewGuid();
+
+        await AppendAsync(TenantA, shared, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, shared, new ManifestFiled("Singapore"), new ManifestAmended("re-routed"));
+
+        IReadOnlyList<long> versions;
+        try
+        {
+            versions = await StreamVersionsAsync(() =>
+                EventStore.ReadStreamAsync(shared.ToString(), null, Cancellation));
+        }
+        catch (Exception e) when (e is NotSupportedException or InvalidOperationException)
+        {
+            return;
+        }
+
+        // Either everything (three events across the two databases) or a refusal. One database's
+        // worth is the answer being ruled out.
+        versions.Count.ShouldBe(3,
+            $"A store-global stream read returned {versions.Count} events for a stream id that exists in two databases, so it answered from one of them and said nothing about the other.");
+    }
+
+    /// <summary>
+    /// A tenant-scoped read routes to that tenant's database. The half that already worked, kept so a
+    /// fix for the facts above cannot regress it.
+    /// </summary>
+    [Fact]
+    public async Task a_tenant_scoped_listing_answers_from_that_tenants_database()
+    {
+        SkipUnlessSupported();
+
+        var inA = Guid.NewGuid();
+        var inB = Guid.NewGuid();
+
+        await AppendAsync(TenantA, inA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, inB, new ManifestFiled("Singapore"));
+
+        var forA = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(Plenty, TenantA, Cancellation));
+
+        forA.ShouldContain(inA.ToString());
+        forA.ShouldNotContain(inB.ToString());
+    }
+}
+
+/// <summary>
+/// <b>Gap 2.</b> The explorer reads against a <em>sharded</em> store — a pool of databases with many
+/// tenants co-located in each, conjoined. This is the arm that pins the <c>tenant_id</c> predicate
+/// (jasperfx#810).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Marten decides between the two tenancy models by cardinality:
+/// </para>
+/// <code>
+/// var spansSeveralDatabases = Options.Tenancy.Cardinality != DatabaseCardinality.Single;
+/// var scopeByColumn = tenantId != null &amp;&amp; !spansSeveralDatabases;
+/// </code>
+/// <para>
+/// So a multi-database store opens the tenant's database and applies <b>no</b> <c>tenant_id</c>
+/// filter, on the stated premise that every stream in that database already belongs to the tenant.
+/// That holds for database-per-tenant. It does <em>not</em> hold for sharded tenancy, which by its own
+/// summary distributes tenants across a pool of databases with conjoined tenancy — many tenants share
+/// each database there. Cardinality and tenancy style are two axes, and this is the cell where they
+/// disagree.
+/// </para>
+/// <para>
+/// The issue filed this as a code-read rather than a reproduction. That is exactly what a compliance
+/// arm is for: it settles the question in whichever direction it turns out, on every store at once,
+/// instead of one maintainer's reading of one store's source.
+/// </para>
+/// <para>
+/// <b>Three tenants, two databases.</b> Two co-located so a leak has somewhere to come from, and a
+/// third alone in the second database so the store's cardinality is genuinely not
+/// <see cref="DatabaseCardinality.Single" /> — which is the whole precondition, since it is the
+/// cardinality test that turns the predicate off.
+/// </para>
+/// </remarks>
+public abstract class ShardedTenancyExplorerCompliance<TFixture, TOperations, TQuerySession>
+    : MultiDatabaseExplorerComplianceBase<TFixture, TOperations, TQuerySession>
+    where TFixture : EventStoreComplianceFixture<TOperations, TQuerySession>, new()
+    where TOperations : TQuerySession, IStorageOperations
+{
+    private const string TenantA = "acme";
+
+    /// <summary>Co-located with <see cref="TenantA" /> — the tenant a leak leaks from.</summary>
+    private const string TenantB = "globex";
+
+    /// <summary>Alone in the second shard, so the store spans several databases.</summary>
+    private const string TenantC = "initech";
+
+    private static readonly Action<ComplianceStoreConfig> _configuration = config =>
+    {
+        config.SchemaName = "compliance_sharded";
+        config.ConjoinedEventTenancy = true;
+
+        config.AddEventType<ManifestFiled>();
+        config.AddEventType<ManifestAmended>();
+
+        config.AssignTenantToDatabase(TenantA, "compliance_shard_one");
+        config.AssignTenantToDatabase(TenantB, "compliance_shard_one");
+        config.AssignTenantToDatabase(TenantC, "compliance_shard_two");
+    };
+
+    protected override Action<ComplianceStoreConfig> Configuration => _configuration;
+
+    /// <summary>
+    /// The positive control, and it has to come first: a database-scoped read with no tenant really
+    /// does see every co-located tenant.
+    /// </summary>
+    /// <remarks>
+    /// Without it, the isolation facts below are satisfied by a store that returns nothing at all —
+    /// and "the read is broken" would be indistinguishable from "the read is correctly scoped". This
+    /// fact is also the statement that database-global and tenant-global are different questions on a
+    /// sharded store, which is the thing cardinality-based scoping collapses.
+    /// </remarks>
+    [Fact]
+    public async Task a_database_scoped_listing_with_no_tenant_sees_every_co_located_tenant()
+    {
+        SkipUnlessSupported();
+
+        var forA = Guid.NewGuid();
+        var forB = Guid.NewGuid();
+
+        await AppendAsync(TenantA, forA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, forB, new ManifestFiled("Singapore"));
+
+        var shard = await DatabaseForAsync(TenantA);
+
+        var ids = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(shard, Plenty, null, Cancellation));
+
+        ids.ShouldContain(forA.ToString());
+        ids.ShouldContain(forB.ToString(),
+            "Two tenants share this database, so a database-scoped read with no tenant must see both. A store answering only one of them is scoping by something it was not asked to scope by.");
+    }
+
+    /// <summary>
+    /// <b>The fact the issue could not reproduce.</b> A tenant-scoped listing on a shared database
+    /// does not return a co-located tenant's streams.
+    /// </summary>
+    [Fact]
+    public async Task a_tenant_scoped_listing_does_not_leak_a_co_located_tenants_streams()
+    {
+        SkipUnlessSupported();
+
+        var forA = Guid.NewGuid();
+        var forB = Guid.NewGuid();
+
+        await AppendAsync(TenantA, forA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, forB, new ManifestFiled("Singapore"));
+
+        var ids = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(Plenty, TenantA, Cancellation));
+
+        ids.ShouldContain(forA.ToString());
+        ids.ShouldNotContain(forB.ToString(),
+            "A tenant-scoped listing returned a co-located tenant's stream. On a sharded store the tenant's database is not the tenant's data: the tenant_id predicate is needed as well as the database, and deciding from cardinality alone drops it.");
+    }
+
+    /// <summary>
+    /// The sharpest form: the same stream id under two co-located tenants. A read that drops the
+    /// predicate does not merely return extra rows — it returns both tenants' events interleaved into
+    /// one version-ordered sequence, which reads as a single stream that has been tampered with.
+    /// </summary>
+    [Fact]
+    public async Task a_tenant_scoped_stream_read_does_not_leak_a_co_located_tenants_events()
+    {
+        SkipUnlessSupported();
+
+        var shared = Guid.NewGuid();
+
+        await AppendAsync(TenantA, shared, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, shared, new ManifestFiled("Singapore"), new ManifestAmended("re-routed"));
+
+        var versions = await StreamVersionsAsync(() =>
+            EventStore.ReadStreamAsync(shared.ToString(), TenantA, Cancellation));
+
+        versions.ShouldBe([1L],
+            "A tenant-scoped stream read returned a co-located tenant's events. Under conjoined tenancy the identity of a stream is (tenant, id), not id alone.");
+    }
+
+    /// <summary>
+    /// The metadata read is scoped the same way. Carried separately because it is a different query
+    /// on every store, and jasperfx#810's audit list names it specifically — Marten's tenant-less path
+    /// opens the default session.
+    /// </summary>
+    [Fact]
+    public async Task tenant_scoped_stream_metadata_does_not_leak_a_co_located_tenants_stream()
+    {
+        SkipUnlessSupported();
+
+        var shared = Guid.NewGuid();
+
+        await AppendAsync(TenantA, shared, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, shared, new ManifestFiled("Singapore"), new ManifestAmended("re-routed"));
+
+        var metadata = await EventStore.GetStreamMetadataAsync(shared.ToString(), TenantA, Cancellation);
+
+        metadata.ShouldNotBeNull();
+        metadata.Version.ShouldBe(1,
+            "Tenant-scoped stream metadata reported a version that includes a co-located tenant's events.");
+    }
+
+    /// <summary>
+    /// Naming the database as well as the tenant does not change the answer. Both dimensions apply;
+    /// supplying one does not turn the other off.
+    /// </summary>
+    /// <remarks>
+    /// This is the fact that says the two scopings compose rather than compete. A store that treats
+    /// the database overload as "the scoping" and drops the tenant would pass every database-scoped
+    /// fact in the sibling arm and fail here.
+    /// </remarks>
+    [Fact]
+    public async Task a_database_and_tenant_scoped_read_applies_both()
+    {
+        SkipUnlessSupported();
+
+        var forA = Guid.NewGuid();
+        var forB = Guid.NewGuid();
+
+        await AppendAsync(TenantA, forA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantB, forB, new ManifestFiled("Singapore"));
+
+        var shard = await DatabaseForAsync(TenantA);
+
+        var ids = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(shard, Plenty, TenantA, Cancellation));
+
+        ids.ShouldContain(forA.ToString());
+        ids.ShouldNotContain(forB.ToString(),
+            "Naming the database turned the tenant predicate off. The two scopings compose: the database says where to look, the tenant says which rows.");
+    }
+
+    /// <summary>
+    /// A tenant in the other shard is not visible from this one, whichever way it is asked.
+    /// </summary>
+    /// <remarks>
+    /// The cross-shard direction, which the co-located facts cannot cover: they would both pass on a
+    /// store that filtered correctly by tenant and then queried every database in the pool.
+    /// </remarks>
+    [Fact]
+    public async Task a_tenant_in_another_shard_is_not_visible_from_this_one()
+    {
+        SkipUnlessSupported();
+
+        var forA = Guid.NewGuid();
+        var forC = Guid.NewGuid();
+
+        await AppendAsync(TenantA, forA, new ManifestFiled("Rotterdam"));
+        await AppendAsync(TenantC, forC, new ManifestFiled("Valparaiso"));
+
+        var shardOne = await DatabaseForAsync(TenantA);
+
+        var ids = await StreamIdsAsync(() =>
+            EventStore.GetRecentStreamsAsync(shardOne, Plenty, null, Cancellation));
+
+        ids.ShouldContain(forA.ToString());
+        ids.ShouldNotContain(forC.ToString());
+    }
+}

--- a/src/JasperFx.Events/IEventStore.cs
+++ b/src/JasperFx.Events/IEventStore.cs
@@ -167,6 +167,27 @@ public interface IEventStore
     /// view. The default implementation throws <see cref="NotImplementedException"/>;
     /// concrete event stores (Marten, Polecat) override it.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A store-global explorer read on a multi-database store must not silently answer from one
+    /// database</b> (jasperfx#810). This overload and its tenant-less siblings mean "everything this
+    /// store has", and on a store whose <see cref="DatabaseCardinality" /> is not
+    /// <see cref="DatabaseCardinality.Single" /> the obvious implementation opens the default session
+    /// — one session, one database — and returns a result indistinguishable from a complete answer.
+    /// Either fan out across <see cref="AllDatabases" /> and merge, or throw pointing at the
+    /// database-scoped overload. Both are fine; the current behavior is the one wrong option, because
+    /// a caller cannot tell a complete answer from one database out of 512.
+    /// </para>
+    /// <para>
+    /// The tenant-scoped overloads have a second, independent rule.
+    /// <b>Whether to filter on <c>tenant_id</c> is decided by tenancy style, not by cardinality</b>:
+    /// filter whenever events are conjoined, <em>and</em> open the tenant's database whenever there is
+    /// more than one. Deciding from cardinality alone rests on the premise that every stream in a
+    /// tenant's database belongs to that tenant, which holds for database-per-tenant and does not hold
+    /// for sharded tenancy, where many tenants share each database. Those are two axes, and sharded
+    /// tenancy is the case that needs both.
+    /// </para>
+    /// </remarks>
     /// <param name="count">Maximum number of streams to return.</param>
     /// <param name="ct">Cancellation token.</param>
     Task<IReadOnlyList<StreamSummary>> GetRecentStreamsAsync(int count, CancellationToken ct)


### PR DESCRIPTION
Refs #810 (the compliance half — proposal items 2, 3 and 5).

#817 gave the explorer reads a database dimension. What was still missing is the thing that makes those overloads worth having: **an arm that runs against a store where there actually is more than one database.** `EventStoreExplorerCompliance` is single-database throughout, so neither gap the issue names was held to a definition anywhere.

## Gap 1 — a store-global read answers from one database

`GetRecentStreamsAsync(count, tenantId: null, ct)` means "store-global" in the contract. On a store whose cardinality is not `Single`, the obvious implementation opens the default session — one session, one database — and the result is indistinguishable from a complete answer. CritterWatch#1231 is that in production: a console over **512 shard databases and 2,173 tenants** listing recent streams from one of them.

The suite accepts **either** remedy, because the choice is a product decision and pinning one would be inventing a contract rather than closing a gap: fan out across `AllDatabases()` and merge, or throw pointing at the database-scoped overload. What it refuses is the third answer. The assertion is "contains both, or threw" rather than a row count, so a store that fans out under its own per-database cap still passes.

## Gap 2 — on a sharded store the tenant predicate is dropped

Marten decides between the two tenancy models by **cardinality**:

```csharp
var spansSeveralDatabases = Options.Tenancy.Cardinality != DatabaseCardinality.Single;
var scopeByColumn = tenantId != null && !spansSeveralDatabases;
```

— on the premise that every stream in a tenant's database belongs to that tenant. True for database-per-tenant. False for `ShardedTenancy`, which distributes tenants across a pool of databases *with conjoined tenancy*: many tenants share each database. Cardinality and tenancy style are two axes and this is the cell where they disagree.

The issue filed this as a code-read, explicitly not reproduced. That is what an arm is for — it settles the question in whichever direction it turns out, on every store at once, rather than on one maintainer's reading of one store's source.

## Two suites, not one

The gaps live on independent axes and one configuration cannot express both. Database-per-tenant has no co-located tenants, so it is blind to a dropped predicate; sharded tenancy has co-located tenants, so it cannot separate "the wrong database answered" from "the right database answered about the wrong tenant".

`ShardedTenancyExplorerCompliance` runs **three tenants over two databases**: two co-located so a leak has somewhere to come from, and a third alone in the second shard so the store's cardinality is genuinely not `Single` — which is the whole precondition, since it is the cardinality test that turns the predicate off.

Both arms open with a precondition fact — two databases really exist, and `DatabaseCardinality` is not `Single` — because a fixture that claims the capability and then builds one database satisfies every "and not the other one's data" assertion *by having no other one*. The sharded arm also carries a positive control (a database-scoped read with no tenant sees both co-located tenants), without which "correctly scoped" and "returns nothing" are the same result.

## Seams

| | |
|---|---|
| `ComplianceStoreConfig.TenantDatabases` / `AssignTenantToDatabase` | Tenant id → **logical** database name. Distinct values is database-per-tenant; two tenants sharing a value plus `ConjoinedEventTenancy` is sharding. The fixture owns the physical databases and maps names onto ones it creates; no suite ever reads a name back. |
| `SupportsMultipleDatabases` | Default **false**, unlike most gates here, because this one is about the *fixture* — replaying the map means creating and dropping real databases — so a fixture that has never had to keeps compiling and skipping across the bump. Fisher is legitimately false: one file, one database. |
| `DatabaseForTenantAsync` | Throwing default. `OpenSession` takes an `IEventDatabase` and nothing store-neutral resolves one from a tenant id. Matching `IEventDatabase.Identifier` against a config name would only work for a fixture that named its physical databases the same way, and falling back to `AllDatabases().First()` would make every isolation fact assert about whichever database the store happened to hand back. |

`IEventStore`'s doc comments now state both rules rather than leaving them to be inferred — the store-global refusal, and that the `tenant_id` predicate is decided by tenancy style rather than by cardinality.

## Not in this PR

Proposal item 4's audit and item 1's remaining siblings are store-side work; the arms above are what will find them. Marten's cardinality-based scoping is the first thing they will exercise. I'll pack this locally against Marten and Polecat before the release — Fisher will skip the arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)